### PR TITLE
feat(sources): connect an MCP server by signing in, and let a run read from it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,11 @@ jobs:
       - name: Test against Cloudflare D1 (workerd)
         run: pnpm --filter @derive/db test:d1
 
+      # The OAuth sign-in path in the runtime it actually deploys to. This feature has already
+      # been broken once by a Node/workerd difference that every Node test missed.
+      - name: Test the sign-in path in workerd
+        run: pnpm --filter @derive/api test:worker
+
       # Bundle budget: build the web client and fail if the gzipped JS blows past
       # the budget (see scripts/check-bundle.mjs), so phosphor / radix / cmdk
       # weight can't regress silently.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -65,6 +65,7 @@
     "@types/better-sqlite3": "^7.6.11",
     "@types/node": "^25.9.3",
     "@types/pg": "^8.11.10",
+    "express": "^5.1.0",
     "fflate": "^0.8.2",
     "tsx": "^4.19.0",
     "typescript": "^6.0.3",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -26,6 +26,7 @@
     "typecheck:tsc": "tsc --noEmit && tsc --noEmit -p tsconfig.worker.json",
     "test": "vitest run",
     "test:live": "vitest run --config vitest.manual.config.ts",
+    "test:worker": "vitest run --config vitest.worker.config.ts",
     "test:coverage": "vitest run --coverage",
     "gen:env": "vitest run test/config-manifest.test.ts -u",
     "gen:openapi": "vitest run test/openapi.test.ts -u"
@@ -59,6 +60,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "^0.16.15",
     "@cloudflare/workers-types": "^4.20260615.1",
     "@types/better-sqlite3": "^7.6.11",
     "@types/node": "^25.9.3",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -34,6 +34,7 @@ import { folderRoutes } from "./routes/folders"
 import { followRoutes } from "./routes/follows"
 import { githubAppRoutes } from "./routes/github-app"
 import { marketingRoutes } from "./routes/marketing"
+import { mcpOauthRoutes } from "./routes/mcp-oauth"
 import { modelCredentialRoutes } from "./routes/model-credentials"
 import { moderationRoutes } from "./routes/moderation"
 import { notificationRoutes } from "./routes/notifications"
@@ -432,6 +433,7 @@ export function createApp(deps: AppDeps): Hono {
     automationRoutes,
     planRoutes,
     connectionRoutes,
+    mcpOauthRoutes,
     modelCredentialRoutes,
     conciergeRoutes,
     reworkRoutes,

--- a/apps/api/src/lib/agent-loop.ts
+++ b/apps/api/src/lib/agent-loop.ts
@@ -152,6 +152,41 @@ const resultText = (value: unknown): string => {
   }
 }
 
+/**
+ * How much tool output ONE RUN may put in front of the model, across every turn.
+ *
+ * The broker caps a single result, which stops one call from blowing the window. It does not stop
+ * TWELVE calls from doing it together, and a run that reads a corpus per turn will do exactly
+ * that. Watched on a real cloud MCP: one `read_wiki_contents` produced a 1,040,577-token prompt
+ * against a 1,048,576-token limit, and every later turn failed identically until the turn budget
+ * ran out — so the run paid twelve times to learn nothing.
+ *
+ * 240k characters is roughly 60k tokens: room for several substantial reads, and far enough below
+ * any current context window that the remaining turns still have somewhere to live.
+ */
+export const TOOL_OUTPUT_BUDGET_CHARS = 240_000
+
+/**
+ * Clip one tool result to what the run can still afford, and SAY what is left.
+ *
+ * The number matters more than the truncation. A model told only "truncated" reasonably tries the
+ * same call again with different arguments — which is how a run spends its remaining turns
+ * re-reading things it cannot keep. A model told it has 12,000 characters left asks a smaller
+ * question, or writes with what it has.
+ */
+const clipToBudget = (text: string, remaining: number): { text: string; used: number } => {
+  if (text.length <= remaining) return { text, used: text.length }
+  if (remaining <= 0)
+    return {
+      text: "[no tool-output budget left for this run — answer with what you already have, and do not call another tool]",
+      used: 0,
+    }
+  return {
+    text: `${text.slice(0, remaining)}\n\n…[truncated ${text.length - remaining} characters: this run's tool-output budget is spent. Answer with what you have rather than calling again.]`,
+    used: remaining,
+  }
+}
+
 /** A truncated reply, duck-typed. TruncatedReplyError (lib/model-openai) carries `truncated`;
  *  matching on the property rather than importing the class keeps this file free of the
  *  provider adapters that depend on IT. */
@@ -172,6 +207,8 @@ export const runAgentLoop = async (input: AgentLoopInput): Promise<AgentLoopResu
   let turns = 0
   // NUDGE_LIMIT is the shared policy (one re-ask), not a local choice.
   let nudges = 0
+  // Tool output already spent, across every turn. See TOOL_OUTPUT_BUDGET_CHARS.
+  let toolChars = 0
 
   while (turns < maxTurns) {
     turns += 1
@@ -204,16 +241,32 @@ export const runAgentLoop = async (input: AgentLoopInput): Promise<AgentLoopResu
       // Gmail. Latency is the right thing to trade for that.
       const results: { tool_use_id: string; content: string }[] = []
       for (const use of turn.toolUses) {
+        let text: string
         try {
-          results.push({
-            tool_use_id: use.id,
-            content: resultText(await input.executeTool(use.name, use.input)),
-          })
+          text = resultText(await input.executeTool(use.name, use.input))
         } catch (e) {
+          // An error is a diagnosis, not payload: it is short, and it must never be squeezed out
+          // by a budget the successful calls spent.
           results.push({ tool_use_id: use.id, content: resultText(e) })
+          continue
         }
+        const clipped = clipToBudget(text, TOOL_OUTPUT_BUDGET_CHARS - toolChars)
+        toolChars += clipped.used
+        results.push({ tool_use_id: use.id, content: clipped.text })
       }
       messages.push({ role: "user", content: results })
+
+      // THE LAST TURN IS ANNOUNCED, not sprung. Without this a run exploring one turn too long is
+      // guillotined at the cap having paid for every turn and produced nothing — which is the
+      // most expensive way for a run to fail and the easiest to avoid. Said once, on the turn
+      // where it changes what the model should do.
+      if (turns === maxTurns - 1) {
+        messages.push({
+          role: "user",
+          content:
+            "This is your final turn: any further tool call is discarded. Produce the revision now, using what you already have.",
+        })
+      }
       continue
     }
 

--- a/apps/api/src/lib/agent-loop.ts
+++ b/apps/api/src/lib/agent-loop.ts
@@ -213,8 +213,18 @@ export const runAgentLoop = async (input: AgentLoopInput): Promise<AgentLoopResu
   while (turns < maxTurns) {
     turns += 1
     let turn: ModelTurn
+    // ON THE FINAL TURN, OFFER NO TOOLS. The warning below asks the model to stop calling them;
+    // a model that ignores it spends the last turn on a call whose result is discarded, and the
+    // run fails having paid for everything. Withdrawing the tools makes that structurally
+    // impossible: the only move left is to answer. Watched on a scheduled run against a live
+    // cloud MCP, where a polite request alone converged some runs and not others.
+    const finalTurn = turns === maxTurns
     try {
-      turn = await input.callModel({ system: input.system, messages, tools: input.tools })
+      turn = await input.callModel({
+        system: input.system,
+        messages,
+        tools: finalTurn ? [] : input.tools,
+      })
     } catch (e) {
       // The model call itself failed (429, 5xx, a network blip). Retryable: the expensive part
       // has not happened yet and a second attempt may well succeed — the same judgement the

--- a/apps/api/src/lib/broker.ts
+++ b/apps/api/src/lib/broker.ts
@@ -3,6 +3,7 @@ import { type McpAuthResolver, makeBroker, quietReason, refRouter } from "@deriv
 import type { ConnectionKind, ConnectionRecord, MetaStore } from "@derive/core"
 import { decryptSecret } from "./crypto"
 import { installationToken } from "./github-app"
+import { liveBearer } from "./mcp-oauth"
 
 /** One tool a hosted run may call, paired with the connected-account ref it executes through.
  *  `kind` and `connectionId` are how the tool proxy routes the call without a second lookup;
@@ -203,7 +204,11 @@ export const mcpAuthFor = (
     }
     const cn = await row
     if (!cn || cn.org_id !== orgId || !cn.secret_enc) return undefined
-    return decryptSecret(cn.secret_enc, encryptionKey)
+    // One call site for BOTH credential shapes. A pasted key comes back as itself; an OAuth blob
+    // is refreshed here if it is about to expire, which is why this resolver runs per call rather
+    // than per request. An unreadable credential returns undefined — never the raw blob, which
+    // would put our ciphertext on somebody else's server. See lib/mcp-oauth.ts.
+    return await liveBearer(meta, cn, encryptionKey)
   }
 }
 

--- a/apps/api/src/lib/mcp-oauth.ts
+++ b/apps/api/src/lib/mcp-oauth.ts
@@ -1,0 +1,144 @@
+/**
+ * OAuth credentials for MCP sources: what is stored, and how a live access token is produced.
+ *
+ * WHY THIS EXISTS. Connecting a real MCP server means pasting a long-lived API key today —
+ * Stripe's own docs call that the fallback "if your MCP client doesn't support OAuth". A pasted
+ * key is scoped by hand, rotated by nobody, and is the first thing a new user is asked to do with
+ * their billing account. OAuth replaces it with one sign-in.
+ *
+ * WHAT IS STORED. Everything rides in the EXISTING `secret_enc` column, encrypted as one JSON
+ * blob, so this needs no migration and no new columns:
+ *
+ *     { v: 1, access_token, refresh_token?, expires_at?, token_endpoint, client_id, ... }
+ *
+ * A pasted key stays exactly what it was — a bare string — and `readCredential` tells the two
+ * apart by shape. That is deliberate: the two kinds have to coexist forever, because plenty of
+ * MCP servers offer no OAuth at all.
+ *
+ * THE PROTOCOL IS NOT OURS. Discovery, registration, PKCE, the code exchange and the refresh all
+ * come from `@modelcontextprotocol/sdk`, which is MIT, already a dependency of this app, and
+ * verified to run in workerd against Stripe's live authorization server. What is ours is the part
+ * no library can do: deciding where the token lives and when it is stale.
+ */
+
+import type { ConnectionRecord, MetaStore } from "@derive/core"
+import { refreshAuthorization } from "@modelcontextprotocol/sdk/client/auth.js"
+import { decryptSecret, encryptSecret } from "./crypto"
+
+/** Refresh this long before the access token actually expires, so a token cannot go stale
+ *  between the check and the call it is about to authorize. */
+const REFRESH_SKEW_MS = 60_000
+
+export interface McpOauthCredential {
+  v: 1
+  access_token: string
+  refresh_token?: string
+  /** Epoch ms. Absent means the server issued no expiry, so the token is used until it 401s. */
+  expires_at?: number
+  /** Where to refresh. Stored because rediscovering it on every refresh is a wasted round trip
+   *  and a second chance for discovery to fail at exactly the wrong moment. */
+  token_endpoint: string
+  authorization_server: string
+  client_id: string
+  client_secret?: string
+  /** RFC 8707: the resource this token is bound to. */
+  resource?: string
+}
+
+export type StoredCredential =
+  | { kind: "oauth"; cred: McpOauthCredential }
+  | { kind: "bearer"; token: string }
+  | { kind: "unreadable" }
+
+export const serializeCredential = (cred: McpOauthCredential, key: string): string =>
+  encryptSecret(JSON.stringify(cred), key)
+
+/**
+ * Read a stored credential without ever handing back something unusable.
+ *
+ * `decryptSecret` FAILS SOFT by design — it returns its input unchanged when the blob has no
+ * `v1.` prefix (a value stored before encryption was configured) and again when the key is wrong
+ * or the ciphertext is corrupt. That is right for a first-party API where a bad token merely
+ * 401s. It is wrong here: an MCP bearer goes to somebody ELSE'S server, so returning the blob
+ * would send our IV, auth tag and ciphertext to a third party, silently, on every run.
+ *
+ * So a value that still looks like an envelope after decryption is treated as UNREADABLE and
+ * nothing is sent. The caller reports it as a fault on our side rather than blaming the server.
+ */
+export const readCredential = (
+  secretEnc: string | null,
+  key: string | undefined,
+): StoredCredential => {
+  if (!secretEnc) return { kind: "unreadable" }
+  if (!key) return { kind: "unreadable" }
+  const plain = decryptSecret(secretEnc, key)
+  // Still an envelope ⇒ decryptSecret handed the input straight back: wrong key, or corrupt.
+  if (plain.startsWith("v1.")) return { kind: "unreadable" }
+  if (!plain.startsWith("{")) return { kind: "bearer", token: plain }
+  try {
+    const parsed = JSON.parse(plain) as McpOauthCredential
+    if (parsed?.v === 1 && typeof parsed.access_token === "string")
+      return { kind: "oauth", cred: parsed }
+  } catch {
+    // A JSON-shaped bearer token is vanishingly unlikely, but falling through to "use it as a
+    // bearer" is the safe reading: it is at worst a token the server rejects.
+  }
+  return { kind: "bearer", token: plain }
+}
+
+const expired = (cred: McpOauthCredential): boolean =>
+  typeof cred.expires_at === "number" && cred.expires_at - REFRESH_SKEW_MS <= Date.now()
+
+/**
+ * The live bearer for one connection: the stored token, refreshed first if it is about to expire.
+ *
+ * Returns undefined when there is nothing usable to send — an unreadable blob, or a refresh that
+ * failed — because sending nothing produces an honest 401 from the server, while sending garbage
+ * produces a confusing one and leaks whatever the garbage was.
+ */
+export const liveBearer = async (
+  meta: MetaStore,
+  cn: ConnectionRecord,
+  key: string | undefined,
+): Promise<string | undefined> => {
+  const stored = readCredential(cn.secret_enc, key)
+  if (stored.kind === "unreadable") return undefined
+  if (stored.kind === "bearer") return stored.token
+  const { cred } = stored
+  if (!expired(cred) || !cred.refresh_token || !key) return cred.access_token
+
+  try {
+    const tokens = await refreshAuthorization(cred.authorization_server, {
+      metadata: { token_endpoint: cred.token_endpoint } as never,
+      clientInformation: { client_id: cred.client_id, client_secret: cred.client_secret },
+      refreshToken: cred.refresh_token,
+      ...(cred.resource ? { resource: new URL(cred.resource) } : {}),
+    })
+    const next: McpOauthCredential = {
+      ...cred,
+      access_token: tokens.access_token,
+      // A server that rotates the refresh token returns a new one; one that does not keeps ours.
+      refresh_token: tokens.refresh_token ?? cred.refresh_token,
+      ...(tokens.expires_in ? { expires_at: Date.now() + tokens.expires_in * 1000 } : {}),
+    }
+    // COMPARE-AND-SWAP against the blob we read. Two runs can hit an expired token in the same
+    // second and both refresh; without this the slower reply overwrites the newer token with an
+    // older one and invalidates a grant that was working. Losing the swap is not an error — the
+    // winner's token is live, and it is the one we return.
+    const saved = await meta.updateConnectionCredential(
+      cn.id,
+      cn.org_id,
+      { secret_enc: serializeCredential(next, key) },
+      cn.secret_enc,
+    )
+    if (saved) return next.access_token
+    const fresh = await meta.getConnection(cn.id)
+    const reread = fresh ? readCredential(fresh.secret_enc, key) : { kind: "unreadable" as const }
+    return reread.kind === "oauth" ? reread.cred.access_token : undefined
+  } catch {
+    // A refresh that fails is a dead grant (revoked, expired beyond refresh, or the server is
+    // down). Send nothing: the run then fails closed naming the source, which is the outcome a
+    // person can act on.
+    return undefined
+  }
+}

--- a/apps/api/src/lib/mcp-oauth.ts
+++ b/apps/api/src/lib/mcp-oauth.ts
@@ -45,13 +45,38 @@ export interface McpOauthCredential {
   resource?: string
 }
 
+/**
+ * A dynamic client registration, kept so a second sign-in reuses the first one's client.
+ *
+ * Registration is not idempotent: Linear hands back a NEW client_id for byte-identical metadata
+ * every time it is asked. Registering per attempt would leave one abandoned OAuth client at the
+ * provider for every Sign in click, every retry and every flow someone thought better of — on an
+ * endpoint that is a standing rate-limit and abuse target.
+ *
+ * It lives in the same encrypted blob as the credential, so it costs no column, and it is written
+ * BEFORE consent — which is the whole point, since a flow that never completes is exactly the case
+ * that would otherwise re-register.
+ */
+export interface McpOauthClient {
+  v: 1
+  kind: "client"
+  client_id: string
+  client_secret?: string
+  /** Which authorization server issued it. A server that moves invalidates the reuse. */
+  authorization_server: string
+}
+
 export type StoredCredential =
   | { kind: "oauth"; cred: McpOauthCredential }
+  | { kind: "client"; client: McpOauthClient }
   | { kind: "bearer"; token: string }
   | { kind: "unreadable" }
 
 export const serializeCredential = (cred: McpOauthCredential, key: string): string =>
   encryptSecret(JSON.stringify(cred), key)
+
+export const serializeClient = (client: McpOauthClient, key: string): string =>
+  encryptSecret(JSON.stringify(client), key)
 
 /**
  * Read a stored credential without ever handing back something unusable.
@@ -76,9 +101,13 @@ export const readCredential = (
   if (plain.startsWith("v1.")) return { kind: "unreadable" }
   if (!plain.startsWith("{")) return { kind: "bearer", token: plain }
   try {
-    const parsed = JSON.parse(plain) as McpOauthCredential
+    const parsed = JSON.parse(plain) as McpOauthCredential & McpOauthClient
     if (parsed?.v === 1 && typeof parsed.access_token === "string")
       return { kind: "oauth", cred: parsed }
+    // A registration with no tokens yet. NOT a bearer: there is nothing here to send, and
+    // falling through would put a JSON blob in an Authorization header.
+    if (parsed?.v === 1 && parsed.kind === "client" && typeof parsed.client_id === "string")
+      return { kind: "client", client: parsed }
   } catch {
     // A JSON-shaped bearer token is vanishingly unlikely, but falling through to "use it as a
     // bearer" is the safe reading: it is at worst a token the server rejects.
@@ -103,6 +132,9 @@ export const liveBearer = async (
 ): Promise<string | undefined> => {
   const stored = readCredential(cn.secret_enc, key)
   if (stored.kind === "unreadable") return undefined
+  // Registered but never authorized: there is no token to send, and sending nothing produces an
+  // honest 401 rather than a confusing one.
+  if (stored.kind === "client") return undefined
   if (stored.kind === "bearer") return stored.token
   const { cred } = stored
   if (!expired(cred) || !cred.refresh_token || !key) return cred.access_token

--- a/apps/api/src/routes/automations.ts
+++ b/apps/api/src/routes/automations.ts
@@ -272,6 +272,10 @@ export const automationRoutes = (ctx: AppContext) => {
         trigger: TRIGGER.optional(),
         instruction: z.string().min(1).max(4000).optional(),
         refs: REFS.nullable().optional(),
+        // Sources were bindable only at CREATE, which meant an automation could never be pointed
+        // at a source connected afterwards — and connecting the source is the step a person does
+        // second, having already built the automation. `null` (or []) unbinds them all.
+        connectionIds: z.array(z.string().max(64)).max(20).nullable().optional(),
         enabled: z.boolean().optional(),
       }),
     )
@@ -280,6 +284,18 @@ export const automationRoutes = (ctx: AppContext) => {
       const agents = await meta.listAgents(org)
       if (!agents.some((ag) => ag.id === b.agentId))
         return bail(fail(c, 400, "agent must be in this workspace"))
+    }
+    // The SAME least-privilege check create makes, for the same reason: the ids must belong to
+    // this workspace and be attachable by this caller. An edit path that skipped it would be a
+    // way to bind someone else's credential to an automation that spends it.
+    if (b.connectionIds?.length) {
+      const bindErr = await connectionBindError(
+        meta,
+        org,
+        { userId: (await privateOwnerId(c)) ?? null, canManage: true },
+        b.connectionIds,
+      )
+      if (bindErr) return bail(fail(c, 400, bindErr))
     }
     const rec = await meta.updateAutomation(a.id, org, {
       agent_id: b.agentId,
@@ -291,6 +307,12 @@ export const automationRoutes = (ctx: AppContext) => {
           : b.refs === null
             ? null
             : JSON.stringify(normalizeSelectors(b.refs)),
+      connection_ids:
+        b.connectionIds === undefined
+          ? undefined
+          : b.connectionIds?.length
+            ? JSON.stringify(b.connectionIds)
+            : null,
       enabled: b.enabled === undefined ? undefined : b.enabled ? 1 : 0,
     })
     if (!rec) return fail(c, 404, "not found")

--- a/apps/api/src/routes/connections.ts
+++ b/apps/api/src/routes/connections.ts
@@ -226,7 +226,13 @@ export const connectionRoutes = (ctx: AppContext) => {
     // A server that refuses to authenticate must not be stored as a usable connection. `connect`
     // reports `pending` for both "unreachable" and "unauthorized", and a pending row is filtered
     // out of every run — so the useful thing to do is say so now, while a human is watching.
-    if (b.mcp_url && link.status !== "active") {
+    // A server that wants authorization and was given no token is not a failure — it is the
+    // START of the OAuth flow. Store the row `pending` (unpinned, so no run can use it) and hand
+    // it back with the reason, so the client can immediately offer "Sign in". Every other failure
+    // still refuses at the door: there is nothing to complete and a stored row would be a
+    // connection that can never come good.
+    const awaitingAuth = b.mcp_url && link.reason === "auth_required" && !b.mcp_secret
+    if (b.mcp_url && link.status !== "active" && !awaitingAuth) {
       // Say which of the four it was. These are the exact words a person reads at the moment they
       // are deciding whether this product works, and until now all four said "did not answer".
       const url = b.mcp_url
@@ -290,7 +296,16 @@ export const connectionRoutes = (ctx: AppContext) => {
       status: link.status,
     })
     // The auth URL rides this response (empty for the local broker's auto-authorized case).
-    return c.json({ ...present(rec), connect_url: link.url }, 201)
+    // `reason` rides it too when the row is waiting on OAuth, so the client can go straight to
+    // "Sign in" instead of showing a connection that looks broken.
+    return c.json(
+      {
+        ...present(rec),
+        connect_url: link.url,
+        ...(awaitingAuth ? { reason: "auth_required" as const } : {}),
+      },
+      201,
+    )
   })
 
   app.delete("/v1/connections/:id", async (c) => {

--- a/apps/api/src/routes/connections.ts
+++ b/apps/api/src/routes/connections.ts
@@ -226,14 +226,44 @@ export const connectionRoutes = (ctx: AppContext) => {
     // A server that refuses to authenticate must not be stored as a usable connection. `connect`
     // reports `pending` for both "unreachable" and "unauthorized", and a pending row is filtered
     // out of every run — so the useful thing to do is say so now, while a human is watching.
-    if (b.mcp_url && link.status !== "active")
+    if (b.mcp_url && link.status !== "active") {
+      // Say which of the four it was. These are the exact words a person reads at the moment they
+      // are deciding whether this product works, and until now all four said "did not answer".
+      const url = b.mcp_url
+      // Parse rather than string-match: a pasted URL can carry a query or a trailing slash, and
+      // the suggestion has to preserve everything except the path segment that is wrong.
+      const rootOf = (raw: string): string | null => {
+        try {
+          const u = new URL(raw)
+          if (!/\/mcp\/?$/.test(u.pathname)) return null
+          u.pathname = u.pathname.replace(/\/mcp\/?$/, "") || "/"
+          return u.toString().replace(/\/$/, "")
+        } catch {
+          return null
+        }
+      }
+      const root = rootOf(url)
+      const trimmed = root ?? url
+      const messages: Record<string, string> = {
+        auth_required: b.mcp_secret
+          ? "that server refused the token — check it is valid and has the scopes the server needs"
+          : "that server needs authorization: sign in with it, or paste a token",
+        not_mcp:
+          trimmed !== url
+            ? `no MCP server answered at ${url}. Many servers live at the root — try ${trimmed}`
+            : `no MCP server answered at ${url} — check the URL`,
+        unreachable: "could not reach that server at all — check the URL and that it is running",
+        protocol_error: "that server answered, but not in a way Derive could use",
+      }
       return fail(
         c,
         400,
-        b.mcp_secret
-          ? "that MCP server did not accept the credential (or is unreachable)"
-          : "that MCP server did not answer — if it requires authentication, pass `mcp_secret`",
+        messages[link.reason ?? ""] ??
+          "that MCP server did not answer — if it requires authentication, pass `mcp_secret`",
+        // The machine-readable half, so the UI can offer "Sign in" rather than parse prose.
+        link.reason ? { reason: link.reason } : undefined,
       )
+    }
     const rec = await meta.createConnection({
       id: newId("conn"),
       org_id: org,

--- a/apps/api/src/routes/mcp-oauth.ts
+++ b/apps/api/src/routes/mcp-oauth.ts
@@ -148,8 +148,23 @@ export const mcpOauthRoutes = (ctx: AppContext) => {
 
     const cn = await meta.getConnection(c.req.param("id"))
     if (!cn || cn.org_id !== org) return fail(c, 404, "not found")
-    // A personal connection is its owner's grant and nobody else's to start.
-    if (cn.scope === "personal" && cn.user_id !== me.id) return fail(c, 403, "forbidden")
+
+    // WHO MAY START ONE, which is not the same question as who may read the list.
+    //
+    // Workspace: admin-managed, the same rule revoke applies even to whoever added it. Finishing
+    // this flow installs a grant into a source EVERY automation in the org can spend, so "read"
+    // was the wrong gate — it let any member attach their own access to shared infrastructure.
+    //
+    // Personal: its OWNER only, and deliberately stricter than revoke, which a manager may do for
+    // someone else. A manager cannot authorize another member's personal connection, because the
+    // row acts as its owner while the credential would be the manager's — the connection would
+    // then spend one person's access under another person's name.
+    if (cn.scope === "workspace") {
+      const gate = await requireWorkspace(c, "manage")
+      if (gate instanceof Response) return gate
+    } else if (cn.user_id !== me.id) {
+      return fail(c, 403, "forbidden")
+    }
     if (cn.kind !== "mcp" || !cn.base_url) return fail(c, 400, "not an MCP connection")
 
     try {

--- a/apps/api/src/routes/mcp-oauth.ts
+++ b/apps/api/src/routes/mcp-oauth.ts
@@ -41,6 +41,32 @@ const STATE_DOMAIN = "derive-mcp-oauth-state:"
 /** Long enough to read a consent screen and sign in; short enough that a leaked URL goes stale. */
 const STATE_TTL_MS = 15 * 60_000
 
+/**
+ * Which scopes to ask a server for.
+ *
+ * Asking for everything it advertises is the obvious implementation and the wrong one. Linear
+ * advertises `read write openid email`, so the consent screen read "Access: Read, Write, Identity,
+ * Email address" for a feature whose own description is "your agents can read from it" and whose
+ * token field says "paste the narrowest token the server will accept". Over-asking is what makes a
+ * careful person press Cancel, and they would be right to.
+ *
+ * Scope names are vendor-specific, so this is a HEURISTIC, not a taxonomy: drop the ones that
+ * plainly grant more than reading, keep the rest. If that leaves nothing recognisable, ask for
+ * nothing and let the authorization server apply its own default, which is what the MCP
+ * authorization spec says to do when a client cannot know the right scopes.
+ *
+ * Deliberately conservative in the direction of asking for LESS. A missing scope surfaces
+ * immediately and loudly — the callback re-lists the tools and a server that will not answer
+ * leaves the connection pending with its own words on screen — whereas an over-broad grant is
+ * silent, permanent until revoked, and ours to have caused.
+ */
+const ELEVATED = /write|admin|delete|manage|create|update|billing|payment/i
+
+export const requestedScope = (supported: string[] | undefined): string | undefined => {
+  const narrow = (supported ?? []).filter((s) => !ELEVATED.test(s))
+  return narrow.length ? narrow.join(" ") : undefined
+}
+
 /** Where the provider sends the person back. One route for every server. */
 export const callbackUri = (baseUrl: string): string =>
   new URL("/v1/connections/oauth/callback", baseUrl).toString()
@@ -151,11 +177,12 @@ export const mcpOauthRoutes = (ctx: AppContext) => {
           "that server needs a pre-registered client, which this deployment has not configured",
         )
 
+      const scope = requestedScope(md.scopes_supported)
       const { authorizationUrl, codeVerifier } = await startAuthorization(authServer, {
         metadata: md,
         clientInformation: client,
         redirectUrl: redirectUri,
-        ...(md.scopes_supported?.length ? { scope: md.scopes_supported.join(" ") } : {}),
+        ...(scope ? { scope } : {}),
         resource: new URL(serverUrl),
       })
 
@@ -259,7 +286,12 @@ export const mcpOauthRoutes = (ctx: AppContext) => {
         scopes_label: "signed in",
       })
       // Back to where they started, not to a JSON body: this is a browser navigation.
-      return c.redirect(new URL("/settings?tab=sources&connected=1", deps.baseUrl).toString(), 302)
+      //
+      // `/settings/sources`, not `/settings?tab=sources`. Settings sections are PATH segments
+      // (routes/settings.$section.tsx); the query form is not a route, so it fell through to
+      // /settings/profile — meaning every completed sign-in landed on the wrong page and the
+      // person never saw whether it had worked. Caught by clicking through it, not by a test.
+      return c.redirect(new URL("/settings/sources?connected=1", deps.baseUrl).toString(), 302)
     } catch (e) {
       return fail(c, 400, `could not complete authorization: ${(e as Error).message}`.slice(0, 200))
     }

--- a/apps/api/src/routes/mcp-oauth.ts
+++ b/apps/api/src/routes/mcp-oauth.ts
@@ -34,7 +34,12 @@ import { Hono } from "hono"
 import type { AppContext } from "../context"
 import { signCapabilityToken, verifyCapabilityToken } from "../lib/capability-token"
 import { fail } from "../lib/http"
-import { type McpOauthCredential, serializeCredential } from "../lib/mcp-oauth"
+import {
+  type McpOauthCredential,
+  readCredential,
+  serializeClient,
+  serializeCredential,
+} from "../lib/mcp-oauth"
 
 /** Its own signing domain, so a state token cannot be replayed as any other capability. */
 const STATE_DOMAIN = "derive-mcp-oauth-state:"
@@ -154,22 +159,37 @@ export const mcpOauthRoutes = (ctx: AppContext) => {
       const md = await discoverAuthorizationServerMetadata(authServer)
       if (!md?.token_endpoint) return fail(c, 400, "that server does not advertise OAuth")
 
-      // Register per (server, deployment). Servers that offer registration hand back a public
-      // client — Stripe's advertises `token_endpoint_auth_methods_supported: ["none"]` — which is
-      // exactly the shape PKCE is designed for and needs no secret of ours anywhere.
+      // REUSE A REGISTRATION BEFORE MAKING ANOTHER. Registration is not idempotent — Linear
+      // returns a fresh client_id for byte-identical metadata — so registering per attempt leaves
+      // an abandoned client at the provider for every retry and every abandoned consent screen.
       const redirectUri = callbackUri(deps.baseUrl)
-      const client = md.registration_endpoint
-        ? await registerClient(authServer, {
-            metadata: md,
-            clientMetadata: {
-              client_name: "Derive",
-              redirect_uris: [redirectUri],
-              grant_types: ["authorization_code", "refresh_token"],
-              response_types: ["code"],
-              token_endpoint_auth_method: "none",
-            },
-          })
-        : undefined
+      const stored = readCredential(cn.secret_enc, secret)
+      const reusable =
+        stored.kind === "client" && stored.client.authorization_server === authServer
+          ? { client_id: stored.client.client_id, client_secret: stored.client.client_secret }
+          : // Re-authorizing an already-connected source: its credential names the client that
+            // was registered for it, and that one is still ours to use.
+            stored.kind === "oauth" && stored.cred.authorization_server === authServer
+            ? { client_id: stored.cred.client_id, client_secret: stored.cred.client_secret }
+            : undefined
+
+      // Servers that offer registration hand back a public client — Stripe's advertises
+      // `token_endpoint_auth_methods_supported: ["none"]` — which is exactly the shape PKCE is
+      // designed for and needs no secret of ours anywhere.
+      const client =
+        reusable ??
+        (md.registration_endpoint
+          ? await registerClient(authServer, {
+              metadata: md,
+              clientMetadata: {
+                client_name: "Derive",
+                redirect_uris: [redirectUri],
+                grant_types: ["authorization_code", "refresh_token"],
+                response_types: ["code"],
+                token_endpoint_auth_method: "none",
+              },
+            })
+          : undefined)
       if (!client?.client_id)
         return fail(
           c,
@@ -178,6 +198,23 @@ export const mcpOauthRoutes = (ctx: AppContext) => {
         )
 
       const scope = requestedScope(md.scopes_supported)
+      // Persist it BEFORE sending them off, because the flow that never comes back is precisely
+      // the one that would otherwise register again. Never over an existing credential: that blob
+      // holds live tokens and this one does not.
+      if (!reusable && stored.kind !== "oauth")
+        await meta.updateConnectionCredential(cn.id, org, {
+          secret_enc: serializeClient(
+            {
+              v: 1,
+              kind: "client",
+              client_id: client.client_id,
+              ...(client.client_secret ? { client_secret: client.client_secret } : {}),
+              authorization_server: authServer,
+            },
+            secret,
+          ),
+        })
+
       const { authorizationUrl, codeVerifier } = await startAuthorization(authServer, {
         metadata: md,
         clientInformation: client,

--- a/apps/api/src/routes/mcp-oauth.ts
+++ b/apps/api/src/routes/mcp-oauth.ts
@@ -1,0 +1,269 @@
+/**
+ * Connecting an MCP server by SIGNING IN, instead of pasting a long-lived key.
+ *
+ * Two routes and one problem worth explaining.
+ *
+ * THE ROUTES. `POST /v1/connections/:id/authorize` discovers the server's authorization server,
+ * registers Derive as a client if the server supports it, and hands back a URL to send the person
+ * to. `GET /v1/connections/oauth/callback` receives them back, exchanges the code, stores the
+ * token, and only then can the connection become usable.
+ *
+ * THE PROBLEM. Everywhere else in this codebase a connection is born complete: `connect()` lists
+ * the server's tools and mints `mcp:<pin>:<url>` in one step, and `toolsFor` REFUSES any ref
+ * whose pin is empty — that refusal is the whole tool-poisoning defense, so it cannot be softened.
+ * But an OAuth connection cannot list anything until after consent comes back, which is a second
+ * HTTP round trip and a different request. So the row is created `pending` with an unpinned ref
+ * (unusable by construction, which is the correct resting state for a half-finished connection),
+ * and the callback is what lists the tools, computes the pin, rewrites the ref and flips it
+ * `active`. Re-pinning after the fact is the one part of this no library does for us.
+ *
+ * WHO MAY FINISH IT. Signed state proves who STARTED the flow; it rides in a URL and is
+ * replayable inside its window, so it cannot also prove who finished it. A live session must, and
+ * must match. Same rule the Slack identity link already applies, for the same reason.
+ */
+
+import { McpBroker } from "@derive/broker"
+import {
+  discoverAuthorizationServerMetadata,
+  discoverOAuthProtectedResourceMetadata,
+  exchangeAuthorization,
+  registerClient,
+  startAuthorization,
+} from "@modelcontextprotocol/sdk/client/auth.js"
+import { Hono } from "hono"
+import type { AppContext } from "../context"
+import { signCapabilityToken, verifyCapabilityToken } from "../lib/capability-token"
+import { fail } from "../lib/http"
+import { type McpOauthCredential, serializeCredential } from "../lib/mcp-oauth"
+
+/** Its own signing domain, so a state token cannot be replayed as any other capability. */
+const STATE_DOMAIN = "derive-mcp-oauth-state:"
+/** Long enough to read a consent screen and sign in; short enough that a leaked URL goes stale. */
+const STATE_TTL_MS = 15 * 60_000
+
+/** Where the provider sends the person back. One route for every server. */
+export const callbackUri = (baseUrl: string): string =>
+  new URL("/v1/connections/oauth/callback", baseUrl).toString()
+
+/**
+ * The PKCE verifier has to survive the round trip, and it must not be guessable from the state.
+ * It rides inside the signed state itself: the state is HMAC'd with the server's own secret, so a
+ * caller can neither forge nor read it as anything but an opaque string, and nothing extra has to
+ * be stored for a flow that may never be completed.
+ */
+interface OauthState {
+  connectionId: string
+  orgId: string
+  userId: string
+  verifier: string
+  authServer: string
+  tokenEndpoint: string
+  clientId: string
+  clientSecret?: string
+  resource?: string
+}
+
+/**
+ * The whole state travels as ONE base64url field, not as nine.
+ *
+ * `signCapabilityToken` joins its fields with "." and recovers only the expiry structurally —
+ * everything before it comes back rejoined, so a kind with several fields has to "pick separators
+ * its field values can't contain". Half of these fields are URLs, and every real one has dots in
+ * it: `https://mcp.stripe.com` would split into four. Encoding the JSON once removes the question,
+ * and base64url is dot-free by construction.
+ */
+const packState = (s: OauthState): string[] => {
+  const bytes = new TextEncoder().encode(JSON.stringify(s))
+  let bin = ""
+  for (const b of bytes) bin += String.fromCharCode(b)
+  return [btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "")]
+}
+
+const unpackState = (rest: string): OauthState | null => {
+  try {
+    const b64 = rest.replace(/-/g, "+").replace(/_/g, "/")
+    const padded = b64 + "=".repeat((4 - (b64.length % 4)) % 4)
+    const bin = atob(padded)
+    const bytes = new Uint8Array(bin.length)
+    for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i)
+    const s = JSON.parse(new TextDecoder().decode(bytes)) as OauthState
+    // The signature already proves we minted it; this only guards against an older token shape.
+    if (!s?.connectionId || !s.orgId || !s.userId || !s.verifier || !s.tokenEndpoint) return null
+    if (!s.authServer || !s.clientId) return null
+    return s
+  } catch {
+    return null
+  }
+}
+
+export const mcpOauthRoutes = (ctx: AppContext) => {
+  const { meta, requireUser, requireWorkspace, deps } = ctx
+  const app = new Hono()
+
+  /**
+   * Begin the flow for a connection that is waiting on authorization. Returns the URL to send the
+   * person to; the caller opens it. Deliberately a POST that returns a URL rather than a redirect,
+   * so the SPA keeps control of the navigation and can show its own "opening Stripe…" state.
+   */
+  app.post("/v1/connections/:id/authorize", async (c) => {
+    const org = await requireWorkspace(c, "read")
+    if (org instanceof Response) return org
+    const me = await requireUser(c)
+    if (me instanceof Response) return me
+    // The same secret the other integrations sign state with — the Node and Worker entries pass
+    // the auth secret in as `encryptionKey`, and Slack's install flow already uses it this way.
+    const secret = deps.encryptionKey
+    if (!secret) return fail(c, 502, "this deployment cannot complete an OAuth connection")
+
+    const cn = await meta.getConnection(c.req.param("id"))
+    if (!cn || cn.org_id !== org) return fail(c, 404, "not found")
+    // A personal connection is its owner's grant and nobody else's to start.
+    if (cn.scope === "personal" && cn.user_id !== me.id) return fail(c, 403, "forbidden")
+    if (cn.kind !== "mcp" || !cn.base_url) return fail(c, 400, "not an MCP connection")
+
+    try {
+      const serverUrl = cn.base_url
+      const prm = await discoverOAuthProtectedResourceMetadata(serverUrl).catch(() => undefined)
+      const authServer = prm?.authorization_servers?.[0] ?? serverUrl
+      const md = await discoverAuthorizationServerMetadata(authServer)
+      if (!md?.token_endpoint) return fail(c, 400, "that server does not advertise OAuth")
+
+      // Register per (server, deployment). Servers that offer registration hand back a public
+      // client — Stripe's advertises `token_endpoint_auth_methods_supported: ["none"]` — which is
+      // exactly the shape PKCE is designed for and needs no secret of ours anywhere.
+      const redirectUri = callbackUri(deps.baseUrl)
+      const client = md.registration_endpoint
+        ? await registerClient(authServer, {
+            metadata: md,
+            clientMetadata: {
+              client_name: "Derive",
+              redirect_uris: [redirectUri],
+              grant_types: ["authorization_code", "refresh_token"],
+              response_types: ["code"],
+              token_endpoint_auth_method: "none",
+            },
+          })
+        : undefined
+      if (!client?.client_id)
+        return fail(
+          c,
+          400,
+          "that server needs a pre-registered client, which this deployment has not configured",
+        )
+
+      const { authorizationUrl, codeVerifier } = await startAuthorization(authServer, {
+        metadata: md,
+        clientInformation: client,
+        redirectUrl: redirectUri,
+        ...(md.scopes_supported?.length ? { scope: md.scopes_supported.join(" ") } : {}),
+        resource: new URL(serverUrl),
+      })
+
+      const state = await signCapabilityToken(
+        STATE_DOMAIN,
+        secret,
+        packState({
+          connectionId: cn.id,
+          orgId: org,
+          userId: me.id,
+          verifier: codeVerifier,
+          authServer,
+          tokenEndpoint: md.token_endpoint,
+          clientId: client.client_id,
+          ...(client.client_secret ? { clientSecret: client.client_secret } : {}),
+          resource: serverUrl,
+        }),
+        Date.now() + STATE_TTL_MS,
+      )
+      const url = new URL(authorizationUrl)
+      url.searchParams.set("state", state)
+      return c.json({ authorize_url: url.toString() })
+    } catch (e) {
+      return fail(c, 400, `could not start authorization: ${(e as Error).message}`.slice(0, 200))
+    }
+  })
+
+  /**
+   * The return leg. A top-level GET, like the Slack and GitHub callbacks, which is what passes the
+   * anonymous-write lockdown — and it still requires a live session below.
+   */
+  app.get("/v1/connections/oauth/callback", async (c) => {
+    const secret = deps.encryptionKey
+    const code = c.req.query("code")
+    const stateRaw = c.req.query("state")
+    if (!secret) return fail(c, 502, "OAuth is not configured")
+    if (c.req.query("error"))
+      return fail(c, 400, `authorization was declined: ${c.req.query("error")}`)
+    if (!code || !stateRaw) return fail(c, 400, "invalid callback")
+
+    const verified = await verifyCapabilityToken(STATE_DOMAIN, secret, stateRaw, Date.now())
+    const state = verified ? unpackState(verified.rest) : null
+    if (!state) return fail(c, 400, "that authorization link has expired — start again")
+
+    // State proves who STARTED it. It rides in a URL and is replayable inside its window, so a
+    // live session has to prove who FINISHES it, and they must be the same person.
+    const me = await requireUser(c)
+    if (me instanceof Response) return me
+    if (me.id !== state.userId) return fail(c, 403, "sign in as the person who started this")
+
+    const cn = await meta.getConnection(state.connectionId)
+    if (!cn || cn.org_id !== state.orgId) return fail(c, 404, "not found")
+
+    try {
+      const tokens = await exchangeAuthorization(state.authServer, {
+        metadata: { token_endpoint: state.tokenEndpoint } as never,
+        clientInformation: { client_id: state.clientId, client_secret: state.clientSecret },
+        authorizationCode: code,
+        codeVerifier: state.verifier,
+        redirectUri: callbackUri(deps.baseUrl),
+        ...(state.resource ? { resource: new URL(state.resource) } : {}),
+      })
+
+      const cred: McpOauthCredential = {
+        v: 1,
+        access_token: tokens.access_token,
+        ...(tokens.refresh_token ? { refresh_token: tokens.refresh_token } : {}),
+        ...(tokens.expires_in ? { expires_at: Date.now() + tokens.expires_in * 1000 } : {}),
+        token_endpoint: state.tokenEndpoint,
+        authorization_server: state.authServer,
+        client_id: state.clientId,
+        ...(state.clientSecret ? { client_secret: state.clientSecret } : {}),
+        ...(state.resource ? { resource: state.resource } : {}),
+      }
+      const secretEnc = serializeCredential(cred, secret)
+
+      // NOW list the tools, with the token we just obtained, and pin what came back. This is the
+      // step `connect()` does inline for a pasted key and cannot do here, because until this
+      // moment there was no credential to list with.
+      const broker = new McpBroker(undefined, () => cred.access_token)
+      const link = await broker.connect({
+        orgId: cn.org_id,
+        userId: cn.user_id,
+        toolkit: cn.base_url ?? "",
+      })
+      if (link.status !== "active") {
+        // Authorized, but the server still would not list. Keep the credential (it is valid and
+        // re-listing is cheap) and leave the row pending rather than pretending it is usable.
+        await meta.updateConnectionCredential(cn.id, cn.org_id, { secret_enc: secretEnc })
+        return fail(
+          c,
+          400,
+          "signed in, but that server would not list its tools — try reconnecting",
+        )
+      }
+
+      await meta.updateConnectionCredential(cn.id, cn.org_id, {
+        secret_enc: secretEnc,
+        broker_ref: link.ref,
+        status: "active",
+        scopes_label: "signed in",
+      })
+      // Back to where they started, not to a JSON body: this is a browser navigation.
+      return c.redirect(new URL("/settings?tab=sources&connected=1", deps.baseUrl).toString(), 302)
+    } catch (e) {
+      return fail(c, 400, `could not complete authorization: ${(e as Error).message}`.slice(0, 200))
+    }
+  })
+
+  return app
+}

--- a/apps/api/test/agent-loop.test.ts
+++ b/apps/api/test/agent-loop.test.ts
@@ -30,10 +30,10 @@ const revisionText = (content = "# Fresh", confidence = 0.9) =>
 
 /** Scripted model: returns the given turns in order, recording what it was asked. */
 const scripted = (turns: ModelTurn[]) => {
-  const seen: { messages: unknown[]; system: string }[] = []
+  const seen: { messages: unknown[]; system: string; tools?: unknown[] }[] = []
   let i = 0
-  const callModel: AgentLoopInput["callModel"] = async ({ messages, system }) => {
-    seen.push({ messages: [...messages], system })
+  const callModel: AgentLoopInput["callModel"] = async ({ messages, system, tools }) => {
+    seen.push({ messages: [...messages], system, tools })
     const t = turns[Math.min(i, turns.length - 1)]
     i += 1
     return t as ModelTurn
@@ -306,6 +306,27 @@ describe("agent loop: what it lets the model read", () => {
     const delivered = JSON.stringify(model.seen[1]?.messages ?? [])
     expect(delivered).toMatch(/truncated \d+ characters/)
     expect(delivered).toMatch(/Answer with what you have rather than calling again/)
+  })
+
+  it("withdraws the tools on the final turn, so they cannot be wasted", async () => {
+    // The announcement is a request, and a model may ignore it — observed on a scheduled run
+    // against a live cloud MCP, where some runs converged and some spent the last turn on a call
+    // whose result is discarded, failing having paid for everything. With no tools offered, the
+    // only move left is to answer.
+    const model = scripted([toolTurn("t1"), toolTurn("t2"), turn({ text: revisionText() })])
+    const out = await runAgentLoop(
+      base({
+        callModel: model.callModel,
+        maxTurns: 3,
+        tools: [{ name: "read", description: "d", params: { type: "object" } }],
+        executeTool: async () => "ok",
+      }),
+    )
+    expect(out.ok).toBe(true)
+    // Offered on the early turns...
+    expect((model.seen[0] as unknown as { tools: unknown[] }).tools ?? []).toHaveLength(1)
+    // ...and withdrawn on the last.
+    expect((model.seen[2] as unknown as { tools: unknown[] }).tools ?? []).toHaveLength(0)
   })
 
   it("announces the last turn instead of springing it", async () => {

--- a/apps/api/test/agent-loop.test.ts
+++ b/apps/api/test/agent-loop.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_MAX_TURNS,
   type ModelTurn,
   runAgentLoop,
+  TOOL_OUTPUT_BUDGET_CHARS,
 } from "../src/lib/agent-loop"
 import { answerContract, revisionContract } from "../src/lib/turn-core"
 
@@ -266,5 +267,63 @@ describe("agent loop: cost", () => {
     // an unreported run cannot quietly look free.
     const out = await runAgentLoop(base({}))
     expect(out.costUsd).toBeNull()
+  })
+})
+
+describe("agent loop: what it lets the model read", () => {
+  const toolTurn = (id: string) => turn({ toolUses: [{ id, name: "read", input: {} }] })
+
+  it("spends a tool-output budget ACROSS turns, not just per call", async () => {
+    // The broker caps one result, which stops a single call blowing the window. It does not stop
+    // twelve calls doing it together — which is what a run reading a corpus per turn does, and
+    // what produced a 1,040,577-token prompt against a 1,048,576-token limit on a real cloud MCP.
+    const model = scripted([
+      toolTurn("t1"),
+      toolTurn("t2"),
+      toolTurn("t3"),
+      toolTurn("t4"),
+      turn({ text: revisionText() }),
+    ])
+    const huge = "x".repeat(150_000)
+    const out = await runAgentLoop(
+      base({ callModel: model.callModel, tools: [], executeTool: async () => huge }),
+    )
+    expect(out.ok).toBe(true)
+
+    const delivered = JSON.stringify(model.seen[model.seen.length - 1]?.messages ?? [])
+    // Four 150k reads would be 600k characters. The budget holds the total down, with headroom
+    // for the envelope around each result.
+    expect(delivered.length).toBeLessThan(TOOL_OUTPUT_BUDGET_CHARS + 20_000)
+  })
+
+  it("tells the model how much room is left, instead of only that it truncated", async () => {
+    // A model told only "truncated" reasonably retries the same call with different arguments,
+    // which is how a run spends its last turns re-reading what it cannot keep.
+    const model = scripted([toolTurn("t1"), turn({ text: revisionText() })])
+    await runAgentLoop(
+      base({ callModel: model.callModel, executeTool: async () => "y".repeat(300_000) }),
+    )
+    const delivered = JSON.stringify(model.seen[1]?.messages ?? [])
+    expect(delivered).toMatch(/truncated \d+ characters/)
+    expect(delivered).toMatch(/Answer with what you have rather than calling again/)
+  })
+
+  it("announces the last turn instead of springing it", async () => {
+    // A run guillotined at the cap has paid for every turn and produced nothing: the most
+    // expensive way to fail, and the easiest to avoid.
+    const model = scripted([
+      toolTurn("t1"),
+      toolTurn("t2"),
+      toolTurn("t3"),
+      turn({ text: revisionText() }),
+    ])
+    const out = await runAgentLoop(
+      base({ callModel: model.callModel, maxTurns: 4, executeTool: async () => "ok" }),
+    )
+    expect(out.ok).toBe(true)
+    const finalPrompt = JSON.stringify(model.seen[3]?.messages ?? [])
+    expect(finalPrompt).toContain("This is your final turn")
+    // And it is said ONCE, on the turn where it changes what to do — not every turn.
+    expect(JSON.stringify(model.seen[1]?.messages ?? [])).not.toContain("final turn")
   })
 })

--- a/apps/api/test/connections.test.ts
+++ b/apps/api/test/connections.test.ts
@@ -128,6 +128,45 @@ describe("connections (Sources — per-user connected accounts)", () => {
     expect(ok.status).toBe(201)
   })
 
+  it("bind policy holds on EDIT too, not only on create", async () => {
+    // Sources used to be bindable only at create, so an automation could never be pointed at a
+    // source connected afterwards — which is the ordinary order: build the automation, then go
+    // connect the thing it should read. Adding the edit path also adds a second door, and the
+    // check on it has to be the same one, or it becomes the way to bind a credential that is not
+    // yours to spend.
+    const auto = await (
+      await app.request(
+        "/v1/automations",
+        jsonAs(as(owner.email), { trigger: { kind: "manual" }, instruction: "Read the source." }),
+      )
+    ).json()
+
+    const theirs = await (await connect(member.email, "notion")).json()
+    const denied = await app.request(
+      `/v1/automations/${auto.id}`,
+      jsonAs(as(owner.email), { connectionIds: [theirs.id] }, "PATCH"),
+    )
+    expect(denied.status).toBe(400)
+    expect((await denied.json()).error).toContain("its owner")
+
+    const mine = await (await connect(owner.email, "calendar")).json()
+    const ok = await app.request(
+      `/v1/automations/${auto.id}`,
+      jsonAs(as(owner.email), { connectionIds: [mine.id] }, "PATCH"),
+    )
+    expect(ok.status).toBe(200)
+    expect((await ok.json()).connection_ids).toEqual([mine.id])
+
+    // And unbinding is reachable: null clears, so a source can be detached without deleting the
+    // automation that used it.
+    const cleared = await app.request(
+      `/v1/automations/${auto.id}`,
+      jsonAs(as(owner.email), { connectionIds: null }, "PATCH"),
+    )
+    expect(cleared.status).toBe(200)
+    expect((await cleared.json()).connection_ids).toEqual([])
+  })
+
   it("paste-a-secret: stored encrypted, write-only — the credential appears in NO response", async () => {
     const secret = "sk_game_admin_9f3a7b2c1d"
     const res = await app.request(

--- a/apps/api/test/helpers.ts
+++ b/apps/api/test/helpers.ts
@@ -407,8 +407,13 @@ export const publishAs = (
   const url = shortId ? `/v1/artifacts/${shortId}/versions` : "/v1/artifacts"
   return app.request(url, { method: "POST", body: form, headers })
 }
-export const jsonAs = (headers: Record<string, string>, body: unknown) => ({
-  method: "POST" as const,
+export const jsonAs = (
+  headers: Record<string, string>,
+  body: unknown,
+  /** POST unless a test is exercising an edit route. */
+  method: "POST" | "PATCH" | "PUT" = "POST",
+) => ({
+  method,
   headers: { "content-type": "application/json", ...headers },
   body: JSON.stringify(body),
 })

--- a/apps/api/test/live-hosted-source.test.ts
+++ b/apps/api/test/live-hosted-source.test.ts
@@ -1,0 +1,185 @@
+import { afterAll, describe, expect, it } from "vitest"
+import { RUN_TOKEN_TTL_MS, signWorkToken } from "../src/lib/run-token"
+import { loopSubstrate } from "../src/lib/substrate-loop"
+import { as, jsonAs, makeAuthedApp, publishAs, type TestUser } from "./helpers"
+
+/**
+ * THE WHOLE SCENARIO, against a server on the real internet: connect a source, bind it to an
+ * automation, run it, and have the run publish a document containing something only that server
+ * could have told us.
+ *
+ * OFF BY DEFAULT — `LIVE_MCP=1 npx vitest run test/live-hosted-source.test.ts`.
+ *
+ * hosted-mcp-source.test.ts already drives this chain end to end, but against a server written in
+ * this file, which agrees with our assumptions by construction. The live run is what catches the
+ * things it cannot: DeepWiki answers over SSE and holds the stream open (that alone stalled every
+ * call for 20 seconds until it was fixed), its tool names and schemas are its own, and its results
+ * are prose rather than the tidy JSON a fixture returns.
+ *
+ * Only the MODEL is scripted, and deliberately so — it picks the tool and writes the document, but
+ * every byte it reasons over came from DeepWiki.
+ */
+
+const live = process.env.LIVE_MCP === "1"
+const DEEPWIKI = "https://mcp.deepwiki.com/mcp"
+
+const owner: TestUser = { id: "u_live_h", email: "liveh@derive.test", name: "O" }
+const SECRET = "zz-live-hosted-secret-at-least-16-chars"
+const { app, meta } = makeAuthedApp("zz-live-hosted", [owner], "editor", {
+  deps: { encryptionKey: SECRET },
+})
+
+afterAll(() => undefined)
+
+describe.skipIf(!live)(
+  "a hosted run reads from a LIVE MCP source and publishes what it read",
+  () => {
+    it("connect, bind, run, publish — with content only the server could supply", async () => {
+      const conn = (await (
+        await app.request(
+          "/v1/connections",
+          jsonAs(as(owner.email), { toolkit: "deepwiki", mcp_url: DEEPWIKI }),
+        )
+      ).json()) as { id: string; status: string }
+      expect(conn.status, "DeepWiki did not connect").toBe("active")
+
+      const art = (await (
+        await publishAs(app, "<h1>MCP</h1><p>Nothing yet.</p>", { title: "MCP" }, as(owner.email))
+      ).json()) as { short_id: string }
+
+      const auto = (await (
+        await app.request(
+          "/v1/automations",
+          jsonAs(as(owner.email), {
+            trigger: { kind: "manual" },
+            instruction: "Look up what an MCP tool is and rewrite the document with the answer.",
+            connectionIds: [conn.id],
+            // publish, so the run REVISES the document. Propose (the default) would file a
+            // proposal instead, and the living-artifact claim is about the page changing.
+            refs: [{ kind: "artifact", id: art.short_id, mode: "publish" }],
+          }),
+        )
+      ).json()) as { id: string }
+
+      const run = (await (
+        await app.request(`/v1/automations/${auto.id}/run`, {
+          method: "POST",
+          headers: as(owner.email),
+        })
+      ).json()) as { id: string }
+
+      const http: string[] = []
+      const offered: string[][] = []
+      let toolResult = ""
+      let turn = 0
+
+      const rec = await meta.getRun(run.id)
+      const runToken = await signWorkToken(
+        "run",
+        SECRET,
+        run.id,
+        rec?.agent_id ?? "",
+        rec?.org_id ?? "",
+        Date.now() + RUN_TOKEN_TTL_MS,
+      )
+      const pending: Promise<unknown>[] = []
+      await loopSubstrate({
+        waitUntil: (p: Promise<unknown>) => {
+          pending.push(p)
+        },
+        fetchImpl: async (req: Request) => {
+          const res = await app.fetch(req)
+          http.push(`${req.method} ${new URL(req.url).pathname} -> ${res.status}`)
+          return res
+        },
+        callModel: async ({ tools, messages }) => {
+          turn += 1
+          offered.push(tools.map((t) => t.name))
+          if (turn === 1) {
+            const ask = tools.find((t) => /ask|question/i.test(t.name))
+            return {
+              text: "",
+              toolUses: [
+                {
+                  id: "t1",
+                  name: ask?.name ?? tools[0]?.name ?? "MISSING",
+                  input: {
+                    repoName: "modelcontextprotocol/modelcontextprotocol",
+                    question: "What is a tool in MCP?",
+                  },
+                },
+              ],
+              costUsd: null,
+              done: false,
+            }
+          }
+          toolResult = JSON.stringify(messages[messages.length - 1])
+          return {
+            text: `<revision>${JSON.stringify({
+              content: `<h1>MCP</h1><p>${toolResult.replace(/[<>]/g, "").slice(0, 600)}</p>`,
+              filename: "index.html",
+              confidence: 0.95,
+              message: "from deepwiki",
+            })}</revision>`,
+            toolUses: [],
+            costUsd: null,
+            done: true,
+          }
+        },
+      }).start({ runId: run.id, token: runToken, server: "http://api.test" })
+      await Promise.all(pending)
+
+      // The live server's real tools were offered, already named legally for a model provider —
+      // DeepWiki's are short, but nothing here got to assume that.
+      expect(offered[0]?.length ?? 0).toBeGreaterThan(0)
+      for (const n of offered[0] ?? []) expect(n).toMatch(/^[a-zA-Z0-9_-]{1,64}$/)
+
+      // The call went through the RUN'S OWN endpoint, where least privilege is re-checked, rather
+      // than straight out of the executor.
+      expect(
+        http.some((h) => h.includes(`/v1/agent/runs/${run.id}/tool`) && h.includes("-> 200")),
+      ).toBe(true)
+
+      // REAL CONTENT, not our own arguments handed back. The echo stub returns the caller's
+      // arguments, which reads exactly like success, so this is the assertion that separates
+      // "a run happened" from "a run learned something".
+      expect(toolResult.length).toBeGreaterThan(200)
+      expect(toolResult).not.toContain("What is a tool in MCP?")
+
+      expect(
+        http.some((h) => h.includes("/finish")),
+        http.join("\n"),
+      ).toBe(true)
+
+      // THE WRITE LANDS AS A PROPOSAL, AND THAT IS CORRECT. The autonomy gate's third rung
+      // files rather than publishes whenever a run had a spendable connection, above any
+      // per-target `mode: "publish"` — a run that reads outside data acts on a human's say-so.
+      // Asserting the document CHANGED would be asserting that safety rung away; asserting the
+      // proposal exists and carries the live bytes is the same end-to-end claim without it.
+      const proposals = await app.request(`/v1/artifacts/${art.short_id}/proposals`, {
+        headers: as(owner.email),
+      })
+      expect(proposals.status).toBe(200)
+      const listed = (await proposals.json()) as {
+        proposals: { id: string; preview_url: string }[]
+      }
+      expect(listed.proposals, "the run filed nothing").toHaveLength(1)
+
+      const content = await app.request(`/v1/artifacts/${art.short_id}/content`, {
+        headers: as(owner.email),
+      })
+      const published = await content.text()
+      expect(published, "a credentialed run must not live-publish").toContain("Nothing yet.")
+
+      // A distinctive fragment of the ACTUAL tool result, in the ACTUAL filed bytes. A length
+      // check here would have passed on an empty proposal list.
+      const fragment = toolResult.replace(/[\\"<>]/g, "").slice(140, 190)
+      expect(fragment.length, "no tool text to match on").toBeGreaterThan(30)
+      // The list is metadata; the BYTES live behind the proposal's own preview URL, which is
+      // also exactly what a reviewer opens.
+      const preview = new URL(listed.proposals[0]?.preview_url ?? "")
+      const filed = await (await app.request(preview.pathname, { headers: as(owner.email) })).text()
+      expect(filed.replace(/[\\"<>]/g, "")).toContain(fragment)
+    }, 120_000)
+  },
+)

--- a/apps/api/test/live-oauth.test.ts
+++ b/apps/api/test/live-oauth.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest"
+import { as, jsonAs, makeAuthedApp, type TestUser } from "./helpers"
+
+/**
+ * The sign-in flow against authorization servers that actually exist.
+ *
+ * OFF BY DEFAULT — `LIVE_MCP=1 npx vitest run test/live-oauth.test.ts`. These make real requests
+ * to third parties, including a real dynamic client registration.
+ *
+ * HOW FAR THIS GOES, precisely: everything up to the consent screen. It creates the connection,
+ * discovers the authorization server, registers Derive as a client for real, and produces the URL
+ * a person would be sent to. It does NOT grant consent — that needs a human with an account at
+ * the far end, and no test can honestly claim it. The callback half is covered against a stub in
+ * mcp-oauth.test.ts.
+ *
+ * That boundary is the point of the file. "Discovery works" is the half that silently breaks per
+ * vendor (different origins, path-aware metadata, registration policies), and it is the half that
+ * a stub written from the spec will always agree with.
+ */
+
+const live = process.env.LIVE_MCP === "1"
+
+/** Vendors whose MCP servers are live and offer dynamic registration to anyone who asks. */
+const VENDORS = [
+  { name: "Linear", url: "https://mcp.linear.app/mcp", authHost: "linear.app" },
+  { name: "Sentry", url: "https://mcp.sentry.dev/mcp", authHost: "sentry.dev" },
+]
+
+describe.skipIf(!live)("starting a sign-in against a live authorization server", () => {
+  for (const vendor of VENDORS) {
+    it(`${vendor.name}: connect parks it, then authorize returns a real consent URL`, async () => {
+      const me: TestUser = { id: "u_live", email: "live@derive.test", name: "L" }
+      const { app } = makeAuthedApp(`live-oauth-${vendor.name}`, [me], "editor", {
+        deps: {
+          encryptionKey: "live-oauth-test-secret-at-least-16",
+          baseUrl: "https://derive.test",
+        },
+      })
+
+      const created = await app.request(
+        "/v1/connections",
+        jsonAs(as(me.email), { toolkit: vendor.name.toLowerCase(), mcp_url: vendor.url }),
+      )
+      const body = (await created.json()) as { id: string; status: string; reason?: string }
+      expect(created.status).toBe(201)
+      expect(body.status).toBe("pending")
+      expect(body.reason).toBe("auth_required")
+
+      const res = await app.request(`/v1/connections/${body.id}/authorize`, {
+        method: "POST",
+        headers: as(me.email),
+      })
+      const text = await res.text()
+      expect(res.status, `authorize failed: ${text}`).toBe(200)
+      const url = new URL((JSON.parse(text) as { authorize_url: string }).authorize_url)
+
+      // A real consent page at the real vendor, not something we assembled from a guess.
+      expect(url.hostname.endsWith(vendor.authHost)).toBe(true)
+      expect(url.searchParams.get("response_type")).toBe("code")
+      expect(url.searchParams.get("code_challenge_method")).toBe("S256")
+      expect(url.searchParams.get("code_challenge")).toBeTruthy()
+      expect(url.searchParams.get("client_id"), "registration produced no client").toBeTruthy()
+      expect(url.searchParams.get("redirect_uri")).toBe(
+        "https://derive.test/v1/connections/oauth/callback",
+      )
+      expect(url.searchParams.get("state"), "our signed state").toBeTruthy()
+
+      // The consent page has to actually be there. A 404 here means the flow dead-ends at the one
+      // step we hand a human, which is exactly the failure a green discovery test would hide.
+      const page = await fetch(url.toString(), { redirect: "manual" })
+      expect([200, 302, 303, 307].includes(page.status), `consent page: ${page.status}`).toBe(true)
+    }, 60_000)
+  }
+})

--- a/apps/api/test/mcp-oauth-roundtrip.test.ts
+++ b/apps/api/test/mcp-oauth-roundtrip.test.ts
@@ -73,7 +73,9 @@ const startReferenceServer = async () => {
   throw new Error("the reference MCP server never came up")
 }
 
-const SECRET = "roundtrip-secret-at-least-16-chars-long"
+// Prefixed like the other suites' keys (hosted-mcp-source, mcp-oauth): long enough for the
+// cipher, and shaped so a secret scanner does not have to guess whether it is real.
+const SECRET = "zz-roundtrip-test-key-not-a-secret-value"
 const owner: TestUser = { id: "u_rt", email: "rt@derive.test", name: "O" }
 const { app, meta } = makeAuthedApp("mcp-oauth-roundtrip", [owner], "editor", {
   deps: { encryptionKey: SECRET, baseUrl: "https://derive.test" },

--- a/apps/api/test/mcp-oauth-roundtrip.test.ts
+++ b/apps/api/test/mcp-oauth-roundtrip.test.ts
@@ -1,0 +1,158 @@
+import { type ChildProcess, spawn } from "node:child_process"
+import { createRequire } from "node:module"
+import { createServer } from "node:net"
+import { afterAll, describe, expect, it } from "vitest"
+import { readCredential } from "../src/lib/mcp-oauth"
+import { as, jsonAs, makeAuthedApp, type TestUser } from "./helpers"
+
+/**
+ * THE CONSENT ROUND TRIP, against somebody else's OAuth server.
+ *
+ * Every other test of this flow drives a server written in this repo, which agrees with our
+ * reading of the spec by construction — and a misreading shared by the client and its test server
+ * is invisible. This one runs the MCP SDK's OWN reference implementation
+ * (`examples/server/simpleStreamableHttp --oauth`, the maintainers' `DemoInMemoryAuthProvider`)
+ * and drives the whole thing: 401, discovery, dynamic registration, consent, the code exchange,
+ * the re-pin, and finally a tool call authorized by the token that came out.
+ *
+ * NO NETWORK AND NO ACCOUNT, so unlike the `LIVE_MCP=1` suites this runs in CI. The reference
+ * provider simulates the login and redirects straight back with a code, which is exactly the step
+ * a real vendor needs a human for. What it therefore CANNOT prove is any one vendor's quirks —
+ * Stripe's authorization server living on another origin, Linear's scope list — and those are
+ * covered separately in live-oauth.test.ts up to the consent screen.
+ *
+ * The server is deliberately reached the same way a stranger's would be: over real HTTP, on a
+ * real port, in another process.
+ *
+ * `express` is an apps/api devDependency for this and nothing else: the reference server needs it,
+ * and it is spawned rather than imported, so knip cannot see the use (hence the ignore in
+ * knip.json). Nothing in src/ touches it.
+ */
+
+const require = createRequire(import.meta.url)
+
+/** An OS-assigned free port, so two of these can run at once and CI never collides. */
+const freePort = (): Promise<number> =>
+  new Promise((resolve, reject) => {
+    const s = createServer()
+    s.on("error", reject)
+    s.listen(0, "127.0.0.1", () => {
+      const port = (s.address() as { port: number }).port
+      s.close(() => resolve(port))
+    })
+  })
+
+const children: ChildProcess[] = []
+afterAll(() => {
+  for (const c of children) c.kill("SIGKILL")
+})
+
+const startReferenceServer = async () => {
+  const mcpPort = await freePort()
+  const authPort = await freePort()
+  const entry = require.resolve("@modelcontextprotocol/sdk/examples/server/simpleStreamableHttp.js")
+  const child = spawn(process.execPath, [entry, "--oauth"], {
+    env: { ...process.env, MCP_PORT: String(mcpPort), MCP_AUTH_PORT: String(authPort) },
+    stdio: "ignore",
+  })
+  children.push(child)
+
+  // Poll until it answers rather than sleeping a guessed interval.
+  const url = `http://localhost:${mcpPort}/mcp`
+  for (let i = 0; i < 100; i++) {
+    try {
+      const res = await fetch(
+        `http://localhost:${mcpPort}/.well-known/oauth-protected-resource/mcp`,
+      )
+      if (res.ok) return { url, mcpPort, authPort }
+    } catch {
+      // not up yet
+    }
+    await new Promise((r) => setTimeout(r, 100))
+  }
+  throw new Error("the reference MCP server never came up")
+}
+
+const SECRET = "roundtrip-secret-at-least-16-chars-long"
+const owner: TestUser = { id: "u_rt", email: "rt@derive.test", name: "O" }
+const { app, meta } = makeAuthedApp("mcp-oauth-roundtrip", [owner], "editor", {
+  deps: { encryptionKey: SECRET, baseUrl: "https://derive.test" },
+})
+
+describe("signing in, end to end, against the MCP SDK's reference server", () => {
+  it("401 → consent → token → re-pin → a tool call that spends it", async () => {
+    const server = await startReferenceServer()
+
+    // 1. CONNECT. The server refuses without a token, so the row is parked pending and unpinned.
+    const created = await app.request(
+      "/v1/connections",
+      jsonAs(as(owner.email), { toolkit: "reference", mcp_url: server.url }),
+    )
+    const conn = (await created.json()) as { id: string; status: string; reason?: string }
+    expect(created.status).toBe(201)
+    expect(conn.status).toBe("pending")
+    expect(conn.reason).toBe("auth_required")
+
+    // 2. AUTHORIZE. Discovery here is genuinely path-aware — this server advertises its metadata
+    // at /.well-known/oauth-protected-resource/mcp and its authorization server on another port —
+    // and the client registers itself, since nothing was pre-arranged between these two processes.
+    const authorize = await app.request(`/v1/connections/${conn.id}/authorize`, {
+      method: "POST",
+      headers: as(owner.email),
+    })
+    expect(authorize.status).toBe(200)
+    const { authorize_url } = (await authorize.json()) as { authorize_url: string }
+    const authUrl = new URL(authorize_url)
+    expect(authUrl.port).toBe(String(server.authPort))
+    expect(authUrl.searchParams.get("code_challenge_method")).toBe("S256")
+
+    // 3. CONSENT. The reference provider simulates the login and redirects back with a code —
+    // the one step a real vendor needs a human for.
+    const consent = await fetch(authorize_url, { redirect: "manual" })
+    expect([302, 303].includes(consent.status), `consent returned ${consent.status}`).toBe(true)
+    const back = new URL(consent.headers.get("location") ?? "")
+    expect(back.pathname).toBe("/v1/connections/oauth/callback")
+    const code = back.searchParams.get("code")
+    const state = back.searchParams.get("state")
+    expect(code, "no authorization code came back").toBeTruthy()
+
+    // 4. CALLBACK. The code is exchanged for a real token, against a token endpoint that verifies
+    // our PKCE verifier — so a verifier that failed to survive the round trip fails right here.
+    const callback = await app.request(
+      `/v1/connections/oauth/callback?code=${encodeURIComponent(code ?? "")}&state=${encodeURIComponent(state ?? "")}`,
+      { headers: as(owner.email) },
+    )
+    expect(callback.status, await callback.clone().text()).toBe(302)
+    expect(callback.headers.get("location")).toContain("/settings/sources?connected=1")
+
+    // 5. THE ROW IS NOW USABLE, which needs both halves: a stored token, and a pin that could only
+    // have been computed by listing the tools with it.
+    const [row] = await meta.getConnectionsByIds([conn.id])
+    expect(row?.status).toBe("active")
+    expect(row?.broker_ref).toMatch(/^mcp:s256-[0-9a-f]{16,}:/)
+    const stored = readCredential(row?.secret_enc ?? null, SECRET)
+    expect(stored.kind).toBe("oauth")
+    if (stored.kind === "oauth") {
+      expect(stored.cred.access_token.length).toBeGreaterThan(8)
+      expect(stored.cred.token_endpoint).toContain(String(server.authPort))
+    }
+
+    // 6. AND IT SPENDS. Everything above could be true of a token nobody ever sent anywhere; the
+    // point of the credential is that the server accepts it, so call a tool and require a result.
+    // The same server answered 401 to the unauthenticated connect at step 1.
+    const { McpBroker } = await import("@derive/broker")
+    const broker = new McpBroker(undefined, () =>
+      stored.kind === "oauth" ? stored.cred.access_token : undefined,
+    )
+    const tools = await broker.toolsFor([row?.broker_ref ?? ""])
+    expect(tools.length, "no tools came back with the token").toBeGreaterThan(0)
+
+    const greet = tools.find((t) => /greet/i.test(t.name)) ?? tools[0]
+    const out = await broker.execute({
+      ref: row?.broker_ref ?? "",
+      tool: greet?.name ?? "",
+      args: { name: "Derive" },
+    })
+    expect(JSON.stringify(out)).toContain("Derive")
+  }, 60_000)
+})

--- a/apps/api/test/mcp-oauth.test.ts
+++ b/apps/api/test/mcp-oauth.test.ts
@@ -1,0 +1,217 @@
+import { createServer, type Server } from "node:http"
+import type { AddressInfo } from "node:net"
+import { afterAll, describe, expect, it } from "vitest"
+import { readCredential } from "../src/lib/mcp-oauth"
+import { as, jsonAs, makeAuthedApp, type TestUser } from "./helpers"
+
+// Connecting an MCP server by SIGNING IN.
+//
+// Driven against a fake server that behaves the way Stripe's real one does — verified by fetching
+// it: 401 at the root until authorized, protected-resource metadata pointing at an authorization
+// server, that server advertising dynamic registration, PKCE S256 and a PUBLIC client
+// (`token_endpoint_auth_methods_supported: ["none"]`). A stub that skipped any of those would be
+// testing a flow no real server offers.
+//
+// The protocol itself comes from @modelcontextprotocol/sdk, which is already a dependency and was
+// verified to run in workerd. What these tests cover is the part that is ours: the row's state
+// machine (pending until consent returns), who is allowed to finish a flow someone else started,
+// and the RE-PIN — because a pinned tool list is the whole tool-poisoning defense and an OAuth
+// connection cannot be pinned until after the callback.
+
+const SECRET = "mcp-oauth-test-secret-at-least-16-chars"
+const owner: TestUser = { id: "u_oa", email: "oa@derive.test", name: "O" }
+const other: TestUser = { id: "u_ob", email: "ob@derive.test", name: "B" }
+const { app, meta } = makeAuthedApp("mcp-oauth", [owner, other], "editor", {
+  deps: { encryptionKey: SECRET, baseUrl: "https://derive.test" },
+})
+
+const servers: Server[] = []
+afterAll(() => {
+  for (const s of servers) s.close()
+})
+
+/** A server that is 401 until it sees the token it issued, and a matching authorization server. */
+const startOauthServer = async (opts: { issue?: string } = {}) => {
+  const token = opts.issue ?? "at_live_1"
+  const state = { registered: 0, exchanged: 0, refreshed: 0, lastCodeVerifier: "" }
+  const server: Server = createServer((req, res) => {
+    let raw = ""
+    req.on("data", (c) => {
+      raw += c
+    })
+    req.on("end", () => {
+      const url = new URL(req.url ?? "/", "http://x")
+      const json = (code: number, body: unknown) => {
+        res.writeHead(code, { "content-type": "application/json" })
+        res.end(JSON.stringify(body))
+      }
+      // 127.0.0.1, not localhost, ON PURPOSE: every real MCP host has dots in it
+      // (`mcp.stripe.com`), and the signed state is packed by a helper whose field separator is
+      // also a dot. A dotless test host would let that mismatch through.
+      const base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`
+
+      // --- discovery -------------------------------------------------------------------------
+      if (url.pathname === "/.well-known/oauth-protected-resource")
+        return json(200, { resource: base, authorization_servers: [base] })
+      // Stripe serves its AS metadata ONLY at the path-aware location; the root is a 404. Mirror
+      // that, so a client that only tries the root fails here exactly as it would in production.
+      if (url.pathname.startsWith("/.well-known/oauth-authorization-server"))
+        return json(200, {
+          issuer: base,
+          authorization_endpoint: `${base}/authorize`,
+          token_endpoint: `${base}/token`,
+          registration_endpoint: `${base}/register`,
+          response_types_supported: ["code"],
+          grant_types_supported: ["authorization_code", "refresh_token"],
+          token_endpoint_auth_methods_supported: ["none"],
+          code_challenge_methods_supported: ["S256"],
+          scopes_supported: ["mcp"],
+        })
+      if (url.pathname === "/register") {
+        state.registered += 1
+        return json(201, { client_id: "client_abc", redirect_uris: [] })
+      }
+      if (url.pathname === "/token") {
+        const body = new URLSearchParams(raw)
+        state.lastCodeVerifier = body.get("code_verifier") ?? ""
+        if (body.get("grant_type") === "refresh_token") {
+          state.refreshed += 1
+          return json(200, { access_token: "at_refreshed", token_type: "bearer", expires_in: 3600 })
+        }
+        state.exchanged += 1
+        return json(200, {
+          access_token: token,
+          refresh_token: "rt_1",
+          token_type: "bearer",
+          expires_in: 3600,
+        })
+      }
+
+      // --- the MCP surface itself -----------------------------------------------------------
+      if (req.headers.authorization !== `Bearer ${token}`) {
+        res.writeHead(401, { "www-authenticate": `Bearer resource_metadata="${base}"` })
+        return res.end(JSON.stringify({ error: "unauthorized" }))
+      }
+      const msg = JSON.parse(raw || "{}") as { id?: number; method?: string }
+      const result =
+        msg.method === "initialize"
+          ? { protocolVersion: "2025-03-26" }
+          : msg.method === "tools/list"
+            ? { tools: [{ name: "get_balance", description: "Account balance." }] }
+            : { content: [] }
+      return json(200, { jsonrpc: "2.0", id: msg.id, result })
+    })
+  })
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r))
+  servers.push(server)
+  return { state, url: `http://127.0.0.1:${(server.address() as AddressInfo).port}` }
+}
+
+const connect = async (body: Record<string, unknown>, who = owner) => {
+  const res = await app.request("/v1/connections", jsonAs(as(who.email), body))
+  return { status: res.status, body: (await res.json()) as Record<string, string> }
+}
+
+describe("connecting an MCP server by signing in", () => {
+  it("a 401 parks the connection PENDING and offers authorization", async () => {
+    const srv = await startOauthServer()
+    const created = await connect({ toolkit: "billing", mcp_url: srv.url })
+    expect(created.status).toBe(201)
+    expect(created.body.status).toBe("pending")
+    expect(created.body.reason).toBe("auth_required")
+
+    // Pending means UNUSABLE, not merely unfinished: the ref carries no pin, and an unpinned ref
+    // is refused outright — which is what stops a half-connected source reaching a run.
+    const [row] = await meta.getConnectionsByIds([created.body.id as string])
+    expect(row?.broker_ref.endsWith(":")).toBe(false)
+    expect(row?.broker_ref).toContain("mcp::")
+    expect(row?.secret_enc ?? null).toBeNull()
+  })
+
+  it("authorize → callback stores a token, PINS the tool list, and activates", async () => {
+    const srv = await startOauthServer()
+    const created = await connect({ toolkit: "billing", mcp_url: srv.url })
+    const id = created.body.id as string
+
+    const auth = await app.request(`/v1/connections/${id}/authorize`, {
+      method: "POST",
+      headers: as(owner.email),
+    })
+    expect(auth.status).toBe(200)
+    const { authorize_url } = (await auth.json()) as { authorize_url: string }
+    const u = new URL(authorize_url)
+    // PKCE and the resource binding are the SDK's job; assert they actually happened.
+    expect(u.searchParams.get("code_challenge_method")).toBe("S256")
+    expect(u.searchParams.get("code_challenge")).toBeTruthy()
+    expect(u.searchParams.get("state")).toBeTruthy()
+    expect(srv.state.registered, "registered dynamically, no vendor setup").toBe(1)
+
+    const cb = await app.request(
+      `/v1/connections/oauth/callback?code=authcode&state=${encodeURIComponent(u.searchParams.get("state") ?? "")}`,
+      { headers: as(owner.email) },
+    )
+    expect(cb.status).toBe(302)
+    expect(srv.state.exchanged).toBe(1)
+    expect(srv.state.lastCodeVerifier, "the verifier survived the round trip").toBeTruthy()
+
+    const [row] = await meta.getConnectionsByIds([id])
+    expect(row?.status).toBe("active")
+    // THE RE-PIN. `connect()` cannot pin an OAuth connection — there is no credential to list
+    // with until consent returns — so the callback lists and pins. Without this the ref stays
+    // unpinned and every run refuses the source.
+    expect(row?.broker_ref).toMatch(/^mcp:s256-[0-9a-f]+:/)
+    const stored = readCredential(row?.secret_enc ?? null, SECRET)
+    expect(stored.kind).toBe("oauth")
+    if (stored.kind === "oauth") {
+      expect(stored.cred.access_token).toBe("at_live_1")
+      expect(stored.cred.refresh_token).toBe("rt_1")
+      expect(stored.cred.expires_at).toBeGreaterThan(Date.now())
+    }
+  })
+
+  it("someone else cannot finish a flow you started, even holding the link", async () => {
+    // Signed state proves who STARTED it and rides in a URL, so it is replayable inside its
+    // window. Only a live session can prove who FINISHES it.
+    const srv = await startOauthServer()
+    const created = await connect({ toolkit: "billing", mcp_url: srv.url })
+    const auth = await app.request(`/v1/connections/${created.body.id}/authorize`, {
+      method: "POST",
+      headers: as(owner.email),
+    })
+    const { authorize_url } = (await auth.json()) as { authorize_url: string }
+    const state = new URL(authorize_url).searchParams.get("state") ?? ""
+
+    const stolen = await app.request(
+      `/v1/connections/oauth/callback?code=authcode&state=${encodeURIComponent(state)}`,
+      { headers: as(other.email) },
+    )
+    expect(stolen.status).toBe(403)
+    const [row] = await meta.getConnectionsByIds([created.body.id as string])
+    expect(row?.status, "and the connection is untouched").toBe("pending")
+  })
+
+  it("a tampered or expired state is refused", async () => {
+    const res = await app.request("/v1/connections/oauth/callback?code=x&state=not-a-real-state", {
+      headers: as(owner.email),
+    })
+    expect(res.status).toBe(400)
+    expect(String(((await res.json()) as { error: string }).error)).toMatch(/expired|invalid/i)
+  })
+
+  it("a pasted-key connection is untouched by any of this", async () => {
+    // The two credential shapes coexist forever: plenty of MCP servers offer no OAuth at all.
+    const srv = await startOauthServer({ issue: "at_live_1" })
+    const created = await connect({
+      toolkit: "pasted",
+      mcp_url: srv.url,
+      mcp_secret: "at_live_1",
+    })
+    expect(created.status).toBe(201)
+    expect(created.body.status).toBe("active")
+    const [row] = await meta.getConnectionsByIds([created.body.id as string])
+    expect(readCredential(row?.secret_enc ?? null, SECRET)).toEqual({
+      kind: "bearer",
+      token: "at_live_1",
+    })
+  })
+})

--- a/apps/api/test/mcp-oauth.test.ts
+++ b/apps/api/test/mcp-oauth.test.ts
@@ -2,6 +2,7 @@ import { createServer, type Server } from "node:http"
 import type { AddressInfo } from "node:net"
 import { afterAll, describe, expect, it } from "vitest"
 import { readCredential } from "../src/lib/mcp-oauth"
+import { requestedScope } from "../src/routes/mcp-oauth"
 import { as, jsonAs, makeAuthedApp, type TestUser } from "./helpers"
 
 // Connecting an MCP server by SIGNING IN.
@@ -167,6 +168,24 @@ describe("connecting an MCP server by signing in", () => {
       expect(stored.cred.refresh_token).toBe("rt_1")
       expect(stored.cred.expires_at).toBeGreaterThan(Date.now())
     }
+  })
+
+  it("asks for the narrowest scopes the server offers, never everything", async () => {
+    // Caught on a real consent screen: Linear advertises `read write openid email`, and asking
+    // for all of it made "Derive is requesting access" say Read, WRITE, Identity, Email — for a
+    // feature whose own description is "your agents can read from it".
+    expect(requestedScope(["read", "write", "openid", "email"])).toBe("read openid email")
+    expect(requestedScope(["org:read", "project:write", "team:write", "event:write"])).toBe(
+      "org:read",
+    )
+    // A single opaque scope is not a privilege claim we can second-guess — Stripe's is just "mcp".
+    expect(requestedScope(["mcp"])).toBe("mcp")
+    expect(requestedScope(["default"])).toBe("default")
+    // Nothing recognisably narrow, and nothing advertised at all, both defer to the server's own
+    // default rather than inventing a request.
+    expect(requestedScope(["write"])).toBeUndefined()
+    expect(requestedScope([])).toBeUndefined()
+    expect(requestedScope(undefined)).toBeUndefined()
   })
 
   it("someone else cannot finish a flow you started, even holding the link", async () => {

--- a/apps/api/test/mcp-oauth.test.ts
+++ b/apps/api/test/mcp-oauth.test.ts
@@ -249,6 +249,45 @@ describe("connecting an MCP server by signing in", () => {
     expect(row?.status, "and the connection is untouched").toBe("pending")
   })
 
+  it("a WORKSPACE source needs manage to sign in, not merely read", async () => {
+    // Finishing this flow installs a grant into a source EVERY automation in the org can spend,
+    // so it follows the same admin-managed rule revoke does. `read` was the original gate, which
+    // let any member attach their own access to shared infrastructure.
+    const srv = await startOauthServer()
+    const created = await app.request(
+      "/v1/connections",
+      jsonAs(as(owner.email), { toolkit: "shared", mcp_url: srv.url, scope: "workspace" }),
+    )
+    const id = ((await created.json()) as { id: string }).id
+
+    // `other` is an editor here: plenty to read the list, not enough to sign in on the org's
+    // behalf.
+    const denied = await app.request(`/v1/connections/${id}/authorize`, {
+      method: "POST",
+      headers: as(other.email),
+    })
+    expect(denied.status).toBe(403)
+
+    const allowed = await app.request(`/v1/connections/${id}/authorize`, {
+      method: "POST",
+      headers: as(owner.email),
+    })
+    expect(allowed.status).toBe(200)
+  })
+
+  it("a PERSONAL source is its owner's alone, even from a manager", async () => {
+    // Stricter than revoke, which a manager may do for someone else, and deliberately: the row
+    // acts as its owner, so a manager's grant stored here would spend one person's access under
+    // another person's name.
+    const srv = await startOauthServer()
+    const created = await connect({ toolkit: "mine", mcp_url: srv.url }, other)
+    const denied = await app.request(`/v1/connections/${created.body.id}/authorize`, {
+      method: "POST",
+      headers: as(owner.email), // the workspace owner, and still refused
+    })
+    expect(denied.status).toBe(403)
+  })
+
   it("a tampered or expired state is refused", async () => {
     const res = await app.request("/v1/connections/oauth/callback?code=x&state=not-a-real-state", {
       headers: as(owner.email),

--- a/apps/api/test/mcp-oauth.test.ts
+++ b/apps/api/test/mcp-oauth.test.ts
@@ -188,6 +188,46 @@ describe("connecting an MCP server by signing in", () => {
     expect(requestedScope(undefined)).toBeUndefined()
   })
 
+  it("registers ONCE per server, however many times you press Sign in", async () => {
+    // Registration is not idempotent: Linear hands back a fresh client_id for byte-identical
+    // metadata every time. So a Sign in pressed three times, or a consent screen abandoned twice
+    // before someone finishes, would leave three OAuth clients at the provider -- on an endpoint
+    // that is a standing rate-limit and abuse target.
+    const srv = await startOauthServer()
+    const created = await connect({ toolkit: "billing", mcp_url: srv.url })
+    const id = created.body.id as string
+
+    const clientIds = new Set<string>()
+    for (let i = 0; i < 3; i++) {
+      const auth = await app.request(`/v1/connections/${id}/authorize`, {
+        method: "POST",
+        headers: as(owner.email),
+      })
+      expect(auth.status).toBe(200)
+      const { authorize_url } = (await auth.json()) as { authorize_url: string }
+      clientIds.add(new URL(authorize_url).searchParams.get("client_id") ?? "")
+    }
+    expect(srv.state.registered).toBe(1)
+    expect(clientIds.size, "the same client every time").toBe(1)
+
+    // And finishing still works on the reused client — the reuse must not have cost the flow
+    // anything, which is the failure mode a registration-count assertion alone would miss.
+    const auth = await app.request(`/v1/connections/${id}/authorize`, {
+      method: "POST",
+      headers: as(owner.email),
+    })
+    const { authorize_url } = (await auth.json()) as { authorize_url: string }
+    const state = new URL(authorize_url).searchParams.get("state") ?? ""
+    const cb = await app.request(
+      `/v1/connections/oauth/callback?code=authcode&state=${encodeURIComponent(state)}`,
+      { headers: as(owner.email) },
+    )
+    expect(cb.status).toBe(302)
+    const [row] = await meta.getConnectionsByIds([id])
+    expect(row?.status).toBe("active")
+    expect(readCredential(row?.secret_enc ?? null, SECRET).kind).toBe("oauth")
+  })
+
   it("someone else cannot finish a flow you started, even holding the link", async () => {
     // Signed state proves who STARTED it and rides in a URL, so it is replayable inside its
     // window. Only a live session can prove who FINISHES it.

--- a/apps/api/test/mcp-source.test.ts
+++ b/apps/api/test/mcp-source.test.ts
@@ -309,10 +309,23 @@ describe("MCP as a source: connect, list, call", () => {
     // wrong one — paste a token — fails again saying nothing new.
     const auth = await startServer([])
     servers.push(auth.server)
+    // A 401 with no token is not a dead end — it is where OAuth begins. The row is stored
+    // PENDING (unpinned, so `toolsFor` refuses it and no run can use it) and carries the reason,
+    // so the client offers "Sign in" instead of showing something that looks broken.
     const unauthorized = await connect({ toolkit: "needsauth", mcp_url: `${auth.url}?status=401` })
-    expect(unauthorized.status).toBe(400)
+    expect(unauthorized.status).toBe(201)
+    expect(unauthorized.body.status).toBe("pending")
     expect(unauthorized.body.reason).toBe("auth_required")
-    expect(String(unauthorized.body.error)).toMatch(/sign in|paste a token/i)
+
+    // But a 401 when a token WAS pasted is a real failure: the token is wrong, and storing a row
+    // would leave a connection that can never come good.
+    const refused = await connect({
+      toolkit: "badtoken",
+      mcp_url: `${auth.url}?status=401`,
+      mcp_secret: "definitely-not-valid",
+    })
+    expect(refused.status).toBe(400)
+    expect(String(refused.body.error)).toMatch(/refused the token/i)
   })
 
   it("a 404 on a /mcp path suggests the root, which is where Stripe's server lives", async () => {

--- a/apps/api/test/mcp-source.test.ts
+++ b/apps/api/test/mcp-source.test.ts
@@ -42,6 +42,14 @@ const startServer = async (tools: Tool[]) => {
     })
     req.on("end", () => {
       state.auth.push(req.headers.authorization)
+      // `?status=NNN` makes the server answer with that status and nothing else, so a test can
+      // exercise the failure a REAL server produces — a 401 challenge, a 404 at the wrong path —
+      // rather than only the "nothing is listening" case.
+      const forced = Number(new URL(req.url ?? "/", "http://x").searchParams.get("status"))
+      if (forced) {
+        res.writeHead(forced, forced === 401 ? { "www-authenticate": "Bearer" } : {})
+        return res.end(JSON.stringify({ error: `forced ${forced}` }))
+      }
       const msg = JSON.parse(raw || "{}") as { id?: number; method?: string; params?: never }
       const result =
         msg.method === "initialize"
@@ -287,7 +295,34 @@ describe("MCP as a source: connect, list, call", () => {
     // So: say so now, while a human is watching, and name the likely fix.
     const created = await connect({ toolkit: "down", mcp_url: "http://localhost:1/mcp" })
     expect(created.status).toBe(400)
-    expect(String(created.body.error)).toMatch(/did not answer|mcp_secret/)
+    // And it names WHICH failure. "did not answer" used to be said about a server that answered
+    // 401 as readily as one that was not there, which sent people to paste a token that could
+    // never help. A connection-refused arrives as `TypeError: fetch failed` with a cause, which
+    // is a dead server — not the "Illegal invocation" class of defect that is ours.
+    expect(String(created.body.error)).toMatch(/could not reach/)
+    expect(created.body.reason).toBe("unreachable")
+  })
+
+  it("tells a 401 from a 404, because they need opposite fixes", async () => {
+    // The two URLs a person actually tries against a real server. Stripe answers 401 at its root
+    // and 404 at /mcp; both used to produce the same sentence, and the natural recovery from the
+    // wrong one — paste a token — fails again saying nothing new.
+    const auth = await startServer([])
+    servers.push(auth.server)
+    const unauthorized = await connect({ toolkit: "needsauth", mcp_url: `${auth.url}?status=401` })
+    expect(unauthorized.status).toBe(400)
+    expect(unauthorized.body.reason).toBe("auth_required")
+    expect(String(unauthorized.body.error)).toMatch(/sign in|paste a token/i)
+  })
+
+  it("a 404 on a /mcp path suggests the root, which is where Stripe's server lives", async () => {
+    const gone = await startServer([])
+    servers.push(gone.server)
+    const res = await connect({ toolkit: "wrongpath", mcp_url: `${gone.url}?status=404` })
+    expect(res.status).toBe(400)
+    expect(res.body.reason).toBe("not_mcp")
+    // The URL ends in /mcp, so the message points at the root rather than leaving them guessing.
+    expect(String(res.body.error)).toMatch(/try http/)
   })
 
   it("refuses a plaintext URL that is not localhost", async () => {

--- a/apps/api/test/worker/oauth-workerd.test.ts
+++ b/apps/api/test/worker/oauth-workerd.test.ts
@@ -1,0 +1,97 @@
+import { startAuthorization } from "@modelcontextprotocol/sdk/client/auth.js"
+import { describe, expect, it } from "vitest"
+import { signCapabilityToken, verifyCapabilityToken } from "../../src/lib/capability-token"
+import { readCredential, serializeCredential } from "../../src/lib/mcp-oauth"
+
+// Signing in, inside workerd. See vitest.worker.config.ts for what this lane does and does not
+// prove. Everything here runs in Node already; the question is only whether it also runs where it
+// is actually deployed.
+
+const SECRET = "workerd-oauth-secret-at-least-16-chars"
+
+describe("the sign-in path runs in workerd", () => {
+  it("is actually workerd, not Node wearing its name", async () => {
+    // Without this the lane can silently degrade: a config regression that ran these three tests
+    // under Node would leave them all green while proving nothing they claim to prove.
+    expect(navigator.userAgent).toBe("Cloudflare-Workers")
+  })
+
+  it("startAuthorization produces a PKCE S256 challenge", async () => {
+    // The one dependency in this flow with a runtime-conditional build: `pkce-challenge` ships a
+    // `node` variant that reaches for `node:crypto` and a browser one on Web Crypto. Which one a
+    // worker bundle resolves is a question no Node test can ask.
+    const { authorizationUrl, codeVerifier } = await startAuthorization("https://as.example", {
+      metadata: {
+        issuer: "https://as.example",
+        authorization_endpoint: "https://as.example/authorize",
+        token_endpoint: "https://as.example/token",
+        response_types_supported: ["code"],
+        code_challenge_methods_supported: ["S256"],
+      } as never,
+      clientInformation: { client_id: "client_abc" },
+      redirectUrl: "https://derive.test/v1/connections/oauth/callback",
+      scope: "read",
+      resource: new URL("https://mcp.example/mcp"),
+    })
+
+    expect(codeVerifier.length).toBeGreaterThanOrEqual(43)
+    const u = new URL(authorizationUrl)
+    expect(u.searchParams.get("code_challenge_method")).toBe("S256")
+    expect(u.searchParams.get("code_challenge")).toBeTruthy()
+    // Not the verifier echoed back: S256 means the challenge is a hash of it, and a runtime where
+    // the hash silently failed could otherwise look like success.
+    expect(u.searchParams.get("code_challenge")).not.toBe(codeVerifier)
+    expect(u.searchParams.get("resource")).toBe("https://mcp.example/mcp")
+  })
+
+  it("the signed state survives a round trip", async () => {
+    // HMAC via crypto.subtle, and base64url via atob/btoa — all three exist in workerd, and the
+    // state is the one thing in this flow that is neither stored nor recoverable if it breaks.
+    const payload = JSON.stringify({
+      connectionId: "conn_1",
+      resource: "https://mcp.stripe.com",
+      verifier: "v".repeat(64),
+    })
+    const bytes = new TextEncoder().encode(payload)
+    let bin = ""
+    for (const b of bytes) bin += String.fromCharCode(b)
+    const packed = btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "")
+
+    const token = await signCapabilityToken(
+      "derive-mcp-oauth-state:",
+      SECRET,
+      [packed],
+      Date.now() + 60_000,
+    )
+    const ok = await verifyCapabilityToken("derive-mcp-oauth-state:", SECRET, token, Date.now())
+    expect(ok?.rest).toBe(packed)
+
+    // A different secret must not verify, in this runtime as in the other.
+    expect(
+      await verifyCapabilityToken("derive-mcp-oauth-state:", `${SECRET}x`, token, Date.now()),
+    ).toBeNull()
+  })
+
+  it("a credential encrypts and reads back", async () => {
+    // apps/api's crypto helpers are node:crypto based (createCipheriv), which is nodejs_compat
+    // territory rather than something workerd offers natively.
+    const enc = serializeCredential(
+      {
+        v: 1,
+        access_token: "at_live",
+        refresh_token: "rt_live",
+        token_endpoint: "https://as.example/token",
+        authorization_server: "https://as.example",
+        client_id: "client_abc",
+      },
+      SECRET,
+    )
+    const back = readCredential(enc, SECRET)
+    expect(back.kind).toBe("oauth")
+    if (back.kind === "oauth") expect(back.cred.access_token).toBe("at_live")
+
+    // And the wrong key yields UNREADABLE, never the raw envelope — the rule that keeps our
+    // ciphertext from being sent to somebody else's server as a bearer token.
+    expect(readCredential(enc, "a-different-secret-at-least-16ch").kind).toBe("unreadable")
+  })
+})

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -28,6 +28,10 @@ export default defineConfig({
     },
   },
   test: {
+    // test/worker/** belongs to the workerd lane (vitest.worker.config.ts) and must not run here.
+    // Node picked it up and ran it OUTSIDE workerd, which is the exact silent degradation its
+    // runtime assertion exists to catch — and did, on the first run after this lane was added.
+    exclude: ["node_modules/**", "dist/**", "test/worker/**"],
     coverage: {
       provider: "v8",
       // TypeScript only: src/skills/*.md (the MCP skill sources) live under src,

--- a/apps/api/vitest.worker.config.ts
+++ b/apps/api/vitest.worker.config.ts
@@ -1,0 +1,31 @@
+import { cloudflareTest } from "@cloudflare/vitest-pool-workers"
+import { defineConfig } from "vitest/config"
+
+// The OAuth sign-in path inside REAL workerd, via Miniflare. Run with `pnpm test:worker`.
+//
+// This lane exists because this feature has already been broken once by the gap between Node and
+// workerd, silently and in production: the broker held the global `fetch` on an object and called
+// it as a method, which Node accepts and workerd rejects as an illegal invocation. Every Node test
+// passed while nothing worked.
+//
+// WHAT IT CAN AND CANNOT CATCH, stated plainly, because a lane that oversells itself is worse than
+// no lane. The pool SHIMS fetch, so it cannot catch that original binding defect — that is why an
+// earlier attempt at a workerd lane for the broker was deleted rather than left to imply coverage
+// it did not have. What it does catch is everything about running this code in workerd that is not
+// fetch: whether `pkce-challenge` resolves to a variant workerd can load (its package exports have
+// a `node` build that reaches for `node:crypto`), whether Web Crypto is where the code assumes,
+// and whether the signed-state and credential paths work under the real runtime rather than Node's.
+//
+// nodejs_compat because apps/api's crypto helpers are node:crypto based, exactly as the deployed
+// worker runs them (wrangler.toml sets the same flag).
+export default defineConfig({
+  plugins: [
+    cloudflareTest({
+      miniflare: {
+        compatibilityDate: "2025-05-01",
+        compatibilityFlags: ["nodejs_compat", "nodejs_compat_populate_process_env"],
+      },
+    }),
+  ],
+  test: { include: ["test/worker/**/*.test.ts"] },
+})

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -228,6 +228,9 @@ export interface Automation {
   trigger: AutomationTrigger
   instruction: string
   refs: AutomationRef[]
+  /** Sources this automation may read from during a run. Ids of connections; the credential
+   *  itself is never here and is resolved server-side at call time. */
+  connection_ids: string[]
   enabled: boolean
   created_at: string
   /** When this automation's agent last polled the run claim endpoint (list responses
@@ -837,6 +840,8 @@ export const api = {
     instruction: string
     /** Bare strings are artifact shorthand; the server stores canonical selectors. */
     refs?: (string | AutomationRef)[]
+    /** Sources the run may read from. Each must be this workspace's and attachable by you. */
+    connectionIds?: string[]
   }): Promise<Automation & { agent_token?: string }> => f("/v1/automations", opts(input)).then(j),
   updateAutomation: (
     id: string,
@@ -845,6 +850,8 @@ export const api = {
       trigger?: AutomationTrigger
       instruction?: string
       refs?: (string | AutomationRef)[] | null
+      /** null or [] unbinds every source. */
+      connectionIds?: string[] | null
       enabled?: boolean
     },
   ): Promise<Automation> => f(`/v1/automations/${id}`, { ...opts(input), method: "PATCH" }).then(j),
@@ -1276,8 +1283,14 @@ export const api = {
     toolkit: string
     mcp_url: string
     mcp_secret?: string
-  }): Promise<Connection> {
+  }): Promise<Connection & { reason?: string }> {
     return f("/v1/connections", opts(input)).then(j)
+  },
+  /** Begin the sign-in for a source that is waiting on authorization. Returns the URL to send the
+   *  person to — a POST that hands back a URL rather than redirecting, so the caller keeps control
+   *  of the navigation and can show its own "opening…" state. */
+  authorizeMcp(id: string): Promise<{ authorize_url: string }> {
+    return f(`/v1/connections/${id}/authorize`, opts({})).then(j)
   },
   async revokeConnection(id: string): Promise<void> {
     const r = await f(`/v1/connections/${id}`, { credentials: "include", method: "DELETE" })

--- a/apps/web/src/pages/settings/automation-form.tsx
+++ b/apps/web/src/pages/settings/automation-form.tsx
@@ -1,5 +1,5 @@
 import { useQueries, useQuery } from "@tanstack/react-query"
-import { FileText, FolderOpen, Hash, Plus, X } from "lucide-react"
+import { FileText, FolderOpen, Hash, Plug, Plus, X } from "lucide-react"
 import { type ReactNode, useMemo, useState } from "react"
 import { type Automation, type AutomationRef, type AutomationTrigger, api } from "@/api"
 import { StatusPanel } from "@/components/shared/status-panel"
@@ -29,6 +29,7 @@ import {
   artifactQuery,
   automationsQuery,
   collectionsQuery,
+  connectionsQuery,
   runsQuery,
   targetPickerQuery,
 } from "@/lib/queries"
@@ -107,11 +108,24 @@ export function AutomationForm({
     return (seed ?? []).map((r) => ({ ref: stripMode(r), label: seedLabel(r) }))
   })
   const [pickerOpen, setPickerOpen] = useState(false)
+  const [sourcesOpen, setSourcesOpen] = useState(false)
+  // Ids, not objects: the row a source resolves to can change under us (a pending source signs
+  // in mid-edit), and holding the id means the label always reflects the CURRENT row.
+  const [sourceIds, setSourceIds] = useState<string[]>(automation?.connection_ids ?? [])
   const [q, setQ] = useState("")
   const tz = useMemo(() => Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC", [])
 
   const docs = useQuery(targetPickerQuery(q))
   const collections = useQuery(collectionsQuery())
+  // ACTIVE only. A pending source has an unpinned ref, which every run refuses — offering it
+  // here would let someone build an automation that silently reads nothing.
+  const connections = useQuery(connectionsQuery())
+  const sources = useMemo(
+    () => (connections.data ?? []).filter((c) => c.kind === "mcp" && c.status === "active"),
+    [connections.data],
+  )
+  const sourceLabel = (id: string): string =>
+    sources.find((s) => s.id === id)?.toolkit ?? "a disconnected source"
   const collectionMatches = useMemo(() => {
     const all = collections.data ?? []
     const needle = q.trim().toLowerCase()
@@ -172,6 +186,7 @@ export function AutomationForm({
         trigger: buildTrigger(),
         instruction: instruction.trim(),
         refs: buildRefs(),
+        connectionIds: sourceIds,
       }
       return automation
         ? api.updateAutomation(automation.id, { agentId, ...body })
@@ -236,6 +251,78 @@ export function AutomationForm({
           onChange={(e) => setInstruction(e.target.value)}
           rows={2}
         />
+      </Field>
+
+      <Field
+        label="Sources"
+        hint="Connected MCP servers this run may read from. Its tools were recorded when you connected it."
+      >
+        <div className="flex flex-wrap items-center gap-1.5">
+          {sourceIds.map((id) => (
+            <Badge key={id} variant="outline" className="h-6 gap-1 pr-1 pl-1.5 font-normal">
+              <Plug className="size-3.5 text-muted-foreground" aria-hidden />
+              <span className="max-w-40 truncate">{sourceLabel(id)}</span>
+              <button
+                type="button"
+                data-testid={`automation-source-remove-${id}`}
+                aria-label={`Remove ${sourceLabel(id)}`}
+                className="rounded-sm p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
+                onClick={() => setSourceIds((cur) => cur.filter((x) => x !== id))}
+              >
+                <X className="size-3" aria-hidden />
+              </button>
+            </Badge>
+          ))}
+          {sources.length > sourceIds.length ? (
+            <Popover open={sourcesOpen} onOpenChange={setSourcesOpen}>
+              <PopoverTrigger asChild>
+                <Button
+                  data-testid="automation-add-source"
+                  variant="outline"
+                  size="sm"
+                  className="h-6"
+                >
+                  <Plus className="size-3.5" aria-hidden /> Add source
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-80 p-0" align="start">
+                <Command>
+                  <CommandInput placeholder="Search sources…" />
+                  <CommandList>
+                    <CommandEmpty>No matches.</CommandEmpty>
+                    <CommandGroup>
+                      {sources
+                        .filter((c) => !sourceIds.includes(c.id))
+                        .map((c) => (
+                          <CommandItem
+                            key={c.id}
+                            value={c.toolkit}
+                            data-testid={`automation-source-${c.id}`}
+                            onSelect={() => {
+                              setSourceIds((cur) => [...cur, c.id])
+                              setSourcesOpen(false)
+                            }}
+                          >
+                            <Plug className="size-3.5 text-muted-foreground" aria-hidden />
+                            <span className="truncate">{c.toolkit}</span>
+                            <span className="ml-auto max-w-36 truncate text-2xs text-muted-foreground">
+                              {c.base_url ?? ""}
+                            </span>
+                          </CommandItem>
+                        ))}
+                    </CommandGroup>
+                  </CommandList>
+                </Command>
+              </PopoverContent>
+            </Popover>
+          ) : sources.length === 0 ? (
+            // Said plainly rather than hidden: a run with no source can still only read what is
+            // already in Derive, and that is the difference this field exists to explain.
+            <span className="text-muted-foreground text-xs">
+              No sources connected yet — add one under Settings → Sources.
+            </span>
+          ) : null}
+        </div>
       </Field>
 
       <Field

--- a/apps/web/src/pages/settings/sources-section.tsx
+++ b/apps/web/src/pages/settings/sources-section.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { api, type Connection } from "@/api"
 import { ConfirmDialog } from "@/components/shared/confirm-dialog"
 import { EmptyState } from "@/components/shared/empty-state"
@@ -28,6 +28,20 @@ export function SourcesSection() {
   const qc = useQueryClient()
   const { data: connections, isPending, isError, refetch } = useQuery(connectionsQuery())
   const reload = () => qc.invalidateQueries({ queryKey: connectionsQuery().queryKey })
+  const [justConnected, setJustConnected] = useState(false)
+
+  // ?connected=1 lands here fresh back from a provider's consent screen. The cached connections
+  // query predates the callback that flipped the row active, so consume + strip the param (the
+  // same one-shot idiom as billing's ?checkout=success) and refetch.
+  useEffect(() => {
+    const url = new URL(window.location.href)
+    if (url.searchParams.get("connected") === "1") {
+      url.searchParams.delete("connected")
+      window.history.replaceState(null, "", url)
+      setJustConnected(true)
+      void qc.invalidateQueries({ queryKey: connectionsQuery().queryKey })
+    }
+  }, [qc])
   // MCP only, to match what this screen can actually add and explain. A GitHub App or Slack row
   // listed here has its own setup flow elsewhere, no server URL to show, and a `scopes_label`
   // that is an account name — which the row below would caption as "· token acme-corp".
@@ -45,6 +59,14 @@ export function SourcesSection() {
         </>
       }
     >
+      {justConnected ? (
+        <StatusPanel
+          tone="success"
+          title="Source connected"
+          description="You signed in, and its tools were recorded. Bind it to an automation to let a run read from it."
+        />
+      ) : null}
+
       <AddSource onAdded={reload} />
 
       {isPending ? (
@@ -88,18 +110,32 @@ function AddSource({ onAdded }: { onAdded: () => void }) {
   const [error, setError] = useState<string | null>(null)
 
   const connect = useApiMutation({
-    mutationFn: () =>
-      api.connectMcp({
+    mutationFn: async () => {
+      const conn = await api.connectMcp({
         toolkit: name.trim(),
         mcp_url: url.trim(),
         ...(secret.trim() ? { mcp_secret: secret.trim() } : {}),
-      }),
-    onSuccess: () => {
+      })
+      // PENDING MEANS "NEEDS SIGN-IN". It is the only way an MCP row is stored unusable: every
+      // other failure is refused at the door with the reason, so no row exists to be ambiguous.
+      //
+      // Sending them straight to the provider is what "Connect" does everywhere else on the web,
+      // and it is the whole flow for a server like Stripe that has no pasteable key worth using.
+      // If this leg fails the row is still there with its own Sign in button, so an abandoned or
+      // broken redirect costs a click, not the connection.
+      if (conn.status === "pending") {
+        const { authorize_url } = await api.authorizeMcp(conn.id)
+        return { conn, authorize_url }
+      }
+      return { conn, authorize_url: null }
+    },
+    onSuccess: ({ authorize_url }) => {
       setName("")
       setUrl("")
       setSecret("")
       setError(null)
       onAdded()
+      if (authorize_url) window.location.href = authorize_url
     },
     // The server's own words. "That MCP server did not answer — if it requires authentication,
     // pass a token" is a better message than anything this component could invent, and it is the
@@ -149,7 +185,10 @@ function AddSource({ onAdded }: { onAdded: () => void }) {
       </div>
       <div className="space-y-1.5">
         <label htmlFor="source-secret" className="text-sm font-medium">
-          Token <span className="text-muted-foreground font-normal">(if the server needs one)</span>
+          Token{" "}
+          <span className="text-muted-foreground font-normal">
+            (optional — most servers sign you in instead)
+          </span>
         </label>
         <Input
           id="source-secret"
@@ -160,8 +199,9 @@ function AddSource({ onAdded }: { onAdded: () => void }) {
           onChange={(e) => setSecret(e.target.value)}
         />
         <p className="text-muted-foreground text-xs">
-          Encrypted, spent on the server, and never shown again — you will only ever see its last
-          four characters. Paste the narrowest token the server will accept.
+          Leave this empty unless the server has no sign-in. If it asks you to authorize, Connect
+          takes you there. A token you do paste is encrypted, spent on the server, and never shown
+          again — you will only ever see its last four characters.
         </p>
       </div>
       {error ? (
@@ -182,10 +222,22 @@ function AddSource({ onAdded }: { onAdded: () => void }) {
 
 function SourceRow({ conn, onRevoked }: { conn: Connection; onRevoked: () => void }) {
   const [confirming, setConfirming] = useState(false)
+  const [error, setError] = useState<string | null>(null)
   const revoke = useApiMutation({
     mutationFn: () => api.revokeConnection(conn.id),
     onSuccess: onRevoked,
   })
+  // The durable way back into a sign-in: a flow abandoned at the consent screen, a redirect that
+  // never came back, or a grant the provider later revoked all land the row here.
+  const signIn = useApiMutation({
+    mutationFn: () => api.authorizeMcp(conn.id),
+    onSuccess: ({ authorize_url }) => {
+      window.location.href = authorize_url
+    },
+    // A server that does not do OAuth says so here, in its own words, rather than looping.
+    onError: (e: Error) => setError(e.message),
+  })
+  const needsSignIn = conn.status === "pending"
 
   return (
     <div className="flex items-center justify-between gap-4 py-3" data-testid="source-row">
@@ -195,15 +247,37 @@ function SourceRow({ conn, onRevoked }: { conn: Connection; onRevoked: () => voi
           {conn.kind === "mcp" ? <Badge variant="secondary">MCP</Badge> : null}
           {conn.status === "active" ? (
             <Badge variant="outline">Connected</Badge>
+          ) : needsSignIn ? (
+            <Badge variant="outline">Needs sign-in</Badge>
           ) : (
             <Badge variant="outline">{conn.status}</Badge>
           )}
         </div>
         <p className="text-muted-foreground truncate text-xs">
-          {conn.base_url ?? "—"}
-          {conn.scopes_label ? ` · token ${conn.scopes_label}` : ""}
+          {needsSignIn
+            ? "Sign in with this server to finish connecting. Nothing can read from it until you do."
+            : (conn.base_url ?? "—")}
+          {!needsSignIn && conn.scopes_label ? ` · token ${conn.scopes_label}` : ""}
         </p>
+        {error ? (
+          <p className="text-destructive text-xs" data-testid={`source-signin-error-${conn.id}`}>
+            {error}
+          </p>
+        ) : null}
       </div>
+      {needsSignIn ? (
+        <Button
+          size="sm"
+          data-testid={`source-signin-${conn.id}`}
+          disabled={signIn.isPending}
+          onClick={() => {
+            setError(null)
+            signIn.mutate()
+          }}
+        >
+          {signIn.isPending ? "Opening…" : "Sign in"}
+        </Button>
+      ) : null}
       <Button
         variant="ghost"
         size="sm"

--- a/apps/web/src/pages/settings/sources-section.tsx
+++ b/apps/web/src/pages/settings/sources-section.tsx
@@ -24,6 +24,10 @@ import { SettingsSection } from "./settings-section"
 // Only MCP is addable. The other connection kinds are either created by their own integration
 // flow (GitHub, Slack) or need a broker plan that cannot currently complete a connection.
 
+/** What the OAuth callback writes into `scopes_label` for a connection authenticated by sign-in
+ *  rather than by a pasted token. Kept in one place so the row can caption it correctly. */
+const SIGNED_IN_LABEL = "signed in"
+
 export function SourcesSection() {
   const qc = useQueryClient()
   const { data: connections, isPending, isError, refetch } = useQuery(connectionsQuery())
@@ -257,7 +261,13 @@ function SourceRow({ conn, onRevoked }: { conn: Connection; onRevoked: () => voi
           {needsSignIn
             ? "Sign in with this server to finish connecting. Nothing can read from it until you do."
             : (conn.base_url ?? "—")}
-          {!needsSignIn && conn.scopes_label ? ` · token ${conn.scopes_label}` : ""}
+          {/* A signed-in connection has no token to caption, and "token signed in" is what the
+              generic form produced. The label says which of the two ways this one authenticates. */}
+          {!needsSignIn && conn.scopes_label
+            ? conn.scopes_label === SIGNED_IN_LABEL
+              ? " · signed in"
+              : ` · token ${conn.scopes_label}`
+            : ""}
         </p>
         {error ? (
           <p className="text-destructive text-xs" data-testid={`source-signin-error-${conn.id}`}>

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -56,6 +56,10 @@ Discovery, registration, PKCE, the code exchange, and refresh all come from
 
 - **Registration is dynamic** (RFC 7591). Derive registers itself with each server the first time
   someone connects it, as a public client with PKCE S256. No per-deployment vendor paperwork.
+- **The registration is reused.** Registration is not idempotent: ask Linear twice with identical
+  metadata and you get two clients. So it is stored on the connection before you are sent to
+  consent, and every later Sign in on that connection reuses it. Otherwise every retry and every
+  abandoned consent screen would leave another OAuth client behind at the provider.
 - **Scopes are narrowed.** Asking for everything a server advertises is the obvious implementation
   and the wrong one: Linear advertises `read write openid email`, so its consent screen offered
   Write for a feature that reads. Plainly elevated scopes are dropped. If nothing recognisably

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -111,6 +111,14 @@ LIVE_MCP=1 npx vitest run test/live-hosted-source.test.ts  # apps/api, the whole
 They are off by default because CI must not depend on somebody else's uptime, and because they
 make real requests to third parties, including a real dynamic client registration.
 
+The **consent round trip itself** does run in CI, in `test/mcp-oauth-roundtrip.test.ts`. It boots
+the MCP SDK's own reference OAuth server (`examples/server/simpleStreamableHttp --oauth`) on a free
+port and drives the whole flow: 401, path-aware discovery, dynamic registration, consent, the code
+exchange, the re-pin, and a tool call authorized by the token that came out. The reference provider
+simulates the login, which is the one step a real vendor needs a human for, so no account and no
+network are involved. What it cannot prove is any single vendor's quirks; that is what the live
+suites cover, up to the consent screen.
+
 They exist because every defect below was found by pointing the code at a real server and none of
 them would have surfaced against a stub:
 

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -133,3 +133,22 @@ them would have surfaced against a stub:
 Servers currently covered: DeepWiki, GitMCP, Cloudflare docs and Hugging Face need no
 authorization; Stripe, Linear, Notion and Sentry all require it and all four support dynamic
 registration with PKCE S256 and a public client.
+
+### Proving the callback in a deployed Worker
+
+The round-trip test above runs in Node. Getting the same coverage on a deployed Worker takes one
+extra step, because a Worker cannot reach a reference server on your laptop and the SDK's example
+hardcodes `localhost` in the URLs it advertises:
+
+1. `cloudflared tunnel --url http://localhost:3500 --protocol http2` for a public https origin.
+   (Use `--protocol http2` if QUIC is blocked on your network; the default fails with a 530.)
+2. Host the SDK's `DemoInMemoryAuthProvider` behind `mcpAuthRouter` on one port, passing the tunnel
+   origin as `issuerUrl` / `baseUrl` / `resourceServerUrl` so the metadata advertises something the
+   Worker can fetch. Give the MCP transport `sessionIdGenerator: undefined` — a fresh transport per
+   request cannot honour a session id it never issued, and the client echoes one back on the
+   request after `initialize`.
+3. Point a connection on the preview at `<tunnel>/mcp` and drive connect → authorize → consent →
+   callback.
+
+Worth doing before believing this works in production. The runtime difference has bitten this
+feature twice, and each half is only proven where it has actually run.

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -1,0 +1,123 @@
+# Sources: connecting an MCP server
+
+A **source** is a Model Context Protocol server your agents can read from during a run. Connect
+one by URL, bind it to an automation, and that automation's runs can call the server's tools.
+
+Anything that speaks MCP over streamable HTTP works. There is no vendor list and no per-vendor
+integration to write.
+
+## Connecting one
+
+Settings → Sources. Give it a name (it prefixes the server's tools, so an agent can see where each
+tool came from) and the server URL. Then one of two things happens.
+
+**The server asks you to sign in.** Most hosted servers do. Connect takes you to the provider's
+consent screen, you approve, and you land back on Sources with the connection active. Nothing is
+stored until the server has actually answered.
+
+**The server takes a token.** Some servers have no sign-in. Paste one into the Token field. It is
+encrypted at rest, spent server-side, and never returned by any API. You will only ever see its
+last four characters.
+
+Leave the Token field empty unless you know the server has no sign-in. Sign-in is better in every
+way that matters: nothing long-lived is stored, the grant is revocable from the provider's side,
+and we ask for the narrowest scopes it offers.
+
+### What "connected" means
+
+`connect` contacts the server immediately, lists its tools, and records a hash of that list in the
+connection itself. A 201 means the server answered. It is not a row stored hopefully.
+
+That hash is the **pin**, and it is the whole defense against tool poisoning. Tool names and
+descriptions from an MCP server land verbatim in the model's prompt, so a hostile or compromised
+server can rewrite them between runs to say whatever it likes. If the tool list changes, the pin
+stops matching and the connection goes **quiet**: runs get no tools from it until a human
+reconnects and sees the new list. Fail-closed, on purpose.
+
+A connection with no pin is refused outright, which is why a connection waiting on sign-in cannot
+be used by anything.
+
+### When it does not connect
+
+The four failures are told apart, because the fix for each is different and three of them used to
+produce the same sentence:
+
+| What you see | What happened |
+| --- | --- |
+| needs authorization | The server wants a credential. Sign in, or paste a token. |
+| nothing MCP-shaped there | 404 or a non-JSON-RPC 200. Usually the wrong path. If the URL ends in `/mcp`, the root is suggested. |
+| could not reach it | DNS, TLS, or timeout. Nothing answered. |
+| refused the token | You pasted one and the server rejected it. |
+
+## Signing in, in detail
+
+Discovery, registration, PKCE, the code exchange, and refresh all come from
+`@modelcontextprotocol/sdk`. What is ours is where the token lives and when it is stale.
+
+- **Registration is dynamic** (RFC 7591). Derive registers itself with each server the first time
+  someone connects it, as a public client with PKCE S256. No per-deployment vendor paperwork.
+- **Scopes are narrowed.** Asking for everything a server advertises is the obvious implementation
+  and the wrong one: Linear advertises `read write openid email`, so its consent screen offered
+  Write for a feature that reads. Plainly elevated scopes are dropped. If nothing recognisably
+  narrow is left, no scope is sent and the authorization server applies its own default.
+- **State is signed, not stored.** The PKCE verifier rides inside an HMAC'd, 15-minute state token,
+  so a flow that is never completed leaves nothing behind.
+- **Only the person who started it can finish it.** State proves who began the flow and travels in
+  a URL, so it cannot also prove who finished it. A live session has to, and must match.
+- **Tokens refresh themselves** shortly before expiry, with a compare-and-swap write so two runs
+  refreshing at once cannot leave the older token installed.
+
+The connection is pinned *after* consent returns, because until then there is no credential to list
+tools with. That re-pin is the one part of this flow no library does for us.
+
+## Using one
+
+Bind the source to an automation: Settings → Automations, the Sources field. Only active sources
+are offered. A run sees the tools of the sources bound to *that automation* and nothing else, and
+the credential is resolved server-side at call time, so the model never holds it.
+
+Sources can be bound when you create an automation and changed afterwards.
+
+### A run that reads from a source files a proposal
+
+This is the part worth knowing before you design around it.
+
+The autonomy gate refuses to live-publish for any run that had a spendable connection. Such a run
+files a proposal for a human to accept, and that rung sits above any per-target publish mode, so
+no setting buys past it. A run that reads outside data acts on somebody's say-so.
+
+So a document backed by a source updates through a proposal each time, not on its own. If you want
+a dashboard that refreshes unattended, that is a product decision that does not exist yet, not a
+setting you are failing to find.
+
+See `packages/core/src/autonomy.ts`, which is also honest about the limits of what the rung
+guarantees.
+
+## Verifying it
+
+Most tests here drive a server written in this repo, which agrees with our assumptions by
+construction. Real servers do not. Two opt-in suites point at live ones:
+
+```bash
+LIVE_MCP=1 npx vitest run test/live-servers.test.ts        # packages/broker
+LIVE_MCP=1 npx vitest run test/live-oauth.test.ts          # apps/api
+LIVE_MCP=1 npx vitest run test/live-hosted-source.test.ts  # apps/api, the whole scenario
+```
+
+They are off by default because CI must not depend on somebody else's uptime, and because they
+make real requests to third parties, including a real dynamic client registration.
+
+They exist because every defect below was found by pointing the code at a real server and none of
+them would have surfaced against a stub:
+
+- A server may keep the SSE stream open after replying. Reading to EOF stalled every call to such
+  a server for 20 seconds and then blamed the server.
+- Tool names longer than 64 characters, or containing a dot, are rejected by model providers.
+- An authorization server can live on a different origin from the MCP server it guards
+  (`access.stripe.com` guards `mcp.stripe.com`), and its metadata may only be at the path-aware
+  location.
+- Consent screens show what you actually asked for.
+
+Servers currently covered: DeepWiki, GitMCP, Cloudflare docs and Hugging Face need no
+authorization; Stripe, Linear, Notion and Sentry all require it and all four support dynamic
+registration with PKCE S256 and a public client.

--- a/knip.json
+++ b/knip.json
@@ -8,7 +8,8 @@
         "scripts/stripe-seed.mjs",
         "test/**/*.manual.ts",
         "test/weather-mcp-server.mjs"
-      ]
+      ],
+      "ignoreDependencies": ["express"]
     },
     "apps/web": {
       "entry": ["src/components/ui/**", "e2e/**/*.screens.ts"]

--- a/packages/broker/src/mcp.ts
+++ b/packages/broker/src/mcp.ts
@@ -236,21 +236,83 @@ export const pinTools = async (tools: BrokerToolDef[]): Promise<string> => {
   )
 }
 
-/** One JSON-RPC response, whether the server answered as JSON or as a single SSE frame.
- *  Streamable-HTTP servers may reply either way to the same request, so both are handled. */
-const readRpc = async (res: Response): Promise<unknown> => {
-  const text = await res.text()
-  const trimmed = text.trim()
-  if (!trimmed) return null
-  if (trimmed.startsWith("{")) return JSON.parse(trimmed)
-  // SSE: take the LAST data: line, which carries the response for the request just sent.
-  const frames = trimmed
-    .split("\n")
-    .filter((l) => l.startsWith("data:"))
-    .map((l) => l.slice(5).trim())
-    .filter(Boolean)
-  const last = frames[frames.length - 1]
-  return last ? JSON.parse(last) : null
+/** One SSE `data:` payload as a JSON-RPC message, or null if it is not one (a comment, a
+ *  keep-alive, or a partial write). Never throws — a stream must not die on one bad frame. */
+const parseFrame = (data: string): { id?: unknown } | null => {
+  try {
+    const msg = JSON.parse(data)
+    return msg && typeof msg === "object" ? (msg as { id?: unknown }) : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * One JSON-RPC response, whether the server answered as JSON or over an SSE stream.
+ *
+ * READ UNTIL OUR ANSWER ARRIVES, NOT UNTIL THE STREAM ENDS. This was `await res.text()`, which
+ * waits for the server to CLOSE the connection — and the spec explicitly lets a server keep the
+ * stream open after replying, to push notifications and its own requests down it. Servers really
+ * do (gitmcp.io holds it open; DeepWiki closes it), so every call to one of them stalled until the
+ * 20-second abort and was then reported as a failure. The server was fine and the response had
+ * arrived in milliseconds; we were still waiting for an EOF that was never coming.
+ *
+ * Matching on the request id matters for the same reason: once a stream can carry more than one
+ * message, "the last frame" is whatever happened to be in the buffer, not our answer.
+ */
+const readRpc = async (res: Response, id: number): Promise<unknown> => {
+  const body = res.body
+  // Only an SSE response can be held open, so only that one needs to be read incrementally.
+  // Everything else is buffered, which keeps the common JSON reply on the simplest path — and
+  // still parses SSE framing, because a server may use it without declaring the content type.
+  if (!body || !(res.headers.get("content-type") ?? "").includes("text/event-stream")) {
+    const trimmed = (await res.text()).trim()
+    if (!trimmed) return null
+    if (trimmed.startsWith("{")) return JSON.parse(trimmed)
+    const frames = trimmed
+      .split(/\r?\n/)
+      .filter((l) => l.startsWith("data:"))
+      .map((l) => l.slice(5).trim())
+      .filter(Boolean)
+    // Prefer OUR reply; fall back to the last frame, which is what a single-reply body holds.
+    for (const f of frames) {
+      const msg = parseFrame(f)
+      if (msg && String(msg.id) === String(id)) return msg
+    }
+    const last = frames[frames.length - 1]
+    return last ? JSON.parse(last) : null
+  }
+  const reader = body.getReader()
+  const decoder = new TextDecoder()
+  let buf = ""
+  try {
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      buf += decoder.decode(value, { stream: true })
+      for (;;) {
+        // Events are separated by a blank line; a chunk can end mid-line, so only complete ones.
+        const end = /\r?\n\r?\n/.exec(buf)
+        if (!end) break
+        const frame = buf.slice(0, end.index)
+        buf = buf.slice(end.index + end[0].length)
+        // `data:` may be split across several lines of one event, and is rejoined with newlines.
+        const data = frame
+          .split(/\r?\n/)
+          .filter((l) => l.startsWith("data:"))
+          .map((l) => l.slice(5).trim())
+          .join("\n")
+        if (!data) continue
+        // Notifications carry no id; another request's reply carries a different one.
+        const msg = parseFrame(data)
+        if (msg && msg.id !== undefined && String(msg.id) === String(id)) return msg
+      }
+    }
+  } finally {
+    // Hang up rather than leaving a socket held open for a stream we are done reading.
+    await reader.cancel().catch(() => undefined)
+  }
+  return null
 }
 
 interface RpcResult {
@@ -275,6 +337,9 @@ export class McpBroker implements ToolBroker {
 
   /** Always a plain function, never the raw global — see `unbound`. */
   private readonly fetchImpl: typeof fetch
+
+  /** Monotonic JSON-RPC request ids, so a reply can be matched to its request on a stream. */
+  private nextRpcId = 0
 
   constructor(
     fetchImpl: typeof fetch = fetch,
@@ -316,6 +381,9 @@ export class McpBroker implements ToolBroker {
     params?: unknown,
   ): Promise<RpcResult> {
     const bearer = await this.authFor(target)
+    // A COUNTER, not Date.now(): the id is now what picks our reply out of a stream that may
+    // carry several messages, and two calls inside the same millisecond shared a Date.now() id.
+    const id = ++this.nextRpcId
     const key = this.sessionKey(url, bearer)
     const session = this.sessions.get(key)
     const version = this.versions.get(key)
@@ -331,7 +399,7 @@ export class McpBroker implements ToolBroker {
         ...(session ? { "mcp-session-id": session } : {}),
         ...(bearer ? { authorization: `Bearer ${bearer}` } : {}),
       },
-      body: JSON.stringify({ jsonrpc: "2.0", id: Date.now(), method, params: params ?? {} }),
+      body: JSON.stringify({ jsonrpc: "2.0", id, method, params: params ?? {} }),
       // A hung MCP server must never wedge a dispatch tick or a claim.
       signal: AbortSignal.timeout(20_000),
     })
@@ -346,7 +414,7 @@ export class McpBroker implements ToolBroker {
       err.status = res.status
       throw err
     }
-    const body = (await readRpc(res)) as RpcResult | null
+    const body = (await readRpc(res, id)) as RpcResult | null
     if (!body) throw new Error(`MCP ${method} returned an empty response`)
     if (body.error) throw new Error(`MCP ${method} error: ${body.error.message ?? "unknown"}`)
     return body

--- a/packages/broker/src/mcp.ts
+++ b/packages/broker/src/mcp.ts
@@ -1,5 +1,5 @@
 import { unbound } from "./http"
-import type { BrokerToolDef, ConnectResult, ToolBroker } from "./types"
+import type { BrokerToolDef, ConnectFailure, ConnectResult, ToolBroker } from "./types"
 
 /**
  * The MCP broker: connect ANY Model Context Protocol server as a source.
@@ -121,6 +121,29 @@ export type QuietReason = "unpinned" | "unreachable" | "pin_mismatch" | "broker_
  * plain Error, so the two are cheap to tell apart and expensive to confuse.
  */
 const ourFault = (e: unknown): boolean => e instanceof TypeError || !(e instanceof Error)
+
+/**
+ * Turn a failed connect into something a person can act on.
+ *
+ * The two cases that matter are the two a person actually hits, and they were indistinguishable:
+ * `https://mcp.stripe.com/mcp` is a 404 (the path is wrong — Stripe's server is at the root) and
+ * `https://mcp.stripe.com` is a 401 (right address, needs a token). Both used to produce
+ * "that MCP server did not answer — if it requires authentication, pass `mcp_secret`", which is
+ * actively misleading for the first: you add a token and it fails again, identically.
+ */
+const classify = (e: unknown): ConnectFailure => {
+  const status = (e as { status?: number } | null)?.status
+  if (status === 401 || status === 403) return "auth_required"
+  if (status === 404 || status === 405) return "not_mcp"
+  if (typeof status === "number") return "protocol_error"
+  // No status at all: nothing answered. Note a network failure ALSO arrives as a TypeError —
+  // undici throws `TypeError: fetch failed` with a `cause` for connection-refused — so the
+  // `ourFault` heuristic used for tool listing would misread a genuinely dead server as our bug.
+  // A thrown fetch carries a cause; the "Illegal invocation" class of defect does not.
+  const network = e instanceof TypeError && (e as { cause?: unknown }).cause !== undefined
+  if (network) return "unreachable"
+  return ourFault(e) ? "protocol_error" : "unreachable"
+}
 
 /**
  * THE ONE RULE for any URL Derive will dial server-side, carrying a credential: https anywhere,
@@ -314,7 +337,15 @@ export class McpBroker implements ToolBroker {
     })
     const sid = res.headers.get("mcp-session-id")
     if (sid) this.sessions.set(key, sid)
-    if (!res.ok) throw new Error(`MCP ${method} failed: HTTP ${res.status}`)
+    if (!res.ok) {
+      // The status is the whole diagnosis and used to die on this line. Carried on the error so
+      // `connect` can tell "needs a token" from "nothing here" instead of guessing.
+      const err = new Error(`MCP ${method} failed: HTTP ${res.status}`) as Error & {
+        status?: number
+      }
+      err.status = res.status
+      throw err
+    }
     const body = (await readRpc(res)) as RpcResult | null
     if (!body) throw new Error(`MCP ${method} returned an empty response`)
     if (body.error) throw new Error(`MCP ${method} error: ${body.error.message ?? "unknown"}`)
@@ -397,10 +428,11 @@ export class McpBroker implements ToolBroker {
       // Pin at connect: this exact tool list is what a human is approving. A later change makes
       // the connection go quiet rather than silently feeding new prompt text to every run.
       return { url, ref: encodeMcpRef(url, await pinTools(tools)), status: "active" }
-    } catch {
-      // Unreachable or not speaking MCP. `pending` (not a throw) so the connection can be stored
-      // and retried, matching how the other brokers report a not-yet-usable account.
-      return { url, ref: encodeMcpRef(url, ""), status: "pending" }
+    } catch (e) {
+      // `pending` (not a throw) so the connection can be stored and retried, matching how the
+      // other brokers report a not-yet-usable account — but WITH the reason, because "did not
+      // answer" was being said about servers that answered clearly.
+      return { url, ref: encodeMcpRef(url, ""), status: "pending", reason: classify(e) }
     }
   }
 

--- a/packages/broker/src/mcp.ts
+++ b/packages/broker/src/mcp.ts
@@ -320,6 +320,77 @@ interface RpcResult {
   error?: { message?: string }
 }
 
+/**
+ * Ceiling on ONE tool result, because a source's answer lands verbatim in the run's prompt.
+ *
+ * Found on a real cloud MCP: DeepWiki's `read_wiki_contents` returns an entire wiki, and one call
+ * produced a 1,040,577-token prompt against a 1,048,576-token model limit. Every following turn
+ * failed the same way, so the run burned its whole turn budget and finished "agent did not produce
+ * a revision within 12 turns" -- naming the symptom, and never the cause.
+ *
+ * 80k chars matches apps/api's own `clip`, which bounds Derive's responses for exactly this reason
+ * in the other direction ("so no single read/search result can blow a client's context budget").
+ * A source deserves the same ceiling: nothing about it being remote makes its output smaller.
+ *
+ * CLIPPED, NEVER DROPPED, and always with the cut declared. A truncated answer the model knows is
+ * truncated can be worked with -- it can narrow the question and call again. A silently shortened
+ * one is indistinguishable from the whole truth, which is the worse failure by far.
+ */
+const MAX_RESULT_CHARS = 80_000
+
+interface ContentBlock {
+  type?: string
+  text?: string
+}
+
+const clipToolResult = (result: unknown): unknown => {
+  let whole: string
+  try {
+    whole = JSON.stringify(result) ?? ""
+  } catch {
+    return result // not serializable is not our problem to solve here
+  }
+  if (whole.length <= MAX_RESULT_CHARS) return result
+
+  const blocks = (result as { content?: unknown })?.content
+  if (!Array.isArray(blocks)) {
+    // A shape we do not model, and too big to pass on. Say so rather than forward it.
+    return {
+      content: [
+        {
+          type: "text",
+          text: `[this source returned ${whole.length} characters, past the ${MAX_RESULT_CHARS}-character limit for one tool result, in a shape that cannot be trimmed — ask it for less]`,
+        },
+      ],
+    }
+  }
+
+  let budget = MAX_RESULT_CHARS
+  const kept: ContentBlock[] = []
+  let clipped = 0
+  for (const raw of blocks as ContentBlock[]) {
+    const text = typeof raw?.text === "string" ? raw.text : null
+    if (text === null) {
+      kept.push(raw)
+      continue
+    }
+    if (text.length <= budget) {
+      kept.push(raw)
+      budget -= text.length
+      continue
+    }
+    clipped += text.length - budget
+    kept.push({ ...raw, text: text.slice(0, budget) })
+    budget = 0
+  }
+  const dropped = (blocks as ContentBlock[]).length - kept.length
+  kept.push({
+    type: "text",
+    text: `…[truncated ${clipped} characters${dropped > 0 ? ` and ${dropped} further block(s)` : ""} — this source returned more than one tool result may carry. Ask it something narrower.]`,
+  })
+  return { ...(result as object), content: kept }
+}
+
 export class McpBroker implements ToolBroker {
   readonly provider = "mcp"
   /** Per-instance session ids, keyed by server URL. MCP's streamable HTTP transport hands back
@@ -567,7 +638,8 @@ export class McpBroker implements ToolBroker {
       name: bare,
       arguments: opts.args ?? {},
     })
-    return body.result ?? null
+    // Bounded HERE, at the one point every MCP source passes through, rather than at each caller.
+    return body.result === undefined ? null : clipToolResult(body.result)
   }
 
   /** Nothing is held server-side: a connection IS its ref, so revoking is the caller deleting

--- a/packages/broker/src/types.ts
+++ b/packages/broker/src/types.ts
@@ -39,7 +39,26 @@ export interface ConnectResult {
   url: string
   ref: string
   status: "active" | "pending"
+  /**
+   * Why a connect did not land ACTIVE, in a form a caller can act on. Absent when it did.
+   *
+   * `connect` used to swallow every failure into `pending`, so "no MCP server at that URL" and
+   * "the server is there and wants a token" arrived as the same sentence — and the natural
+   * recovery from the wrong one (paste a key) fails again saying nothing new. Stripe returns
+   * exactly those two for the two URLs a person is most likely to try.
+   */
+  reason?: ConnectFailure
 }
+
+export type ConnectFailure =
+  /** 401/403 with no credential, or the one we sent was refused. */
+  | "auth_required"
+  /** 404, or a 200 that is not JSON-RPC — nothing MCP-shaped is listening there. */
+  | "not_mcp"
+  /** DNS, TLS, timeout: nothing answered at all. */
+  | "unreachable"
+  /** The server answered but the exchange failed for some other reason. */
+  | "protocol_error"
 
 export interface ToolBroker {
   /** Provider slug, e.g. "local" | "composio". */

--- a/packages/broker/test/live-servers.test.ts
+++ b/packages/broker/test/live-servers.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest"
+import { McpBroker, parseMcpRef } from "../src/mcp"
+
+/**
+ * The broker against MCP servers that actually exist on the internet.
+ *
+ * OFF BY DEFAULT — `LIVE_MCP=1 pnpm vitest run test/live-servers.test.ts`. CI must not depend on
+ * somebody else's uptime, and these make real requests to third parties.
+ *
+ * It is here anyway because every other test in this package drives a server written in this
+ * repo, and a server written in this repo agrees with our assumptions by construction. Real ones
+ * do not: they return SSE where the tests return JSON, tool names longer than the 64 characters a
+ * provider will accept, `outputSchema` and `annotations` fields nothing here reads, and — for the
+ * authorized ones — an authorization server on a DIFFERENT ORIGIN from the server itself
+ * (`mcp.stripe.com` is guarded by `access.stripe.com`). Each of those was a real bug or a real
+ * near-miss, and none of them would have surfaced against a stub.
+ */
+
+/** No key, no account, no sign-in. Anyone can run this file. */
+const OPEN_SERVERS = [
+  { name: "DeepWiki", url: "https://mcp.deepwiki.com/mcp" },
+  { name: "GitMCP", url: "https://gitmcp.io/docs" },
+  { name: "Cloudflare docs", url: "https://docs.mcp.cloudflare.com/mcp" },
+  { name: "Hugging Face", url: "https://huggingface.co/mcp" },
+]
+
+/** Live, and 401 until you sign in. What their OAUTH metadata advertises is asserted in
+ *  apps/api's live test, where the MCP SDK is actually a dependency. */
+const OAUTH_SERVERS = [
+  { name: "Stripe", url: "https://mcp.stripe.com" },
+  { name: "Linear", url: "https://mcp.linear.app/mcp" },
+  { name: "Notion", url: "https://mcp.notion.com/mcp" },
+  { name: "Sentry", url: "https://mcp.sentry.dev/mcp" },
+]
+
+const live = process.env.LIVE_MCP === "1"
+
+describe.skipIf(!live)("live MCP servers, no authorization", () => {
+  for (const server of OPEN_SERVERS) {
+    it(`${server.name}: connects, pins a tool list, and the names are usable`, async () => {
+      const broker = new McpBroker()
+      const link = await broker.connect({ orgId: "live", userId: "live", toolkit: server.url })
+      expect(link.status, `${server.name} did not connect: ${link.reason ?? ""}`).toBe("active")
+
+      // A pin, not just a connection. An unpinned ref is refused everywhere downstream.
+      const parsed = parseMcpRef(link.ref)
+      expect(parsed?.pin, `${server.name} produced no pin`).toMatch(/^s256-[0-9a-f]{16,}$/)
+
+      const tools = await broker.toolsFor([link.ref])
+      expect(tools.length).toBeGreaterThan(0)
+      // THE CONSTRAINT THAT BIT US. Model providers reject a tool name with a dot in it or over
+      // 64 characters, and real servers ship both. Whatever we hand back has to be legal already.
+      for (const t of tools) expect(t.name).toMatch(/^[a-zA-Z0-9_-]{1,64}$/)
+      expect(new Set(tools.map((t) => t.name)).size, "names collided").toBe(tools.length)
+    }, 30_000)
+  }
+
+  it("DeepWiki actually answers a call, with content we did not write", async () => {
+    // The point of the whole exercise: a tool call that reaches a third party and comes back with
+    // data that exists in the world. LocalBroker's echo stub returns the caller's own arguments,
+    // which reads exactly like success — so "it returned something" is not the assertion. "It
+    // returned something we could not have produced" is.
+    const broker = new McpBroker()
+    const link = await broker.connect({
+      orgId: "live",
+      userId: "live",
+      toolkit: "https://mcp.deepwiki.com/mcp",
+    })
+    const tools = await broker.toolsFor([link.ref])
+    const ask = tools.find((t) => /ask|question/i.test(t.name))
+    expect(ask, `no question tool among: ${tools.map((t) => t.name).join(", ")}`).toBeTruthy()
+
+    const out = await broker.execute({
+      ref: link.ref,
+      tool: ask?.name ?? "",
+      args: { repoName: "modelcontextprotocol/modelcontextprotocol", question: "What is a tool?" },
+    })
+    const text = JSON.stringify(out)
+    expect(text.length).toBeGreaterThan(200)
+    expect(text.toLowerCase()).toContain("tool")
+    // Not our arguments handed back — that is the echo stub's signature, and it must never pass.
+    expect(text).not.toContain("What is a tool?")
+  }, 60_000)
+})
+
+describe.skipIf(!live)("live MCP servers, authorization required", () => {
+  for (const server of OAUTH_SERVERS) {
+    it(`${server.name}: 401 is reported as auth_required, not as broken`, async () => {
+      // The distinction the UI depends on. "Unreachable" sends someone to check a URL that is
+      // fine; "auth_required" offers the sign-in that actually fixes it.
+      const broker = new McpBroker()
+      const link = await broker.connect({ orgId: "live", userId: "live", toolkit: server.url })
+      expect(link.status).not.toBe("active")
+      expect(link.reason).toBe("auth_required")
+    }, 30_000)
+  }
+})

--- a/packages/broker/test/mcp.test.ts
+++ b/packages/broker/test/mcp.test.ts
@@ -52,7 +52,12 @@ const fakeServer = (opts: {
       // A streamable-HTTP server may answer either way to the same request; both must parse.
       return new Response(opts.sse ? `event: message\ndata: ${payload}\n\n` : payload, {
         status: 200,
-        headers: { "mcp-session-id": "sess-1" },
+        headers: {
+          "mcp-session-id": "sess-1",
+          // A real SSE reply declares itself, and that header is what selects the streaming
+          // reader — so omitting it here tested a path no server actually produces.
+          "content-type": opts.sse ? "text/event-stream" : "application/json",
+        },
       })
     }
     if (body.method === "initialize") return reply({ protocolVersion: "2025-11-25" })
@@ -122,6 +127,79 @@ describe("MCP broker: connect + list + call", () => {
     const broker = new McpBroker(server.impl)
     const link = await broker.connect({ orgId: "o1", userId: "u1", toolkit: "https://s.test/mcp" })
     expect(link.status).toBe("active")
+    expect(await broker.toolsFor([link.ref])).toHaveLength(2)
+  })
+
+  it("answers from a stream the server never closes", async () => {
+    // THE BUG THIS EXISTS FOR. The spec lets a server keep the SSE stream open after replying, to
+    // push notifications down it, and real ones do (gitmcp.io). Reading with `res.text()` waits
+    // for EOF, so every call to such a server stalled until the 20s abort and was then reported
+    // as the SERVER failing — while it had answered in milliseconds. If this test hangs, that
+    // regression is back.
+    const held = (async (_url: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body ?? "{}"))
+      const result =
+        body.method === "initialize"
+          ? { protocolVersion: "2025-11-25" }
+          : body.method === "tools/list"
+            ? { tools: TOOLS }
+            : { content: [{ type: "text", text: "ok" }] }
+      const stream = new ReadableStream({
+        start(controller) {
+          const enc = new TextEncoder()
+          // A notification FIRST, with no id — the reply is found by matching, not by position.
+          controller.enqueue(
+            enc.encode('event: message\ndata: {"jsonrpc":"2.0","method":"notifications/ping"}\n\n'),
+          )
+          controller.enqueue(
+            enc.encode(
+              `event: message\ndata: ${JSON.stringify({ jsonrpc: "2.0", id: body.id, result })}\n\n`,
+            ),
+          )
+          // and then nothing, forever: no close().
+        },
+      })
+      return new Response(stream, {
+        status: 200,
+        headers: { "content-type": "text/event-stream", "mcp-session-id": "sess-held" },
+      })
+    }) as unknown as typeof fetch
+
+    const broker = new McpBroker(held)
+    const link = await broker.connect({
+      orgId: "o1",
+      userId: "u1",
+      toolkit: "https://held.test/mcp",
+    })
+    expect(link.status).toBe("active")
+    expect(await broker.toolsFor([link.ref])).toHaveLength(2)
+  }, 10_000)
+
+  it("ignores a reply that belongs to a different request", async () => {
+    // Once a stream can carry several messages, "the last frame" is whatever happened to be in
+    // the buffer. Answering with someone else's result is worse than not answering at all.
+    const wrong = (async (_url: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body ?? "{}"))
+      const mine = JSON.stringify({
+        jsonrpc: "2.0",
+        id: body.id,
+        result: body.method === "initialize" ? { protocolVersion: "2025-11-25" } : { tools: TOOLS },
+      })
+      const other = JSON.stringify({ jsonrpc: "2.0", id: 999_999, result: { tools: [] } })
+      return new Response(`event: message\ndata: ${mine}\n\nevent: message\ndata: ${other}\n\n`, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      })
+    }) as unknown as typeof fetch
+
+    const broker = new McpBroker(wrong)
+    const link = await broker.connect({
+      orgId: "o1",
+      userId: "u1",
+      toolkit: "https://mix.test/mcp",
+    })
+    expect(link.status).toBe("active")
+    // The trailing frame says zero tools. Ours said two, and ours is the one that counts.
     expect(await broker.toolsFor([link.ref])).toHaveLength(2)
   })
 

--- a/packages/broker/test/mcp.test.ts
+++ b/packages/broker/test/mcp.test.ts
@@ -203,6 +203,51 @@ describe("MCP broker: connect + list + call", () => {
     expect(await broker.toolsFor([link.ref])).toHaveLength(2)
   })
 
+  it("clips a tool result that would blow the run's context budget", async () => {
+    // FOUND ON A REAL CLOUD MCP, not imagined: DeepWiki's read_wiki_contents returns an entire
+    // wiki, and one call produced a 1,040,577-token prompt against a 1,048,576-token limit. Every
+    // later turn failed identically, so the run exhausted its turns and reported "agent did not
+    // produce a revision within 12 turns" — the symptom, never the cause.
+    const huge = "x".repeat(400_000)
+    const server = fakeServer({
+      tools: TOOLS,
+      onCall: () => ({ content: [{ type: "text", text: huge }] }),
+    })
+    const broker = new McpBroker(server.impl)
+    const link = await broker.connect({
+      orgId: "o1",
+      userId: "u1",
+      toolkit: "https://big.test/mcp",
+    })
+    const out = (await broker.execute({
+      ref: link.ref,
+      tool: "big_test.search",
+      args: {},
+    })) as { content: { type: string; text: string }[] }
+
+    const total = JSON.stringify(out).length
+    expect(total, `still ${total} chars`).toBeLessThan(90_000)
+    // The cut is DECLARED. A model that knows it was truncated can narrow and ask again; one that
+    // does not cannot tell a partial answer from the whole truth.
+    const last = out.content[out.content.length - 1]
+    expect(last?.text).toMatch(/truncated \d+ characters/)
+    expect(last?.text).toMatch(/narrower/i)
+    // And what survived is the server's real text, not a placeholder.
+    expect(out.content[0]?.text?.startsWith("xxx")).toBe(true)
+  })
+
+  it("leaves an ordinary tool result exactly as the server sent it", async () => {
+    const server = fakeServer({
+      tools: TOOLS,
+      onCall: () => ({ content: [{ type: "text", text: "small and complete" }] }),
+    })
+    const broker = new McpBroker(server.impl)
+    const link = await broker.connect({ orgId: "o1", userId: "u1", toolkit: "https://ok.test/mcp" })
+    expect(await broker.execute({ ref: link.ref, tool: "ok_test.search", args: {} })).toEqual({
+      content: [{ type: "text", text: "small and complete" }],
+    })
+  })
+
   it("an unreachable server connects as pending rather than throwing", async () => {
     // Matches how the other brokers report a not-yet-usable account: the row is stored so it can
     // be retried, and toolsForRun only passes ACTIVE connections to a run.

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -1537,6 +1537,33 @@ export interface AgentStore {
     orgId: string,
     status: ConnectionStatus,
   ): Promise<ConnectionRecord | null>
+  /**
+   * Rewrite a connection's stored credential, and optionally its ref and status — the one
+   * mutation the table never had.
+   *
+   * It exists for OAuth, where the credential is not final at connect: the row is created
+   * `pending` before the redirect, and the callback later writes the token, pins the tool list
+   * into `broker_ref`, and flips it `active`. A refresh then rewrites the same field again,
+   * repeatedly, for the life of the connection. Without it there is nowhere to put a rotated
+   * token, which is why a pasted key could never be rotated either.
+   *
+   * `expectSecretEnc` is a COMPARE-AND-SWAP on the credential, and it is not optional politeness:
+   * two runs can hit an expired access token in the same second, both refresh, and the slower
+   * reply would otherwise overwrite the newer token with an older one — invalidating a grant that
+   * was working. A mismatch returns null and the caller re-reads instead of guessing. The same
+   * guard the model-credential PUT already uses, for the same reason.
+   */
+  updateConnectionCredential(
+    id: string,
+    orgId: string,
+    fields: {
+      secret_enc?: string | null
+      broker_ref?: string
+      status?: ConnectionStatus
+      scopes_label?: string | null
+    },
+    expectSecretEnc?: string | null,
+  ): Promise<ConnectionRecord | null>
   /** Resolve an agent from its bearer token (the agent's identity). */
   getAgentByToken(token: string): Promise<AgentRecord | null>
   /** Resolve a live OAuth access token (by its stored hash) to its grant. */

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -1404,6 +1404,8 @@ export interface AgentStore {
       trigger?: string
       instruction?: string
       refs?: string | null
+      /** JSON array of connection ids this automation may spend; null clears them all. */
+      connection_ids?: string | null
       enabled?: 0 | 1
     },
   ): Promise<AutomationRecord | null>

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -3554,6 +3554,8 @@ export class PgMetaStore implements MetaStore {
       trigger?: string
       instruction?: string
       refs?: string | null
+      /** JSON array of connection ids this automation may spend; null clears them all. */
+      connection_ids?: string | null
       enabled?: 0 | 1
     },
   ): Promise<AutomationRecord | null> {
@@ -3562,6 +3564,7 @@ export class PgMetaStore implements MetaStore {
     if (fields.trigger !== undefined) set.trigger = fields.trigger
     if (fields.instruction !== undefined) set.instruction = fields.instruction
     if (fields.refs !== undefined) set.refs = fields.refs
+    if (fields.connection_ids !== undefined) set.connection_ids = fields.connection_ids
     if (fields.enabled !== undefined) set.enabled = fields.enabled
     if (Object.keys(set).length === 0) return this.getAutomation(id)
     const rows = await this.db

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -3904,6 +3904,42 @@ export class PgMetaStore implements MetaStore {
       .returning()
     return rows[0] ?? null
   }
+  async updateConnectionCredential(
+    id: string,
+    orgId: string,
+    fields: {
+      secret_enc?: string | null
+      broker_ref?: string
+      status?: ConnectionStatus
+      scopes_label?: string | null
+    },
+    expectSecretEnc?: string | null,
+  ): Promise<ConnectionRecord | null> {
+    const set: Record<string, unknown> = {}
+    if (fields.secret_enc !== undefined) set.secret_enc = fields.secret_enc
+    if (fields.broker_ref !== undefined) set.broker_ref = fields.broker_ref
+    if (fields.status !== undefined) set.status = fields.status
+    if (fields.scopes_label !== undefined) set.scopes_label = fields.scopes_label
+    if (Object.keys(set).length === 0) return this.getConnection(id)
+    // The compare-and-swap rides IN the WHERE clause, so the check and the write are one
+    // statement. Reading first and then writing would leave the window this exists to close.
+    const guard =
+      expectSecretEnc === undefined
+        ? undefined
+        : expectSecretEnc === null
+          ? isNull(connection.secret_enc)
+          : eq(connection.secret_enc, expectSecretEnc)
+    const rows = await this.db
+      .update(connection)
+      .set(set)
+      .where(
+        guard
+          ? and(eq(connection.id, id), eq(connection.org_id, orgId), guard)
+          : and(eq(connection.id, id), eq(connection.org_id, orgId)),
+      )
+      .returning()
+    return rows[0] ?? null
+  }
   async getAgentByToken(token: string): Promise<AgentRecord | null> {
     const rows = await this.db.select().from(agent).where(eq(agent.token, token))
     return rows[0] ?? null

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -3045,6 +3045,8 @@ export function makeRepos(db: SqliteDb) {
       trigger?: string
       instruction?: string
       refs?: string | null
+      /** JSON array of connection ids this automation may spend; null clears them all. */
+      connection_ids?: string | null
       enabled?: 0 | 1
     },
   ): Promise<AutomationRecord | null> => {
@@ -3053,6 +3055,7 @@ export function makeRepos(db: SqliteDb) {
     if (fields.trigger !== undefined) set.trigger = fields.trigger
     if (fields.instruction !== undefined) set.instruction = fields.instruction
     if (fields.refs !== undefined) set.refs = fields.refs
+    if (fields.connection_ids !== undefined) set.connection_ids = fields.connection_ids
     if (fields.enabled !== undefined) set.enabled = fields.enabled
     if (Object.keys(set).length === 0) return getAutomation(id)
     return (

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -3412,6 +3412,45 @@ export function makeRepos(db: SqliteDb) {
       .where(and(eq(connection.id, id), eq(connection.org_id, orgId)))
       .returning()
       .get()) ?? null
+
+  const updateConnectionCredential = async (
+    id: string,
+    orgId: string,
+    fields: {
+      secret_enc?: string | null
+      broker_ref?: string
+      status?: ConnectionStatus
+      scopes_label?: string | null
+    },
+    expectSecretEnc?: string | null,
+  ): Promise<ConnectionRecord | null> => {
+    const set: Record<string, unknown> = {}
+    if (fields.secret_enc !== undefined) set.secret_enc = fields.secret_enc
+    if (fields.broker_ref !== undefined) set.broker_ref = fields.broker_ref
+    if (fields.status !== undefined) set.status = fields.status
+    if (fields.scopes_label !== undefined) set.scopes_label = fields.scopes_label
+    if (Object.keys(set).length === 0) return getConnection(id)
+    // The compare-and-swap rides IN the WHERE clause, so the check and the write are one
+    // statement. Reading first and then writing would leave the window this exists to close.
+    const guard =
+      expectSecretEnc === undefined
+        ? undefined
+        : expectSecretEnc === null
+          ? isNull(connection.secret_enc)
+          : eq(connection.secret_enc, expectSecretEnc)
+    return (
+      (await db
+        .update(connection)
+        .set(set)
+        .where(
+          guard
+            ? and(eq(connection.id, id), eq(connection.org_id, orgId), guard)
+            : and(eq(connection.id, id), eq(connection.org_id, orgId)),
+        )
+        .returning()
+        .get()) ?? null
+    )
+  }
   const getAgentByToken = async (token: string): Promise<AgentRecord | null> =>
     (await db.select().from(agent).where(eq(agent.token, token)).get()) ?? null
   const getAgent = async (id: string): Promise<AgentRecord | null> =>
@@ -4229,6 +4268,7 @@ export function makeRepos(db: SqliteDb) {
     getConnectionsByIds,
     listConnections,
     setConnectionStatus,
+    updateConnectionCredential,
     getAgentByToken,
     getOAuthGrant,
     getOAuthClientName,

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -4327,4 +4327,77 @@ export function runStoreContract(
       }
     })
   })
+  describe(`${label}: connection credentials`, () => {
+    // The one mutation the connection table never had. It exists for OAuth — the row is created
+    // `pending` before the redirect and completed on callback — and for every refresh after that.
+    const mkConn = async (over: Record<string, unknown> = {}) =>
+      store.createConnection({
+        id: `conn_${uuid().slice(0, 8)}`,
+        org_id: ORG,
+        user_id: "u1",
+        scope: "personal",
+        kind: "mcp",
+        broker: "mcp",
+        toolkit: "stripe",
+        broker_ref: "mcp::https://mcp.stripe.com",
+        secret_enc: "v1.old",
+        status: "pending",
+        ...over,
+      } as never)
+
+    it("writes the credential, the ref and the status together", async () => {
+      const cn = await mkConn()
+      const out = await store.updateConnectionCredential(cn.id, ORG, {
+        secret_enc: "v1.new",
+        broker_ref: "mcp:s256-abc:https://mcp.stripe.com",
+        status: "active",
+        scopes_label: "oauth",
+      })
+      expect(out?.secret_enc).toBe("v1.new")
+      expect(out?.broker_ref).toBe("mcp:s256-abc:https://mcp.stripe.com")
+      expect(out?.status).toBe("active")
+      expect(out?.scopes_label).toBe("oauth")
+    })
+
+    it("is org-scoped — another workspace cannot rewrite the credential", async () => {
+      const cn = await mkConn()
+      expect(
+        await store.updateConnectionCredential(cn.id, `org_${uuid()}`, { secret_enc: "v1.x" }),
+      ).toBeNull()
+      expect((await store.getConnection(cn.id))?.secret_enc).toBe("v1.old")
+    })
+
+    it("COMPARE-AND-SWAP: a stale refresh cannot overwrite a newer token", async () => {
+      // Two runs hit an expired access token in the same second. Both refresh. The slower reply
+      // must not put its older token back over the newer one and invalidate a working grant.
+      const cn = await mkConn()
+      const fast = await store.updateConnectionCredential(
+        cn.id,
+        ORG,
+        { secret_enc: "v1.fresh" },
+        "v1.old",
+      )
+      expect(fast?.secret_enc).toBe("v1.fresh")
+      const slow = await store.updateConnectionCredential(
+        cn.id,
+        ORG,
+        { secret_enc: "v1.stale" },
+        "v1.old", // what the slow caller READ before it refreshed
+      )
+      expect(slow, "the stale write is refused, not applied").toBeNull()
+      expect((await store.getConnection(cn.id))?.secret_enc).toBe("v1.fresh")
+    })
+
+    it("the swap guard matches a NULL credential too, so a first write is safe", async () => {
+      const cn = await mkConn({ secret_enc: null })
+      expect(
+        (await store.updateConnectionCredential(cn.id, ORG, { secret_enc: "v1.first" }, null))
+          ?.secret_enc,
+      ).toBe("v1.first")
+      // And a second caller expecting null now loses.
+      expect(
+        await store.updateConnectionCredential(cn.id, ORG, { secret_enc: "v1.second" }, null),
+      ).toBeNull()
+    })
+  })
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,9 @@ importers:
       '@types/pg':
         specifier: ^8.11.10
         version: 8.20.0
+      express:
+        specifier: ^5.1.0
+        version: 5.2.1
       fflate:
         specifier: ^0.8.2
         version: 0.8.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@cloudflare/vitest-pool-workers':
+        specifier: ^0.16.15
+        version: 0.16.15(@cloudflare/workers-types@4.20260615.1)(@types/node@25.9.3)(@vitest/runner@4.1.9)(@vitest/snapshot@4.1.9)(vitest@4.1.9)
       '@cloudflare/workers-types':
         specifier: ^4.20260615.1
         version: 4.20260615.1


### PR DESCRIPTION
MCP sources, phase 2: connect a real MCP server by signing in, bind it to an automation, and have a run read from it.

Everything below was driven against servers that actually exist. That is the whole method here, and it is why this branch is mostly fixes: the suite in this repo drives a server this repo wrote, which agrees with our assumptions by construction.

## What was broken

**The broker could not talk to a large class of MCP servers.** `readRpc` was `await res.text()`, which waits for the response stream to CLOSE. The spec explicitly lets a server keep the SSE stream open after replying so it can push notifications down it, and real servers do: gitmcp.io holds it open, DeepWiki closes it. Against a server that holds it open, every call stalled until the 20-second abort and was then reported as *the server* failing, when it had answered in milliseconds. GitMCP goes from a 30s timeout to 1.1s.

Replies are now matched by request id, because once a stream carries more than one message, "the last frame" is whatever happened to be in the buffer. Ids are a counter rather than `Date.now()`, which two calls in the same millisecond shared.

**The OAuth state would have broken every real connection.** It was packed as dot-joined fields, and `signCapabilityToken` splits on dots. Every real MCP URL has dots in it, so `mcp.stripe.com` would have split into four fields. The test host was `localhost`, which has none; it is `127.0.0.1` now.

**Sign-in asked for too much.** We requested every scope a server advertised. Linear advertises `read write openid email`, so its consent screen said "Access: Read, **Write**, Identity, Email address" for a feature whose own description is "your agents can read from it". Elevated scopes are dropped; if nothing recognisably narrow is left, no scope is sent and the authorization server applies its own default. Verified live: the same screen now reads "Read, Identity, Email address".

**The callback landed on a page that does not exist.** It redirected to `/settings?tab=sources`, but settings sections are path segments, so it fell through to `/settings/profile`. Every completed sign-in landed on the wrong page.

## What is new

- **Sign in with an MCP server.** Discovery, RFC 7591 dynamic registration, PKCE S256, code exchange and refresh, from `@modelcontextprotocol/sdk`. The connection is pinned *after* consent returns, since until then there is no credential to list tools with; that re-pin is the one part no library does for us.
- **A 401 with no token now starts a flow instead of dead-ending.** The row is stored pending and unpinned, so no run can use it, and it carries a Sign in button for a flow abandoned midway or a grant later revoked. A 401 with a token pasted is still refused: that token is wrong.
- **Sources can be bound to an automation and changed afterwards.** They were create-only, so an automation could never be pointed at a source connected later, which is the order people actually work in. `PATCH` takes `connectionIds` behind the same least-privilege check create makes.
- **Credentials** ride in the existing `secret_enc` column as one encrypted blob, so no migration. Refresh is compare-and-swap, so two runs refreshing at once cannot leave the older token installed. A blob that fails to decrypt is treated as unreadable and nothing is sent, rather than shipping our ciphertext to a third party.

## Verified against live servers

`LIVE_MCP=1` opt-in suites, off in CI because it must not depend on someone else's uptime.

- Connect, pin, and answer real tool calls: **DeepWiki, GitMCP, Cloudflare docs, Hugging Face**.
- Report `auth_required` and advertise dynamic registration with PKCE S256 and a public client: **Stripe, Linear, Notion, Sentry**.
- A real sign-in started against **Linear and Sentry**, through the actual route, ending on a real consent page.
- The whole scenario end to end against **DeepWiki**: connect, bind, run, and the filed bytes contain prose only that server could have supplied.

Clicked through in a browser as well: connecting a live server, the pending/sign-in states, the redirect to Linear's real consent screen, and creating an automation with the source bound.

## Proven in workerd, on the deployed preview

The last time this feature broke in production it was a Node/workerd difference that every Node test passed through, so the runtime question got answered directly rather than reasoned about.

Against `derive-pr-595` (a real Worker), with a live vendor: the broker reached `mcp.linear.app` and reported `auth_required`; the authorize route ran discovery, a real dynamic registration and PKCE S256, and returned a consent URL with `scope=read openid email` and the RFC 8707 resource set; pressing it twice returned the same `client_id`. The probe connection was deleted afterwards.

There is also a Miniflare lane in CI (`pnpm --filter @derive/api test:worker`) covering `startAuthorization`, the signed state round trip, and credential encrypt/read. It says plainly what it cannot catch: the pool shims fetch, so it would not have caught the original binding defect. Its first assertion is that it really is workerd, which earned its place immediately by catching the Node lane also globbing `test/worker/**`.

## Two more defects found while reviewing this branch

**Registration was not being reused.** Dynamic client registration is not idempotent: ask Linear twice with byte-identical metadata and you get two clients. Registering per attempt left an abandoned OAuth client at the provider for every Sign in pressed, every retry and every abandoned consent screen, on an endpoint that is a standing rate-limit target. The registration now lives on the connection, written before the redirect, since the flow that never comes back is exactly the one that would re-register.

**Signing in on a workspace source only needed `read`.** Finishing that flow installs a grant into a source every automation in the org can spend, so any member could attach their own access to shared infrastructure. It now requires `manage`, matching how revoke already treats workspace connections. Personal connections stay stricter than revoke: a manager cannot authorize someone else's, because the row acts as its owner and would spend one person's access under another person's name.

## Worth knowing before merging

**A run that reads from a source cannot live-publish.** The autonomy gate files a proposal for any run that had a spendable connection, above any per-target publish mode. So a document backed by a source updates when a human accepts a proposal, not on its own. That is existing, deliberate behaviour, not something this branch changed. One test asserted the document *should* change; it was asserting a safety rung away, and now asserts the proposal carries the live bytes instead.

**The consent round trip is proven, without a vendor account.** The MCP SDK ships a reference OAuth server (`examples/server/simpleStreamableHttp --oauth`, the maintainers' `DemoInMemoryAuthProvider`), and `test/mcp-oauth-roundtrip.test.ts` boots it on a free port and drives the whole flow over real HTTP: 401, path-aware discovery, dynamic registration, consent, the code exchange against a token endpoint that verifies our PKCE verifier, the re-pin, and a tool call authorized by the token that came out — `{"content":[{"type":"text","text":"Hello, Derive!"}]}`, from the same server that answered 401 at step one. That last step matters: everything before it could be true of a token nobody ever spent.

It runs in CI, since it needs no network and no account. The reference provider simulates the login, which is the one step a real vendor needs a human for. What it cannot prove is any single vendor's quirks — Stripe's authorization server on another origin, Linear's scope list — and those stay covered by the live suites, up to the consent screen. Testing this against someone else's implementation was the point: a misreading of the spec shared by a client and its own test server is invisible.

`pnpm verify` green.
