### PR TITLE
fix(slack): deferred work was killed at its first await, so link previews never ran

### DIFF
--- a/apps/api/src/routes/slack.ts
+++ b/apps/api/src/routes/slack.ts
@@ -73,7 +73,7 @@ import { buildSlackManifest, slackSetupHTML } from "../slack-app-setup"
  *  the web client's type; the OAuth redirects and the Slack Events webhook stay plain
  *  routes (not typed JSON). */
 export const slackRoutes = (ctx: AppContext) => {
-  const { meta, deps, bus, notify, requireUser, authorizeUserStanding } = ctx
+  const { meta, deps, bus, notify, background, requireUser, authorizeUserStanding } = ctx
   const { activeWorkspace, workspaceCan, requireWorkspace } = ctx
   const { blobs, sourceText, search, notifyRender, billingBlocked } = ctx
   const app = new OpenAPIHono<BlankEnv>()
@@ -102,22 +102,34 @@ export const slackRoutes = (ctx: AppContext) => {
   }
 
   // Run best-effort work AFTER we've acked Slack (which demands a reply within 3s). On Workers,
-  // executionCtx.waitUntil keeps the isolate alive until it settles; Node has no executionCtx, so
-  // the promise just runs in-process. Either way a terminal .catch() is attached FIRST: an
+  // waitUntil keeps the isolate alive until it settles; on Node the promise just runs in-process.
+  // Either way a terminal .catch() is attached FIRST: an
   // unawaited reject (e.g. a lookup throwing inside a deferred proposal action, which runs its
   // early lookups outside its own try/catch) would otherwise escape as an unhandledRejection.
   // Not fatal here — node.ts installs a log-only last-resort handler — but that logs a bare,
   // contextless line and only exists on the Node path; catching at the call site attributes the
   // failure to the Slack deferral on both runtimes instead of leaning on the global net.
-  const runAfterAck = (c: Context, work: Promise<unknown>): void => {
+  const runAfterAck = (work: Promise<unknown>): void => {
     const guarded = work.catch((err) =>
       log.warn("slack deferred work failed", { err: String(err) }),
     )
-    try {
-      c.executionCtx.waitUntil(guarded)
-    } catch {
-      void guarded // Node has no executionCtx; the promise runs in-process
-    }
+    // Via ctx.background, NOT c.executionCtx.
+    //
+    // The worker calls Hono as `ready.fetch(req)` — one argument — and stashes the real
+    // ExecutionContext in an AsyncLocalStorage instead (worker.ts, edgeCtx.run). Hono therefore
+    // never receives a ctx, and `c.executionCtx` THROWS on Workers, not only on Node as the old
+    // comment assumed. The catch swallowed that into fire-and-forget, so the response returned
+    // and the isolate was torn down at the promise's FIRST await — with no log and no exception,
+    // because everything worth logging happens after it.
+    //
+    // Link previews were dead in production for a day on exactly this: link_shared arrived, the
+    // synchronous prefix ran, and nothing downstream ever executed. Proposal decisions, the
+    // interactivity repaint and the deferred /derive search shared the fault; the response_url
+    // ones only appeared to work because their fetch is dispatched before the first await.
+    //
+    // ctx.background reads the SAME AsyncLocalStorage the worker populates, which is why the
+    // comment mirror — its only other user — never had this problem.
+    void background(guarded)
   }
 
   // Render previews for the Derive links in one `link_shared` event.
@@ -433,7 +445,7 @@ export const slackRoutes = (ctx: AppContext) => {
     // ack like every other slow path here: resolving each link reads the artifact, its versions
     // and its comments, and Slack still wants a reply inside 3s.
     if (body.type === "event_callback" && ev?.type === "link_shared" && body.team_id && ev.user) {
-      runAfterAck(c, unfurlSharedLinks(body.team_id, ev))
+      runAfterAck(unfurlSharedLinks(body.team_id, ev))
       return c.json({ ok: true })
     }
     // Only human thread replies: a message with a thread_ts, no bot_id, not an edit/delete.
@@ -640,7 +652,6 @@ export const slackRoutes = (ctx: AppContext) => {
       const pt = decodeProposalAction(action.value)
       if (pt && payload.team?.id && payload.user?.id) {
         runAfterAck(
-          c,
           runSlackProposalAction(
             { meta, blobs, bus, notify, notifyRender, search, billingBlocked },
             {
@@ -707,7 +718,6 @@ export const slackRoutes = (ctx: AppContext) => {
           const blocks = [section0, ...threadStateBlocks(op, action.value, who)].filter(Boolean)
           if (payload.response_url) {
             runAfterAck(
-              c,
               postSlackResponseUrl(payload.response_url, {
                 text: op === "resolved" ? "Thread resolved" : "Thread reopened",
                 blocks,
@@ -902,7 +912,7 @@ export const slackRoutes = (ctx: AppContext) => {
           replace_original: true,
         }),
       )
-    runAfterAck(c, deliver)
+    runAfterAck(deliver)
     return c.json({ response_type: "ephemeral", text: "Searching…" })
   })
 

--- a/apps/api/test/slack-deferred-work.test.ts
+++ b/apps/api/test/slack-deferred-work.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+
+// Deferred Slack work must not reach for `c.executionCtx`.
+//
+// The Worker entry invokes Hono as `ready.fetch(req)` — ONE argument — and stashes the real
+// ExecutionContext in an AsyncLocalStorage instead (worker.ts, `edgeCtx.run(ctx, …)`). Hono
+// therefore never receives a ctx, and `c.executionCtx` throws on Workers, not merely on Node.
+//
+// That is not a theoretical mismatch. `runAfterAck` used to try it and swallow the throw into
+// fire-and-forget, so every deferred Slack path — link previews, proposal decisions, the
+// interactivity repaint, the deferred /derive search — returned its response and was torn down at
+// the promise's FIRST await. Silently: no log and no exception, because everything worth logging
+// happens after that await. Link previews were dead in production for a day, with `link_shared`
+// arriving correctly the whole time and every downstream log absent.
+//
+// Asserted against the source because there is no way to observe it from a test: under vitest
+// there is no ExecutionContext at all, so both the broken and the fixed version behave the same.
+// That is exactly why it survived a green suite.
+const src = (p: string) => readFileSync(join(__dirname, "..", "src", p), "utf8")
+
+describe("Slack deferred work uses the context the worker actually provides", () => {
+  // Comments about executionCtx are wanted — the explanation is the point. What must not exist
+  // is a READ of it, so strip comments before asserting.
+  const code = (p: string) =>
+    src(p)
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/^\s*\/\/.*$/gm, "")
+
+  it("routes/slack.ts never reads c.executionCtx", () => {
+    expect(code("routes/slack.ts")).not.toMatch(/\bexecutionCtx\b/)
+  })
+
+  it("defers through ctx.background, which reads the worker's AsyncLocalStorage", () => {
+    const body = code("routes/slack.ts").match(/const runAfterAck[\s\S]*?\n {2}\}/)?.[0] ?? ""
+    expect(body).toContain("background(")
+  })
+
+  // The premise the above depends on. If the worker ever starts passing env+ctx to Hono,
+  // c.executionCtx becomes valid and this comment (and the reasoning) needs revisiting — better
+  // to be told than to leave a stale explanation in place.
+  it("the worker still calls Hono without an ExecutionContext", () => {
+    const w = src("worker.ts")
+    expect(w).toContain("edgeCtx.run(ctx, () => ready.fetch(req))")
+  })
+
+  // ctx.background is the shared, correct mechanism — the comment mirror's only reason for
+  // never having had this bug.
+  it("context.background resolves the ExecutionContext from that same store", () => {
+    const c = src("context.ts")
+    expect(c).toMatch(/const background[\s\S]{0,400}edgeCtx\.getStore\(\)[\s\S]{0,200}waitUntil/)
+  })
+})


### PR DESCRIPTION
Link previews have been dead in production. Not configuration, not the account link, not the workspace — **the code never ran.**

## The bug

`worker.ts:402` invokes Hono with one argument:

```js
return edgeCtx.run(ctx, () => ready.fetch(req))
```

The real `ExecutionContext` goes into an AsyncLocalStorage; Hono never receives one. So `c.executionCtx` **throws on Workers** — and `runAfterAck` caught that, assuming it only happened on Node:

```js
try { c.executionCtx.waitUntil(guarded) }
catch { void guarded }   // "Node has no executionCtx" — Workers hits this too
```

Fire-and-forget means the response returns and the isolate is torn down **at the promise's first `await`**. Everything worth logging in `unfurlSharedLinks` happens after that await, so the failure produced no log and no exception.

`ctx.background` reads that same AsyncLocalStorage — which is why the comment mirror, its only other user, never had this problem. Slack's deferral now goes through it.

## Blast radius

All four `runAfterAck` call sites:

| path | visible? |
|---|---|
| link unfurls | **dead** |
| proposal approve / request-changes | **dead after the first await** |
| interactivity repaint | *appeared* to work — its `fetch` is dispatched before the first await |
| deferred `/derive` search | same |

## How it was found

Everything else was eliminated first, each by direct measurement rather than inference:

- `link_shared` **does** arrive — `links:4`, user and team present (worker log)
- app config correct field-by-field, from Slack's own `apps.manifest.export`
- `chat.unfurl` returns `ok` for both the card and the `user_auth_required` variant, called by hand with the production bot token — the cards are visible in the channel
- URL → short-id parsing correct, run against the real functions
- workspace-mismatch theory disproven: one artifact published into each of four workspaces, none unfurled

The decider was Workers **persisted** observability (`[observability] enabled = true`), which — unlike `wrangler tail` — captures deferred work. It showed `slack event` firing 6 times and `unfurl skipped` / `slack deferred work failed` **zero** times. Not "the ladder declined", but "the ladder never executed".

## Why no test catches it

Under vitest there is no `ExecutionContext` either, so broken and fixed behave identically — a green suite was never going to see this. Hence source-level assertions: `routes/slack.ts` never reads `c.executionCtx`, `runAfterAck` defers through `background`, and the worker still calls Hono without a ctx — the premise the reasoning rests on, so changing it announces itself instead of silently invalidating the fix.

Confirmed the assertions fail when the old deferral is restored.

`pnpm ci` clean; 1896 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/610"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788174795&installation_model_id=428097&pr_number=610&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F610&signature=eab52ccf430ca78ca0573dec99fed19eaf87950c505e7b8d88af59f25971d164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->