### PR TITLE
fix(api): a comment made over REST by an agent reached no channel

### DIFF
--- a/apps/api/src/routes/comments.ts
+++ b/apps/api/src/routes/comments.ts
@@ -27,6 +27,7 @@ export const commentRoutes = (ctx: AppContext) => {
     notify,
     background,
     actingUser,
+    privateOwnerId,
     anonLocked,
     requireArtifact,
     authorize,
@@ -205,7 +206,15 @@ export const commentRoutes = (ctx: AppContext) => {
           { meta, bus, blobs, baseUrl: deps.baseUrl, notify, pokeWebhooks: deps.pokeWebhooks },
           artifact,
           created,
-          { mentions, actorId: acting?.id ?? null },
+          // onBehalfOf satisfies the contract commentCreatedAction states: requireArtifact
+          // above already authorized this request for `comment` AS this principal, and
+          // privateOwnerId is that principal's human — the grantor for an OAuth agent, the
+          // caller themselves for a session. Without it an OAuth-authenticated comment authors
+          // as the synthetic `oauth:<client>` id, which is a row in no table the collaborator
+          // check reads, so the author is untrusted and the Slack and GitHub mirrors are
+          // skipped in silence. The MCP tool has always passed it; this route never did, and it
+          // is the same REST surface every non-MCP integration comments through.
+          { mentions, actorId: acting?.id ?? null, onBehalfOf: await privateOwnerId(c) },
         ),
       )
       return c.json(commentJson(created), 201)

--- a/apps/api/test/comment-route-onbehalfof.test.ts
+++ b/apps/api/test/comment-route-onbehalfof.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { as, jsonAs, makeAuthedApp, pub, type TestUser } from "./helpers"
+
+// commentCreatedAction states a CONTRACT in its own docstring: a caller that authorized the
+// request as a human principal must pass that principal as `onBehalfOf`, because an OAuth grant
+// authors under the synthetic `oauth:<client>` id, which is a row in no table the collaborator
+// check reads. Miss it and the author is untrusted, and the Slack and GitHub mirrors are skipped
+// in silence — the comment lands in Derive and reaches no channel.
+//
+// The gate itself was already tested, by calling commentCreatedAction with onBehalfOf passed by
+// hand. That proved the branch works and said nothing about whether the route supplies it. It
+// did not, for as long as the route has existed, and the failure is invisible: no error, no log,
+// just a mirror that never fires. So this asserts the call site, which is where the defect was.
+const captured: { onBehalfOf?: string | null; actorId: string | null }[] = []
+vi.mock("../src/lib/comment-actions", async (orig) => {
+  const real = await orig<typeof import("../src/lib/comment-actions")>()
+  return {
+    ...real,
+    commentCreatedAction: async (
+      deps: Parameters<typeof real.commentCreatedAction>[0],
+      artifact: Parameters<typeof real.commentCreatedAction>[1],
+      comment: Parameters<typeof real.commentCreatedAction>[2],
+      opts: Parameters<typeof real.commentCreatedAction>[3],
+    ) => {
+      captured.push({ onBehalfOf: opts.onBehalfOf, actorId: opts.actorId })
+      return real.commentCreatedAction(deps, artifact, comment, opts)
+    },
+  }
+})
+
+const owner: TestUser = { id: "u-own", email: "own@x.com", name: "Owner", username: "own" }
+
+afterEach(() => {
+  captured.length = 0
+})
+
+describe("POST /v1/artifacts/:id/comments supplies onBehalfOf", () => {
+  it("passes the request's human principal, not just the acting id", async () => {
+    const { app } = makeAuthedApp("comment-obo", [owner], "editor")
+    const r = await pub(app, "# Doc", { visibility: "org" }, undefined, as(owner.email))
+    const shortId = (await r.json()).short_id as string
+
+    const posted = await app.request(
+      `/v1/artifacts/${shortId}/comments`,
+      jsonAs(as(owner.email), { body_md: "a note" }),
+    )
+    expect(posted.status).toBe(201)
+    expect(captured).toHaveLength(1)
+    // Present at all — its absence is the whole defect. For a session caller it is the caller
+    // themselves; for an OAuth grant it resolves to the grantor, which is the case that was
+    // silently unmirrored.
+    expect(captured[0]?.onBehalfOf).toBe(owner.id)
+    expect(captured[0]?.actorId).toBe(owner.id)
+  })
+})


### PR DESCRIPTION
Found by driving the real loop against production, not by reading code.

Published through the CLI → the card reached `#slack-app` in three seconds. Commented on the same artifact through `POST /v1/artifacts/:shortId/comments` with the same OAuth bearer → **nothing ever arrived.**

## Not the author filter

The obvious suspect was the people-vs-agents filter, so I checked what each side actually classified as. Read back, the comment's stored author is:

```
author     : Derive CLI
author_id  : oauth:VcLbiBhKSBqmoBlfiXlNlFvlnfDVRXRL
```

Both the publish and the comment classify as **agent**, so the filter would have taken both or neither. It was the collaborator gate.

## The gate, and the contract it states

`commentCreatedAction` gates both mirrors on a collaborator author, and its own docstring spells out what callers owe:

> An OAuth grant authors as `oauth:<client>` — a synthetic id that is never a row in the agents table — so the collaborator check can't see it… **Without this, comments from the standard remote-MCP connector (the main way agents reach Derive) mirror nowhere.**
>
> CONTRACT: the caller must already have authorized the request AS this principal for THIS artifact… **Any new caller owes the same guarantee.**

The route passed `{ mentions, actorId }` and no `onBehalfOf`. So the author was untrusted, and `enqueueSlackComment` was skipped. Silently — no error, no log, no dead-letter row to find. The comment lands in Derive and simply reaches no channel.

`requireArtifact(c, "comment")` has already authorized the request as this principal, which is exactly the guarantee the contract asks for, so `privateOwnerId(c)` is the correct value — the grantor for an OAuth agent, the caller themselves for a session.

## Why the existing test didn't catch it

The gate *was* tested. That test calls `commentCreatedAction` directly with `onBehalfOf` passed by hand:

```js
{ mentions: [], actorId: "oauth:cli", onBehalfOf }
```

It proved the branch works and said nothing about whether the route supplies it. Same shape as the manifest defect in #597 — every assertion checked *contents*, none checked *wiring*.

The new test asserts the call site. Verified it fails without the fix (`expected undefined to be 'u-own'`) and passes with it.

## Blast radius

Any agent or integration commenting through the REST API — the documented, OpenAPI-described surface — got no Slack mirror and no GitHub PR comment. MCP was unaffected (it always passed its equivalent), as was the web app (a session principal is its own collaborator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788091499&installation_model_id=428097&pr_number=600&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F600&signature=72809f537e132ea738d5f64817cbdcb32282bba2827736cbfdd6a09479ad9940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->