### PR TITLE
fix(slack): name the rung when a link preview is withheld

### DIFF
--- a/apps/api/src/routes/slack.ts
+++ b/apps/api/src/routes/slack.ts
@@ -128,23 +128,31 @@ export const slackRoutes = (ctx: AppContext) => {
   // the link; that's what an unlinked sharer gets, since without a link there is no principal to
   // authorize against.
   const unfurlSharedLinks = async (teamId: string, ev: SlackEventPayload): Promise<void> => {
+    // Every exit below is silent by design — Slack is told nothing, so the channel shows nothing.
+    // That is correct behaviour and undiagnosable behaviour at the same time: "I pasted a link
+    // and got no preview" has eight possible causes here and, without this, no way to tell them
+    // apart short of reasoning through the ladder. One line naming the rung turns that into a
+    // log search. Info, not warn: most of these are the system working.
+    const why = (reason: string, extra: Record<string, unknown> = {}) =>
+      log.info("unfurl skipped", { reason, team: teamId, channel: ev.channel, ...extra })
+
     const links = (ev.links ?? []).slice(0, 10) // one paste shouldn't fan out unbounded
-    if (!links.length || !ev.user) return
+    if (!links.length || !ev.user) return why(!ev.user ? "no sharer on the event" : "no links")
     // Slack dispatches link_shared for EVERY channel in the workspace, not just the ones the bot
     // is in. Unfurling everywhere would put an artifact's title wherever any member happened to
     // paste a link — so this stays where an admin has actually invited Derive, which is the same
     // consent boundary the channel subscriptions use. Absent (older payloads) is treated as
     // present so this can't silently disable previews.
-    if (ev.is_bot_user_member === false) return
+    if (ev.is_bot_user_member === false) return why("bot is not in this channel")
     const installs = await meta.listSlackInstallsByTeam(teamId)
-    if (!installs.length) return
+    if (!installs.length) return why("no Derive workspace is connected to this Slack team")
     const userLink = await meta.getSlackUserLinkBySlackId(teamId, ev.user)
     // One Slack team can back more than one Derive workspace; unfurl into the sharer's own when
     // we know it, else the sole/first install for the team.
     const install = installs.find((i) => i.org_id === userLink?.org_id) ?? installs[0]
-    if (!install) return
+    if (!install) return why("no install resolved for the team")
     const bot = await resolveBotToken(meta, install.org_id, deps.encryptionKey)
-    if (!bot) return
+    if (!bot) return why("no usable bot token", { org: install.org_id })
     const target = {
       channel: ev.channel,
       ts: ev.message_ts,
@@ -155,7 +163,8 @@ export const slackRoutes = (ctx: AppContext) => {
     // Not linked: prompt once, and only when they actually shared an artifact link — a paste of
     // some other page on our domain shouldn't nag them to connect an account.
     if (!userLink) {
-      if (!links.some((l) => artifactRefFromUrl(deps.baseUrl, l.url))) return
+      if (!links.some((l) => artifactRefFromUrl(deps.baseUrl, l.url)))
+        return why("sharer has no linked Derive account, and no link was an artifact")
       await unfurlSlackLinks(
         bot.token,
         target,
@@ -181,8 +190,18 @@ export const slackRoutes = (ctx: AppContext) => {
         userLink.user_id,
       )
       if (d.kind === "card") unfurls[d.url] = { blocks: d.blocks }
+      // `skip` is the ladder's catch-all — not ours, gone, another workspace, or not readable by
+      // this viewer — and it is the rung that most often surprises someone. Naming the URL is
+      // what makes it actionable.
+      else why(`decision: ${d.kind}`, { url: l.url, viewer: userLink.user_id })
     }
-    if (Object.keys(unfurls).length) await unfurlSlackLinks(bot.token, target, unfurls)
+    if (!Object.keys(unfurls).length) return why("no link produced a card", { links: links.length })
+    await unfurlSlackLinks(bot.token, target, unfurls)
+    log.info("unfurl sent", {
+      team: teamId,
+      channel: ev.channel,
+      count: Object.keys(unfurls).length,
+    })
   }
 
   interface ConnectState {


### PR DESCRIPTION
> "i didnt get anything though, not even a sign in thing"

Diagnosing that from outside took a Cloudflare log tail, a manifest export, a channel-membership check — and I still guessed wrong twice.

`unfurlSharedLinks` has **eight silent exits**, and Slack is told nothing in every one, so the channel shows nothing:

- no links on the event, or no sharer
- the bot isn't in that channel
- no Derive workspace connected to the team
- no install resolved
- no usable bot token
- the sharer has no linked account *and* pasted nothing artifact-shaped
- every URL came back `skip` from the decision ladder

All correct behaviour. All indistinguishable from a break.

A real paste produced three `200`s at `/v1/slack/events` with no exception — which told me the event arrived and nothing more. I couldn't tell whether it was skipped at the channel gate, answered with a sign-in prompt, or declined by the ladder.

Each exit now names itself, with the URL and viewer on a decision so it's actionable:

```
unfurl skipped  { reason: "bot is not in this channel", team, channel }
unfurl skipped  { reason: "decision: skip", url, viewer, team, channel }
unfurl sent     { team, channel, count: 1 }
```

`info`, not `warn` — most of these are the system working. An unfurl declined for a channel Derive was never invited to is a consent boundary being enforced, not a fault. The success line matters too: its absence separates *"never reached this code"* from *"reached it and declined"*, which is exactly the distinction I couldn't make.

Same shape and same reason as the mirror-withheld log in #602. A deliberate refusal that leaves no trace reads as a bug, and costs an hour every time.

No behaviour change — every branch returns exactly what it returned before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788104137&installation_model_id=428097&pr_number=603&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F603&signature=b3b02f85fa7a4b4b1c394941e1f3f771f885fa46260d74ab5dc00ef588f5609a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->