### PR TITLE
fix(api): a run's capability token could act on any session of its context

### DIFF
--- a/apps/api/src/routes/contexts.ts
+++ b/apps/api/src/routes/contexts.ts
@@ -70,26 +70,15 @@ export const contextRoutes = (ctx: AppContext) => {
   } = ctx
   const app = new OpenAPIHono<BlankEnv>()
 
-  /**
-   * A pass minted for an automation RUN has no business in the session lane.
+  /** A run-scoped capability token, which must not reach the session lane.
    *
-   * The run lane has always checked this in the other direction (routes/automations.ts refuses a
-   * session token at claim, finish and tool). The session lane never got the mirror, and
-   * OWNERSHIP CANNOT COVER FOR IT: a context-bound automation runs AS the context's agent, so
-   * `context.agent_id === agent.id` is true for a run token aimed at any session of that
-   * context. The two kinds are cryptographically distinct, which stops a token verifying as the
-   * wrong kind — it does not stop the wrong kind being accepted where kind was never checked.
-   *
-   * Measured before this guard existed, with a `dkrun_` token against a session of its own
-   * context: the tool door executed a third-party call with the context's credential attached,
-   * the messages door posted and settled an answer in someone else's session, the state door
-   * failed that session out from under the executor that owned it, and the queue claimed
-   * sessions. The run's status did not matter — queued and running behaved identically.
-   *
-   * routes/model-credentials.ts is the precedent, including its reason: belonging to the same
-   * agent is not enough.
-   */
+   *  The ownership checks below cannot stand in for this: a context-bound automation runs AS the
+   *  context's agent, so `context.agent_id === agent.id` holds for a run token aimed at any
+   *  session of that context. Mirrors `isSessionBearer` in routes/automations.ts; see
+   *  routes/model-credentials.ts for the same rule stated once more — belonging to the same
+   *  agent is not enough. Covered by test/work-token-lanes.test.ts. */
   const isRunBearer = (c: Context): boolean => agentRunScope(c) !== null
+  const NOT_THIS_LANE = "a run token cannot act on a session"
 
   /** Is this workspace allowed to spend the operator's model key? See DERIVE_CHAT_ALLOWLIST. */
   const chatAllowed = (orgId: string): boolean =>
@@ -1408,7 +1397,7 @@ export const contextRoutes = (ctx: AppContext) => {
 
       const agent = await agentFor(c)
       if (agent) {
-        if (isRunBearer(c)) return bail(fail(c, 403, "a run token cannot act on a session"))
+        if (isRunBearer(c)) return bail(fail(c, 403, NOT_THIS_LANE))
         if (!linked || agent.id !== linked.context.agent_id) return bail(fail(c, 404, "not found"))
         const gone = closed()
         if (gone) return bail(gone)
@@ -1569,7 +1558,7 @@ export const contextRoutes = (ctx: AppContext) => {
 
       const agent = await agentFor(c)
       if (agent) {
-        if (isRunBearer(c)) return bail(fail(c, 403, "a run token cannot act on a session"))
+        if (isRunBearer(c)) return bail(fail(c, 403, NOT_THIS_LANE))
         if (agent.id !== linked.context.agent_id) return bail(fail(c, 404, "not found"))
         // The asker may close mid-run; the run's eventual failure must not reopen
         // a conversation they deliberately ended.
@@ -1627,7 +1616,7 @@ export const contextRoutes = (ctx: AppContext) => {
       if (!agent) return bail(fail(c, 401, "agent token required"))
       // Reading this queue CLAIMS sessions (open → working), so a run's pass crossing here
       // would quietly take over the ask lane's work.
-      if (isRunBearer(c)) return bail(fail(c, 403, "a run token cannot act on a session"))
+      if (isRunBearer(c)) return bail(fail(c, 403, NOT_THIS_LANE))
       const x = await meta.getContext(c.req.param("id"))
       if (!x || x.agent_id !== agent.id) return bail(fail(c, 404, "not found"))
       // Liveness IS this poll — no heartbeat protocol. Stamp at most once a
@@ -1770,7 +1759,7 @@ export const contextRoutes = (ctx: AppContext) => {
   app.post("/v1/agent/sessions/:id/tool", async (c) => {
     const agent = await agentFor(c)
     if (!agent) return fail(c, 401, "agent token required")
-    if (isRunBearer(c)) return fail(c, 403, "a run token cannot act on a session")
+    if (isRunBearer(c)) return fail(c, 403, NOT_THIS_LANE)
     // A session capability bearer may act ONLY on the session it was minted for. A standing
     // agent bearer (the BYO polling runner) has no session scope, and is allowed here for
     // sessions of a context it owns — the ownership check below is what bounds it, exactly

--- a/apps/api/src/routes/contexts.ts
+++ b/apps/api/src/routes/contexts.ts
@@ -53,6 +53,7 @@ export const contextRoutes = (ctx: AppContext) => {
     meta,
     activeWorkspace,
     agentFor,
+    agentRunScope,
     agentSessionScope,
     authorize,
     bus,
@@ -68,6 +69,27 @@ export const contextRoutes = (ctx: AppContext) => {
     workspaceCan,
   } = ctx
   const app = new OpenAPIHono<BlankEnv>()
+
+  /**
+   * A pass minted for an automation RUN has no business in the session lane.
+   *
+   * The run lane has always checked this in the other direction (routes/automations.ts refuses a
+   * session token at claim, finish and tool). The session lane never got the mirror, and
+   * OWNERSHIP CANNOT COVER FOR IT: a context-bound automation runs AS the context's agent, so
+   * `context.agent_id === agent.id` is true for a run token aimed at any session of that
+   * context. The two kinds are cryptographically distinct, which stops a token verifying as the
+   * wrong kind — it does not stop the wrong kind being accepted where kind was never checked.
+   *
+   * Measured before this guard existed, with a `dkrun_` token against a session of its own
+   * context: the tool door executed a third-party call with the context's credential attached,
+   * the messages door posted and settled an answer in someone else's session, the state door
+   * failed that session out from under the executor that owned it, and the queue claimed
+   * sessions. The run's status did not matter — queued and running behaved identically.
+   *
+   * routes/model-credentials.ts is the precedent, including its reason: belonging to the same
+   * agent is not enough.
+   */
+  const isRunBearer = (c: Context): boolean => agentRunScope(c) !== null
 
   /** Is this workspace allowed to spend the operator's model key? See DERIVE_CHAT_ALLOWLIST. */
   const chatAllowed = (orgId: string): boolean =>
@@ -1386,6 +1408,7 @@ export const contextRoutes = (ctx: AppContext) => {
 
       const agent = await agentFor(c)
       if (agent) {
+        if (isRunBearer(c)) return bail(fail(c, 403, "a run token cannot act on a session"))
         if (!linked || agent.id !== linked.context.agent_id) return bail(fail(c, 404, "not found"))
         const gone = closed()
         if (gone) return bail(gone)
@@ -1546,6 +1569,7 @@ export const contextRoutes = (ctx: AppContext) => {
 
       const agent = await agentFor(c)
       if (agent) {
+        if (isRunBearer(c)) return bail(fail(c, 403, "a run token cannot act on a session"))
         if (agent.id !== linked.context.agent_id) return bail(fail(c, 404, "not found"))
         // The asker may close mid-run; the run's eventual failure must not reopen
         // a conversation they deliberately ended.
@@ -1601,6 +1625,9 @@ export const contextRoutes = (ctx: AppContext) => {
     async (c) => {
       const agent = await agentFor(c)
       if (!agent) return bail(fail(c, 401, "agent token required"))
+      // Reading this queue CLAIMS sessions (open → working), so a run's pass crossing here
+      // would quietly take over the ask lane's work.
+      if (isRunBearer(c)) return bail(fail(c, 403, "a run token cannot act on a session"))
       const x = await meta.getContext(c.req.param("id"))
       if (!x || x.agent_id !== agent.id) return bail(fail(c, 404, "not found"))
       // Liveness IS this poll — no heartbeat protocol. Stamp at most once a
@@ -1743,6 +1770,7 @@ export const contextRoutes = (ctx: AppContext) => {
   app.post("/v1/agent/sessions/:id/tool", async (c) => {
     const agent = await agentFor(c)
     if (!agent) return fail(c, 401, "agent token required")
+    if (isRunBearer(c)) return fail(c, 403, "a run token cannot act on a session")
     // A session capability bearer may act ONLY on the session it was minted for. A standing
     // agent bearer (the BYO polling runner) has no session scope, and is allowed here for
     // sessions of a context it owns — the ownership check below is what bounds it, exactly

--- a/apps/api/test/work-token-lanes.test.ts
+++ b/apps/api/test/work-token-lanes.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest"
+import { dispatchPass, type Substrate } from "../src/lib/dispatch"
+import { as, bearer, jsonAs, makeAuthedApp, publishAs, type TestUser } from "./helpers"
+
+// WORK-TOKEN LANES — a pass minted for one job may act on that job, in its own lane, and
+// nowhere else.
+//
+// Derive mints a short-lived capability token per work item: `dkrun_` for an automation run,
+// `dksess_` for one asked question. The run lane checks the kind explicitly at every door
+// (routes/automations.ts refuses a session token to claim, finish, or call a tool). The SESSION
+// lane never got the mirror, and ownership cannot cover for it: a context-bound automation runs
+// AS the context's agent, so `context.agent_id === agent.id` is TRUE for a run token aimed at
+// any session of that context. The lanes are cryptographically distinct, which stops a token
+// verifying as the wrong kind — it does not stop the wrong kind being accepted where kind was
+// never checked.
+//
+// The same lesson is already written down one file over, in routes/model-credentials.ts:
+// "belonging to the same agent is not enough".
+const SECRET = "test-secret-at-least-16-chars"
+
+describe("a run token cannot act in the session lane", () => {
+  const owner: TestUser = { id: "u_wt_own", email: "wtown@derive.test", name: "Owner" }
+  const { app, meta } = makeAuthedApp("work-token-lanes", [owner], "editor", {
+    deps: { encryptionKey: SECRET },
+  })
+
+  /** A context, plus an automation BOUND to it — so the automation's runs act as the context's
+   *  own agent, which is what makes this confusion reachable at all. */
+  const contextBoundAutomation = async () => {
+    // A real tool on the context, so a crossing at the tool door is OBSERVABLE: without a bound
+    // connection every call is refused as "tool not allowed" and a lane bug hides behind it.
+    const conn = (await (
+      await app.request(
+        "/v1/connections",
+        jsonAs(as(owner.email), {
+          toolkit: "game",
+          kind: "secret",
+          secret: "fixture-secret-value",
+          base_url: "https://api.game.test",
+          scope: "workspace",
+        }),
+      )
+    ).json()) as { id: string }
+    const manifest = await publishAs(app, "# How to answer", { title: "Lanes" }, as(owner.email))
+    const { short_id } = (await manifest.json()) as { short_id: string }
+    const ctx = (await (
+      await app.request(
+        "/v1/contexts",
+        jsonAs(as(owner.email), {
+          name: "Lanes",
+          manifest_short_id: short_id,
+          connection_ids: [conn.id],
+        }),
+      )
+    ).json()) as { id: string; agent_id: string; agent_token: string }
+    const auto = (await (
+      await app.request(
+        "/v1/automations",
+        jsonAs(as(owner.email), {
+          trigger: { kind: "manual" },
+          instruction: "Do the scheduled thing.",
+          // camelCase, and asserted below. Spelled `context_id` this silently binds NOTHING —
+          // zod strips unknown keys, a fresh managed agent is minted, and every crossing below
+          // then gets an honest 404 for the wrong reason. That typo cost a full debugging cycle.
+          contextId: ctx.id,
+        }),
+      )
+    ).json()) as { id: string; agent_id: string }
+    // The precondition that makes the confusion reachable at all: one agent, two lanes.
+    expect(auto.agent_id).toBe(ctx.agent_id)
+    await app.request(`/v1/automations/${auto.id}/run`, {
+      method: "POST",
+      headers: as(owner.email),
+    })
+    return { ctx, auto }
+  }
+
+  /** Drain dispatch and hand back the token it minted for one work item. Pass the literal
+   *  "*first-run*" to take whatever RUN it started first — used when the run id isn't known
+   *  yet, because learning it by claiming would consume the very run we want dispatched. */
+  const dispatchedTokenFor = async (workId: string) => {
+    const started: { runId: string; token: string }[] = []
+    const substrate: Substrate = {
+      name: "fake",
+      async start(input) {
+        started.push(input)
+      },
+    }
+    for (let pass = 0; pass < 6; pass++) {
+      await dispatchPass({
+        meta,
+        substrate,
+        server: "https://derive.test",
+        secret: SECRET,
+        perOrgLimit: 50,
+      })
+      const hit =
+        workId === "*first-run*"
+          ? started.find((s) => s.token.startsWith("dkrun_"))
+          : started.find((s) => s.runId === workId)
+      if (hit) return hit.token
+    }
+    return ""
+  }
+
+  it("is refused at the session tool door, the messages door, and the state door", async () => {
+    const { ctx, auto } = await contextBoundAutomation()
+    expect(auto.id).toBeTruthy()
+    // Let DISPATCH mint the run's pass — deliberately without claiming the run ourselves first,
+    // which would move it out of the queue dispatch draws from and leave us with no token to
+    // test the crossing with.
+    const runToken = await dispatchedTokenFor("*first-run*")
+
+    // A real session on the SAME context, so ownership checks will pass.
+    const ask = await app.request(
+      `/v1/contexts/${ctx.id}/sessions`,
+      jsonAs(as(owner.email), { body_md: "what is our refund rate?" }),
+    )
+    const session = ((await ask.json()) as { session: { id: string } }).session.id
+    const sessToken = await dispatchedTokenFor(session)
+    expect(sessToken).toBeTruthy()
+
+    // Only meaningful if we actually obtained a run-scoped pass; otherwise this test would
+    // pass vacuously and prove nothing.
+    if (!runToken) throw new Error("expected a dispatched run token to test the crossing with")
+    expect(runToken.startsWith("dkrun_")).toBe(true)
+    expect(sessToken.startsWith("dksess_")).toBe(true)
+
+    // 1. Tools. A run's pass must not reach a session's tool surface. Uses the context's REAL
+    //    tool: unfixed this returns 502 (`callTool` attached the decrypted credential and
+    //    actually attempted the outbound call), which is the crossing, visible.
+    const realFetch = globalThis.fetch
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ ok: 1 }), { status: 200 })) as typeof fetch
+    let tool: Response
+    try {
+      tool = await app.request(
+        `/v1/agent/sessions/${session}/tool`,
+        jsonAs(bearer(runToken), { tool: "game.get", args: { path: "/x" } }),
+      )
+    } finally {
+      globalThis.fetch = realFetch
+    }
+    expect([403, 404]).toContain(tool.status)
+    // Specifically NOT 200/502 — either would mean the call was executed.
+    expect(tool.status).not.toBe(200)
+
+    // 2. Settling. It must not answer somebody's question either — that would post an agent
+    //    message as this context and close the ask.
+    const answer = await app.request(
+      `/v1/sessions/${session}/messages`,
+      jsonAs(bearer(runToken), { body_md: "answered by the wrong lane", state: "answered" }),
+    )
+    expect([401, 403, 404]).toContain(answer.status)
+
+    // 3. State. Nor may it fail the session out from under the executor that owns it.
+    const patch = await app.request(`/v1/sessions/${session}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json", ...bearer(runToken) },
+      body: JSON.stringify({ state: "failed" }),
+    })
+    expect([401, 403, 404]).toContain(patch.status)
+
+    // 4. The queue. Crossing here CLAIMS sessions (open → working) as a side effect, so a run's
+    //    pass could quietly take over the ask lane's work.
+    const queue = await app.request(`/v1/contexts/${ctx.id}/queue`, { headers: bearer(runToken) })
+    expect([403, 404]).toContain(queue.status)
+
+    // CONTROL — the session's OWN pass still reaches the same tool door, so the refusals above
+    // are about the LANE and not about these routes being broken for everyone.
+    const realFetch2 = globalThis.fetch
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ ok: 1 }), { status: 200 })) as typeof fetch
+    let rightLane: Response
+    try {
+      rightLane = await app.request(
+        `/v1/agent/sessions/${session}/tool`,
+        jsonAs(bearer(sessToken), { tool: "game.get", args: { path: "/x" } }),
+      )
+    } finally {
+      globalThis.fetch = realFetch2
+    }
+    expect(rightLane.status).toBe(200)
+    // And its own queue read is served.
+    const ownQueue = await app.request(`/v1/contexts/${ctx.id}/queue`, {
+      headers: bearer(ctx.agent_token),
+    })
+    expect(ownQueue.status).toBe(200)
+  })
+})

--- a/apps/api/test/work-token-lanes.test.ts
+++ b/apps/api/test/work-token-lanes.test.ts
@@ -59,9 +59,9 @@ describe("a run token cannot act in the session lane", () => {
         jsonAs(as(owner.email), {
           trigger: { kind: "manual" },
           instruction: "Do the scheduled thing.",
-          // camelCase, and asserted below. Spelled `context_id` this silently binds NOTHING —
-          // zod strips unknown keys, a fresh managed agent is minted, and every crossing below
-          // then gets an honest 404 for the wrong reason. That typo cost a full debugging cycle.
+          // camelCase. Zod strips unknown keys, so `context_id` binds nothing, mints a fresh
+          // agent, and every crossing below then 404s for the wrong reason — hence the assertion
+          // on agent_id rather than trusting this line.
           contextId: ctx.id,
         }),
       )
@@ -75,10 +75,10 @@ describe("a run token cannot act in the session lane", () => {
     return { ctx, auto }
   }
 
-  /** Drain dispatch and hand back the token it minted for one work item. Pass the literal
-   *  "*first-run*" to take whatever RUN it started first — used when the run id isn't known
-   *  yet, because learning it by claiming would consume the very run we want dispatched. */
-  const dispatchedTokenFor = async (workId: string) => {
+  /** Drain dispatch (several passes: it starts at most `perOrgLimit` per pass, and this suite
+   *  leaves earlier work queued) and hand back everything it booted, with the token it minted
+   *  for each. */
+  const dispatchAll = async () => {
     const started: { runId: string; token: string }[] = []
     const substrate: Substrate = {
       name: "fake",
@@ -86,7 +86,7 @@ describe("a run token cannot act in the session lane", () => {
         started.push(input)
       },
     }
-    for (let pass = 0; pass < 6; pass++) {
+    for (let pass = 0; pass < 6; pass++)
       await dispatchPass({
         meta,
         substrate,
@@ -94,66 +94,65 @@ describe("a run token cannot act in the session lane", () => {
         secret: SECRET,
         perOrgLimit: 50,
       })
-      const hit =
-        workId === "*first-run*"
-          ? started.find((s) => s.token.startsWith("dkrun_"))
-          : started.find((s) => s.runId === workId)
-      if (hit) return hit.token
-    }
-    return ""
+    return started
   }
 
-  it("is refused at the session tool door, the messages door, and the state door", async () => {
-    const { ctx, auto } = await contextBoundAutomation()
-    expect(auto.id).toBeTruthy()
-    // Let DISPATCH mint the run's pass — deliberately without claiming the run ourselves first,
-    // which would move it out of the queue dispatch draws from and leave us with no token to
-    // test the crossing with.
-    const runToken = await dispatchedTokenFor("*first-run*")
+  /** The run token out of a dispatch sweep. Fails loudly rather than returning "" — an empty
+   *  token would make every refusal below pass for the wrong reason. */
+  const runTokenFrom = (started: { runId: string; token: string }[]): string => {
+    const hit = started.find((s) => s.token.startsWith("dkrun_"))
+    if (!hit) throw new Error("dispatch minted no run token; nothing to test the crossing with")
+    return hit.token
+  }
 
-    // A real session on the SAME context, so ownership checks will pass.
+  /** Run one request with `fetch` stubbed, so a tool call that gets past the door attempts a
+   *  real outbound call and returns 200 rather than a network error we would have to squint at. */
+  const withStubbedFetch = async (send: () => Promise<Response> | Response) => {
+    const real = globalThis.fetch
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ ok: 1 }), { status: 200 })) as typeof fetch
+    try {
+      return await send()
+    } finally {
+      globalThis.fetch = real
+    }
+  }
+
+  it("is refused at every session door its ownership check would otherwise let through", async () => {
+    const { ctx } = await contextBoundAutomation()
+    // Dispatch mints the run's pass. Deliberately not claimed first: claiming moves the run out
+    // of the queue dispatch draws from, leaving no token to test the crossing with.
+    const runToken = runTokenFrom(await dispatchAll())
+
     const ask = await app.request(
       `/v1/contexts/${ctx.id}/sessions`,
       jsonAs(as(owner.email), { body_md: "what is our refund rate?" }),
     )
     const session = ((await ask.json()) as { session: { id: string } }).session.id
-    const sessToken = await dispatchedTokenFor(session)
-    expect(sessToken).toBeTruthy()
+    const sessToken = (await dispatchAll()).find((s) => s.runId === session)?.token ?? ""
 
-    // Only meaningful if we actually obtained a run-scoped pass; otherwise this test would
-    // pass vacuously and prove nothing.
-    if (!runToken) throw new Error("expected a dispatched run token to test the crossing with")
+    // Both kinds in hand, or the refusals below prove nothing.
     expect(runToken.startsWith("dkrun_")).toBe(true)
     expect(sessToken.startsWith("dksess_")).toBe(true)
 
-    // 1. Tools. A run's pass must not reach a session's tool surface. Uses the context's REAL
-    //    tool: unfixed this returns 502 (`callTool` attached the decrypted credential and
-    //    actually attempted the outbound call), which is the crossing, visible.
-    const realFetch = globalThis.fetch
-    globalThis.fetch = (async () =>
-      new Response(JSON.stringify({ ok: 1 }), { status: 200 })) as typeof fetch
-    let tool: Response
-    try {
-      tool = await app.request(
+    // The context's real tool, so getting past the door executes an outbound call and returns
+    // 200 — the crossing is visible rather than hidden behind "tool not allowed".
+    const tool = await withStubbedFetch(() =>
+      app.request(
         `/v1/agent/sessions/${session}/tool`,
         jsonAs(bearer(runToken), { tool: "game.get", args: { path: "/x" } }),
-      )
-    } finally {
-      globalThis.fetch = realFetch
-    }
+      ),
+    )
     expect([403, 404]).toContain(tool.status)
-    // Specifically NOT 200/502 — either would mean the call was executed.
-    expect(tool.status).not.toBe(200)
 
-    // 2. Settling. It must not answer somebody's question either — that would post an agent
-    //    message as this context and close the ask.
+    // Answering: would post an agent message as this context and settle someone's ask.
     const answer = await app.request(
       `/v1/sessions/${session}/messages`,
       jsonAs(bearer(runToken), { body_md: "answered by the wrong lane", state: "answered" }),
     )
     expect([401, 403, 404]).toContain(answer.status)
 
-    // 3. State. Nor may it fail the session out from under the executor that owns it.
+    // State: would fail the session out from under the executor that owns it.
     const patch = await app.request(`/v1/sessions/${session}`, {
       method: "PATCH",
       headers: { "content-type": "application/json", ...bearer(runToken) },
@@ -161,27 +160,20 @@ describe("a run token cannot act in the session lane", () => {
     })
     expect([401, 403, 404]).toContain(patch.status)
 
-    // 4. The queue. Crossing here CLAIMS sessions (open → working) as a side effect, so a run's
-    //    pass could quietly take over the ask lane's work.
+    // The queue: reading it claims sessions (open → working), so crossing here takes over the
+    // ask lane's work.
     const queue = await app.request(`/v1/contexts/${ctx.id}/queue`, { headers: bearer(runToken) })
     expect([403, 404]).toContain(queue.status)
 
-    // CONTROL — the session's OWN pass still reaches the same tool door, so the refusals above
-    // are about the LANE and not about these routes being broken for everyone.
-    const realFetch2 = globalThis.fetch
-    globalThis.fetch = (async () =>
-      new Response(JSON.stringify({ ok: 1 }), { status: 200 })) as typeof fetch
-    let rightLane: Response
-    try {
-      rightLane = await app.request(
+    // The session's OWN pass still reaches both, so the refusals are about the lane and not
+    // about these routes being broken for everyone.
+    const rightLane = await withStubbedFetch(() =>
+      app.request(
         `/v1/agent/sessions/${session}/tool`,
         jsonAs(bearer(sessToken), { tool: "game.get", args: { path: "/x" } }),
-      )
-    } finally {
-      globalThis.fetch = realFetch2
-    }
+      ),
+    )
     expect(rightLane.status).toBe(200)
-    // And its own queue read is served.
     const ownQueue = await app.request(`/v1/contexts/${ctx.id}/queue`, {
       headers: bearer(ctx.agent_token),
     })

--- a/apps/api/test/work-token-lanes.test.ts
+++ b/apps/api/test/work-token-lanes.test.ts
@@ -17,6 +17,9 @@ import { as, bearer, jsonAs, makeAuthedApp, publishAs, type TestUser } from "./h
 // The same lesson is already written down one file over, in routes/model-credentials.ts:
 // "belonging to the same agent is not enough".
 const SECRET = "test-secret-at-least-16-chars"
+/** The refusal the guard gives. Asserted rather than just the status, so a 403 arriving for some
+ *  unrelated reason cannot stand in for the lane check. */
+const LANE = "a run token cannot act on a session"
 
 describe("a run token cannot act in the session lane", () => {
   const owner: TestUser = { id: "u_wt_own", email: "wtown@derive.test", name: "Owner" }
@@ -131,8 +134,7 @@ describe("a run token cannot act in the session lane", () => {
     const session = ((await ask.json()) as { session: { id: string } }).session.id
     const sessToken = (await dispatchAll()).find((s) => s.runId === session)?.token ?? ""
 
-    // Both kinds in hand, or the refusals below prove nothing.
-    expect(runToken.startsWith("dkrun_")).toBe(true)
+    // `runTokenFrom` already guaranteed the run kind; this is the one that can come back empty.
     expect(sessToken.startsWith("dksess_")).toBe(true)
 
     // The context's real tool, so getting past the door executes an outbound call and returns
@@ -143,14 +145,16 @@ describe("a run token cannot act in the session lane", () => {
         jsonAs(bearer(runToken), { tool: "game.get", args: { path: "/x" } }),
       ),
     )
-    expect([403, 404]).toContain(tool.status)
+    expect(tool.status).toBe(403)
+    expect(await tool.text()).toContain(LANE)
 
     // Answering: would post an agent message as this context and settle someone's ask.
     const answer = await app.request(
       `/v1/sessions/${session}/messages`,
       jsonAs(bearer(runToken), { body_md: "answered by the wrong lane", state: "answered" }),
     )
-    expect([401, 403, 404]).toContain(answer.status)
+    expect(answer.status).toBe(403)
+    expect(await answer.text()).toContain(LANE)
 
     // State: would fail the session out from under the executor that owns it.
     const patch = await app.request(`/v1/sessions/${session}`, {
@@ -158,12 +162,14 @@ describe("a run token cannot act in the session lane", () => {
       headers: { "content-type": "application/json", ...bearer(runToken) },
       body: JSON.stringify({ state: "failed" }),
     })
-    expect([401, 403, 404]).toContain(patch.status)
+    expect(patch.status).toBe(403)
+    expect(await patch.text()).toContain(LANE)
 
     // The queue: reading it claims sessions (open → working), so crossing here takes over the
     // ask lane's work.
     const queue = await app.request(`/v1/contexts/${ctx.id}/queue`, { headers: bearer(runToken) })
-    expect([403, 404]).toContain(queue.status)
+    expect(queue.status).toBe(403)
+    expect(await queue.text()).toContain(LANE)
 
     // The session's OWN pass still reaches both, so the refusals are about the lane and not
     // about these routes being broken for everyone.


### PR DESCRIPTION
Four session-lane endpoints accept a `dkrun_` capability token today. Small diff, security fix, no feature — the credential-delivery work this was found alongside is still parked and unmerged.

## What's wrong

The run lane checks token *kind* at every door: `routes/automations.ts` refuses a `dksess_` token at claim, finish and tool, with a comment explaining that the two kinds being cryptographically distinct only stops a token *verifying* as the wrong kind — not the wrong kind being *accepted* where kind was never checked.

The session lane never got the mirror. And ownership can't cover for it: a **context-bound automation runs as the context's agent** (`automations.ts`: `agentId = b.agentId ?? boundContext?.agent_id`), so `context.agent_id === agent.id` is **true** for a run token aimed at any session of that context.

Measured on `main` with a `dkrun_` token against a session of its own context:

| Door | Result before this fix |
|---|---|
| `POST /v1/agent/sessions/:id/tool` | Executed a third-party call **with the context's decrypted credential attached** |
| `POST /v1/sessions/:id/messages` | `201` — posted and settled an answer in a session it doesn't own |
| `PATCH /v1/sessions/:id` | `200` — failed that session out from under the executor that owns it |
| `GET /v1/contexts/:id/queue` | `200`, and reading it **claims** sessions `open → working` |

Run status was irrelevant — queued and running behaved identically.

**Why it matters past a tenant boundary:** a hosted container's model process holds `DERIVE_TOKEN` (`substrate-container.ts` passes it in, and the runner's `stripModelTokens` doesn't strip it), so one prompt injection in content an agent reads reaches all four doors.

## The fix

One predicate in `routes/contexts.ts` — `isRunBearer(c) => agentRunScope(c) !== null` — applied at all four, mirroring `automations.ts`'s `isSessionBearer`. `routes/model-credentials.ts` is the precedent, including its reason: *belonging to the same agent is not enough.* Humans are unaffected (a signed-in user has no run scope), so the guard sits at the top of the agent branch on the two routes that serve both.

## The test, and a warning inside it

`work-token-lanes.test.ts` asserts the crossing is refused at all four doors **and** that the session's own token still reaches the tool door and the queue — so it can't pass by these routes simply being broken for everyone. It uses the context's *real* bound tool, because with nothing bound every call is refused as "tool not allowed" and a lane bug hides behind that.

It also asserts the precondition (`auto.agent_id === ctx.agent_id`) with a comment saying why: my first version wrote `context_id` where the schema says `contextId`. Zod strips unknown keys, so nothing bound, a fresh managed agent was minted, and every crossing returned an honest `404`. **That version passed against unfixed code and proved nothing** — I only caught it because the test was supposed to fail first and didn't.

## Verification

Test fails on `main`, passes with the fix. Full local gates green: typecheck, biome, the custom lints (schema, api, surfaces, deadcode, boundaries), and every suite (api 1796, core 470, cli 188, db 302, web 207, mcp 34, broker 42, facts 65).

## Not in scope

The remaining findings from the same review — including delivery's own version of this bug, which is confined to the unmerged endpoint — are written up in [The key-delivery build, and why I stopped](https://derive.to/artifacts/the-key-delivery-build-and-why-i-stopped-b1o76d88).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788097985&installation_model_id=428097&pr_number=601&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F601&signature=b3140b5bc9ab824a9b90af50c7884ccf9d2be605d4a0f93d3394b51c68d1fe77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->