### PR TITLE
fix(slack): the Save to Derive shortcut was declared in the wrong manifest section

### DIFF
--- a/apps/api/src/slack-app-setup.ts
+++ b/apps/api/src/slack-app-setup.ts
@@ -46,6 +46,22 @@ export const buildSlackManifest = (baseUrl: string) => {
           should_escape: false,
         },
       ],
+      // "Save to Derive" on any message's overflow menu — the capture path (lib/slack-capture.ts).
+      // A MESSAGE shortcut rather than a global one: it needs the message it was fired on, and a
+      // global shortcut carries none. It belongs under `features`, beside slash_commands, NOT
+      // under `settings` beside interactivity — Slack's manifest schema rejects unknown keys, so
+      // the misplacement did not degrade to "shortcut missing", it failed the whole manifest.
+      // A manifest is the only way to declare one; an existing app picks it up when the manifest
+      // is re-applied, and the shortcut then appears without a per-workspace reinstall (it needs
+      // no new scope — `commands` already covers it).
+      shortcuts: [
+        {
+          name: "Save to Derive",
+          type: "message",
+          callback_id: SLACK_CAPTURE_CALLBACK,
+          description: "Save this message as a comment on a Derive doc",
+        },
+      ],
     },
     oauth_config: {
       // The bot install callback + the per-user "Sign in with Slack" (OIDC) link callback.
@@ -74,18 +90,6 @@ export const buildSlackManifest = (baseUrl: string) => {
           "tokens_revoked",
         ],
       },
-      // "Save to Derive" on any message's overflow menu — the capture path (lib/slack-capture.ts).
-      // A MESSAGE shortcut rather than a global one: it needs the message it was fired on, and a
-      // global shortcut carries none. Declared here because a manifest is the only way to add
-      // one; an existing install picks it up on reinstall, like the unfurl domains.
-      shortcuts: [
-        {
-          name: "Save to Derive",
-          type: "message",
-          callback_id: SLACK_CAPTURE_CALLBACK,
-          description: "Save this message as a comment on a Derive doc",
-        },
-      ],
       // Buttons on comment cards (resolve / reopen a thread) POST here.
       interactivity: {
         is_enabled: true,

--- a/apps/api/test/slack-app-setup.test.ts
+++ b/apps/api/test/slack-app-setup.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest"
+import { SLACK_CAPTURE_CALLBACK } from "../src/lib/slack-capture"
 import { buildSlackManifest, slackSetupHTML } from "../src/slack-app-setup"
 
 const BASE = "https://api.derive.example.com"
@@ -82,6 +83,34 @@ describe("buildSlackManifest", () => {
     const cmd = m.features.slash_commands?.[0]
     expect(cmd?.command).toBe("/derive")
     expect(cmd?.url).toBe(`${BASE}/v1/slack/commands`)
+  })
+
+  // Placement, not just presence. Slack's manifest schema rejects unknown keys outright, so a
+  // shortcut declared one level away — under `settings`, beside interactivity, where it reads
+  // like it belongs — does not degrade to "the shortcut is missing". It fails the whole manifest,
+  // and the app cannot be created or updated at all. That is exactly how this shipped, and every
+  // other assertion in this file passed while it did, because they all check contents rather
+  // than where the contents live.
+  it("declares Save to Derive as a message shortcut under features, not settings", () => {
+    expect(m.features.shortcuts).toEqual([
+      {
+        name: "Save to Derive",
+        type: "message",
+        callback_id: "derive_capture",
+        description: expect.any(String),
+      },
+    ])
+    expect((m.settings as Record<string, unknown>).shortcuts).toBeUndefined()
+    // The callback_id is the contract between the manifest and the interactivity handler: Slack
+    // routes a message_action by this string, so a rename on one side alone is a dead shortcut.
+    expect(m.features.shortcuts[0]?.callback_id).toBe(SLACK_CAPTURE_CALLBACK)
+  })
+
+  // Slack caps a shortcut's name at 24 characters and its description at 150.
+  it("keeps the shortcut inside Slack's field limits", () => {
+    const s = m.features.shortcuts[0]
+    expect(s?.name.length).toBeLessThanOrEqual(24)
+    expect(s?.description.length).toBeLessThanOrEqual(150)
   })
 
   it("is named just Derive (Slack caps the app name at 35 chars)", () => {


### PR DESCRIPTION
Found while writing the testing instructions for #585: the manifest endpoint is admin-gated, so I couldn't fetch it anonymously to check — which prompted me to read where the shortcut had actually been placed.

It was under `settings`, beside `interactivity`. Slack's manifest schema puts shortcuts under `features`, beside `slash_commands`.

```
features:            <- shortcuts belong here, with bot_user / unfurl_domains / slash_commands
oauth_config:
settings:            <- they were here, with event_subscriptions / interactivity
```

The schema **rejects unknown keys outright**, so this doesn't degrade to "the shortcut doesn't appear" — the whole manifest fails, and an app can be neither created nor updated from it. The single instruction for picking the feature up, *"re-apply the manifest"*, is precisely what would have broken.

## Why nothing caught it

Every assertion in `slack-app-setup.test.ts` checks what the manifest *contains* — the scopes, the events, the unfurl domain, the slash command, the name and description caps. None checked where anything lives, so all 13 stayed green.

Two tests now pin placement:

- the shortcut is under `features`, and nothing named `shortcuts` exists under `settings`
- its `callback_id` equals `SLACK_CAPTURE_CALLBACK` — the string Slack routes a `message_action` by, so a rename on one side alone is a dead shortcut
- plus Slack's field caps (name ≤ 24, description ≤ 150), matching the guards the app name and description already have

Verified the tests have teeth by re-introducing the misplacement: both fail, the other 13 pass — the same blind spot reproduced exactly.

No behaviour change to the handler; `routes/slack.ts` was always routing `message_action` correctly. This is the declaration that never reached Slack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/597"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788085118&installation_model_id=428097&pr_number=597&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F597&signature=6dd3b957bfcc068814f729d9e8ca10f3c41da200fb4a7ddc2cd23c078d6d6a8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->