### PR TITLE
refactor(library): take tags out of the UI, keep the machinery

### DIFF
--- a/apps/web/e2e/library-multi-select.smoke.spec.ts
+++ b/apps/web/e2e/library-multi-select.smoke.spec.ts
@@ -10,7 +10,7 @@ import { expect, publishArtifact, test } from "./fixtures"
  *
  * The mobile block is not a duplicate of the desktop one: it pins the two things that a
  * hover-built selection UI gets wrong on a phone — a checkbox that only appears on hover
- * (there is no hover), and a four-action bar that silently overflows a 375px viewport.
+ * (there is no hover), and an action bar that silently overflows a 375px viewport.
  */
 
 // Publish n artifacts and land on the library with all of them on screen.
@@ -25,58 +25,6 @@ async function seedLibrary(page: Parameters<typeof publishArtifact>[0], n: numbe
   }
   return ids
 }
-
-test("select cards, tag the set, and the tags land on every artifact", async ({ owner }) => {
-  const [a, b, c] = await seedLibrary(owner, 3)
-
-  // No selection, no bar — the library is a gallery until you say otherwise.
-  await expect(owner.getByTestId("library-selection-bar")).toBeHidden()
-
-  await owner.getByTestId(`artifact-card-select-${a}`).click()
-  await owner.getByTestId(`artifact-card-select-${b}`).click()
-
-  await expect(owner.getByTestId("library-selection-bar")).toBeVisible()
-  await expect(owner.getByTestId("library-selection-count")).toHaveText("2")
-
-  await owner.getByTestId("library-selection-tags").click()
-  await owner.getByTestId("bulk-tag-input").fill("q3")
-  await owner.getByTestId("bulk-tag-stage").click()
-  await owner.getByTestId("bulk-tag-apply").click()
-
-  await expect(owner.getByText("Tagged 2 artifacts")).toBeVisible()
-  // The write cleared the selection, so the bar retires on its own.
-  await expect(owner.getByTestId("library-selection-bar")).toBeHidden()
-
-  // The real assertion: the server says both artifacts carry the tag, and the third —
-  // never selected — was not touched.
-  for (const id of [a, b]) {
-    const res = await owner.request.get(`/v1/artifacts/${id}`)
-    expect(res.ok()).toBeTruthy()
-    expect(((await res.json()) as { tags: string[] }).tags).toContain("q3")
-  }
-  const untouched = await owner.request.get(`/v1/artifacts/${c}`)
-  expect(((await untouched.json()) as { tags: string[] }).tags).not.toContain("q3")
-})
-
-test("tagging a set MERGES — it never replaces the tags an artifact already has", async ({
-  owner,
-}) => {
-  const [a] = await seedLibrary(owner, 2)
-  // Pre-existing tag, set the way the single-artifact dialog would.
-  await owner.request.put(`/v1/artifacts/${a}/tags`, { data: { tags: ["keepme"] } })
-  await owner.reload()
-
-  await owner.getByTestId(`artifact-card-select-${a}`).click()
-  await owner.getByTestId("library-selection-tags").click()
-  await owner.getByTestId("bulk-tag-input").fill("added")
-  await owner.getByTestId("bulk-tag-stage").click()
-  await owner.getByTestId("bulk-tag-apply").click()
-  await expect(owner.getByText("Tagged 1 artifact")).toBeVisible()
-
-  // Both, not just the new one — the bulk path unions against each artifact's own set.
-  const tags = (await (await owner.request.get(`/v1/artifacts/${a}`)).json()) as { tags: string[] }
-  expect(tags.tags.sort()).toEqual(["added", "keepme"])
-})
 
 test("shift-click selects the range between two cards", async ({ owner }) => {
   const [a, , c] = await seedLibrary(owner, 3)
@@ -215,27 +163,32 @@ test.describe("mobile", () => {
     )
     expect(overflows, "the library must not scroll horizontally").toBe(false)
 
-    // All four actions are reachable — they collapse to icons, they don't disappear into
+    // Every action is reachable — they collapse to icons, they don't disappear into
     // an overflow menu.
-    for (const id of ["tags", "collections", "favorite", "delete"]) {
+    for (const id of ["collections", "favorite", "delete"]) {
       await expect(owner.getByTestId(`library-selection-${id}`)).toBeVisible()
     }
   })
 
-  test("the full tag flow works on a phone", async ({ owner }) => {
+  test("the full add-to-collection flow works on a phone", async ({ owner }) => {
     const [a, b] = await seedLibrary(owner, 2)
 
     await owner.getByTestId(`artifact-card-select-${a}`).tap()
     await owner.getByTestId(`artifact-card-select-${b}`).tap()
-    await owner.getByTestId("library-selection-tags").tap()
-    await owner.getByTestId("bulk-tag-input").fill("mobile")
-    await owner.getByTestId("bulk-tag-stage").tap()
-    await owner.getByTestId("bulk-tag-apply").tap()
+    await owner.getByTestId("library-selection-collections").tap()
+    await owner.getByTestId("bulk-collection-new-input").fill("Mobile")
+    await owner.getByTestId("bulk-collection-create").tap()
+    await owner.getByTestId("bulk-collection-apply").tap()
 
-    await expect(owner.getByText("Tagged 2 artifacts")).toBeVisible()
-    for (const id of [a, b]) {
-      const res = await owner.request.get(`/v1/artifacts/${id}`)
-      expect(((await res.json()) as { tags: string[] }).tags).toContain("mobile")
+    await expect(owner.getByText("Added 2 artifacts")).toBeVisible()
+    const cols = (await (await owner.request.get("/v1/collections")).json()) as {
+      collections: { id: string; title: string }[]
     }
+    const col = cols.collections.find((x) => x.title === "Mobile")
+    expect(col, "the collection was created").toBeTruthy()
+    const listed = (await (
+      await owner.request.get(`/v1/artifacts?collection=${col?.id}`)
+    ).json()) as { artifacts: { short_id: string }[] }
+    expect(listed.artifacts.map((x) => x.short_id).sort()).toEqual([a, b].sort())
   })
 })

--- a/apps/web/e2e/screens/multiselect.screens.ts
+++ b/apps/web/e2e/screens/multiselect.screens.ts
@@ -34,20 +34,6 @@ test.describe("multiselect screens", () => {
     await owner.screenshot({ path: `${OUT}/desktop-dark.png` })
   })
 
-  test("desktop — the add-tags dialog", async ({ owner }) => {
-    await owner.setViewportSize({ width: 1280, height: 900 })
-    const ids = await seed(owner, ["Q3 Roadmap", "Launch Brief", "Retro Notes"])
-    await owner.getByTestId(`artifact-card-select-${ids[0]}`).click()
-    await owner.getByTestId(`artifact-card-select-${ids[1]}`).click()
-    await owner.getByTestId("library-selection-tags").click()
-    await owner.getByTestId("bulk-tag-input").fill("q3")
-    await owner.getByTestId("bulk-tag-stage").click()
-    await owner.getByTestId("bulk-tag-input").fill("planning")
-    await owner.getByTestId("bulk-tag-stage").click()
-    await owner.getByTestId("bulk-tag-apply").waitFor()
-    await owner.screenshot({ path: `${OUT}/desktop-tags-dialog.png` })
-  })
-
   test("mobile — checkboxes + collapsed bar", async ({ owner }) => {
     await owner.setViewportSize({ width: 390, height: 844 })
     const ids = await seed(owner, ["Q3 Roadmap", "Launch Brief", "Retro Notes"])

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -608,7 +608,6 @@ export const api = {
   listArtifacts: (
     params?: {
       q?: string
-      tag?: string
       collection?: string
       favorite?: boolean
       /** Narrow to artifacts last changed by this GitHub login. */
@@ -636,7 +635,6 @@ export const api = {
   }> => {
     const qs = new URLSearchParams()
     if (params?.q) qs.set("query", params.q)
-    if (params?.tag) qs.set("tag", params.tag)
     if (params?.collection) qs.set("collection", params.collection)
     if (params?.favorite) qs.set("favorite", "true")
     if (params?.author) qs.set("author", params.author)
@@ -816,16 +814,11 @@ export const api = {
 
   favorite: (id: string, on: boolean): Promise<{ favorite: boolean }> =>
     f(`/v1/artifacts/${id}/favorite`, { ...opts(), method: on ? "PUT" : "DELETE" }).then(j),
-  setTags: (id: string, tags: string[]): Promise<{ tags: string[] }> =>
-    f(`/v1/artifacts/${id}/tags`, { ...opts({ tags }), method: "PUT" }).then(j),
 
   // Bulk organize — the library multi-select bar. Each is ONE call over a set of
   // short_ids; the server authorizes every artifact on its own and returns a
   // {ok, skipped, failed} tally (skipped = not yours to touch), so the client sends the
-  // whole selection and shows what actually landed. Tags ADD (never replace); the server
-  // computes the per-artifact union, so the client sends only the tags to add.
-  bulkTags: (shortIds: string[], add: string[]): Promise<BulkSummary> =>
-    f("/v1/bulk/tags", opts({ shortIds, add })).then(j),
+  // whole selection and shows what actually landed.
   bulkFavorite: (shortIds: string[], favorite: boolean): Promise<BulkSummary> =>
     f("/v1/bulk/favorite", opts({ shortIds, favorite })).then(j),
   bulkAddToCollections: (shortIds: string[], collectionIds: string[]): Promise<BulkSummary> =>

--- a/apps/web/src/components/chrome/nav-rail.tsx
+++ b/apps/web/src/components/chrome/nav-rail.tsx
@@ -344,7 +344,7 @@ export function RailSkeleton() {
 // recessed surface (bg-sidebar, distinct from the content canvas); inactive rows
 // sit dim and the active row lifts off it as a raised chip (ui/sidebar). Reads as
 // calm tiers top to bottom: brand + search → primary nav → your library
-// (collections + tags) → tools → account — separated by whitespace, not dividers.
+// (collections) → tools → account — separated by whitespace, not dividers.
 export function NavRail() {
   const { switchWorkspace } = useShell()
   const { me, loading } = useAuth()
@@ -372,9 +372,9 @@ export function NavRail() {
   const loc = useLocation()
   const search = loc.search as LibrarySearch
   const onLibrary = loc.pathname === "/"
-  // Feeds are routes now; the home library reads "active > All" only when no tag/
-  // collection filter narrows it. (A ?query= search doesn't change which feed you're in.)
-  const isAll = onLibrary && !search.tag && !search.collection
+  // Feeds are routes now; the home library reads "active > All" only when no collection
+  // filter narrows it. (A ?query= search doesn't change which feed you're in.)
+  const isAll = onLibrary && !search.collection
   const isFav = loc.pathname === "/favorites"
   const onShared = loc.pathname === "/shared"
   // People + its Activity sub-view (the /following feed) are one tab; the row lights for both.
@@ -382,7 +382,6 @@ export function NavRail() {
   const onContexts = loc.pathname.startsWith("/contexts")
   const onBrandprint = loc.pathname === "/brandprint"
   const onSettings = loc.pathname.startsWith("/settings")
-  const tags = summary?.tags ?? []
 
   // Picking a destination on mobile closes the drawer (no-op on desktop).
   const closeMobile = () => setOpenMobile(false)
@@ -709,27 +708,6 @@ export function NavRail() {
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>
-
-        {tags.length > 0 && (
-          <SidebarGroup className="group-data-[collapsible=icon]:hidden">
-            <SidebarGroupLabel>Tags</SidebarGroupLabel>
-            <SidebarGroupContent>
-              <SidebarMenu>
-                {tags.map(({ tag, count }) => (
-                  <FilterItem
-                    key={tag}
-                    icon="tag"
-                    label={tag}
-                    count={count}
-                    search={{ tag }}
-                    active={onLibrary && search.tag === tag}
-                    testId={`sidebar-tag-${tag}`}
-                  />
-                ))}
-              </SidebarMenu>
-            </SidebarGroupContent>
-          </SidebarGroup>
-        )}
 
         {/* Tools — a running sync, notifications, Settings. Pinned to the foot of
             the scroll (mt-auto); the whitespace above sets them apart, no divider. */}

--- a/apps/web/src/components/icons.tsx
+++ b/apps/web/src/components/icons.tsx
@@ -49,7 +49,6 @@ import {
   Smile,
   Sparkles,
   Star,
-  Tag,
   Trash2,
   User,
   Users,
@@ -74,7 +73,6 @@ const REG = {
   context: Bot,
   // Brandprint — the brand's fingerprint.
   brandprint: Fingerprint,
-  tag: Tag,
   search: Search,
   settings: Settings,
   // pod / workspace

--- a/apps/web/src/components/shared/organize-dialogs.tsx
+++ b/apps/web/src/components/shared/organize-dialogs.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react"
 import { api, type Collection } from "@/api"
 import { Icon } from "@/components/icons"
-import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -16,13 +15,11 @@ import { useApiMutation } from "@/lib/use-api-mutation"
 import { useBrandprintCollectionIds } from "@/lib/use-brandprint-ids"
 import { cn } from "@/lib/utils"
 
-// The two "organize" dialogs, shared by the artifact workbench's ⋯ menu and the
-// library cards' quick-actions menu. Both own their API calls and report the new
-// state through `onChange`; the caller keeps the cache writes.
-
-// Collections dialog: toggle this artifact in/out of collections, or create one on
-// the fly. Adding to a shared collection grants its members their role on this
-// artifact too. Opened from a ⋯ menu (controlled).
+// The "organize" dialog, shared by the artifact workbench's ⋯ menu and the library
+// cards' quick-actions menu (controlled by both): toggle this artifact in/out of
+// collections, or create one on the fly. Adding to a shared collection grants its members
+// their role on this artifact too. Owns its API calls and reports the new state through
+// `onChange`; the caller keeps the cache writes.
 export function CollectionsDialog({
   shortId,
   inCollections,
@@ -142,103 +139,6 @@ export function CollectionsDialog({
             Add
           </Button>
         </div>
-      </DialogContent>
-    </Dialog>
-  )
-}
-
-// Tags dialog: view tags; editors add/remove. Writes replace the full set (the
-// server normalizes: trim, lowercase, dedupe, cap). Opened from a ⋯ menu.
-export function TagsDialog({
-  shortId,
-  tags,
-  canEdit,
-  onChange,
-  open,
-  onOpenChange,
-}: {
-  shortId: string
-  tags: string[]
-  canEdit: boolean
-  onChange: (t: string[]) => void
-  open: boolean
-  onOpenChange: (o: boolean) => void
-}) {
-  const [draft, setDraft] = useState("")
-  // Replace the tag set optimistically; the primitive rolls back + toasts on failure —
-  // the old hand-rolled save toasted but never reverted the optimistic change.
-  const saveTags = useApiMutation({
-    mutationFn: (next: string[]) => api.setTags(shortId, next),
-    optimistic: (next) => {
-      const prev = tags
-      onChange(next)
-      return () => onChange(prev)
-    },
-    onSuccess: (r) => onChange(r.tags),
-  })
-  const save = (next: string[]) => saveTags.mutate(next)
-  const add = () => {
-    const v = draft.trim().toLowerCase()
-    setDraft("")
-    if (v && !tags.includes(v)) save([...tags, v])
-  }
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Tags</DialogTitle>
-          <DialogDescription>
-            Workspace-wide labels for finding this artifact later.
-          </DialogDescription>
-        </DialogHeader>
-        {tags.length === 0 && (
-          <div className="text-sm text-muted-foreground">
-            {canEdit ? "No tags yet — add one below." : "No tags."}
-          </div>
-        )}
-        {tags.length > 0 && (
-          <div className="flex flex-wrap gap-1.5">
-            {tags.map((t) => (
-              <Badge key={t} variant="outline" className="gap-1">
-                #{t}
-                {canEdit && (
-                  <button
-                    type="button"
-                    data-icon="inline-end"
-                    data-testid={`tag-remove-${t}`}
-                    onClick={() => save(tags.filter((x) => x !== t))}
-                    aria-label={`Remove ${t}`}
-                    className="rounded-sm outline-none hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
-                  >
-                    <Icon name="close" size={12} />
-                  </button>
-                )}
-              </Badge>
-            ))}
-          </div>
-        )}
-        {canEdit && (
-          <div className="flex gap-1.5">
-            <Input
-              value={draft}
-              placeholder="Add a tag…"
-              data-testid="tag-new-input"
-              onChange={(e) => setDraft(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") add()
-              }}
-            />
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={add}
-              disabled={!draft.trim()}
-              data-testid="tag-add"
-            >
-              Add
-            </Button>
-          </div>
-        )}
       </DialogContent>
     </Dialog>
   )

--- a/apps/web/src/components/showcase/showcase.tsx
+++ b/apps/web/src/components/showcase/showcase.tsx
@@ -198,7 +198,6 @@ const TINTS = [
   { cls: "bg-collection", label: "collection" },
   { cls: "bg-share", label: "share" },
   { cls: "bg-comments", label: "comments" },
-  { cls: "bg-tag", label: "tag" },
   { cls: "bg-gold", label: "gold" },
 ]
 
@@ -256,7 +255,6 @@ const ICONS: IconName[] = [
   "favorites",
   "following",
   "collections",
-  "tag",
   "search",
   "settings",
   "user",

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -59,11 +59,10 @@ export const workspacesQuery = () =>
 const LIBRARY_PAGE = 30
 
 // The library list as an infinite query: each page is a keyset slice, and the
-// next cursor drives infinite scroll. Keyed by the active filter (search / tag /
+// next cursor drives infinite scroll. Keyed by the active filter (search /
 // collection / favorites) so each view caches independently.
 export type LibraryParams = {
   q?: string
-  tag?: string
   collection?: string
   favorite?: boolean
   // Narrow to artifacts last changed by this GitHub login.

--- a/apps/web/src/pages/artifact/artifact-top-bar.tsx
+++ b/apps/web/src/pages/artifact/artifact-top-bar.tsx
@@ -2,7 +2,7 @@ import { Maximize2, MousePointer2Off, Zap } from "lucide-react"
 import { useState } from "react"
 import type { CollectionGrant, LinkRole, Listed, Role, WorkspaceAccess } from "@/api"
 import { Icon } from "@/components/icons"
-import { CollectionsDialog, TagsDialog } from "@/components/shared/organize-dialogs"
+import { CollectionsDialog } from "@/components/shared/organize-dialogs"
 import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
@@ -25,7 +25,7 @@ import { ShareButton } from "./share-dialog"
  *   [ Share · ★ · ⋯ ]        [ comments ]
  *     actions cluster          the discussion panel toggle (terminal)
  * The filled-ink Share leads as the one primary; the favorited star is glanceable
- * state; the ⋯ holds everything else (Focus/Present, Tags/Collections, Insights/
+ * state; the ⋯ holds everything else (Focus/Present, Collections, Insights/
  * History/Proposals, Edit/Lock/Report). Comments hugs the panel it opens. Presence +
  * the cursor picker are the ambient cluster the page renders ahead of this. Props-
  * driven; the page keeps the cache writes.
@@ -43,11 +43,9 @@ export function ArtifactTopBar(props: {
   passwordProtected?: boolean
   publicHistory?: boolean
   favorite: boolean
-  tags: string[]
   collections: string[]
   /** Collections whose sharing reaches this artifact — the share dialog's disclosure rows. */
   collectionAccess: CollectionGrant[]
-  canEditTags: boolean
   openProposals: number
   proposalsTotal: number
   isMobile: boolean
@@ -73,7 +71,6 @@ export function ArtifactTopBar(props: {
    *  tab, so both gates come from one fetch. */
   automateBeta: boolean
   onFavorite: (fav: boolean) => void
-  onTags: (tags: string[]) => void
   onCollections: (ids: string[]) => void
   onInsights: () => void
   onHistory: () => void
@@ -89,7 +86,6 @@ export function ArtifactTopBar(props: {
   const { shortId, openProposals, proposalsTotal } = props
   const { pref: cursorPref, setPref: setCursorPref } = useCursorPref()
   const [reportOpen, setReportOpen] = useState(false)
-  const [tagsOpen, setTagsOpen] = useState(false)
   const [collectionsOpen, setCollectionsOpen] = useState(false)
   const [moveOpen, setMoveOpen] = useState(false)
   const [automateOpen, setAutomateOpen] = useState(false)
@@ -166,15 +162,7 @@ export function ArtifactTopBar(props: {
             </DropdownMenuCheckboxItem>
             <DropdownMenuSeparator />
 
-            {/* Organize — open as dialogs. */}
-            <DropdownMenuItem data-testid="artifact-tags" onSelect={() => setTagsOpen(true)}>
-              <Icon name="tag" size={16} /> Tags
-              {props.tags.length > 0 && (
-                <span className="ml-auto font-mono text-2xs tabular-nums text-muted-foreground">
-                  {props.tags.length}
-                </span>
-              )}
-            </DropdownMenuItem>
+            {/* Organize — opens as a dialog. */}
             <DropdownMenuItem
               data-testid="artifact-collections"
               onSelect={() => setCollectionsOpen(true)}
@@ -264,14 +252,6 @@ export function ArtifactTopBar(props: {
       )}
 
       {/* Portaled dialogs — invisible until opened from the ⋯ menu. */}
-      <TagsDialog
-        shortId={shortId}
-        tags={props.tags}
-        canEdit={props.canEditTags}
-        onChange={props.onTags}
-        open={tagsOpen}
-        onOpenChange={setTagsOpen}
-      />
       <CollectionsDialog
         shortId={shortId}
         inCollections={props.collections}

--- a/apps/web/src/pages/artifact/header-actions.tsx
+++ b/apps/web/src/pages/artifact/header-actions.tsx
@@ -24,8 +24,8 @@ import { useApiMutation } from "@/lib/use-api-mutation"
 
 // Favorite is the one property kept VISIBLE in the header — the filled star is a
 // glanceable state (you see at a glance that this artifact is starred), and a
-// sanctioned ink moment. Everything else (tags, collections, report) opens from the
-// ⋯ menu as a dialog; the tags/collections dialogs live in
+// sanctioned ink moment. Everything else (collections, report) opens from the
+// ⋯ menu as a dialog; the collections dialog lives in
 // components/shared/organize-dialogs (shared with the library's quick actions).
 export function StarButton({
   shortId,

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -636,7 +636,7 @@ export function Artifact() {
   const isDeckLike = !!deck || art.current_content_type === "text/x-derive-deck"
   // A logged-out visitor on a public/link artifact: strictly view-only. They get
   // the document + live presence/cursors (Google-Docs style) and nothing else —
-  // no favorite, tags, collections, share, report, comments, or version tools.
+  // no favorite, collections, share, report, comments, or version tools.
   // The API gates every one of those for anon (anonLocked); hiding them here keeps
   // the chrome honest so there's no dead/forbidden affordance to bump into.
   const isAnon = !me
@@ -874,10 +874,8 @@ export function Artifact() {
               passwordProtected={!!art.password_protected}
               publicHistory={!!art.public_history}
               favorite={!!art.favorite}
-              tags={art.tags ?? []}
               collections={art.collections ?? []}
               collectionAccess={art.collection_access ?? []}
-              canEditTags={art.my_role === "editor" || art.my_role === "owner"}
               openProposals={art.open_proposals ?? 0}
               proposalsTotal={art.proposals_total ?? 0}
               isMobile={isMobile}
@@ -905,9 +903,6 @@ export function Artifact() {
                 qc.setQueryData(artifactQuery(shortId).queryKey, (a) =>
                   a ? { ...a, favorite: fav } : a,
                 )
-              }
-              onTags={(tags) =>
-                qc.setQueryData(artifactQuery(shortId).queryKey, (a) => (a ? { ...a, tags } : a))
               }
               onCollections={(collections) =>
                 // Pure cache write — CollectionsDialog calls this during its OPTIMISTIC

--- a/apps/web/src/pages/library/artifact-card.tsx
+++ b/apps/web/src/pages/library/artifact-card.tsx
@@ -28,14 +28,12 @@ import { ProposalSignal } from "./proposal-signal"
 // accent (a persistent "needs you" state) shows at rest.
 //
 // Stretched-link pattern: the open button's ::after covers the whole card (preview
-// included), while the actions / author / tag chips sit above it (z-20) and stay
-// independently clickable.
+// included), while the actions and author sit above it (z-20) and stay independently
+// clickable.
 export function ArtifactCard({
   artifact: a,
   onOpen,
   onToggleFavorite,
-  onPickTag,
-  onEditTags,
   onAddToCollection,
   onDelete,
   onPrefetch,
@@ -46,11 +44,9 @@ export function ArtifactCard({
   artifact: Artifact
   onOpen: () => void
   onToggleFavorite: () => void
-  onPickTag: (tag: string) => void
-  // Quick actions in the ⋯ menu — organize without opening the artifact. Tags
-  // are gated per-item (owner/editor), collections apply to any signed-in
-  // viewer (you're organizing your collections, not mutating the artifact).
-  onEditTags?: () => void
+  // Quick action in the ⋯ menu — organize without opening the artifact.
+  // Collections apply to any signed-in viewer (you're organizing your
+  // collections, not mutating the artifact).
   onAddToCollection?: () => void
   onDelete?: () => void
   // Warm the artifact (metadata + comments + rendered HTML) when the card is
@@ -67,15 +63,13 @@ export function ArtifactCard({
 }) {
   const titleRef = useRef<HTMLSpanElement>(null)
   const isOwner = a.my_role === "owner"
-  const showTags = !!onEditTags && (a.my_role === "owner" || a.my_role === "editor")
   const showDelete = isOwner && !!onDelete
-  const showMenu = showTags || !!onAddToCollection || showDelete
+  const showMenu = !!onAddToCollection || showDelete
   const author = a.author ?? null
   const hasAuthor = !!(author?.name || author?.login || a.author_login || a.author_name)
   const updated = a.updated_at ?? a.created_at ?? a.versions[0]?.created_at
   const versionDepth = Math.max(a.current_version, a.versions.length)
   const sourceDir = a.source_path ? dirOf(a.source_path) : ""
-  const tags = a.tags ?? []
   const isPrivate = a.workspace_access === "none" && (a.link_role ?? "none") === "none"
   // Proposals you can act on (owner/editor) are a "needs you" signal — they soft-ink
   // the card edge (the `i_participated` tier) and the review count.
@@ -168,17 +162,7 @@ export function ArtifactCard({
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent onClick={(e) => e.stopPropagation()}>
-                {/* Same organize order as the workbench ⋯ menu: Tags, then
-                    Add to collection; Delete stays last behind a separator. */}
-                {showTags && (
-                  <DropdownMenuItem
-                    data-testid={`artifact-card-tags-${a.short_id}`}
-                    onSelect={() => onEditTags?.()}
-                  >
-                    <Icon name="tag" size={16} />
-                    Tags
-                  </DropdownMenuItem>
-                )}
+                {/* Delete stays last, behind a separator — same as the workbench ⋯ menu. */}
                 {onAddToCollection && (
                   <DropdownMenuItem
                     data-testid={`artifact-card-collections-${a.short_id}`}
@@ -190,7 +174,7 @@ export function ArtifactCard({
                 )}
                 {showDelete && (
                   <>
-                    {(showTags || onAddToCollection) && <DropdownMenuSeparator />}
+                    {onAddToCollection && <DropdownMenuSeparator />}
                     <DropdownMenuItem
                       data-testid={`artifact-card-delete-${a.short_id}`}
                       variant="destructive"
@@ -323,45 +307,6 @@ export function ArtifactCard({
             )}
           </span>
         </div>
-
-        {tags.length > 0 && (
-          // One row only — chips are `nowrap` + clipped so a heavily-tagged artifact
-          // can't grow the card taller than its siblings. First three are interactive
-          // filter chips; a trailing "+N" counts the rest.
-          <div className="relative z-20 flex min-w-0 items-center gap-1.5 overflow-hidden">
-            {tags.slice(0, 3).map((t) => (
-              <Badge
-                key={t}
-                asChild
-                variant="outline"
-                className="max-w-32 shrink-0 border-border-soft px-1.5 font-mono text-2xs text-muted-foreground hover:border-foreground/25 hover:text-foreground"
-              >
-                <button
-                  type="button"
-                  data-testid={`artifact-card-tag-${t}`}
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    onPickTag(t)
-                  }}
-                >
-                  <span className="truncate">#{t}</span>
-                </button>
-              </Badge>
-            ))}
-            {tags.length > 3 && (
-              <Badge
-                variant="outline"
-                className="shrink-0 border-border-soft px-1.5 font-mono text-2xs text-muted-foreground/70"
-                title={tags
-                  .slice(3)
-                  .map((t) => `#${t}`)
-                  .join(" ")}
-              >
-                +{tags.length - 3}
-              </Badge>
-            )}
-          </div>
-        )}
       </CardContent>
     </Card>
   )

--- a/apps/web/src/pages/library/artifact-grid.tsx
+++ b/apps/web/src/pages/library/artifact-grid.tsx
@@ -27,8 +27,6 @@ export function ArtifactGrid({
   onLoadMore,
   onOpen,
   onToggleFavorite,
-  onPickTag,
-  onEditTags,
   onAddToCollection,
   onDelete,
   onPrefetch,
@@ -42,8 +40,6 @@ export function ArtifactGrid({
   onLoadMore: () => void
   onOpen: (a: Artifact) => void
   onToggleFavorite: (a: Artifact) => void
-  onPickTag: (tag: string) => void
-  onEditTags: (a: Artifact) => void
   onAddToCollection: (a: Artifact) => void
   onDelete: (a: Artifact) => void
   onPrefetch: (a: Artifact) => void
@@ -127,8 +123,6 @@ export function ArtifactGrid({
                 artifact={a}
                 onOpen={() => onOpen(a)}
                 onToggleFavorite={() => onToggleFavorite(a)}
-                onPickTag={onPickTag}
-                onEditTags={() => onEditTags(a)}
                 onAddToCollection={() => onAddToCollection(a)}
                 onDelete={() => onDelete(a)}
                 onPrefetch={() => onPrefetch(a)}

--- a/apps/web/src/pages/library/artifact-row.tsx
+++ b/apps/web/src/pages/library/artifact-row.tsx
@@ -21,16 +21,14 @@ import { ProposalSignal } from "./proposal-signal"
 /**
  * A compact list row for the library (the default for collections / synced repos,
  * where a flat thumbnail grid is noise for hundreds of docs). Reads top-to-bottom:
- * title, when it was last updated, then a meta line of type + folder location + tags.
+ * title, when it was last updated, then a meta line of type + folder location.
  * Same stretched-link + independently-clickable-controls pattern as ArtifactCard.
  */
 export function ArtifactRow({
   artifact: a,
   onOpen,
   onToggleFavorite,
-  onPickTag,
   onPickAuthor,
-  onEditTags,
   onAddToCollection,
   onDelete,
   onPrefetch,
@@ -41,14 +39,12 @@ export function ArtifactRow({
   artifact: Artifact
   onOpen: () => void
   onToggleFavorite: () => void
-  onPickTag: (tag: string) => void
   // Clicking the author filters the list by their GitHub login. Omit to render
   // the author as a non-filtering chip (still links to a known profile).
   onPickAuthor?: (login: string) => void
-  // Quick actions in the ⋯ menu — organize without opening the artifact. Tags
-  // are gated per-item (owner/editor), collections apply to any signed-in
-  // viewer (you're organizing your collections, not mutating the artifact).
-  onEditTags?: () => void
+  // Quick action in the ⋯ menu — organize without opening the artifact.
+  // Collections apply to any signed-in viewer (you're organizing your
+  // collections, not mutating the artifact).
   onAddToCollection?: () => void
   onDelete?: () => void
   onPrefetch?: () => void
@@ -59,12 +55,10 @@ export function ArtifactRow({
   onSelect?: (shift: boolean) => void
 }) {
   const isOwner = a.my_role === "owner"
-  const showTags = !!onEditTags && (a.my_role === "owner" || a.my_role === "editor")
   const showDelete = isOwner && !!onDelete
-  const showMenu = showTags || !!onAddToCollection || showDelete
+  const showMenu = !!onAddToCollection || showDelete
   const updated = a.updated_at ?? a.created_at ?? a.versions[0]?.created_at
   const dir = a.source_path ? dirOf(a.source_path) : ""
-  const tags = a.tags ?? []
   // "Who last changed this": prefer the resolved author (carries the Derive handle),
   // fall back to the denormalized fields. Present only for synced artifacts.
   const author = a.author ?? null
@@ -174,32 +168,6 @@ export function ArtifactRow({
         </div>
       )}
 
-      {/* Tags sit above the stretched link so they stay independently clickable.
-          Badges rendered as buttons (asChild) — same chip grammar as ArtifactCard. */}
-      {tags.length > 0 && (
-        <div className="relative z-20 hidden max-w-2/5 flex-wrap justify-end gap-1.5 sm:flex">
-          {tags.slice(0, 4).map((t) => (
-            <Badge
-              key={t}
-              asChild
-              variant="outline"
-              className="px-1.5 font-mono text-2xs hover:border-foreground/25 hover:text-foreground"
-            >
-              <button
-                type="button"
-                data-testid={`artifact-row-tag-${t}`}
-                onClick={(e) => {
-                  e.stopPropagation()
-                  onPickTag(t)
-                }}
-              >
-                #{t}
-              </button>
-            </Badge>
-          ))}
-        </div>
-      )}
-
       <Button
         size="icon"
         variant="outline"
@@ -244,17 +212,7 @@ export function ArtifactRow({
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent onClick={(e) => e.stopPropagation()}>
-            {/* Same organize order as the workbench ⋯ menu: Tags, then
-                Add to collection; Delete stays last behind a separator. */}
-            {showTags && (
-              <DropdownMenuItem
-                data-testid={`artifact-row-tags-${a.short_id}`}
-                onSelect={() => onEditTags?.()}
-              >
-                <Icon name="tag" size={16} />
-                Tags
-              </DropdownMenuItem>
-            )}
+            {/* Delete stays last, behind a separator — same as the workbench ⋯ menu. */}
             {onAddToCollection && (
               <DropdownMenuItem
                 data-testid={`artifact-row-collections-${a.short_id}`}
@@ -266,7 +224,7 @@ export function ArtifactRow({
             )}
             {showDelete && (
               <>
-                {(showTags || onAddToCollection) && <DropdownMenuSeparator />}
+                {onAddToCollection && <DropdownMenuSeparator />}
                 <DropdownMenuItem
                   data-testid={`artifact-row-delete-${a.short_id}`}
                   variant="destructive"

--- a/apps/web/src/pages/library/bulk-organize.tsx
+++ b/apps/web/src/pages/library/bulk-organize.tsx
@@ -4,7 +4,6 @@ import { useState } from "react"
 import { type Artifact, api, type Folder } from "@/api"
 import { Icon } from "@/components/icons"
 import { StatusPanel } from "@/components/shared/status-panel"
-import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -15,152 +14,17 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
-import {
-  artifactQuery,
-  collectionFoldersQuery,
-  collectionsQuery,
-  summaryQuery,
-} from "@/lib/queries"
+import { artifactQuery, collectionFoldersQuery, collectionsQuery } from "@/lib/queries"
 import { useApiMutation } from "@/lib/use-api-mutation"
 import { useBrandprintCollectionIds } from "@/lib/use-brandprint-ids"
 import { cn } from "@/lib/utils"
 import { summarize } from "./bulk-apply"
 
-// The two organize dialogs in their MANY-artifact form, opened from the selection bar.
-// They mirror the single-artifact dialogs in components/shared/organize-dialogs (same
-// grammar, same API calls) with one deliberate difference: they ADD, never replace.
-// Applying "#q3" to eight artifacts must not flatten the tags the other seven already
-// carry — so tags are merged per artifact, and collections are only ever added to.
-
-// The artifacts a bulk write will touch, and the ones it will pass over. Every dialog
-// states this up front: a bulk write should never be a surprise.
-function ScopeLine({ count, skipped }: { count: number; skipped: number }) {
-  if (skipped === 0) return null
-  return (
-    <p className="text-sm text-muted-foreground">
-      {count} of {count + skipped} selected — {skipped} you can’t edit will be skipped.
-    </p>
-  )
-}
-
-export function BulkTagsDialog({
-  items,
-  skipped,
-  listKey,
-  onDone,
-  open,
-  onOpenChange,
-}: {
-  // The full selection — the server authorizes each artifact and skips what the caller
-  // can't edit. `skipped` is the caller's own pre-action estimate for the preview line.
-  items: Artifact[]
-  skipped: number
-  listKey: QueryKey
-  onDone: () => void
-  open: boolean
-  onOpenChange: (o: boolean) => void
-}) {
-  const [draft, setDraft] = useState("")
-  const [adding, setAdding] = useState<string[]>([])
-
-  const apply = useApiMutation({
-    // One call over the whole selection: the server ADDS the tags to each artifact's
-    // existing set (computing the union itself, so the client sends only the tags to add)
-    // and authorizes every artifact on its own — anything the caller can't edit comes back
-    // in `skipped`. Normalization (lowercase, dedupe, cap 20) is the server's too.
-    mutationFn: (tags: string[]) =>
-      api.bulkTags(
-        items.map((a) => a.short_id),
-        tags,
-      ),
-    invalidate: [
-      listKey,
-      summaryQuery().queryKey,
-      ...items.map((a) => artifactQuery(a.short_id).queryKey),
-    ],
-    success: (r) => summarize("Tagged", r),
-    onSuccess: onDone,
-  })
-
-  const stage = () => {
-    const v = draft.trim().toLowerCase()
-    setDraft("")
-    if (v && !adding.includes(v)) setAdding((prev) => [...prev, v])
-  }
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Add tags</DialogTitle>
-          <DialogDescription>
-            Tags are added to each artifact’s existing set — nothing is replaced.
-          </DialogDescription>
-        </DialogHeader>
-        <ScopeLine count={items.length} skipped={skipped} />
-        {adding.length > 0 && (
-          <div className="flex flex-wrap gap-1.5">
-            {adding.map((t) => (
-              <Badge key={t} variant="outline" className="gap-1">
-                #{t}
-                <button
-                  type="button"
-                  data-icon="inline-end"
-                  data-testid={`bulk-tag-remove-${t}`}
-                  onClick={() => setAdding((prev) => prev.filter((x) => x !== t))}
-                  aria-label={`Remove ${t}`}
-                  className="rounded-sm outline-none hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
-                >
-                  <Icon name="close" size={12} />
-                </button>
-              </Badge>
-            ))}
-          </div>
-        )}
-        <div className="flex gap-1.5">
-          <Input
-            value={draft}
-            placeholder="Add a tag…"
-            data-testid="bulk-tag-input"
-            onChange={(e) => setDraft(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") stage()
-            }}
-          />
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={stage}
-            disabled={!draft.trim()}
-            data-testid="bulk-tag-stage"
-          >
-            Add
-          </Button>
-        </div>
-        <DialogFooter>
-          <Button
-            variant="outline"
-            size="sm"
-            data-testid="bulk-tag-cancel"
-            onClick={() => onOpenChange(false)}
-          >
-            Cancel
-          </Button>
-          <Button
-            size="sm"
-            data-testid="bulk-tag-apply"
-            disabled={adding.length === 0 || apply.isPending}
-            onClick={() => apply.mutate(adding)}
-          >
-            {apply.isPending
-              ? "Tagging…"
-              : `Tag ${items.length} ${items.length === 1 ? "artifact" : "artifacts"}`}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  )
-}
+// The organize dialogs in their MANY-artifact form, opened from the selection bar. Same
+// grammar and endpoints as the single-artifact dialog in shared/organize-dialogs, with one
+// safeguard: adding to a collection never removes, so a mis-click on a 30-artifact
+// selection costs a cleanup, not data. (Folders are single-valued and don't get that
+// guarantee — see BulkFolderDialog.)
 
 // Move the selected artifacts INTO a folder of the current collection (or unfile them).
 // One target folder for the whole selection; applies per item (folder membership is

--- a/apps/web/src/pages/library/collection-folders.tsx
+++ b/apps/web/src/pages/library/collection-folders.tsx
@@ -23,8 +23,6 @@ import type { LibrarySelection } from "./use-library-selection"
 interface CardHandlers {
   onOpen: (a: Artifact) => void
   onToggleFavorite: (a: Artifact) => void
-  onPickTag: (tag: string) => void
-  onEditTags: (a: Artifact) => void
   onAddToCollection: (a: Artifact) => void
   onDelete: (a: Artifact) => void
   onPrefetch: (a: Artifact) => void
@@ -355,8 +353,6 @@ function Section({
                 artifact={a}
                 onOpen={() => handlers.onOpen(a)}
                 onToggleFavorite={() => handlers.onToggleFavorite(a)}
-                onPickTag={handlers.onPickTag}
-                onEditTags={() => handlers.onEditTags(a)}
                 onAddToCollection={() => handlers.onAddToCollection(a)}
                 onDelete={() => handlers.onDelete(a)}
                 onPrefetch={() => handlers.onPrefetch(a)}

--- a/apps/web/src/pages/library/folder-groups.tsx
+++ b/apps/web/src/pages/library/folder-groups.tsx
@@ -14,9 +14,7 @@ import type { LibrarySelection } from "./use-library-selection"
 interface Handlers {
   onOpen: (a: Artifact) => void
   onToggleFavorite: (a: Artifact) => void
-  onPickTag: (tag: string) => void
   onPickAuthor: (login: string) => void
-  onEditTags: (a: Artifact) => void
   onAddToCollection: (a: Artifact) => void
   onDelete: (a: Artifact) => void
   onPrefetch: (a: Artifact) => void
@@ -149,9 +147,7 @@ function FolderSection({
               artifact={a}
               onOpen={() => handlers.onOpen(a)}
               onToggleFavorite={() => handlers.onToggleFavorite(a)}
-              onPickTag={handlers.onPickTag}
               onPickAuthor={handlers.onPickAuthor}
-              onEditTags={() => handlers.onEditTags(a)}
               onAddToCollection={() => handlers.onAddToCollection(a)}
               onDelete={() => handlers.onDelete(a)}
               onPrefetch={() => handlers.onPrefetch(a)}

--- a/apps/web/src/pages/library/index.tsx
+++ b/apps/web/src/pages/library/index.tsx
@@ -44,7 +44,7 @@ import { FollowingStrip } from "./following-strip"
 import { HowItWorks } from "./how-it-works"
 import { LibrarySkeleton } from "./library-skeleton"
 import { PublishCard } from "./publish-card"
-import { LibraryCollectionsDialog, LibraryTagsDialog } from "./quick-organize"
+import { LibraryCollectionsDialog } from "./quick-organize"
 import { RepoPullRequests } from "./repo-pull-requests"
 import { SelectionBar } from "./selection-bar"
 import { ShareCollectionDialog } from "./share-collection-dialog"
@@ -56,7 +56,7 @@ import { type LibrarySelection, useLibrarySelection } from "./use-library-select
 
 // The library surface, shared by five routes: "/" (your work), "/favorites",
 // "/following", "/shared", and "/feedback". The base feed comes from the route (the
-// `view` prop); the tag/collection/author filters + free-text search come from the URL
+// `view` prop); the collection/author filters + free-text search come from the URL
 // query. The persistent AppShell owns the rail/pod + auth gate, so this renders the
 // library body only. Reconceived from a 660-line god-component: the feed + its optimistic
 // mutations live in useLibraryFeed; the promoted "needs feedback" / "shared" card-strips
@@ -79,8 +79,8 @@ function scopeFor(view: LibraryView) {
 }
 
 // The active filter = the base feed (from the route: `view`) unless it's the home
-// library, where a tag/collection query param narrows it. The named feeds are their own
-// routes, so their filters (tag/collection) can't apply.
+// library, where a collection query param narrows it. The named feeds are their own
+// routes, so their collection filter can't apply.
 function deriveFilter(
   view: LibraryView,
   search: LibrarySearch,
@@ -91,7 +91,6 @@ function deriveFilter(
   if (view === "shared") return { kind: "shared" }
   if (view === "feedback") return { kind: "feedback" }
   if (search.tab === "mine") return { kind: "mine" }
-  if (search.tag) return { kind: "tag", tag: search.tag }
   if (search.collection)
     return {
       kind: "collection",
@@ -126,7 +125,7 @@ function LibraryBody({ view }: { view: LibraryView }) {
   // Reflect the SETTLED search in the URL so a filtered library is shareable/deep-linkable —
   // the field seeds FROM ?query= above but must also write back. `replace` so keystrokes
   // don't stack history; the guard skips a no-op nav (and its re-render loop). Keeps the
-  // current route (one of five feeds) and the other params (tag/collection/author).
+  // current route (one of five feeds) and the other params (collection/author).
   useEffect(() => {
     if (debouncedQ === (search.query ?? "").trim()) return
     nav({
@@ -146,7 +145,6 @@ function LibraryBody({ view }: { view: LibraryView }) {
   // all in the feed hook, keyed by the active filter.
   const params = {
     q: debouncedQ || undefined,
-    tag: search.tag,
     collection: search.collection,
     favorite: view === "favorites" || undefined,
     author: search.author,
@@ -262,30 +260,11 @@ function LibraryBody({ view }: { view: LibraryView }) {
   // Destructive intent is confirmed in the shared ConfirmDialog — rows only stage here.
   const [pendingDelete, setPendingDelete] = useState<Artifact | null>(null)
 
-  // Quick organize from the card ⋯ menu (edit tags / add to collection). The dialogs own
-  // the API calls and report the result here; these handlers sync the caches that render
-  // the artifact's tags/collections — the CURRENT view's feed page + the artifact detail —
-  // plus the rail counts. The named-feed caches (/shared, /feedback) aren't synced: they're
-  // not the visible view, and refetchOnMount:"always" makes them fresh on navigation.
-  const [pendingTags, setPendingTags] = useState<Artifact | null>(null)
+  // Quick organize from the card ⋯ menu. The dialog owns the API call and reports the
+  // result here; this syncs what a membership change affects — the artifact detail, and
+  // the rail's per-collection counts. Feed cards don't render collections, so the list
+  // caches are left alone.
   const [pendingCollections, setPendingCollections] = useState<Artifact | null>(null)
-  const tagsChanged = (shortId: string, tags: string[]) => {
-    qc.setQueryData(listQuery.queryKey, (old) =>
-      old
-        ? {
-            ...old,
-            pages: old.pages.map((pg) => ({
-              ...pg,
-              artifacts: pg.artifacts.map((x) => (x.short_id === shortId ? { ...x, tags } : x)),
-            })),
-          }
-        : old,
-    )
-    qc.setQueryData(artifactQuery(shortId).queryKey, (a) => (a ? { ...a, tags } : a))
-    // Tag counts in the rail come from the summary.
-    qc.invalidateQueries({ queryKey: summaryQuery().queryKey })
-    if (filter.kind === "tag") qc.invalidateQueries({ queryKey: listQuery.queryKey })
-  }
   const collectionsChanged = (shortId: string, ids: string[]) => {
     qc.setQueryData(artifactQuery(shortId).queryKey, (a) => (a ? { ...a, collections: ids } : a))
     // Collection counts in the rail.
@@ -321,7 +300,7 @@ function LibraryBody({ view }: { view: LibraryView }) {
 
   // The home greeting + publish launcher + the quiet triage line span BOTH home tabs
   // ("All artifacts" / "Created by me") — the tab only filters the grid, it doesn't
-  // leave home. Searching or a tag/collection filter drops the home chrome.
+  // leave home. Searching or a collection filter drops the home chrome.
   const homeView = (filter.kind === "all" || filter.kind === "mine") && !isSearching
   const { data: feedbackData } = useQuery({ ...needsFeedbackArtifactsQuery(), enabled: homeView })
   const feedbackCount = feedbackData?.length ?? 0
@@ -356,10 +335,8 @@ function LibraryBody({ view }: { view: LibraryView }) {
               ? "Needs your feedback"
               : filter.kind === "mine"
                 ? "Created by me"
-                : filter.kind === "tag"
-                  ? `#${filter.tag}`
-                  : collectionTitle
-  // The tab names the view — a tag, a collection, Favorites, Created by me… —
+                : collectionTitle
+  // The tab names the view — a collection, Favorites, Created by me… —
   // while the unfiltered home stays plain "Derive".
   useDocumentTitle(filter.kind === "all" ? null : heading)
   // Only the counts the server can state authoritatively (preloaded summary / the
@@ -373,18 +350,12 @@ function LibraryBody({ view }: { view: LibraryView }) {
         ? summary?.favorites
         : filter.kind === "mine"
           ? summary?.mine
-          : filter.kind === "tag"
-            ? summary?.tags.find((t) => t.tag === filter.tag)?.count
-            : filter.kind === "collection"
-              ? activeCollection?.count
-              : undefined
+          : filter.kind === "collection"
+            ? activeCollection?.count
+            : undefined
 
   const showPublish =
-    !isSearching &&
-    (filter.kind === "all" ||
-      filter.kind === "mine" ||
-      filter.kind === "tag" ||
-      filter.kind === "favorites")
+    !isSearching && (filter.kind === "all" || filter.kind === "mine" || filter.kind === "favorites")
 
   const emptyProps = emptyStateFor(filter, isSearching, debouncedQ, nav)
   // The first-run guide is for a genuinely blank home (your work is empty and you're not
@@ -444,20 +415,14 @@ function LibraryBody({ view }: { view: LibraryView }) {
           hotkey
           className="min-w-50 flex-1"
         />
-        {(filter.kind === "tag" || filter.kind === "collection") && (
+        {filter.kind === "collection" && (
           <Button
             variant="outline"
             size="sm"
             data-testid="library-clear-filter"
             onClick={() => nav({ to: "/", search: {} })}
           >
-            {filter.kind === "tag" ? (
-              `#${filter.tag}`
-            ) : (
-              <>
-                <Icon name="collection" size={16} /> {collectionTitle}
-              </>
-            )}
+            <Icon name="collection" size={16} /> {collectionTitle}
             <Icon name="close" size={16} />
           </Button>
         )}
@@ -613,9 +578,7 @@ function LibraryBody({ view }: { view: LibraryView }) {
             nav({ to: "/artifacts/$ref", params: { ref: refFor(a) }, search: openContext })
           }
           onToggleFavorite={toggleFavorite}
-          onPickTag={(tag) => nav({ to: "/", search: { tag } })}
           onPickAuthor={pickAuthor}
-          onEditTags={setPendingTags}
           onAddToCollection={setPendingCollections}
           onDelete={setPendingDelete}
           onPrefetch={(a) => prefetch(a.short_id, a.current_version)}
@@ -639,8 +602,6 @@ function LibraryBody({ view }: { view: LibraryView }) {
               nav({ to: "/artifacts/$ref", params: { ref: refFor(a) }, search: openContext })
             }
             onToggleFavorite={toggleFavorite}
-            onPickTag={(tag) => nav({ to: "/", search: { tag } })}
-            onEditTags={setPendingTags}
             onAddToCollection={setPendingCollections}
             onDelete={setPendingDelete}
             onPrefetch={(a) => prefetch(a.short_id, a.current_version)}
@@ -658,8 +619,6 @@ function LibraryBody({ view }: { view: LibraryView }) {
                 nav({ to: "/artifacts/$ref", params: { ref: refFor(a) }, search: openContext })
               }
               onToggleFavorite={toggleFavorite}
-              onPickTag={(tag) => nav({ to: "/", search: { tag } })}
-              onEditTags={setPendingTags}
               onAddToCollection={setPendingCollections}
               onDelete={setPendingDelete}
               onPrefetch={(a) => prefetch(a.short_id, a.current_version)}
@@ -689,8 +648,6 @@ function LibraryBody({ view }: { view: LibraryView }) {
               nav({ to: "/artifacts/$ref", params: { ref: refFor(a) }, search: openContext })
             }
             onToggleFavorite={toggleFavorite}
-            onPickTag={(tag) => nav({ to: "/", search: { tag } })}
-            onEditTags={setPendingTags}
             onAddToCollection={setPendingCollections}
             onDelete={setPendingDelete}
             onPrefetch={(a) => prefetch(a.short_id, a.current_version)}
@@ -734,14 +691,7 @@ function LibraryBody({ view }: { view: LibraryView }) {
           if (pendingDelete) deleteArtifact(pendingDelete)
         }}
       />
-      {/* Quick-organize dialogs — opened from a card/row ⋯ menu (edit tags / collections). */}
-      {pendingTags && (
-        <LibraryTagsDialog
-          artifact={pendingTags}
-          onChange={tagsChanged}
-          onClose={() => setPendingTags(null)}
-        />
-      )}
+      {/* Quick-organize dialog — opened from a card/row ⋯ menu. */}
       {pendingCollections && (
         <LibraryCollectionsDialog
           artifact={pendingCollections}
@@ -765,9 +715,7 @@ function SyncedCollection({
   onLoadMore,
   onOpen,
   onToggleFavorite,
-  onPickTag,
   onPickAuthor,
-  onEditTags,
   onAddToCollection,
   onDelete,
   onPrefetch,
@@ -781,9 +729,7 @@ function SyncedCollection({
   onLoadMore: () => void
   onOpen: (a: Artifact) => void
   onToggleFavorite: (a: Artifact) => void
-  onPickTag: (tag: string) => void
   onPickAuthor: (login: string) => void
-  onEditTags: (a: Artifact) => void
   onAddToCollection: (a: Artifact) => void
   onDelete: (a: Artifact) => void
   onPrefetch: (a: Artifact) => void
@@ -817,9 +763,7 @@ function SyncedCollection({
           onLoadMore={onLoadMore}
           onOpen={onOpen}
           onToggleFavorite={onToggleFavorite}
-          onPickTag={onPickTag}
           onPickAuthor={onPickAuthor}
-          onEditTags={onEditTags}
           onAddToCollection={onAddToCollection}
           onDelete={onDelete}
           onPrefetch={onPrefetch}
@@ -833,9 +777,7 @@ function SyncedCollection({
               artifact={a}
               onOpen={() => onOpen(a)}
               onToggleFavorite={() => onToggleFavorite(a)}
-              onPickTag={onPickTag}
               onPickAuthor={onPickAuthor}
-              onEditTags={() => onEditTags(a)}
               onAddToCollection={() => onAddToCollection(a)}
               onDelete={() => onDelete(a)}
               onPrefetch={() => onPrefetch(a)}
@@ -962,12 +904,6 @@ function emptyStateFor(
         icon: <Icon name="check" strokeWidth={1.75} />,
         title: "You’re all caught up.",
         description: "Artifacts with an open thread that needs you show up here.",
-      }
-    case "tag":
-      return {
-        icon: <Icon name="tag" strokeWidth={1.75} />,
-        title: `Nothing tagged #${filter.tag} yet.`,
-        description: "Tag artifacts to group them here.",
       }
     case "collection":
       return {

--- a/apps/web/src/pages/library/quick-organize.tsx
+++ b/apps/web/src/pages/library/quick-organize.tsx
@@ -1,13 +1,13 @@
 import { useQuery } from "@tanstack/react-query"
 import { useState } from "react"
 import type { Artifact } from "@/api"
-import { CollectionsDialog, TagsDialog } from "@/components/shared/organize-dialogs"
+import { CollectionsDialog } from "@/components/shared/organize-dialogs"
 import { artifactQuery } from "@/lib/queries"
 
-// Library-level mounts for the card ⋯ menu's organize actions. The shared
-// dialogs own the API calls; these wrappers own the state the dialogs render
-// from, and report changes up so LibraryBody can sync its caches. Mounted only
-// while staged (`{pending && <…/>}`).
+// Library-level mount for the card ⋯ menu's organize action. The shared dialog
+// owns the API calls; this wrapper owns the state the dialog renders from, and
+// reports changes up so LibraryBody can sync its caches. Mounted only while
+// staged (`{pending && <…/>}`).
 
 // Close by letting Radix finish first: the dialog holds a pointer-events lock
 // on <body> until its exit transition ends, and unmounting it mid-close leaks
@@ -21,33 +21,6 @@ function useDialogClose(onClose: () => void) {
     window.setTimeout(onClose, 200)
   }
   return { open, onOpenChange }
-}
-
-export function LibraryTagsDialog({
-  artifact,
-  onChange,
-  onClose,
-}: {
-  artifact: Artifact
-  onChange: (shortId: string, tags: string[]) => void
-  onClose: () => void
-}) {
-  const close = useDialogClose(onClose)
-  // Tags ride on the list payload; local state keeps the dialog's chips live
-  // across its optimistic + server-normalized onChange calls.
-  const [tags, setTags] = useState(artifact.tags ?? [])
-  return (
-    <TagsDialog
-      shortId={artifact.short_id}
-      tags={tags}
-      canEdit={artifact.my_role === "owner" || artifact.my_role === "editor"}
-      onChange={(t) => {
-        setTags(t)
-        onChange(artifact.short_id, t)
-      }}
-      {...close}
-    />
-  )
 }
 
 export function LibraryCollectionsDialog({

--- a/apps/web/src/pages/library/selection-bar.tsx
+++ b/apps/web/src/pages/library/selection-bar.tsx
@@ -8,11 +8,11 @@ import { collectionsQuery, summaryQuery } from "@/lib/queries"
 import { useApiMutation } from "@/lib/use-api-mutation"
 import { cn } from "@/lib/utils"
 import { summarize } from "./bulk-apply"
-import { BulkCollectionsDialog, BulkFolderDialog, BulkTagsDialog } from "./bulk-organize"
+import { BulkCollectionsDialog, BulkFolderDialog } from "./bulk-organize"
 
 // One action in the bar. The label is the button's text on a roomy viewport and its
 // accessible name everywhere — below `sm` the text collapses and the icon carries it, so
-// four actions still fit a phone without a scroll or an overflow menu.
+// the row still fits a phone without a scroll or an overflow menu.
 function BarAction({
   testId,
   icon,
@@ -52,12 +52,11 @@ function BarAction({
 // a card's ⋯ menu can already do to one artifact — this just does it to the set, through
 // the very same endpoints.
 //
-// Every action states its own scope before it runs. A library selection mixes what you
-// own with what you can merely read, so each action narrows the set to the artifacts it
-// may legally touch (tags: owner/editor; delete: owner) and reports the rest as
-// "skipped" rather than failing the batch or, worse, half-silently dropping them.
-// Collections are the exception: adding is an act of curation on YOUR collection, so the
-// server decides per artifact and anything it refuses comes back as skipped too.
+// A library selection mixes what you own with what you can merely read, so no action
+// assumes the whole set is fair game. Each one sends the full selection and lets the
+// server authorize artifact by artifact, reporting what it passed over as "skipped"
+// rather than failing the batch or, worse, half-silently dropping them. Delete is the
+// only action also gated client-side — it says how many it will skip before you confirm.
 export function SelectionBar({
   items,
   listKey,
@@ -74,17 +73,14 @@ export function SelectionBar({
   // "Move to folder" action (folders are per-collection, so it needs that collection).
   folderContext?: { collectionId: string; folders: Folder[] }
 }) {
-  const [showTags, setShowTags] = useState(false)
   const [showCollections, setShowCollections] = useState(false)
   const [showFolder, setShowFolder] = useState(false)
   const [showDelete, setShowDelete] = useState(false)
 
   const n = items.length
   const shortIds = items.map((a) => a.short_id)
-  // Client-side role counts drive the button-enable + the pre-action preview text ONLY.
-  // The server is the source of truth for what actually happens: each bulk call sends the
-  // whole selection and reports back what it could and couldn't touch.
-  const taggable = items.filter((a) => a.my_role === "owner" || a.my_role === "editor")
+  // Drives the delete button's enabled state and the count in its confirm copy, nothing
+  // more — the server re-authorizes every artifact and reports back what it skipped.
   const deletable = items.filter((a) => a.my_role === "owner")
   // All-starred → the star becomes the un-star (the card's own toggle, at scale).
   const allFavorite = n > 0 && items.every((a) => a.favorite)
@@ -117,7 +113,7 @@ export function SelectionBar({
           data-testid="library-selection-bar"
           // The floating-surface recipe (popover step + hairline ring), same as every
           // other surface that lifts off the page. Labels collapse to icons below `sm`
-          // so all four actions + the count fit a 320px phone without wrapping or
+          // so the actions and the count fit a 320px phone without wrapping or
           // horizontal scroll; each keeps its aria-label, so the icon-only form stays
           // announced.
           className="pointer-events-auto flex max-w-[calc(100vw-1.5rem)] items-center gap-0.5 rounded-2xl bg-popover px-2 py-2 text-popover-foreground shadow-[var(--shadow-pop)] ring-1 ring-foreground/10 duration-200 ease-out animate-in fade-in-0 slide-in-from-bottom-2 sm:gap-1 sm:px-3"
@@ -133,19 +129,6 @@ export function SelectionBar({
               selected
             </span>
           </div>
-
-          <BarAction
-            testId="library-selection-tags"
-            icon={<Icon name="tag" size={16} />}
-            label="Tags"
-            disabled={busy || taggable.length === 0}
-            title={
-              taggable.length === 0
-                ? "You can only tag artifacts you own or can edit"
-                : "Add tags to the selected artifacts"
-            }
-            onClick={() => setShowTags(true)}
-          />
 
           <BarAction
             testId="library-selection-collections"
@@ -212,21 +195,6 @@ export function SelectionBar({
         </div>
       </div>
 
-      {showTags && (
-        // The FULL selection goes to the dialog; the server tags what the caller can edit
-        // and reports the rest as skipped. `skipped` here is only the pre-action preview.
-        <BulkTagsDialog
-          items={items}
-          skipped={n - taggable.length}
-          listKey={listKey}
-          open={showTags}
-          onOpenChange={setShowTags}
-          onDone={() => {
-            setShowTags(false)
-            onClear()
-          }}
-        />
-      )}
       {showCollections && (
         <BulkCollectionsDialog
           items={items}

--- a/apps/web/src/pages/library/types.ts
+++ b/apps/web/src/pages/library/types.ts
@@ -18,10 +18,7 @@ export type Filter =
   // member row — written at creation, agents' on-behalf publishes included), any
   // visibility.
   | { kind: "mine" }
-  | { kind: "tag"; tag: string }
   | { kind: "collection"; id: string; title: string }
-
-export type TagCount = { tag: string; count: number }
 
 export type Summary = {
   total: number
@@ -29,7 +26,6 @@ export type Summary = {
   mine: number
   // Owned docs still private — the "waiting to be shared" signal.
   mine_private: number
-  tags: TagCount[]
   workspace: string
 }
 
@@ -41,10 +37,9 @@ export type LibraryView = "all" | "favorites" | "following" | "shared" | "feedba
 // The library's URL-encoded filters + search (query params on the home route), so
 // the persistent nav rail can drive them from any page and a filtered/searched
 // library is shareable and survives reload. These compose ON TOP of the base view
-// (a tag within all, a search within favorites). The named feeds themselves are
-// routes, not params — see LibraryView.
+// (a collection within all, a search within favorites). The named feeds themselves
+// are routes, not params — see LibraryView.
 export type LibrarySearch = {
-  tag?: string
   collection?: string
   // Anchor a collection view to one of its folders — scroll that section into view on
   // open. Set by the artifact breadcrumb's folder segment; ignored outside a collection.

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -23,7 +23,7 @@ export const Route = createFileRoute("/")({
   // hits and the header still paints complete on the first frame.
   // The filters are search params, so the loader keys on them: without loaderDeps the
   // router treats every filtered library as the same match and an intent hover on a
-  // sidebar tag/collection link cannot preload the view it actually opens.
+  // sidebar collection link cannot preload the view it actually opens.
   loaderDeps: ({ search }) => search,
   loader: ({ context: { queryClient }, deps }) => {
     // prefetchQuery never throws — a failed warm just leaves the in-component useQuery
@@ -41,7 +41,6 @@ export const Route = createFileRoute("/")({
     void queryClient.prefetchInfiniteQuery(
       libraryArtifactsQuery({
         q: deps.query || undefined,
-        tag: deps.tag,
         collection: deps.collection,
         author: deps.author,
         scope: deps.tab === "mine" ? "mine" : undefined,
@@ -64,7 +63,6 @@ export const Route = createFileRoute("/")({
   // shareable. The named feeds (Favorites, Following) are their OWN routes, not params
   // here — path = the feed you're viewing, query = how it's filtered (docs/decisions/0002).
   validateSearch: (s: Record<string, unknown>): LibrarySearch => ({
-    tag: typeof s.tag === "string" ? s.tag : undefined,
     collection: typeof s.collection === "string" ? s.collection : undefined,
     folder: typeof s.folder === "string" ? s.folder : undefined,
     query: typeof s.query === "string" ? s.query : undefined,

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -117,7 +117,6 @@
   --color-gold: #c2a15e;
   --color-share: #8781b0;
   --color-comments: #6b8bac;
-  --color-tag: #5f9a90;
   --color-collection: #bd8b62;
   --color-insights: #7f97c2;
   --color-review: #7a9f70;

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -57,7 +57,7 @@ holds itself to the same standard voluntarily.
   an alert never reads as decoration — and status is never the accent.
 - **Calm categorical tints** — a muted, low-chroma family for feature wayfinding and
   categorical charts: `--color-share`, `--color-review`, `--color-insights`,
-  `--color-collection`, `--color-comments`, `--color-tag`, `--color-gold` (with
+  `--color-collection`, `--color-comments`, `--color-gold` (with
   `--chart-1…5` mirroring them). Theme-invariant by design, surfaced as `text-share` /
   `text-review` / … utilities and applied per call-site — never a blanket icon default,
   so a glyph inside a button or an active nav row still takes that surface's ink. "Calm
@@ -450,9 +450,9 @@ variants.
   live-cursor layer needs no control of its own), then the **actions** — the ONE filled-ink
   **Share** leads as the page's single primary (everything else ghost), then the favorited
   **star** (glanceable ink state), then a single sectioned **⋯** (view modes → organize →
-  activity → manage; Tags & Collections open as dialogs from it) — then the terminal
+  activity → manage; Collections opens as a dialog from it) — then the terminal
   **Comments** toggle hugging the panel it opens. Everything that used to crowd the row
-  (Present / Insights / History / Proposals / Edit / Lock / Report / Tags / Collections) now
+  (Present / Insights / History / Proposals / Edit / Lock / Report / Collections) now
   lives behind the ⋯ — the render is the hero, the chrome recedes.
 - **Live cursors** — peers' cursors are a slim arrow tinted by their **identity**: a stable,
   distinct tint from the shared identity palette (`colorForName`, the same palette avatar


### PR DESCRIPTION
Collections plus semantic search already cover what artifact tags were for, so every tag affordance comes out of the web app.

**Nothing changes underneath.** The `artifact_tag` table, all six endpoints, `organize`'s tag params, `publish --tags`, `derive tag`, and automation tag targets are untouched. Agents keep tagging; the app just stops showing it.

## What comes out of the UI

| Surface | Was | Now |
|---|---|---|
| Sidebar | A **Tags** group under Collections, one row per tag with a count | Gone |
| Artifact card | Chip row as the last element — three tags plus a `+N` badge | Gone |
| Artifact row | Up to four right-aligned chips, claiming up to 40% of the row | Gone |
| Card / row ⋯ | *Tags* then *Add to collection* | *Add to collection* alone |
| Artifact ⋯ | *Tags* with a count badge | Gone |
| Multi-select bar | Four actions, Tags first | Three (four in a collection) |
| Dialogs | `TagsDialog`, `LibraryTagsDialog`, `BulkTagsDialog` | All deleted |

## Also cut, as dead weight rather than as tags

- **The `/?tag=` filter view.** Keeping it meant maintaining a `Filter` variant, a route param, a heading, a count lookup, a clear chip and an empty state for a view nothing links to. Old links fall back to the unfiltered library. `TagCount`, `Summary.tags`, `LibraryParams.tag` and the `tag` icon go with it — that empty state was the icon's last consumer.
- **`ScopeLine`**, the *"N of M selected — K will be skipped"* preview. It lived in one bulk dialog while its own comment claimed every dialog had it. The reversible bulk actions already report what the server skipped in the result toast, and delete — the one where a warning genuinely matters — keeps its count plus type-to-confirm.
- **`--color-tag`**, a palette token nothing referenced. Not mirrored into `--chart-1…5`, so no chart colour moves.

## Two things worth knowing for review

**Tags were never in the search index.** `indexArtifact` only ever took title and body — no tag text, no tag boost. The sole coupling ran the other direction, with tag *suggestions* querying the semantic arm and aggregating neighbours' tags. Removing tags removes a consumer of search, not a producer.

**Tags double as an automation write-target.** An automation can name a tag among its targets and the runner stamps it on everything the run writes. That's why this is a UI removal rather than a full one, and why the "Stamp with #tag" picker in the automation form stays deliberately.

## Tests

Two e2e tag tests deleted, one retargeted. They were the only coverage of *"the bulk bar writes through to the API across the whole set"*, so that assertion moved onto collections rather than disappearing, and the phone's end-to-end dialog test now runs add-to-collection. The `desktop-tags-dialog.png` screenshot is dropped.

## Verification

- `pnpm verify` green — ci (all 25 gates, including `lint:deadcode` and `lint:testids`), typecheck, coverage across every package.
- Playwright smoke 8/8, run separately since it isn't part of `verify`.
- **Not verified: anything visual.** No screenshots were taken of the library, a card grid, a collection row list, or the rail in a sparse workspace.

## Follow-ups for design

Holes the deletion left in layouts that were composed around tags — worth a designer's pass, none of them blocking:

- Card and row composition around the removed chip row (cards are shorter; the row's right side is now empty).
- The sidebar's middle tier can now be empty in a workspace with no collections.
- The selection bar was tuned for four actions at 375px and now has three.
- A one-item "organise" section left in three ⋯ menus.
- Cards lost their only free-form "what is this about" signal for scanning.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/607"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788122684&installation_model_id=428097&pr_number=607&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F607&signature=52ba8a2a8c132080907d333a73e459511114e6da8443d6d88d537de625a3b287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->