### PR TITLE
fix(slack): the generated manifest never declared the Sign in with Slack scopes

### DIFF
--- a/apps/api/src/lib/slack.ts
+++ b/apps/api/src/lib/slack.ts
@@ -72,6 +72,15 @@ export const exchangeSlackOAuth = async (
  *  scopes in one call, so linking a personal identity is its own lightweight flow. `nonce` is
  *  required by OIDC; we read identity from the back-channel userinfo, so the signed `state`
  *  (not the id_token) is what binds the callback to the Derive user who started it. */
+/** The USER scopes behind "Sign in with Slack" — the per-member account link, not the bot
+ *  install. Shared with the generated app manifest (slack-app-setup.ts) because declaring one
+ *  without the other is silently broken in the direction that is hardest to notice: the manifest
+ *  already lists /v1/slack/link/callback as a redirect URL, so the flow looks configured, and it
+ *  is only when a member actually clicks Link account that Slack refuses the authorize call for
+ *  scopes the app never asked for. An app built from a manifest missing these can never link
+ *  anyone, and nothing about the install says so. */
+export const SLACK_USER_SCOPES = ["openid", "profile", "email"] as const
+
 export const slackOidcAuthorizeUrl = (
   clientId: string,
   redirectUri: string,
@@ -81,7 +90,7 @@ export const slackOidcAuthorizeUrl = (
 ): string => {
   const u = new URL("https://slack.com/openid/connect/authorize")
   u.searchParams.set("response_type", "code")
-  u.searchParams.set("scope", "openid profile email")
+  u.searchParams.set("scope", SLACK_USER_SCOPES.join(" "))
   u.searchParams.set("client_id", clientId)
   u.searchParams.set("redirect_uri", redirectUri)
   u.searchParams.set("state", state)

--- a/apps/api/src/slack-app-setup.ts
+++ b/apps/api/src/slack-app-setup.ts
@@ -7,7 +7,7 @@
 // is born with the events config, so a fresh "Add to Slack" is two-way from the first
 // message — nothing to toggle by hand.
 import { esc, brandShell as SHELL } from "./brand-page"
-import { SLACK_BOT_SCOPES } from "./lib/slack"
+import { SLACK_BOT_SCOPES, SLACK_USER_SCOPES } from "./lib/slack"
 import { SLACK_CAPTURE_CALLBACK } from "./lib/slack-capture"
 
 /** The Slack app manifest, born with everything Derive's Slack integration needs and
@@ -66,7 +66,11 @@ export const buildSlackManifest = (baseUrl: string) => {
     oauth_config: {
       // The bot install callback + the per-user "Sign in with Slack" (OIDC) link callback.
       redirect_urls: [u("/v1/slack/oauth/callback"), u("/v1/slack/link/callback")],
-      scopes: { bot: SLACK_BOT_SCOPES },
+      // BOTH lists, and the user one is not optional: this manifest declares the link callback
+      // above, so an app built without the user scopes looks configured for account linking and
+      // refuses the very first authorize call. Sourced from lib/slack.ts so the manifest and the
+      // authorize URL cannot drift.
+      scopes: { bot: SLACK_BOT_SCOPES, user: SLACK_USER_SCOPES },
     },
     settings: {
       event_subscriptions: {

--- a/apps/api/test/slack-app-setup.test.ts
+++ b/apps/api/test/slack-app-setup.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest"
+import { slackOidcAuthorizeUrl } from "../src/lib/slack"
 import { SLACK_CAPTURE_CALLBACK } from "../src/lib/slack-capture"
 import { buildSlackManifest, slackSetupHTML } from "../src/slack-app-setup"
 
@@ -42,6 +43,22 @@ describe("buildSlackManifest", () => {
 
   // Regression: /derive shipped in #454 but `commands` was never added, so Slack refused the
   // manifest ("Slash Commands requires `commands` bot scope") — the app was uncreatable.
+  // The manifest lists /v1/slack/link/callback as a redirect URL, so an app built from it LOOKS
+  // configured for account linking. Without the user scopes it refuses the first authorize call
+  // a member makes, and nothing about the install hints at it. The live app carried these only
+  // because someone added them by hand; the generator omitted them entirely.
+  it("declares the user scopes Sign in with Slack needs, not just the bot ones", () => {
+    expect(m.oauth_config.scopes.user).toEqual(["openid", "profile", "email"])
+    expect(m.oauth_config.redirect_urls).toContain(`${BASE}/v1/slack/link/callback`)
+  })
+
+  // The authorize URL and the manifest must ask for the SAME set — a scope in one and not the
+  // other fails at the point of use, long after install.
+  it("asks for exactly the scopes its own authorize URL sends", () => {
+    const sent = new URL(slackOidcAuthorizeUrl("cid", `${BASE}/cb`, "st", "nonce")).searchParams
+    expect(sent.get("scope")?.split(" ").sort()).toEqual([...m.oauth_config.scopes.user].sort())
+  })
+
   it("declares the commands scope its slash command requires", () => {
     expect(m.oauth_config.scopes.bot).toContain("commands")
   })


### PR DESCRIPTION
Found by pointing a Slack **app configuration token** at the real app: `apps.manifest.export` the live manifest, diff it against what `buildSlackManifest` produces. The diff had a removal in it.

```
- /oauth_config/scopes/user: email, openid, profile
```

The live app carries the OIDC user scopes. **Ours has never emitted them.**

## Why that matters

The manifest already lists `/v1/slack/link/callback` among its redirect URLs, so an app built from it *looks* configured for account linking. It isn't — Slack will not grant `openid profile email` to an app that never declared them, so `slackOidcAuthorizeUrl` is refused on the first click of **Link account**. Nothing at install time hints at it; the failure surfaces on a member, long after whoever set the app up has moved on.

Same shape as the manifest defects in #558 and the linking bug in #560: declared half a feature, and the half that was missing only fails at the point of use.

The live app works today because someone added the scopes **by hand**. That's also why nobody noticed the generator had never produced them — and it means applying our manifest over that app would have *stripped* them and broken linking for the whole workspace. Exporting before applying is what caught it.

## The fix

`SLACK_USER_SCOPES` lives in `lib/slack.ts` beside `SLACK_BOT_SCOPES`, and both `slackOidcAuthorizeUrl` and the manifest read it. A test asserts the manifest asks for exactly what the authorize URL sends, so a scope added to one can't go missing from the other.

## Verified against Slack, not just against tests

| check | result |
|---|---|
| `apps.manifest.validate` on the generated manifest | `ok: true, errors: []` |
| same, with `shortcuts` back under `settings` (the #597 bug) | `invalid_manifest` — `invalid additional property: shortcuts` at `/settings` |
| diff vs the live app after this fix | purely additive — no removals |

The second row also independently confirms #597's claim, which until now I could only assert: Slack rejects the entire manifest rather than ignoring the misplaced key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/598"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788086767&installation_model_id=428097&pr_number=598&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F598&signature=59787f6bdc6cdde2f8660379b05566f3b23642ed1366a6e4a00a44f794456b92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->