### PR TITLE
feat(slack): Derive artifacts as Work Objects

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -6063,7 +6063,10 @@
                           "version.published",
                           "proposal.created",
                           "proposal.approved",
-                          "proposal.changes_requested"
+                          "proposal.changes_requested",
+                          "review.requested",
+                          "review.sent_back",
+                          "review.approved"
                         ]
                       }
                     }

--- a/apps/api/src/lib/artifact-status.ts
+++ b/apps/api/src/lib/artifact-status.ts
@@ -1,0 +1,97 @@
+// What an artifact's card should LEAD with: is it waiting on someone, is there open
+// feedback, and is it still current.
+//
+// Every peer integration answers "what is this thing?" — Linear's unfurl leads with status and
+// assignee, GitHub's with title and description. Derive can answer something sharper, because a
+// review round names the person it is blocked on: `getPendingRound` returns `requested_for`, and
+// with agents as first-class authors the common shape is "an agent published this and nobody has
+// looked yet". That is the fact worth the top line, not the file type.
+//
+// Returns STRUCTURED data, deliberately, not a rendered string. The Work Object maps it onto
+// Slack's typed fields (which Slack renders itself, so it never passes through our mrkdwn
+// escaping), while the Block Kit surfaces render and escape it their own way. One resolver, three
+// presentations — the consistency rule GitLab's unfurl design settled on: notifications, slash
+// commands and unfurls should describe a thing the same way.
+//
+// NOT folded into `UnfurlInfo`. That feeds /v1/og, the most-trafficked anonymous surface, and was
+// deliberately collapsed into one round trip (`meta.unfurlInfo`); adding queries there would tax
+// every crawler fetch to serve a panel only Slack shows. This resolves on the Slack path alone,
+// which is also the only place the result is both authorized and actionable.
+
+import type { ArtifactRecord, MetaStore, ReviewRoundState } from "@derive/core"
+
+export interface ArtifactStatus {
+  /** The pending round, when the artifact is waiting on a human. Null when nothing is pending —
+   *  including after it settles, since a settled round is history rather than status. */
+  review: {
+    state: ReviewRoundState
+    /** The person asked to answer. Compare against the viewer to say "your review". */
+    reviewerId: string
+    /** Their display name, or null when the directory has no row for them. Untrusted: escape at
+     *  render on any surface that interpolates it into markup. */
+    reviewerName: string | null
+  } | null
+  /** Distinct OPEN threads. More actionable than a total comment count: "7 comments" is inert,
+   *  "2 open threads" is an invitation. */
+  openThreads: number
+  updatedAt: string | null
+}
+
+export const artifactStatus = async (
+  meta: MetaStore,
+  artifact: ArtifactRecord,
+): Promise<ArtifactStatus> => {
+  // Any pending round, not one scoped to a viewer: the card is answering "is this blocked", and
+  // on a single-reviewer round the asker is whoever was named. routes/review.ts resolves it the
+  // same way when no specific person is in hand.
+  const round = await meta.getPendingRound(artifact.id)
+  const signals = await meta.commentSignals([artifact.id], null)
+  const [reviewer] = round ? await meta.getUsers([round.requested_for]) : []
+  return {
+    review: round
+      ? {
+          state: round.state,
+          reviewerId: round.requested_for,
+          reviewerName: reviewer?.name ?? reviewer?.username ?? null,
+        }
+      : null,
+    openThreads: signals[artifact.id]?.open_threads ?? 0,
+    updatedAt: artifact.updated_at,
+  }
+}
+
+/** How long ago, in the coarse terms a card wants. Exact timestamps are noise when the question
+ *  is only "is this still current" — a doc touched an hour ago and one touched in February are
+ *  different in kind, and the reader does not need the minute. */
+export const agoLabel = (iso: string | null, now = Date.now()): string | null => {
+  if (!iso) return null
+  const then = Date.parse(iso)
+  if (Number.isNaN(then)) return null
+  const mins = Math.floor((now - then) / 60_000)
+  if (mins < 1) return "just now"
+  if (mins < 60) return `${mins}m ago`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 30) return `${days}d ago`
+  const months = Math.floor(days / 30)
+  return months < 12 ? `${months}mo ago` : `${Math.floor(months / 12)}y ago`
+}
+
+/** The status as a short human phrase, for the surfaces that render text rather than typed
+ *  fields. `viewerId` is what turns "Awaiting review from Mert" into "Awaiting your review" —
+ *  the difference between information and a prompt. Null when there is nothing worth leading
+ *  with, so callers fall back to the existing description. */
+export const statusPhrase = (
+  s: ArtifactStatus,
+  viewerId?: string | null,
+): { text: string; reviewerName: string | null } | null => {
+  if (!s.review) return null
+  const mine = !!viewerId && viewerId === s.review.reviewerId
+  if (s.review.state === "pending")
+    return mine
+      ? { text: "Awaiting your review", reviewerName: null }
+      : { text: "Awaiting review from", reviewerName: s.review.reviewerName }
+  if (s.review.state === "sent_back") return { text: "Answers sent back", reviewerName: null }
+  return { text: "Approved", reviewerName: null }
+}

--- a/apps/api/src/lib/slack-comments.ts
+++ b/apps/api/src/lib/slack-comments.ts
@@ -217,6 +217,9 @@ const CHANNEL_EVENTS = new Set<WebhookEvent>([
   "proposal.created",
   "proposal.approved",
   "proposal.changes_requested",
+  "review.requested",
+  "review.sent_back",
+  "review.approved",
 ])
 
 /** Enqueue a top-level channel card for an artifact-lifecycle event, when the org has a
@@ -281,6 +284,17 @@ const eventBlocks = (p: SlackEventPayload): unknown[] => {
       break
     case "proposal.changes_requested":
       head = `:leftwards_arrow_with_hook: Changes were requested on a proposal for ${link}`
+      break
+    // The review round. `who` is the actor — the agent that asked, or the human who answered —
+    // so the line names whoever moved it, the same way the proposal cases do.
+    case "review.requested":
+      head = `:mag: *${who}* asked for a review of ${link}`
+      break
+    case "review.sent_back":
+      head = `:leftwards_arrow_with_hook: *${who}* sent back answers on ${link}`
+      break
+    case "review.approved":
+      head = `:white_check_mark: *${who}* approved ${link}`
       break
     default:
       head = `${link} — ${escapeMrkdwn(p.event)}`

--- a/apps/api/src/lib/slack-review.ts
+++ b/apps/api/src/lib/slack-review.ts
@@ -1,0 +1,113 @@
+// Approve / send back a review round from a Work Object button.
+//
+// The sibling of lib/slack-proposal.ts, and deliberately its twin: same resolution order, same
+// re-read-don't-trust-the-button rule, same Actor construction, same ephemeral-on-refusal
+// behaviour. A reviewer clicking Approve in Slack must land in exactly the state
+// `derive approve` or the sidebar button would produce, because the agent polling catch_up
+// cannot tell — and must not care — which surface settled the round.
+//
+// Permissions mirror routes/review.ts rather than inventing a Slack-specific rule: `comment` to
+// send back (answering is collaboration), `approve` to approve (it is the build go-signal), and
+// the billing gate on approve alone.
+
+import { type Actor, type ArtifactRecord, can, type MetaStore, maxRole } from "@derive/core"
+import type { Backplane } from "../bus"
+import { postSlackResponseUrl } from "./slack"
+
+export interface SlackReviewDeps {
+  meta: MetaStore
+  bus: Backplane
+  billingBlocked: (orgId: string) => Promise<{ code: string; message: string } | null>
+}
+
+export interface SlackReviewArgs {
+  teamId: string
+  slackUserId: string
+  /** The artifact the card is for, resolved from the Work Object's external_ref. */
+  artifact: ArtifactRecord
+  op: "approve" | "send_back"
+  responseUrl?: string
+}
+
+/** Settle the artifact's pending round as the clicking user. All feedback rides `response_url`,
+ *  so this runs off the interaction ack path. */
+export const runSlackReviewAction = async (
+  deps: SlackReviewDeps,
+  args: SlackReviewArgs,
+): Promise<void> => {
+  const { meta, bus } = deps
+  const artifact = args.artifact
+  const eph = (text: string): Promise<boolean> =>
+    args.responseUrl
+      ? postSlackResponseUrl(args.responseUrl, { text, response_type: "ephemeral" })
+      : Promise.resolve(false)
+
+  // No link → no Derive principal to authorize against. Same prompt the proposal buttons give.
+  const link = await meta.getSlackUserLinkBySlackId(args.teamId, args.slackUserId)
+  if (!link) {
+    await eph("Link your Slack account (Settings → Integrations) to review from Slack.")
+    return
+  }
+
+  // Re-read the round rather than trusting anything on the card: it may have been settled from
+  // Derive, or by someone else in this channel, since the unfurl was rendered.
+  const round = await meta.getPendingRound(artifact.id)
+  if (!round) {
+    await eph("There's no review pending on that doc any more.")
+    return
+  }
+
+  // Authorize as the linked Derive user — mirrors context.actorFor's human branch, then can().
+  const orgRole = (await meta.getMembership(artifact.org_id, link.user_id))?.role ?? null
+  const am = await meta.getArtifactMember(artifact.id, link.user_id)
+  const cRoles = await meta.collectionRolesForArtifact(artifact.id, link.user_id)
+  const actor: Actor = {
+    kind: "user",
+    userId: link.user_id,
+    artifactRole: maxRole(am?.role ?? null, ...cRoles),
+    orgRole,
+    locked: !!artifact.password_hash,
+    unlocked: false,
+  }
+  const need = args.op === "approve" ? "approve" : "comment"
+  if (!can(actor, need, artifact.workspace_access, artifact.link_role)) {
+    await eph(
+      args.op === "approve"
+        ? "You don't have permission to approve on that doc."
+        : "You don't have permission to comment on that doc.",
+    )
+    return
+  }
+
+  try {
+    if (args.op === "approve") {
+      // Approving is the go-signal that unblocks a build; request-changes-shaped actions stay
+      // free, exactly as the proposal path gates only its publishing branch.
+      const blocked = await deps.billingBlocked(artifact.org_id)
+      if (blocked) {
+        await eph(blocked.message)
+        return
+      }
+    }
+    const updated = await meta.resolveReviewRound(round.id, {
+      state: args.op === "approve" ? "approved" : "sent_back",
+      note: null,
+    })
+    if (!updated) {
+      // Lost a race with another surface settling the same round.
+      await eph("That review was just settled somewhere else.")
+      return
+    }
+    bus.publish(artifact.id, {
+      type: args.op === "approve" ? "review.approved" : "review.sent_back",
+      round_id: round.id,
+    })
+    await eph(
+      args.op === "approve"
+        ? ":white_check_mark: Approved — the agent is unblocked."
+        : ":leftwards_arrow_with_hook: Sent back — your answers are on their way.",
+    )
+  } catch {
+    await eph("Sorry — that didn't go through. Try it in Derive.")
+  }
+}

--- a/apps/api/src/lib/slack-subscriptions.ts
+++ b/apps/api/src/lib/slack-subscriptions.ts
@@ -21,6 +21,13 @@ export const SLACK_SUBSCRIBABLE_EVENTS = [
   "proposal.created",
   "proposal.approved",
   "proposal.changes_requested",
+  // The review round — the loop's most decision-relevant moment. These already reach the
+  // reviewer's DM, but until now no CHANNEL could hear that a doc was blocked on someone, which
+  // is exactly the fact a team wants ambient. Existing subscriptions are unaffected: `*` picks
+  // them up, an explicit list does not, and the Settings picker reads this constant.
+  "review.requested",
+  "review.sent_back",
+  "review.approved",
 ] as const satisfies readonly WebhookEvent[]
 
 /** Whether an author id belongs to an agent. Two shapes count: a registered agent row, and the

--- a/apps/api/src/lib/slack-unfurl.ts
+++ b/apps/api/src/lib/slack-unfurl.ts
@@ -89,11 +89,21 @@ export const lockedUnfurlBlocks = (baseUrl: string, shortId: string): unknown[] 
   context("Derive"),
 ]
 
-/** What the caller should do with one shared link. */
+/** What the caller should do with one shared link.
+ *
+ *  `card` and `locked` both carry the artifact so the caller can build a Work Object entity from
+ *  it; `blocks` remains on both as the fallback for a workspace where Work Objects are not
+ *  available (see lib/slack.ts unfurlSlackEntities, which throws on the warning that signals it).
+ *
+ *  `locked` is split out from `card` rather than folded into it because the two differ in what
+ *  the FLEXPANE may then show. The broadcast half of a locked artifact must stay title-less, as
+ *  before — but the flexpane is per-viewer, so a reader entitled to the artifact can be shown the
+ *  real thing there. Keeping the distinction in the type is what lets the caller honour both. */
 export type UnfurlDecision =
   | { kind: "skip" }
   | { kind: "auth" }
-  | { kind: "card"; url: string; blocks: unknown[] }
+  | { kind: "card"; url: string; blocks: unknown[]; artifact: ArtifactRecord; info: UnfurlInfo }
+  | { kind: "locked"; url: string; blocks: unknown[]; artifact: ArtifactRecord }
 
 export interface UnfurlDeps {
   meta: MetaStore
@@ -139,7 +149,12 @@ export const decideUnfurl = async (
   // Build the locked card BEFORE unfurlInfoFor: it needs none of that, and the whole point is
   // to touch as little of the artifact as possible.
   if (artifact.listed === "none")
-    return { kind: "card", url, blocks: lockedUnfurlBlocks(deps.baseUrl, artifact.short_id) }
+    return {
+      kind: "locked",
+      url,
+      blocks: lockedUnfurlBlocks(deps.baseUrl, artifact.short_id),
+      artifact,
+    }
 
   const info = await unfurlInfoFor(deps.meta, deps.baseUrl, artifact)
   const open = await deps.meta.listProposals(artifact.id, { state: "open" })
@@ -147,6 +162,8 @@ export const decideUnfurl = async (
     kind: "card",
     url,
     blocks: unfurlBlocks(info, open.length > 0, artifact.id, open[0]?.id ?? null),
+    artifact,
+    info,
   }
 }
 

--- a/apps/api/src/lib/slack-work-object.ts
+++ b/apps/api/src/lib/slack-work-object.ts
@@ -1,0 +1,182 @@
+// Derive artifacts as Slack Work Objects.
+//
+// Work Objects (GA October 2025) replace a block-rendered unfurl with a TYPED entity, and add a
+// second surface. That second surface is why this exists at all. The header of slack-unfurl.ts
+// records the constraint the old design was built around:
+//
+//   an unfurl is attached to the MESSAGE, not to a viewer. `chat.unfurl` takes no `user`
+//   parameter, so whatever we render is seen by everyone in the channel.
+//
+// The flexpane — the panel Slack opens when someone clicks the card — carries the clicking
+// `user`, and may demand auth or return a restricted view. It is the per-viewer surface that
+// parameter never provided. So the broadcast card can stay minimal while each viewer who clicks
+// sees exactly what they are entitled to, instead of everyone sharing the most cautious answer.
+//
+// Two further wins fall out of the typing. Slack renders `status`, `assignee` and dates itself,
+// so none of them pass through mrkdwn escaping — the most bug-prone part of this integration
+// (fenced language tags, `<!channel>`, entity handling) simply stops applying to those fields.
+// And the entity is searchable in Slack, with the flexpane aggregating every conversation that
+// referenced it, both keyed on `external_ref.id` — which is why that id must stay the artifact's
+// stable short id and never a slug.
+
+import type { ArtifactRecord, UnfurlInfo } from "@derive/core"
+import { unfurlDescription } from "@derive/core"
+import { type ArtifactStatus, agoLabel, statusPhrase } from "./artifact-status"
+
+/** The interactivity `action_id`s a Work Object's buttons carry. Routed as ordinary
+ *  `block_actions`, so they land beside the thread and proposal handlers. */
+export const SLACK_REVIEW_ACTION = {
+  approve: "derive_review_approve",
+  sendBack: "derive_review_send_back",
+} as const
+
+/** `external_ref.type` — the namespace half of the key Slack stores. Stable forever: changing it
+ *  orphans every previously-unfurled card from its related conversations and search entries. */
+export const DERIVE_ENTITY_TYPE = "artifact"
+
+/** A review state as a Slack status tag. `tag_color` is the whole point of using a typed field —
+ *  a blocked doc reads as blocked at a glance, without us rendering a single character. */
+const statusField = (s: ArtifactStatus): Record<string, unknown> | null => {
+  if (!s.review) return null
+  const byState = {
+    pending: { value: "Awaiting review", tag_color: "blue" },
+    sent_back: { value: "Answers sent back", tag_color: "yellow" },
+    approved: { value: "Approved", tag_color: "green" },
+  } as const
+  return byState[s.review.state]
+}
+
+export interface WorkObjectArgs {
+  /** The URL exactly as pasted — Slack matches the unfurl back to the message by this, so it is
+   *  NOT interchangeable with the canonical url below. */
+  pastedUrl: string
+  artifact: ArtifactRecord
+  info: UnfurlInfo
+  status: ArtifactStatus
+  /** Only for a world-readable artifact. Slack fetches preview images ANONYMOUSLY, and /v1/og
+   *  answers an anonymous fetch by link role — a workspace-only artifact would return the
+   *  title-less padlock, so a card that people paste most would carry a padlock graphic. */
+  previewUrl?: string | null
+  /** Buttons ride the broadcast card, so they are offered only when a round is pending. A click
+   *  is re-authorized as the clicker's own linked account, so showing them is safe. */
+  withActions?: boolean
+  /** Absolute icon URL. Slack requires `alt_text` alongside it; omitting that is a documented
+   *  SILENT failure — the API answers 200 with a `warning` rather than an error. */
+  iconUrl: string
+}
+
+/** The entity for one artifact, as `chat.unfurl`'s `metadata.entities[]` wants it. */
+export const artifactEntity = (a: WorkObjectArgs): Record<string, unknown> => {
+  const { artifact, info, status } = a
+  const fields: Record<string, unknown> = {}
+  const st = statusField(status)
+  if (st) fields.status = st
+  if (status.review?.reviewerName)
+    // `{ text }` rather than `{ user_id }`: the reviewer is a DERIVE user, and we cannot assume
+    // their Slack id — only a linked account would give us one, and most reviewers are not the
+    // person who pasted the link.
+    fields.assignee = { type: "slack#/types/user", user: { text: status.review.reviewerName } }
+
+  const custom: Record<string, unknown>[] = []
+  if (status.openThreads > 0)
+    custom.push({
+      key: "open_threads",
+      label: "Open threads",
+      value: status.openThreads,
+      type: "integer",
+    })
+  custom.push({
+    key: "version",
+    label: "Version",
+    value: `v${artifact.current_version}`,
+    type: "string",
+  })
+  if (info.dataSummary)
+    custom.push({ key: "data", label: "Data", value: info.dataSummary, type: "string" })
+
+  const attributes: Record<string, unknown> = {
+    title: { text: info.title },
+    display_type: info.kindLabel,
+    product_name: "Derive",
+    // alt_text is REQUIRED. Its absence is the documented silent failure for this API.
+    product_icon: { url: a.iconUrl, alt_text: "Derive" },
+  }
+  if (status.updatedAt) {
+    const ms = Date.parse(status.updatedAt)
+    if (!Number.isNaN(ms)) attributes.metadata_last_modified = Math.floor(ms / 1000)
+  }
+  if (a.previewUrl)
+    attributes.full_size_preview = {
+      is_supported: true,
+      preview_url: a.previewUrl,
+      mime_type: "image/png",
+    }
+
+  const payload: Record<string, unknown> = { attributes, fields, custom_fields: custom }
+  if (a.withActions)
+    payload.actions = {
+      primary_actions: [
+        { text: "Approve", action_id: SLACK_REVIEW_ACTION.approve, style: "primary" },
+        { text: "Send back", action_id: SLACK_REVIEW_ACTION.sendBack },
+      ],
+    }
+
+  return {
+    app_unfurl_url: a.pastedUrl,
+    url: info.pageUrl,
+    external_ref: { id: artifact.short_id, type: DERIVE_ENTITY_TYPE },
+    // `content_item` over `file`: an artifact is a living page with versions and review state,
+    // not a static attachment. Slack's own examples put articles and pages here.
+    entity_type: "slack#/entities/content_item",
+    entity_payload: payload,
+  }
+}
+
+/** The flexpane body — the per-viewer half, shown only to someone who passed the read check.
+ *  Richer than the broadcast card precisely because it is not broadcast: the description, the
+ *  open-thread count and the review state are safe here for a reader who could open the doc
+ *  anyway. */
+export const artifactDetails = (
+  info: UnfurlInfo,
+  status: ArtifactStatus,
+  viewerId: string | null,
+  iconUrl: string,
+): Record<string, unknown> => {
+  const fields: Record<string, unknown> = {
+    description: { value: unfurlDescription(info), format: "plain_text" },
+  }
+  const st = statusField(status)
+  if (st) fields.status = st
+  const phrase = statusPhrase(status, viewerId)
+  if (phrase)
+    fields.waiting_on = {
+      type: "slack#/types/user",
+      user: { text: phrase.reviewerName ?? phrase.text },
+    }
+  const ago = agoLabel(status.updatedAt)
+  return {
+    entity_type: "slack#/entities/content_item",
+    entity_payload: {
+      attributes: {
+        title: { text: info.title },
+        display_type: info.kindLabel,
+        product_name: "Derive",
+        product_icon: { url: iconUrl, alt_text: "Derive" },
+      },
+      fields,
+      custom_fields: [
+        ...(status.openThreads > 0
+          ? [
+              {
+                key: "open_threads",
+                label: "Open threads",
+                value: status.openThreads,
+                type: "integer",
+              },
+            ]
+          : []),
+        ...(ago ? [{ key: "updated", label: "Updated", value: ago, type: "string" }] : []),
+      ],
+    },
+  }
+}

--- a/apps/api/src/lib/slack.ts
+++ b/apps/api/src/lib/slack.ts
@@ -403,6 +403,79 @@ export const unfurlSlackLinks = async (
   if (!data.ok) throw new SlackApiError(data.error ?? "unknown")
 }
 
+/** Unfurl one or more links as WORK OBJECTS — typed entities rather than rendered blocks.
+ *
+ *  Throws on a warning as well as on `ok: false`, which is not paranoia: this API's documented
+ *  failure mode is answering **200 OK with a buried `warning`** when the payload is subtly wrong
+ *  (a missing `alt_text` on an icon is the canonical example) or when Work Objects are not
+ *  enabled on the app, in which case the metadata is ignored in silence. A caller that only
+ *  checked `ok` would see success and an empty channel — the exact shape of failure that cost
+ *  this integration a day. Treating a warning as an error is what lets the caller fall back to
+ *  the block unfurl instead of shipping nothing. */
+export const unfurlSlackEntities = async (
+  token: string,
+  target: SlackUnfurlTarget,
+  entities: unknown[],
+): Promise<void> => {
+  const res = await fetch(`${API}/chat.unfurl`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json; charset=utf-8",
+    },
+    body: JSON.stringify({
+      ...(target.channel && target.ts
+        ? { channel: target.channel, ts: target.ts }
+        : { unfurl_id: target.unfurlId, source: target.source }),
+      metadata: { entities },
+    }),
+  })
+  const data = (await res.json()) as { ok: boolean; error?: string; warning?: string }
+  if (!data.ok) throw new SlackApiError(data.error ?? "unknown")
+  if (data.warning) throw new SlackApiError(`warning: ${data.warning}`)
+}
+
+/** Fill the flexpane for one viewer, in response to `entity_details_requested`.
+ *
+ *  The three shapes are the whole reason Work Objects are worth adopting. `details` renders the
+ *  entity for someone entitled to it; `auth` asks an unlinked viewer to connect; `restricted`
+ *  tells someone without access, in a panel only THEY see — where the broadcast card, seen by
+ *  the channel, must keep saying nothing at all. */
+export const presentSlackEntityDetails = async (
+  token: string,
+  triggerId: string,
+  body:
+    | { kind: "details"; metadata: Record<string, unknown> }
+    | { kind: "auth"; url: string }
+    | { kind: "restricted"; title: string; message: string },
+): Promise<void> => {
+  const payload: Record<string, unknown> =
+    body.kind === "details"
+      ? { trigger_id: triggerId, metadata: body.metadata }
+      : body.kind === "auth"
+        ? { trigger_id: triggerId, user_auth_required: true, user_auth_url: body.url }
+        : {
+            trigger_id: triggerId,
+            error: {
+              status: "custom_partial_view",
+              custom_title: body.title,
+              custom_message: body.message,
+              message_format: "plain_text",
+            },
+          }
+  const res = await fetch(`${API}/entity.presentDetails`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json; charset=utf-8",
+    },
+    body: JSON.stringify(payload),
+  })
+  const data = (await res.json()) as { ok: boolean; error?: string; warning?: string }
+  if (!data.ok) throw new SlackApiError(data.error ?? "unknown")
+  if (data.warning) throw new SlackApiError(`warning: ${data.warning}`)
+}
+
 /** The public channels the bot can see, for the subscription picker — so nobody has to paste a
  *  raw channel id. Paginated; capped rather than exhaustive, because a picker only needs enough
  *  to choose from and a huge workspace would otherwise page for a long time. This is what

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -859,6 +859,11 @@ export const artifactRoutes = (ctx: AppContext) => {
           await notify(artifact, "review.requested", {
             version: version.n,
             requested_by: actor?.name ?? "An agent",
+            // `author` is what the channel card renders, and `actor_id` is what its human/agent
+            // filter keys on — enqueueSlackChannelEvent reads both. Without them a review
+            // request reaching a channel would be attributed to "someone" and counted as human.
+            author: actor?.name ?? "An agent",
+            actor_id: agentPrincipal?.id ?? actor?.id ?? null,
           })
           // The review request is the one event that earns an email: the loop is
           // blocked on the reviewer, who may have no tab open. Never for your own

--- a/apps/api/src/routes/review.ts
+++ b/apps/api/src/routes/review.ts
@@ -10,7 +10,7 @@ import { bail, fail, readJson, str } from "../lib/http"
  *  routes; a terminal "go" records the same call. Humans never resolve threads.
  *  The ReviewRound response schema is the single source for the web client's type. */
 export const reviewRoutes = (ctx: AppContext) => {
-  const { meta, bus, currentUser, requireArtifact, billingGate } = ctx
+  const { meta, bus, notify, currentUser, requireArtifact, billingGate } = ctx
   const app = new OpenAPIHono<BlankEnv>()
 
   const ReviewRound = z
@@ -73,6 +73,13 @@ export const reviewRoutes = (ctx: AppContext) => {
       })
       if (!updated) return bail(fail(c, 409, "no review pending on this artifact"))
       bus.publish(artifact.id, { type: "review.sent_back", round_id: round.id })
+      // Fan out like every other lifecycle event. These two settled the round only on the bus
+      // before, so a webhook subscriber — and, now that channels can subscribe, a team — never
+      // learned the doc had stopped waiting.
+      await notify(artifact, "review.sent_back", {
+        author: me?.name ?? "Someone",
+        actor_id: me?.id ?? null,
+      })
       return c.json({ round: updated })
     },
   )
@@ -108,6 +115,10 @@ export const reviewRoutes = (ctx: AppContext) => {
       })
       if (!updated) return bail(fail(c, 409, "no review pending on this artifact"))
       bus.publish(artifact.id, { type: "review.approved", round_id: round.id })
+      await notify(artifact, "review.approved", {
+        author: me?.name ?? "Someone",
+        actor_id: me?.id ?? null,
+      })
       return c.json({ round: updated })
     },
   )

--- a/apps/api/src/routes/slack.ts
+++ b/apps/api/src/routes/slack.ts
@@ -1,8 +1,15 @@
-import { newId, roleAllows, type SlackInstallRecord } from "@derive/core"
+import {
+  type ArtifactRecord,
+  candidateShortIds,
+  newId,
+  roleAllows,
+  type SlackInstallRecord,
+} from "@derive/core"
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import type { Context } from "hono"
 import type { BlankEnv } from "hono/types"
 import type { AppContext } from "../context"
+import { artifactStatus } from "../lib/artifact-status"
 import { commentCreatedAction } from "../lib/comment-actions"
 import { commentDeepLink } from "../lib/comments"
 import { encryptSecret, signState, verifyState } from "../lib/crypto"
@@ -14,12 +21,14 @@ import {
   listSlackChannels,
   openSlackView,
   postSlackResponseUrl,
+  presentSlackEntityDetails,
   slackAuthorizeUrl,
   slackChannelReach,
   slackOidcAuthorizeUrl,
   slackOidcUserinfo,
   slackPermalink,
   slackUserName,
+  unfurlSlackEntities,
   unfurlSlackLinks,
   verifySlackSignature,
 } from "../lib/slack"
@@ -55,13 +64,21 @@ import {
 import { flagSlackReauth, resolveBotToken } from "../lib/slack-delivery"
 import { enqueueSlackDm, wantsSlackDm } from "../lib/slack-dm"
 import { runSlackProposalAction } from "../lib/slack-proposal"
+import { runSlackReviewAction } from "../lib/slack-review"
 import {
   channelIsSubscribed,
   SLACK_SUBSCRIBABLE_EVENTS,
   subscribableEvents,
 } from "../lib/slack-subscriptions"
-import { artifactRefFromUrl, decideUnfurl } from "../lib/slack-unfurl"
+import { artifactRefFromUrl, decideUnfurl, type UnfurlDecision } from "../lib/slack-unfurl"
+import {
+  artifactDetails,
+  artifactEntity,
+  DERIVE_ENTITY_TYPE,
+  SLACK_REVIEW_ACTION,
+} from "../lib/slack-work-object"
 import { resolveThreadAction } from "../lib/thread-actions"
+import { unfurlInfoFor } from "../lib/unfurl-info"
 import { log } from "../log"
 import { buildSlackManifest, slackSetupHTML } from "../slack-app-setup"
 
@@ -190,6 +207,7 @@ export const slackRoutes = (ctx: AppContext) => {
     }
 
     const unfurls: Record<string, unknown> = {}
+    const entities: unknown[] = []
     for (const l of links) {
       const d = await decideUnfurl(
         {
@@ -201,19 +219,151 @@ export const slackRoutes = (ctx: AppContext) => {
         l.url,
         userLink.user_id,
       )
-      if (d.kind === "card") unfurls[d.url] = { blocks: d.blocks }
       // `skip` is the ladder's catch-all — not ours, gone, another workspace, or not readable by
       // this viewer — and it is the rung that most often surprises someone. Naming the URL is
       // what makes it actionable.
-      else why(`decision: ${d.kind}`, { url: l.url, viewer: userLink.user_id })
+      if (d.kind === "skip" || d.kind === "auth") {
+        why(`decision: ${d.kind}`, { url: l.url, viewer: userLink.user_id })
+        continue
+      }
+      unfurls[d.url] = { blocks: d.blocks }
+      entities.push(await entityFor(d, l.url))
     }
     if (!Object.keys(unfurls).length) return why("no link produced a card", { links: links.length })
-    await unfurlSlackLinks(bot.token, target, unfurls)
-    log.info("unfurl sent", {
-      team: teamId,
-      channel: ev.channel,
-      count: Object.keys(unfurls).length,
+
+    // Work Object first; the block card is the fallback. unfurlSlackEntities throws on a WARNING
+    // as well as an error, because this API answers 200-with-a-warning when the payload is subtly
+    // wrong or Work Objects are not enabled on the app — a silent nothing in the channel. Falling
+    // back means a workspace without the feature still gets the card it got yesterday.
+    try {
+      await unfurlSlackEntities(bot.token, target, entities)
+      log.info("unfurl sent", {
+        team: teamId,
+        channel: ev.channel,
+        count: entities.length,
+        kind: "entity",
+      })
+    } catch (err) {
+      log.warn("work object unfurl refused; falling back to blocks", {
+        team: teamId,
+        channel: ev.channel,
+        err: String(err),
+      })
+      await unfurlSlackLinks(bot.token, target, unfurls)
+      log.info("unfurl sent", {
+        team: teamId,
+        channel: ev.channel,
+        count: Object.keys(unfurls).length,
+        kind: "blocks",
+      })
+    }
+  }
+
+  /** The Work Object for one decided link. A locked artifact still gets an entity — a title-less
+   *  one, exactly as broadcast-safe as the block card it replaces — because the entity is what
+   *  makes the card CLICKABLE, and the flexpane behind it is per-viewer. That is how someone
+   *  entitled to a private doc finally sees it while the channel still sees nothing. */
+  const entityFor = async (
+    d: Extract<UnfurlDecision, { kind: "card" | "locked" }>,
+    pastedUrl: string,
+  ): Promise<unknown> => {
+    const iconUrl = new URL("/icon.png", deps.baseUrl).toString()
+    if (d.kind === "locked")
+      return {
+        app_unfurl_url: pastedUrl,
+        url: `${deps.baseUrl}/artifacts/${encodeURIComponent(d.artifact.short_id)}`,
+        external_ref: { id: d.artifact.short_id, type: DERIVE_ENTITY_TYPE },
+        entity_type: "slack#/entities/content_item",
+        entity_payload: {
+          attributes: {
+            title: { text: "A private Derive artifact" },
+            display_type: "Private",
+            product_name: "Derive",
+            product_icon: { url: iconUrl, alt_text: "Derive" },
+          },
+          fields: {},
+        },
+      }
+    const status = await artifactStatus(meta, d.artifact)
+    return artifactEntity({
+      pastedUrl,
+      artifact: d.artifact,
+      info: d.info,
+      status,
+      // Slack fetches preview images ANONYMOUSLY, so only a world-readable artifact can carry
+      // one; anything else would render /v1/og's title-less padlock as the card's picture.
+      previewUrl: d.artifact.listed === "public" ? d.info.imageUrl : null,
+      withActions: status.review?.state === "pending",
+      iconUrl,
     })
+  }
+
+  /** Fill the flexpane for one viewer.
+   *
+   *  Three answers, and the middle one is the reason Work Objects are worth adopting. An
+   *  unlinked viewer is asked to connect — privately, where the old broadcast prompt shouted at
+   *  the whole channel. A linked viewer without access is told so plainly, in a panel only they
+   *  see, while the card in the channel keeps revealing nothing. And a viewer who may read it
+   *  gets the real thing, INCLUDING for an artifact whose broadcast card is deliberately
+   *  title-less. Authorization is the same standing-only rule decideUnfurl applies: a link role
+   *  is personal to whoever holds the URL and must never be what unlocks a preview.
+   */
+  const presentEntityDetails = async (teamId: string, ev: SlackEventPayload): Promise<void> => {
+    const ref = ev.external_ref?.id
+    const trigger = ev.trigger_id
+    if (!ref || !trigger || !ev.user) return
+    const installs = await meta.listSlackInstallsByTeam(teamId)
+    const userLink = await meta.getSlackUserLinkBySlackId(teamId, ev.user)
+    const install = installs.find((i) => i.org_id === userLink?.org_id) ?? installs[0]
+    if (!install) return
+    const bot = await resolveBotToken(meta, install.org_id, deps.encryptionKey)
+    if (!bot) return
+    const iconUrl = new URL("/icon.png", deps.baseUrl).toString()
+
+    const say = async (
+      b: Parameters<typeof presentSlackEntityDetails>[2],
+      reason: string,
+    ): Promise<void> => {
+      try {
+        await presentSlackEntityDetails(bot.token, trigger, b)
+        log.info("flexpane presented", { team: teamId, ref, outcome: reason })
+      } catch (err) {
+        log.warn("flexpane failed", { team: teamId, ref, reason, err: String(err) })
+      }
+    }
+
+    if (!userLink)
+      return say(
+        { kind: "auth", url: new URL("/v1/slack/link", deps.baseUrl).toString() },
+        "not linked",
+      )
+
+    let artifact: ArtifactRecord | null = null
+    for (const id of candidateShortIds(ref)) {
+      artifact = await meta.getByShortId(id)
+      if (artifact) break
+    }
+    if (!artifact || artifact.removed_at || artifact.org_id !== install.org_id)
+      return say(
+        { kind: "restricted", title: "Not available", message: "This doc no longer exists." },
+        "gone",
+      )
+    if (!(await authorizeUserStanding(userLink.user_id, "read", artifact)))
+      return say(
+        {
+          kind: "restricted",
+          title: "No access",
+          message: "You don't have access to this doc in Derive. Ask its owner to share it.",
+        },
+        "no access",
+      )
+
+    const info = await unfurlInfoFor(meta, deps.baseUrl, artifact)
+    const status = await artifactStatus(meta, artifact)
+    return say(
+      { kind: "details", metadata: artifactDetails(info, status, userLink.user_id, iconUrl) },
+      "details",
+    )
   }
 
   interface ConnectState {
@@ -441,6 +591,19 @@ export const slackRoutes = (ctx: AppContext) => {
         }
       return c.json({ ok: true })
     }
+    // Someone clicked a Work Object card, opening the flexpane. THIS is the per-viewer surface
+    // chat.unfurl never had: the event names the clicking `user`, so the answer can finally
+    // depend on who is asking rather than on the most cautious reader in the channel.
+    if (
+      body.type === "event_callback" &&
+      ev?.type === "entity_details_requested" &&
+      body.team_id &&
+      ev.user &&
+      ev.trigger_id
+    ) {
+      runAfterAck(presentEntityDetails(body.team_id, ev))
+      return c.json({ ok: true })
+    }
     // A Derive link was pasted (or is being typed). Render a preview for it. Deferred behind the
     // ack like every other slow path here: resolving each link reads the artifact, its versions
     // and its comments, and Slack still wants a reply inside 3s.
@@ -666,6 +829,39 @@ export const slackRoutes = (ctx: AppContext) => {
             },
           ),
         )
+      }
+      return c.json({ ok: true })
+    }
+
+    // A Work Object review button. The artifact comes from the card's external_ref rather than a
+    // button value — Slack round-trips the entity, so there is no attacker-supplied id to bind.
+    if (
+      action.action_id === SLACK_REVIEW_ACTION.approve ||
+      action.action_id === SLACK_REVIEW_ACTION.sendBack
+    ) {
+      const ref = payload.entity?.external_ref?.id
+      if (ref && payload.team?.id && payload.user?.id) {
+        let artifact: ArtifactRecord | null = null
+        for (const id of candidateShortIds(ref)) {
+          artifact = await meta.getByShortId(id)
+          if (artifact) break
+        }
+        // Bind the acting Slack team to the artifact's workspace, exactly as the thread and
+        // proposal branches do: one signed workspace must not act on another org's review.
+        const install = artifact ? await meta.getSlackInstall(artifact.org_id) : null
+        if (artifact && install && install.team_id === payload.team.id)
+          runAfterAck(
+            runSlackReviewAction(
+              { meta, bus, billingBlocked },
+              {
+                teamId: payload.team.id,
+                slackUserId: payload.user.id,
+                artifact,
+                op: action.action_id === SLACK_REVIEW_ACTION.approve ? "approve" : "send_back",
+                responseUrl: payload.response_url,
+              },
+            ),
+          )
       }
       return c.json({ ok: true })
     }
@@ -1267,6 +1463,11 @@ interface SlackEventPayload {
    *  `oauth` = per-user tokens (a member's "Sign in with Slack" grant); `bot` = the bot's own,
    *  the only class that invalidates the install. Either key may be absent. */
   tokens?: { oauth?: string[]; bot?: string[] }
+  /** On `entity_details_requested` only: which Work Object was clicked, and the one-shot token
+   *  that authorizes filling its flexpane. `external_ref` is the pair we set on the entity, so
+   *  `id` is the artifact's stable short id. */
+  external_ref?: { id?: string; type?: string }
+  trigger_id?: string
   /** On `link_shared` only. `message_ts` + `channel` locate a posted message; `unfurl_id` +
    *  `source` are the alternative handle Slack gives for a link still in the composer.
    *  `is_bot_user_member` says whether the bot is actually in that channel — the event fires
@@ -1298,6 +1499,9 @@ interface SlackInteractionPayload {
   /** block_suggestion only: what has been typed into the select so far. */
   value?: string
   action_id?: string
+  /** Present on a Work Object action: the entity whose button was pressed. Slack round-trips
+   *  what we set, so `external_ref.id` is our own short id coming home. */
+  entity?: { external_ref?: { id?: string; type?: string } }
   /** view_submission / block_suggestion: the modal the interaction came from. */
   view?: {
     callback_id?: string

--- a/apps/api/src/slack-app-setup.ts
+++ b/apps/api/src/slack-app-setup.ts
@@ -94,6 +94,11 @@ export const buildSlackManifest = (baseUrl: string) => {
           "message.channels",
           "message.groups",
           "link_shared",
+          // Work Objects: fired when someone CLICKS an unfurled card, opening the flexpane. It
+          // carries the clicking user, which is what makes that surface per-viewer — the thing
+          // link_shared and chat.unfurl cannot be. Needs no new scope, so an existing install
+          // picks it up on a manifest re-apply without a reconnect.
+          "entity_details_requested",
           "app_uninstalled",
           "tokens_revoked",
         ],

--- a/apps/api/test/slack-review-action.test.ts
+++ b/apps/api/test/slack-review-action.test.ts
@@ -1,0 +1,150 @@
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { type ArtifactRecord, newId } from "@derive/core"
+import { SqliteMetaStore } from "@derive/db/sqlite"
+import { afterAll, describe, expect, it, vi } from "vitest"
+import { runSlackReviewAction } from "../src/lib/slack-review"
+
+// Approving from Slack must land in exactly the state `derive approve` or the sidebar button
+// would produce — the agent polling catch_up cannot tell which surface settled the round, and
+// must not have to. So the permissions mirror routes/review.ts rather than inventing a
+// Slack-specific rule: `comment` to send back, `approve` to approve.
+const dir = mkdtempSync(join(tmpdir(), "derive-slack-review-"))
+afterAll(() => rmSync(dir, { recursive: true, force: true }))
+
+const bus = { publish: () => {}, subscribe: () => () => {} } as never
+const noBilling = async () => null
+
+const setup = async (name: string, opts: { role?: string; link?: boolean } = {}) => {
+  const meta = new SqliteMetaStore(join(dir, `${name}.db`))
+  await meta.ready
+  const artifact = await meta.createArtifact({
+    id: newId("a"),
+    short_id: newId("s").slice(0, 8),
+    org_id: "default",
+    slug: null,
+    title: "Doc",
+    workspace_access: "member",
+    link_role: "none",
+    listed: "workspace",
+    kind: "file",
+    spa: 0,
+  })
+  if (opts.link !== false)
+    await meta.setSlackUserLink({
+      id: newId("sul"),
+      org_id: "default",
+      user_id: "u-1",
+      team_id: "T1",
+      slack_user_id: "U1",
+      created_at: new Date().toISOString(),
+    })
+  if (opts.role)
+    await meta.setMembership({
+      id: newId("mem"),
+      org_id: "default",
+      user_id: "u-1",
+      role: opts.role as "owner",
+    })
+  const round = await meta.createReviewRound({
+    id: newId("rr"),
+    artifact_id: artifact.id,
+    version: 1,
+    requested_by: "ag-1",
+    requested_for: "u-1",
+    note: null,
+  })
+  return { meta, artifact: artifact as ArtifactRecord, round }
+}
+
+const run = (
+  meta: SqliteMetaStore,
+  artifact: ArtifactRecord,
+  op: "approve" | "send_back",
+  sent: string[],
+) => {
+  vi.stubGlobal("fetch", async (_u: string, init: RequestInit) => {
+    sent.push(String((JSON.parse(String(init.body)) as { text?: string }).text ?? ""))
+    return new Response("ok", { status: 200 })
+  })
+  return runSlackReviewAction(
+    { meta: meta as never, bus, billingBlocked: noBilling },
+    {
+      teamId: "T1",
+      slackUserId: "U1",
+      artifact,
+      op,
+      responseUrl: "https://hooks.slack.test/x",
+    },
+  )
+}
+
+describe("runSlackReviewAction", () => {
+  it("approves as the linked account, settling the round", async () => {
+    const { meta, artifact, round } = await setup("approve-ok", { role: "owner" })
+    const sent: string[] = []
+    await run(meta, artifact, "approve", sent)
+    expect(await meta.getPendingRound(artifact.id)).toBeNull()
+    const rounds = await meta.listReviewRounds(artifact.id)
+    expect(rounds.find((r) => r.id === round.id)?.state).toBe("approved")
+    expect(sent.join(" ")).toContain("Approved")
+  })
+
+  it("sends back on a comment-level role, which may not approve", async () => {
+    const { meta, artifact, round } = await setup("sendback-ok", { role: "commenter" })
+    const sent: string[] = []
+    await run(meta, artifact, "send_back", sent)
+    const rounds = await meta.listReviewRounds(artifact.id)
+    expect(rounds.find((r) => r.id === round.id)?.state).toBe("sent_back")
+
+    const second = await setup("approve-denied", { role: "commenter" })
+    const denied: string[] = []
+    await run(second.meta, second.artifact, "approve", denied)
+    expect(denied.join(" ")).toContain("permission")
+    expect(await second.meta.getPendingRound(second.artifact.id)).not.toBeNull()
+  })
+
+  // No Derive principal ⇒ nothing to authorize against. Same prompt the proposal buttons give.
+  it("refuses an unlinked clicker", async () => {
+    const { meta, artifact } = await setup("no-link", { role: "owner", link: false })
+    const sent: string[] = []
+    await run(meta, artifact, "approve", sent)
+    expect(sent.join(" ")).toContain("Link your Slack account")
+    expect(await meta.getPendingRound(artifact.id)).not.toBeNull()
+  })
+
+  // The card may have been rendered minutes ago; the round can be settled from Derive meanwhile.
+  it("says so when the round is already gone, rather than acting", async () => {
+    const { meta, artifact, round } = await setup("already", { role: "owner" })
+    await meta.resolveReviewRound(round.id, { state: "approved", note: null })
+    const sent: string[] = []
+    await run(meta, artifact, "approve", sent)
+    expect(sent.join(" ")).toContain("no review pending")
+  })
+
+  it("honours the billing gate on approve only", async () => {
+    const { meta, artifact } = await setup("billing", { role: "owner" })
+    const sent: string[] = []
+    vi.stubGlobal("fetch", async (_u: string, init: RequestInit) => {
+      sent.push(String((JSON.parse(String(init.body)) as { text?: string }).text ?? ""))
+      return new Response("ok", { status: 200 })
+    })
+    await runSlackReviewAction(
+      {
+        meta: meta as never,
+        bus,
+        billingBlocked: async () => ({ code: "past_due", message: "Billing is past due." }),
+      },
+      {
+        teamId: "T1",
+        slackUserId: "U1",
+        artifact,
+        op: "approve",
+        responseUrl: "https://hooks.slack.test/x",
+      },
+    )
+    expect(sent.join(" ")).toContain("past due")
+    expect(await meta.getPendingRound(artifact.id)).not.toBeNull()
+  })
+})

--- a/apps/api/test/slack-review-action.test.ts
+++ b/apps/api/test/slack-review-action.test.ts
@@ -18,7 +18,6 @@ const noBilling = async () => null
 
 const setup = async (name: string, opts: { role?: string; link?: boolean } = {}) => {
   const meta = new SqliteMetaStore(join(dir, `${name}.db`))
-  await meta.ready
   const artifact = await meta.createArtifact({
     id: newId("a"),
     short_id: newId("s").slice(0, 8),

--- a/apps/api/test/slack-routes.test.ts
+++ b/apps/api/test/slack-routes.test.ts
@@ -1161,7 +1161,89 @@ describe("slack link unfurls", () => {
     await called
     expect(seen[0]?.channel).toBe("C9")
     expect(seen[0]?.ts).toBe("1700000000.1")
-    expect(JSON.stringify(seen[0]?.unfurls)).toContain("Q4 roadmap")
+    // A Work Object, not blocks: a typed entity Slack renders itself, keyed on the artifact's
+    // stable short id (the key its search and related-conversation aggregation both use).
+    const ents = (seen[0]?.metadata as { entities?: Record<string, unknown>[] })?.entities
+    expect(ents).toHaveLength(1)
+    const ent = ents?.[0] as Record<string, unknown>
+    expect(ent.entity_type).toBe("slack#/entities/content_item")
+    expect((ent.external_ref as { id: string }).id).toBe(artifact.short_id)
+    expect(JSON.stringify(ent.entity_payload)).toContain("Q4 roadmap")
+    // Every image carries alt_text. Its absence is this API's documented SILENT failure: a 200
+    // with a buried warning, and an empty channel.
+    const payload = JSON.stringify(ent.entity_payload)
+    for (const m of payload.matchAll(/"url":"[^"]*"/g)) void m
+    expect(payload).toContain('"alt_text"')
+  })
+
+  // Work Objects answer 200-with-a-warning when the payload is subtly wrong or the feature is
+  // off on the app — a silent nothing in the channel. The block card must still go out.
+  it("falls back to the block card when Slack warns on the entity", async () => {
+    const { app, meta } = make("slack-unfurl-fallback")
+    await meta.setSlackInstall({
+      org_id: "default",
+      team_id: "T1",
+      team_name: "Acme",
+      bot_token: encryptSecret("xoxb-1", KEY),
+      bot_user_id: "UBOT",
+      created_at: new Date().toISOString(),
+    })
+    await meta.setSlackUserLink({
+      id: newId("sul"),
+      org_id: "default",
+      user_id: owner.id,
+      team_id: "T1",
+      slack_user_id: "U1",
+      created_at: new Date().toISOString(),
+    })
+    const artifact = await meta.createArtifact({
+      id: newId("a"),
+      short_id: newId("s").slice(0, 8),
+      org_id: "default",
+      slug: null,
+      title: "Fallback doc",
+      workspace_access: "member",
+      link_role: "viewer",
+      listed: "workspace",
+      kind: "file",
+      spa: 0,
+    })
+    const seen: Record<string, unknown>[] = []
+    let resolveSecond: (v: unknown) => void = () => {}
+    const twice = new Promise((r) => {
+      resolveSecond = r
+    })
+    vi.stubGlobal("fetch", async (url: string, init: RequestInit) => {
+      if (String(url).includes("chat.unfurl")) {
+        const body = JSON.parse(String(init.body)) as Record<string, unknown>
+        seen.push(body)
+        if (seen.length === 2) resolveSecond(null)
+        // The entity attempt "succeeds" with a warning; the block retry is clean.
+        if (body.metadata)
+          return new Response(JSON.stringify({ ok: true, warning: "missing_alt_text" }), {
+            status: 200,
+          })
+      }
+      return new Response(JSON.stringify({ ok: true }), { status: 200 })
+    })
+    await postEvent(
+      app,
+      JSON.stringify({
+        type: "event_callback",
+        team_id: "T1",
+        event: {
+          type: "link_shared",
+          user: "U1",
+          channel: "C9",
+          message_ts: "1700000000.1",
+          links: [{ url: `http://derive.test/artifacts/${artifact.short_id}` }],
+        },
+      }),
+    )
+    await twice
+    expect(seen).toHaveLength(2)
+    expect(seen[0]?.metadata).toBeTruthy()
+    expect(JSON.stringify(seen[1]?.unfurls)).toContain("Fallback doc")
   })
 
   // An unlinked sharer gets Slack's own sign-in prompt instead of a card — the only per-person
@@ -1928,5 +2010,115 @@ describe("Save to Derive", () => {
     const r = await postInteract(app, submission(artifact.id))
     expect(JSON.stringify(await r.json())).toContain("Connect your Derive account")
     expect(await meta.listComments(artifact.id)).toHaveLength(0)
+  })
+})
+
+// The flexpane — the per-viewer half. `chat.unfurl` never had a `user` parameter, so the
+// broadcast card has always had to assume the most cautious reader in the channel. This surface
+// carries the clicking user, so the answer can finally depend on who is asking.
+describe("entity_details_requested (the flexpane)", () => {
+  const withInstall = async (name: string, opts: { link?: boolean; listed?: string } = {}) => {
+    const { app, meta } = make(name)
+    await meta.setSlackInstall({
+      org_id: "default",
+      team_id: "T1",
+      team_name: "Acme",
+      bot_token: encryptSecret("xoxb-1", KEY),
+      bot_user_id: "UBOT",
+      created_at: new Date().toISOString(),
+    })
+    if (opts.link !== false)
+      await meta.setSlackUserLink({
+        id: newId("sul"),
+        org_id: "default",
+        user_id: owner.id,
+        team_id: "T1",
+        slack_user_id: "U1",
+        created_at: new Date().toISOString(),
+      })
+    const artifact = await meta.createArtifact({
+      id: newId("a"),
+      short_id: newId("s").slice(0, 8),
+      org_id: "default",
+      slug: null,
+      title: "Secret plan",
+      workspace_access: "member",
+      link_role: "viewer",
+      listed: (opts.listed ?? "workspace") as "workspace",
+      kind: "file",
+      spa: 0,
+    })
+    return { app, meta, artifact }
+  }
+
+  const clickAndCapture = async (
+    app: ReturnType<typeof make>["app"],
+    shortId: string,
+    user = "U1",
+  ) => {
+    const seen: Record<string, unknown>[] = []
+    let fired: (v: unknown) => void = () => {}
+    const called = new Promise((r) => {
+      fired = r
+    })
+    vi.stubGlobal("fetch", async (url: string, init: RequestInit) => {
+      if (String(url).includes("entity.presentDetails")) {
+        seen.push(JSON.parse(String(init.body)) as Record<string, unknown>)
+        fired(null)
+      }
+      return new Response(JSON.stringify({ ok: true }), { status: 200 })
+    })
+    await postEvent(
+      app,
+      JSON.stringify({
+        type: "event_callback",
+        team_id: "T1",
+        event: {
+          type: "entity_details_requested",
+          user,
+          trigger_id: "trig-1",
+          external_ref: { id: shortId, type: "artifact" },
+        },
+      }),
+    )
+    await called
+    return seen[0] ?? {}
+  }
+
+  it("asks an unlinked viewer to connect — privately, not to the channel", async () => {
+    const { app, artifact } = await withInstall("flex-unlinked", { link: false })
+    const body = await clickAndCapture(app, artifact.short_id)
+    expect(body.user_auth_required).toBe(true)
+    expect(String(body.user_auth_url)).toContain("/v1/slack/link")
+  })
+
+  // The point of the whole change: a viewer entitled to a doc sees it, even when the broadcast
+  // card is deliberately saying nothing.
+  it("shows the real detail to a viewer who may read it", async () => {
+    const { app, artifact } = await withInstall("flex-allowed")
+    const body = await clickAndCapture(app, artifact.short_id)
+    expect(JSON.stringify(body.metadata)).toContain("Secret plan")
+    expect(body.error).toBeUndefined()
+  })
+
+  // …and someone without access is told so in a panel only THEY see, while the channel's card
+  // continues to reveal nothing.
+  it("returns a restricted view to a linked viewer without access", async () => {
+    const { app, meta } = await withInstall("flex-denied")
+    const theirs = await meta.createArtifact({
+      id: newId("a"),
+      short_id: newId("s").slice(0, 8),
+      org_id: "someone-else",
+      slug: null,
+      title: "Not yours",
+      workspace_access: "member",
+      link_role: "none",
+      listed: "workspace",
+      kind: "file",
+      spa: 0,
+    })
+    const body = await clickAndCapture(app, theirs.short_id)
+    expect((body.error as { status: string }).status).toBe("custom_partial_view")
+    expect(JSON.stringify(body)).not.toContain("Not yours")
   })
 })

--- a/apps/api/test/slack-unfurl.test.ts
+++ b/apps/api/test/slack-unfurl.test.ts
@@ -76,8 +76,11 @@ describe("decideUnfurl — the broadcast gate", () => {
   it("renders a locked card that leaks the title in no form, including the slug", async () => {
     const { deps, url, artifact } = await setup("unfurl-private", "none")
     const d = await decideUnfurl(deps, url, "u-1")
-    expect(d.kind).toBe("card")
-    if (d.kind !== "card") return
+    // `locked` is its own kind now: the BROADCAST half must still say nothing, but the artifact
+    // rides along so the caller can build a clickable entity whose flexpane answers per-viewer.
+    expect(d.kind).toBe("locked")
+    if (d.kind !== "locked") return
+    expect(d.artifact.short_id).toBe(artifact.short_id)
     const json = JSON.stringify(d.blocks)
     expect(json).toContain("private Derive artifact")
     // It links to the bare short id, which the canonical redirect resolves.
@@ -98,8 +101,8 @@ describe("decideUnfurl — the broadcast gate", () => {
   it("does not add a title the pasted URL never carried", async () => {
     const { deps, artifact } = await setup("unfurl-private-bare", "none")
     const d = await decideUnfurl(deps, `${BASE}/artifacts/${artifact.short_id}`, "u-1")
-    expect(d.kind).toBe("card")
-    if (d.kind === "card") expect(JSON.stringify(d.blocks)).not.toMatch(/q4/i)
+    expect(d.kind).toBe("locked")
+    if (d.kind === "locked") expect(JSON.stringify(d.blocks)).not.toMatch(/q4/i)
   })
 
   it("skips an artifact the sharer cannot read", async () => {

--- a/apps/api/test/slack-work-object.test.ts
+++ b/apps/api/test/slack-work-object.test.ts
@@ -1,0 +1,186 @@
+import type { ArtifactRecord, UnfurlInfo } from "@derive/core"
+import { describe, expect, it } from "vitest"
+import { type ArtifactStatus, agoLabel, statusPhrase } from "../src/lib/artifact-status"
+import { SLACK_SUBSCRIBABLE_EVENTS } from "../src/lib/slack-subscriptions"
+import { artifactDetails, artifactEntity, SLACK_REVIEW_ACTION } from "../src/lib/slack-work-object"
+
+const artifact = (over: Partial<ArtifactRecord> = {}) =>
+  ({
+    id: "a1",
+    short_id: "abc123",
+    org_id: "default",
+    title: "Q4 plan",
+    listed: "workspace",
+    current_version: 3,
+    updated_at: "2026-08-01T10:00:00.000Z",
+    ...over,
+  }) as ArtifactRecord
+
+const info: UnfurlInfo = {
+  title: "Q4 plan",
+  kindLabel: "Doc",
+  versionCount: 3,
+  commentCount: 7,
+  pageUrl: "https://derive.to/artifacts/q4-plan-abc123",
+  imageUrl: "https://derive.to/v1/og/abc123",
+  oembedUrl: "x",
+  embedUrl: "y",
+}
+
+const status = (over: Partial<ArtifactStatus> = {}): ArtifactStatus => ({
+  review: null,
+  openThreads: 0,
+  updatedAt: "2026-08-01T10:00:00.000Z",
+  ...over,
+})
+
+const base = { pastedUrl: "https://derive.to/artifacts/q4-plan-abc123", iconUrl: "https://d/i.png" }
+
+describe("artifactEntity", () => {
+  // external_ref is the key Slack stores for search and related-conversation aggregation. It has
+  // to be the STABLE short id — a slug is re-derived on every rename, which would orphan every
+  // previously-unfurled card from its history.
+  it("keys on the stable short id, never a slug", () => {
+    const e = artifactEntity({ ...base, artifact: artifact(), info, status: status() })
+    expect(e.external_ref).toEqual({ id: "abc123", type: "artifact" })
+    expect(e.entity_type).toBe("slack#/entities/content_item")
+    // The pasted URL is how Slack matches the unfurl back to the message; it is NOT the
+    // canonical url, and swapping them silently unfurls nothing.
+    expect(e.app_unfurl_url).toBe(base.pastedUrl)
+    expect(e.url).toBe(info.pageUrl)
+  })
+
+  // A missing alt_text is this API's documented silent failure: 200 OK, a buried warning, and an
+  // empty channel. Every image we emit must carry one.
+  it("gives every image an alt_text", () => {
+    const e = artifactEntity({
+      ...base,
+      artifact: artifact({ listed: "public" }),
+      info,
+      status: status(),
+      previewUrl: info.imageUrl,
+    })
+    const attrs = (e.entity_payload as { attributes: Record<string, never> }).attributes
+    expect(attrs.product_icon).toMatchObject({ alt_text: expect.any(String) })
+    // And no alt_text anywhere is present-but-empty, which Slack treats the same as missing.
+    const walk = (v: unknown): void => {
+      if (Array.isArray(v)) return void v.forEach(walk)
+      if (v && typeof v === "object") {
+        const o = v as Record<string, unknown>
+        if ("alt_text" in o) expect(String(o.alt_text).length).toBeGreaterThan(0)
+        Object.values(o).forEach(walk)
+      }
+    }
+    walk(e)
+  })
+
+  it("leads with the review state as a coloured status tag", () => {
+    const e = artifactEntity({
+      ...base,
+      artifact: artifact(),
+      info,
+      status: status({
+        review: { state: "pending", reviewerId: "u-mert", reviewerName: "Mert" },
+        openThreads: 2,
+      }),
+      withActions: true,
+    })
+    const p = e.entity_payload as Record<string, never>
+    expect(p.fields).toMatchObject({
+      status: { value: "Awaiting review", tag_color: "blue" },
+      assignee: { type: "slack#/types/user", user: { text: "Mert" } },
+    })
+    expect(JSON.stringify(p.custom_fields)).toContain("Open threads")
+  })
+
+  // Buttons ride the BROADCAST card, so they appear only when there is something to settle.
+  it("offers review buttons only while a round is pending", () => {
+    const withRound = artifactEntity({
+      ...base,
+      artifact: artifact(),
+      info,
+      status: status({ review: { state: "pending", reviewerId: "u", reviewerName: "M" } }),
+      withActions: true,
+    })
+    const actions = (withRound.entity_payload as Record<string, never>).actions as {
+      primary_actions: { action_id: string }[]
+    }
+    expect(actions.primary_actions.map((a) => a.action_id)).toEqual([
+      SLACK_REVIEW_ACTION.approve,
+      SLACK_REVIEW_ACTION.sendBack,
+    ])
+    const settled = artifactEntity({ ...base, artifact: artifact(), info, status: status() })
+    expect((settled.entity_payload as Record<string, never>).actions).toBeUndefined()
+  })
+
+  // Slack fetches preview images ANONYMOUSLY, and /v1/og answers an anonymous fetch by link
+  // role — so a workspace-only artifact would render the title-less padlock as its picture.
+  it("carries a preview for a public artifact and none for a workspace one", () => {
+    const pub = artifactEntity({
+      ...base,
+      artifact: artifact({ listed: "public" }),
+      info,
+      status: status(),
+      previewUrl: info.imageUrl,
+    })
+    expect((pub.entity_payload as Record<string, never>).attributes).toHaveProperty(
+      "full_size_preview",
+    )
+    const ws = artifactEntity({ ...base, artifact: artifact(), info, status: status() })
+    expect((ws.entity_payload as Record<string, never>).attributes).not.toHaveProperty(
+      "full_size_preview",
+    )
+  })
+})
+
+describe("artifactDetails (the flexpane)", () => {
+  it("describes the artifact for a viewer entitled to it", () => {
+    const d = artifactDetails(
+      info,
+      status({ review: { state: "pending", reviewerId: "u-me", reviewerName: "Mert" } }),
+      "u-me",
+      "https://d/i.png",
+    )
+    expect(JSON.stringify(d)).toContain("Q4 plan")
+    expect((d.entity_payload as Record<string, never>).fields).toHaveProperty("status")
+  })
+})
+
+describe("statusPhrase", () => {
+  // The single most clickable word on the card: "your".
+  it("says 'your review' to the reviewer and names them to everyone else", () => {
+    const s = status({ review: { state: "pending", reviewerId: "u-mert", reviewerName: "Mert" } })
+    expect(statusPhrase(s, "u-mert")?.text).toBe("Awaiting your review")
+    expect(statusPhrase(s, "u-other")).toEqual({
+      text: "Awaiting review from",
+      reviewerName: "Mert",
+    })
+  })
+
+  it("is null when nothing is pending, so callers fall back to the description", () => {
+    expect(statusPhrase(status(), "u")).toBeNull()
+  })
+})
+
+describe("agoLabel", () => {
+  const now = Date.parse("2026-08-01T12:00:00.000Z")
+  it("is coarse on purpose — the question is 'still current', not 'what minute'", () => {
+    expect(agoLabel("2026-08-01T11:59:30.000Z", now)).toBe("just now")
+    expect(agoLabel("2026-08-01T10:00:00.000Z", now)).toBe("2h ago")
+    expect(agoLabel("2026-07-20T12:00:00.000Z", now)).toBe("12d ago")
+    expect(agoLabel("2026-02-01T12:00:00.000Z", now)).toBe("6mo ago")
+  })
+  it("survives a null or unparseable timestamp", () => {
+    expect(agoLabel(null, now)).toBeNull()
+    expect(agoLabel("not a date", now)).toBeNull()
+  })
+})
+
+// The loop's most decision-relevant moment. These reached the reviewer's DM but no CHANNEL could
+// hear that a doc was blocked on someone — the fact a team most wants ambient.
+describe("review events are channel-subscribable", () => {
+  it("offers the review round alongside publishes and proposals", () => {
+    for (const e of ["review.requested", "review.sent_back", "review.approved"])
+      expect(SLACK_SUBSCRIBABLE_EVENTS).toContain(e)
+  })
+})

--- a/apps/api/test/slack-work-object.test.ts
+++ b/apps/api/test/slack-work-object.test.ts
@@ -102,7 +102,7 @@ describe("artifactEntity", () => {
       status: status({ review: { state: "pending", reviewerId: "u", reviewerName: "M" } }),
       withActions: true,
     })
-    const actions = (withRound.entity_payload as Record<string, never>).actions as {
+    const actions = (withRound.entity_payload as { actions?: unknown }).actions as {
       primary_actions: { action_id: string }[]
     }
     expect(actions.primary_actions.map((a) => a.action_id)).toEqual([

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -3276,7 +3276,7 @@ export interface paths {
                     content: {
                         "application/json": {
                             subscriptions: components["schemas"]["SlackSubscription"][];
-                            event_options: ("comment.created" | "version.published" | "proposal.created" | "proposal.approved" | "proposal.changes_requested")[];
+                            event_options: ("comment.created" | "version.published" | "proposal.created" | "proposal.approved" | "proposal.changes_requested" | "review.requested" | "review.sent_back" | "review.approved")[];
                         };
                     };
                 };


### PR DESCRIPTION
A pasted Derive link unfurled as inventory — `Markdown · 1 version · 0 comments · on Derive`. That answers *"what is this?"*, not *"does this want something from me?"*.

And the whole design was boxed in by the constraint documented at the top of `slack-unfurl.ts`:

> an unfurl is attached to the MESSAGE, not to a viewer. `chat.unfurl` takes no `user` parameter, so whatever we render is seen by everyone in the channel.

That is why a private artifact gets a title-less padlock, and why there is no screenshot. **Work Objects remove that constraint.**

## What changed

The unfurl becomes a **typed entity**, and clicking it opens a **flexpane** that carries the clicking `user` and may demand auth or return a restricted view — the per-viewer surface `chat.unfurl` never had.

| viewer | flexpane |
|---|---|
| not linked | `user_auth_required` — a private prompt, where the old one shouted at the channel |
| linked, no access | a restricted panel only *they* see; the channel's card still reveals nothing |
| linked, entitled | the real detail — **including for an artifact whose broadcast card is deliberately title-less** |

That last row is the point. No arrangement of blocks could do it.

## The card leads with what Derive knows

`getPendingRound` names the human a doc is **blocked on**. With agents as first-class authors, "an agent published this and nobody has looked" is the common case — and it is the fact that decides whether you click. It lands in Slack's typed `status` (with `tag_color`) and `assignee` fields, exactly where Linear puts the same thing, with **Approve** and **Send back** beside it.

Permissions mirror `routes/review.ts` rather than inventing a Slack rule: `comment` to send back, `approve` to approve, billing gated on approve alone.

Because the fields are typed, **Slack renders them** — so status, assignee and dates no longer pass through our mrkdwn escaping, historically the most bug-prone part of this integration.

## Two gaps closed on the way

- `review.requested` reached a DM but **no channel could subscribe to it** — a team could never see a doc was blocked.
- `review.sent_back` / `review.approved` only hit the realtime bus, reaching **neither webhooks nor channels**.

All three are now first-class events with cards and actor attribution.

## Fallback, because this API fails silently

`chat.unfurl` answers **`200 OK` with a buried `warning`** when a payload is subtly wrong (a missing `alt_text`) or when Work Objects are not enabled on the app — and the channel just stays empty. Given the day this project spent on exactly that failure shape, `unfurlSlackEntities` throws on a warning so the block card can still go out. Both halves are pinned by a test.

## Research

- **Linear** — the closest analogue: status, assignee, dates, and actions *in the unfurl*. No screenshot.
- **GitLab's** unfurl design issue — *"Slack notifications, slash commands, and unfurled links should show the same content"*, and private unfurls split off as a separate, harder problem.
- **Slack's own guidance** — Block Kit, interactivity central, images as accessories.
- Screenshots stay **public-artifact only**: `/v1/og` serves a real PNG to an anonymous fetch for world-readable artifacts and a padlock SVG otherwise (verified against production), and Slack fetches preview images anonymously.

## Verification

`pnpm ci` clean, 1915 API tests, 258 web. No reinstall needed — the new event requires no scope, so a manifest re-apply suffices.

Live checks still to run in `#slack-app-test`: the typed card, a warning-free `chat.unfurl` response, the flexpane's three branches, and the Approve / Send back round trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788178414&installation_model_id=428097&pr_number=611&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F611&signature=e7aa1acf767f80dd4e84a8a22078b77f079dd64c3dd38dc9956b7b1be41b0db0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->