### PR TITLE
fix(slack): log what Slack actually sent to /v1/slack/events

### DIFF
--- a/apps/api/src/routes/slack.ts
+++ b/apps/api/src/routes/slack.ts
@@ -386,6 +386,21 @@ export const slackRoutes = (ctx: AppContext) => {
     if (body.type === "url_verification") return c.json({ challenge: body.challenge })
 
     const ev = body.event
+    // What Slack ACTUALLY sent. Every branch below is conditional on `ev.type`, and every
+    // non-match falls through to a bare ok — so an event we don't handle, or one that arrives
+    // in a shape a condition rejects, is indistinguishable from an event that never arrived.
+    // That cost a long afternoon: link previews were silent, and the only way to ask "is Slack
+    // even sending link_shared?" was to reason backwards from the absence of a downstream log.
+    // One line makes it a fact. Cheap — Slack events are not high-frequency — and the shape
+    // fields are here because a rejected condition is as interesting as an unknown type.
+    log.info("slack event", {
+      type: body.type,
+      event: ev?.type,
+      team: body.team_id ?? null,
+      channel: ev?.channel ?? null,
+      user: ev?.user ?? null,
+      links: ev?.links?.length ?? 0,
+    })
     // Install lifecycle: the app was removed, or a token was revoked. Flag the affected installs
     // for re-auth and let the Settings banner ask for a reconnect. Flag rather than delete — the
     // members' account links must survive, and a reconnect then restores service without redoing


### PR DESCRIPTION
Every branch in the events handler is conditional on `ev.type`, and anything matching none of them falls through to a bare `ok`. So three different situations look identical from outside:

- an event we don't handle
- an event that arrives in a shape one of those conditions rejects (`ev.user` missing, say)
- an event that never arrived at all

Distinguishing them is precisely what an afternoon of debugging link previews turned on. Slack was delivering to the endpoint — `200`s, no exceptions, three deliveries per paste — and the only way to ask *"is it sending `link_shared`?"* was to reason backwards from the absence of a downstream log, then eliminate causes one reinstall at a time.

What made it worse: the app config was **provably correct** throughout, verified field by field against Slack's own `apps.manifest.export`:

```
unfurl_domains   ["derive.to"]
bot_events       …, link_shared, …
bot scopes       links:read, links:write
request_url      https://derive.to/v1/slack/events
```

Correct config plus silence is harder to diagnose than a visible error, because every hypothesis you can form is already contradicted.

One line per inbound event, carrying the shape fields the conditions actually read — `ev.user` or `links` being absent is invisible otherwise, and a rejected condition is as interesting as an unknown type:

```
slack event { type: "event_callback", event: "message", team: "T0…", channel: "C0…", user: "U0…", links: 0 }
```

Volume is fine; Slack events aren't high-frequency, and this is the endpoint's single most useful fact.

Third in the same series as #602 and #603 — a silent path that's correct by design and undiagnosable in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788105584&installation_model_id=428097&pr_number=604&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F604&signature=5250902c53c9803e734a15d9affcdfa6a7f4d1299e6831c9ca5047477ea6737e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->