### PR TITLE
fix(slack): make the /derive subcommands findable, and stop two silent failures

### DIFF
--- a/apps/api/src/lib/slack-commands.ts
+++ b/apps/api/src/lib/slack-commands.ts
@@ -43,14 +43,24 @@ export const deriveRecentBlocks = (baseUrl: string, artifacts: ArtifactRecord[])
   return [
     section("*Your recent artifacts*"),
     ...artifacts.map((a) => section(artifactLink(artifactUrl(baseUrl, a), a.title, a.short_id))),
-    context("Only you can see this · run `/derive <query>` to search"),
+    context("Only you can see this · `/derive <query>` searches · `/derive help` lists the rest"),
   ]
 }
 
 /** `/derive settings`, run in a channel: what Derive posts here, if anything. */
 export const subscriptionBlocks = (
   baseUrl: string,
-  subs: { scope_kind: string; scope_id: string; events: string; authors: string; active: 0 | 1 }[],
+  subs: {
+    scope_kind: string
+    scope_id: string
+    /** The collection's TITLE. `scope_id` is an opaque `col_…`, which is what this card used to
+     *  print — telling an admin their channel is scoped to `col_9f2ac1` and nothing more. Null
+     *  for a workspace scope, and for a collection since deleted. */
+    scope_title?: string | null
+    events: string
+    authors: string
+    active: 0 | 1
+  }[],
 ): unknown[] => {
   if (!subs.length)
     return [
@@ -63,7 +73,7 @@ export const subscriptionBlocks = (
       section(
         [
           s.scope_kind === "collection"
-            ? `Collection \`${mrkdwnLabel(s.scope_id, 60)}\``
+            ? `Collection *${mrkdwnLabel(s.scope_title ?? "(deleted)", 60)}*`
             : "The whole workspace",
           s.events === "*" ? "all events" : s.events.split(",").join(" · "),
           s.authors === "all" ? "people and agents" : `${s.authors}s only`,
@@ -76,3 +86,24 @@ export const subscriptionBlocks = (
     ),
   ]
 }
+
+/** `/derive help`. The subcommands exist only in the slash-command autocomplete otherwise, and
+ *  that is one line of hint text — this is where someone who half-remembers `subscribe` can
+ *  actually find out what it takes. Reached by `/derive help`, and pointed at from the footer of
+ *  the search and recent cards, since those are what people land on by accident. */
+export const helpBlocks = (baseUrl: string): unknown[] => [
+  section("*What `/derive` can do*"),
+  section(
+    [
+      "`/derive <query>` — search everything you can see",
+      "`/derive` — your most recent artifacts",
+      "`/derive subscribe [collection]` — post this channel's activity here; name a collection to narrow it",
+      "`/derive unsubscribe` — stop posting here",
+      "`/derive settings` — what this channel currently gets",
+    ].join("\n"),
+  ),
+  section(
+    "You can also pick *Save to Derive* from any message's shortcut menu to file it as a comment on a doc.",
+  ),
+  context(`Subscriptions are admin-only · manage them at ${baseUrl}/settings/integrations`),
+]

--- a/apps/api/src/lib/slack.ts
+++ b/apps/api/src/lib/slack.ts
@@ -223,6 +223,38 @@ export const postSlackMessage = async (
   return { ts: data.ts, channel: data.channel ?? args.channel }
 }
 
+/** Whether the bot can actually post in a conversation.
+ *
+ *  `conversations.info` answers `channel_not_found` for a PRIVATE channel the bot is not in —
+ *  it cannot see one — so a miss is itself the signal, not an error to surface. A public channel
+ *  needs no membership: the sender self-joins on the first `not_in_channel` (postWithRecovery's
+ *  autoJoin). A private one cannot be joined by the app at all, and that is the case worth
+ *  catching early, because otherwise the subscription is accepted and every delivery to it
+ *  quietly dead-letters. Returns null when Slack could not be asked — never block on a maybe. */
+export const slackChannelReach = async (
+  token: string,
+  channel: string,
+): Promise<{ reachable: boolean; name: string | null } | null> => {
+  try {
+    const q = new URLSearchParams({ channel })
+    const res = await fetch(`${API}/conversations.info?${q}`, {
+      headers: { authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(2500),
+    })
+    const data = (await res.json()) as {
+      ok: boolean
+      error?: string
+      channel?: { is_private?: boolean; is_member?: boolean; name?: string }
+    }
+    if (!data.ok)
+      return data.error === "channel_not_found" ? { reachable: false, name: null } : null
+    const c = data.channel ?? {}
+    return { reachable: !c.is_private || c.is_member === true, name: c.name ?? null }
+  } catch {
+    return null
+  }
+}
+
 /** Open a modal via views.open. `triggerId` is single-use and expires ~3s after the interaction
  *  that produced it, which is why the caller must reach this BEFORE doing any slow work — the
  *  modal is the ack. Throws SlackApiError(code) on a Slack-level failure. */

--- a/apps/api/src/routes/slack.ts
+++ b/apps/api/src/routes/slack.ts
@@ -15,6 +15,7 @@ import {
   openSlackView,
   postSlackResponseUrl,
   slackAuthorizeUrl,
+  slackChannelReach,
   slackOidcAuthorizeUrl,
   slackOidcUserinfo,
   slackPermalink,
@@ -39,6 +40,7 @@ import { mrkdwnLabel } from "../lib/slack-cards"
 import {
   deriveRecentBlocks,
   deriveResultsBlocks,
+  helpBlocks,
   notLinkedBlocks,
   subscriptionBlocks,
 } from "../lib/slack-commands"
@@ -706,6 +708,13 @@ export const slackRoutes = (ctx: AppContext) => {
     if (!teamId || !slackUserId)
       return c.json({ response_type: "ephemeral", text: "Sorry — malformed command." })
 
+    // `/derive help` is answered BEFORE the account-link gate: it describes the command and
+    // reveals nothing about the workspace, and someone who has not linked yet is exactly who
+    // needs it. Gating it behind linking would hide the instructions from the only person
+    // reading them.
+    if (text.trim().toLowerCase() === "help")
+      return c.json({ response_type: "ephemeral", blocks: helpBlocks(deps.baseUrl) })
+
     // Resolve the acting Derive user (and their workspace) from the account link. No link →
     // we can't scope results to them, so prompt them to link rather than leak or over-share.
     const link = await meta.getSlackUserLinkBySlackId(teamId, slackUserId)
@@ -742,11 +751,30 @@ export const slackRoutes = (ctx: AppContext) => {
         const subs = (await meta.listSlackSubscriptions(link.org_id)).filter(
           (x) => x.channel_id === channelId,
         )
+        // Resolve titles so the card can name the collection rather than print `col_9f2ac1`.
+        // Only when something here is actually scoped — most channels take the whole workspace.
+        const titles = new Map<string, string>()
+        if (subs.some((x) => x.scope_kind === "collection"))
+          for (const col of await meta.listCollections(link.org_id)) titles.set(col.id, col.title)
         return c.json({
           response_type: "ephemeral",
-          blocks: subscriptionBlocks(deps.baseUrl, subs),
+          blocks: subscriptionBlocks(
+            deps.baseUrl,
+            subs.map((x) => ({ ...x, scope_title: titles.get(x.scope_id) ?? null })),
+          ),
         })
       }
+      // A private channel the app was never invited to accepts the subscription and then drops
+      // every delivery into the dead-letter queue, with nothing anywhere saying why. The bot can
+      // self-join a PUBLIC channel on its first post (postWithRecovery autoJoin), so only the
+      // unreachable case is worth stopping, and only when Slack actually answered.
+      const bot = await resolveBotToken(meta, link.org_id, deps.encryptionKey)
+      const reach = bot ? await slackChannelReach(bot.token, channelId) : null
+      if (reach && !reach.reachable)
+        return c.json({
+          response_type: "ephemeral",
+          text: "Invite me to this channel first — `/invite @Derive` — then run `/derive subscribe` again. I can't post in a private channel I'm not a member of.",
+        })
       // `/derive subscribe [collection name]` — the collection is matched by name so nobody has
       // to know an id; omit it to subscribe the whole workspace.
       const wanted = rest.join(" ").trim()

--- a/apps/api/src/slack-app-setup.ts
+++ b/apps/api/src/slack-app-setup.ts
@@ -41,8 +41,12 @@ export const buildSlackManifest = (baseUrl: string) => {
         {
           command: "/derive",
           url: u("/v1/slack/commands"),
-          description: "Search your Derive artifacts",
-          usage_hint: "[query]",
+          // Slack shows BOTH of these in the autocomplete as soon as someone types `/derive`,
+          // and they are the only place the subcommands are discoverable — there is no other
+          // surface that lists them. A description naming only search is why `/derive subscribe`
+          // reads as if it does not exist.
+          description: "Search Derive, or choose what this channel gets",
+          usage_hint: "[query] | subscribe [collection] | unsubscribe | settings | help",
           should_escape: false,
         },
       ],

--- a/apps/api/test/slack-routes.test.ts
+++ b/apps/api/test/slack-routes.test.ts
@@ -984,6 +984,95 @@ describe("/derive subscription subcommands", () => {
     expect(await meta.listSlackSubscriptions("default")).toHaveLength(1)
   })
 
+  // The subcommands live in exactly two places a person can find them: the slash-command
+  // autocomplete (one line, from the manifest) and this. Nothing else lists them.
+  it("answers /derive help — and answers it without an account link", async () => {
+    const { app, meta } = make("cmd-help")
+    await meta.setSlackInstall({
+      org_id: "default",
+      team_id: "T1",
+      team_name: "Acme",
+      bot_token: encryptSecret("xoxb-1", KEY),
+      bot_user_id: "UBOT",
+      created_at: new Date().toISOString(),
+    })
+    // Deliberately NO setSlackUserLink: someone who has not linked yet is exactly who needs to
+    // read what the command does, so help must not sit behind the link prompt.
+    const body = JSON.stringify((await (await cmd(app, "help")).json()).blocks)
+    for (const verb of ["subscribe", "unsubscribe", "settings", "Save to Derive"])
+      expect(body).toContain(verb)
+    expect(body).not.toContain("Connect your Derive account")
+  })
+
+  // Naming the collection matters most here: a channel can carry several subscriptions, and the
+  // card used to print the opaque scope_id, which identifies nothing to a human.
+  it("names the collection in /derive settings rather than printing its id", async () => {
+    const { app, meta } = make("cmd-settings-title")
+    await linked(meta)
+    await meta.createCollection({
+      id: "col_9f2ac1",
+      org_id: "default",
+      title: "API docs",
+      created_by: owner.id,
+    })
+    await cmd(app, "subscribe API docs")
+    const shown = JSON.stringify((await (await cmd(app, "settings")).json()).blocks)
+    expect(shown).toContain("API docs")
+    expect(shown).not.toContain("col_9f2ac1")
+  })
+
+  // A private channel the app was never invited to accepts the subscription and then drops every
+  // delivery into the dead-letter queue with nothing saying why.
+  it("refuses to subscribe a channel it cannot post in, and says how to fix it", async () => {
+    const { app, meta } = make("cmd-unreachable")
+    await linked(meta)
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (u: string) =>
+        String(u).includes("conversations.info")
+          ? new Response(JSON.stringify({ ok: false, error: "channel_not_found" }), { status: 200 })
+          : new Response(JSON.stringify({ ok: true }), { status: 200 }),
+      ),
+    )
+    const r = await (await cmd(app, "subscribe")).json()
+    expect(String(r.text)).toContain("/invite @Derive")
+    expect(await meta.listSlackSubscriptions("default")).toHaveLength(0)
+  })
+
+  // A PUBLIC channel needs no membership — the sender self-joins on its first not_in_channel —
+  // so the guard must not stand in the way of the common case.
+  it("subscribes a public channel the bot has not joined yet", async () => {
+    const { app, meta } = make("cmd-public-ok")
+    await linked(meta)
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (u: string) =>
+        String(u).includes("conversations.info")
+          ? new Response(
+              JSON.stringify({ ok: true, channel: { is_private: false, is_member: false } }),
+              { status: 200 },
+            )
+          : new Response(JSON.stringify({ ok: true }), { status: 200 }),
+      ),
+    )
+    await cmd(app, "subscribe")
+    expect(await meta.listSlackSubscriptions("default")).toHaveLength(1)
+  })
+
+  // Slack unreachable must not block an admin from configuring their own workspace.
+  it("subscribes anyway when Slack could not be asked", async () => {
+    const { app, meta } = make("cmd-reach-unknown")
+    await linked(meta)
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("network down")
+      }),
+    )
+    await cmd(app, "subscribe")
+    expect(await meta.listSlackSubscriptions("default")).toHaveLength(1)
+  })
+
   it("unsubscribes the channel, and reports settings", async () => {
     const { app, meta } = make("cmd-unsubscribe")
     await linked(meta)


### PR DESCRIPTION
> "`/derive subscribe` doesn't show up as a shortcut?"

It doesn't show up anywhere. The manifest described the command as **"Search your Derive artifacts"** with a usage hint of `[query]`, and Slack's autocomplete is the *only* surface that lists what a slash command accepts. So the three subcommands that shipped with channel subscriptions were invisible unless you'd read DEPLOY.md.

Chasing that turned up three more of the same shape — things that work, but only if you already know they exist or already know why they failed.

## Findable

**The command advertises itself.** `[query] | subscribe [collection] | unsubscribe | settings | help`, and a description that mentions channels. Validated with `apps.manifest.validate` rather than guessed — 47 and 64 characters, `ok: true`.

**`/derive help` exists.** It was previously searched for as the literal word "help". Answered *before* the account-link gate: someone who hasn't linked yet is exactly who's reading it, and it discloses nothing about the workspace.

## Silent failures

**`/derive settings` printed `scope_id`.** It told an admin their channel was scoped to `col_9f2ac1` and stopped there. The REST surface got `scope_title` when the Settings picker landed; the slash command was missed, so the two disagreed about the same row.

**Subscribing an unreachable channel is refused.** A private channel the app was never invited to used to *accept* the subscription and then drop every delivery into the dead-letter queue, with nothing anywhere explaining why. Now it answers with the `/invite @Derive` that fixes it.

`conversations.info` returns `channel_not_found` for a private channel the bot can't see, so a miss is the signal rather than an error. Two cases are deliberately left alone:

- **public channels** — the sender self-joins on its first `not_in_channel`, so requiring membership up front would break the common case
- **Slack unreachable** — never block an admin from configuring their own workspace on a maybe

Both are pinned by tests, along with the refusal and the `/derive help` content.

## Not changed

`/derive <anything-else>` still searches, including near-misses like `subscrbe`. Guessing intent from a typo risks swallowing a genuine query; the fix for discovery is the autocomplete and `help`, which now exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788089574&installation_model_id=428097&pr_number=599&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F599&signature=70118dfed4a40749713c5c5195583f3c39483a0750ed93f1aaf6790b74537a00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->