### PR TITLE
feat(dev): run the local stack against a remote database, safely

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -217,6 +217,14 @@ DATA_DIR=./data
 # set only to pin a specific id (e.g. to match an existing deployment).
 # DERIVE_DEFAULT_ORG_ID=ws_...
 
+# Set to 0 to stop this process running the shared background work: the webhook delivery
+# worker, the daily prune, the expired-draft sweep, and GitHub sync resume. They are ON by
+# default and a deployment should leave them on. This exists for one case — pointing a local
+# process at a REMOTE database to reproduce something. Those workers WRITE (the prune and the
+# sweep delete rows, and both the prune and sync-resume fire on boot, not just on a timer), so
+# without this a laptop joins that database's worker pool the moment it starts.
+# DERIVE_BACKGROUND_WORKERS=0
+
 # Render artifact preview screenshots on this Node deploy (needs a Playwright Chromium —
 # bundled in the Docker image; on a bare Node host run
 # `pnpm --filter @derive/api exec playwright install chromium`). Unset = previews off.

--- a/apps/api/src/config-manifest.ts
+++ b/apps/api/src/config-manifest.ts
@@ -328,6 +328,12 @@ const CONFIG_VARS: ConfigVar[] = [
     example: "ws_...",
   },
   {
+    name: "DERIVE_BACKGROUND_WORKERS",
+    group: "advanced",
+    doc: "Set to 0 to stop this process running the shared background work: the webhook delivery\nworker, the daily prune, the expired-draft sweep, and GitHub sync resume. They are ON by\ndefault and a deployment should leave them on. This exists for one case — pointing a local\nprocess at a REMOTE database to reproduce something. Those workers WRITE (the prune and the\nsweep delete rows, and both the prune and sync-resume fire on boot, not just on a timer), so\nwithout this a laptop joins that database's worker pool the moment it starts.",
+    example: "0",
+  },
+  {
     name: "DERIVE_PREVIEWS",
     group: "advanced",
     doc: "Render artifact preview screenshots on this Node deploy (needs a Playwright Chromium —\nbundled in the Docker image; on a bare Node host run\n`pnpm --filter @derive/api exec playwright install chromium`). Unset = previews off.",

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -85,6 +85,10 @@ export interface Config {
    *  locally-installed Playwright Chromium (bundled in the Docker image; bare Node
    *  hosts run `pnpm --filter @derive/api exec playwright install chromium`).
    *  Default false — no rendering on self-host unless explicitly enabled. */
+  /** Background timers + the webhook delivery worker. On by default; a deploy never
+   *  turns this off. Exists so a local process can share a REMOTE database read-mostly
+   *  (see scripts/dev-prod-db.sh) without joining that database's worker pool. */
+  backgroundWorkers: boolean
   previews: boolean
   /** EXPERIMENTAL: hosted automation runs on this Node deploy — the API process
    *  materializes due schedules and executes each run by spawning the derive CLI as a
@@ -189,6 +193,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     // Comma-separated operator emails (case-insensitive). More than one person
     // can run + host a deployment, so this is a list, not a single owner.
     superAdmins: superAdminsFromEnv(env),
+    backgroundWorkers: env.DERIVE_BACKGROUND_WORKERS !== "0",
     previews: env.DERIVE_PREVIEWS === "true",
     hostedRuns: env.DERIVE_HOSTED_RUNS === "true",
     runnerBin: env.DERIVE_RUNNER_BIN || "derive",

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -62,9 +62,11 @@ const cfg = loadConfig()
 // A dev server must never point at a remote database silently. The .env load
 // above makes that a one-line accident: a production DATABASE_URL left in the
 // repo root (say, from debugging an outage) turns every `pnpm dev` — and the
-// e2e harness — into a writer against prod. It happened. `pnpm dev` runs under
-// npm_lifecycle_event="dev"; deployments launch the entry directly, so they are
-// unaffected by this gate.
+// e2e harness — into a writer against prod. It happened. Matched on the whole `dev*`
+// family, not `dev` alone: a sibling script (`dev:prod-db`, and whatever comes next)
+// arrives with its own lifecycle event, and keying on one exact string would let any
+// of them walk straight past this. Deployments launch the entry directly with no
+// lifecycle event, so they are unaffected.
 const LOCAL_DB_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]", "0.0.0.0"])
 const dbHost = (() => {
   try {
@@ -77,7 +79,7 @@ const dbHost = (() => {
 })()
 const localDb = !!dbHost && (LOCAL_DB_HOSTS.has(dbHost) || dbHost.endsWith(".localhost"))
 const remoteDb = !!cfg.databaseUrl && !localDb
-if (remoteDb && process.env.npm_lifecycle_event === "dev") {
+if (remoteDb && (process.env.npm_lifecycle_event ?? "").startsWith("dev")) {
   if (!allowRemoteDbFromShell) {
     log.error(
       "refusing to start: dev mode with a remote DATABASE_URL (set DERIVE_ALLOW_REMOTE_DB=1 to override)",
@@ -332,7 +334,11 @@ const channelSenders: ChannelSenders = {
   // write the Derive comment here, off the ack path, publishing to the shared bus.
   slack_ingest: makeSlackIngestSender(meta, authSecret, backplane),
 }
-const webhookWorker = startWebhookWorker(meta, nodeDnsGuard, channelSenders)
+// Off only when DERIVE_BACKGROUND_WORKERS=0 — a local process sharing a remote database
+// must not drain that database's delivery outbox out from under the real deployment.
+const webhookWorker = cfg.backgroundWorkers
+  ? startWebhookWorker(meta, nodeDnsGuard, channelSenders)
+  : undefined
 
 // Preview render worker: an in-process interval + poke that renders screenshot jobs via
 // Playwright Chromium. Only started when DERIVE_PREVIEWS=true; when off the render queue
@@ -476,7 +482,9 @@ const app = createApp({
   publishRate: cfg.publishRate,
   commentRate: cfg.commentRate,
   // Deliver freshly enqueued events immediately instead of on the next interval.
-  pokeWebhooks: webhookWorker.poke,
+  // No worker (DERIVE_BACKGROUND_WORKERS=0) ⇒ nothing to poke; events still enqueue,
+  // and the real deployment's worker delivers them.
+  pokeWebhooks: webhookWorker?.poke,
   // Enqueue a render job on publish and drain on demand when previews are enabled.
   renderPreviews: cfg.previews,
   pokePreviews: previewWorker?.poke,
@@ -516,26 +524,32 @@ const maintain = async () => {
     .pruneStaleOAuthClients(new Date(Date.now() - OAUTH_ANON_CLIENT_TTL_MS).toISOString())
     .catch(() => 0)
 }
-void maintain()
-pruneTimer = setInterval(maintain, 24 * 3600_000)
-pruneTimer.unref?.()
+if (cfg.backgroundWorkers) {
+  // Note this fires on BOOT as well as on the interval, and it DELETES — which is why
+  // it is gated rather than merely slowed for a process pointed at a remote database.
+  void maintain()
+  pruneTimer = setInterval(maintain, 24 * 3600_000)
+  pruneTimer.unref?.()
+}
 
 // Expired anonymous drafts (the claim flow): swept hourly — the 24h maintenance
 // cadence is too coarse for a 72h TTL. The serve path already 410s an expired
 // draft, so this only reclaims rows; the mint route also sweeps opportunistically.
-const draftSweepTimer = setInterval(
-  () => void sweepExpiredDrafts(meta, search).catch(() => 0),
-  3600_000,
-)
-draftSweepTimer.unref?.()
+const draftSweepTimer = cfg.backgroundWorkers
+  ? setInterval(() => void sweepExpiredDrafts(meta, search).catch(() => 0), 3600_000)
+  : undefined
+draftSweepTimer?.unref?.()
 
 // Resume any GitHub sync left mid-flight: once on boot (a restart mid-sync) and on a
 // short interval (a self-heal backstop, mirroring the edge cron). The persisted
 // file-map makes resume idempotent, and the runner dedupes already-running loops, so
 // this is safe to call repeatedly. unref'd so it never holds the process open.
-void syncRunner.resumeStalled()
-const syncResumeTimer = setInterval(() => void syncRunner.resumeStalled(), 60_000)
-syncResumeTimer.unref?.()
+let syncResumeTimer: ReturnType<typeof setInterval> | undefined
+if (cfg.backgroundWorkers) {
+  void syncRunner.resumeStalled()
+  syncResumeTimer = setInterval(() => void syncRunner.resumeStalled(), 60_000)
+  syncResumeTimer.unref?.()
+}
 
 // EXPERIMENTAL hosted runs (DERIVE_HOSTED_RUNS=true, default off): this API process becomes
 // the executor host. A minutely tick materializes due schedules, reclaims runs whose executor
@@ -598,10 +612,13 @@ const server = serve({ fetch: app.fetch, port: cfg.port }, () => {
   log.info("derive api listening", {
     port: cfg.port,
     base_url: cfg.baseUrl,
-    meta: cfg.databaseUrl ? "postgres" : `sqlite (${cfg.dataDir})`,
+    // Name the HOST, not just the driver: "postgres" alone once read the same for a
+    // local database and a production one, and nobody could tell for a day.
+    meta: cfg.databaseUrl ? `postgres (${dbHost ?? "unparseable"})` : `sqlite (${cfg.dataDir})`,
     blobs: cfg.objectStoreUrl ? "S3/R2" : `local disk (${cfg.dataDir})`,
     web: cfg.serveWeb ? "bundled SPA" : "API only",
     spaces: `multi-workspace (bootstrap org ${defaultOrg})`,
+    workers: cfg.backgroundWorkers ? "on" : "OFF (DERIVE_BACKGROUND_WORKERS=0)",
   })
 })
 
@@ -616,13 +633,13 @@ const shutdown = makeShutdown({
       "closeIdleConnections" in server ? () => server.closeIdleConnections() : undefined,
   },
   stopWorker: () => {
-    webhookWorker.stop()
+    webhookWorker?.stop()
     previewWorker?.stop()
   },
   clearTimers: () => {
     if (pruneTimer) clearInterval(pruneTimer)
-    clearInterval(syncResumeTimer)
-    clearInterval(draftSweepTimer)
+    if (syncResumeTimer) clearInterval(syncResumeTimer)
+    if (draftSweepTimer) clearInterval(draftSweepTimer)
   },
   closeStores,
   log,

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "dev": "pnpm --filter @derive/api dev",
     "dev:web": "pnpm --filter @derive/web dev",
     "dev:all": "pnpm --parallel --filter \"./apps/*\" dev",
+    "dev:remote": "bash scripts/dev-remote-db.sh",
     "start": "pnpm --filter @derive/api start",
     "typecheck": "pnpm -r typecheck",
     "typecheck:tsc": "pnpm -r typecheck:tsc",

--- a/scripts/dev-remote-db.sh
+++ b/scripts/dev-remote-db.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Run the local dev stack (API + web) against a REMOTE database.
+#
+# This exists because "does my UI change work against real data" is a question local
+# seed data answers badly. It is also how a day of writes once went to production
+# unnoticed, so this script is deliberately loud and deliberately narrow.
+#
+# Two protections, neither of which this script removes:
+#
+#   1. The API's remote-database guard (apps/api/src/node.ts). That guard
+# refuses a remote DATABASE_URL under `pnpm dev` unless DERIVE_ALLOW_REMOTE_DB=1 comes
+# from the actual shell — it snapshots the value before loading any .env precisely so a
+# stray file can't grant its own permission. This script sets it in the shell, which is
+# the consent the guard asks for: typing the command IS the deliberate act. The guard
+#      still fires, still logs its warning, and you still see which host answered.
+#
+#   2. DERIVE_BACKGROUND_WORKERS=0, forced below. The API otherwise runs shared
+#      background work that WRITES: the webhook delivery worker every 1.5s, a daily
+#      prune and an expired-draft sweep that DELETE rows, and GitHub sync resume. The
+#      prune and sync-resume fire on BOOT, not just on a timer — so without this, merely
+#      starting this script would delete rows in that database and start delivering its
+#      webhooks from this machine.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="$ROOT/.env.remote"
+
+if [ ! -f "$ENV_FILE" ]; then
+  echo "dev:remote: missing $ENV_FILE" >&2
+  echo "  see the header of this script for the keys it expects" >&2
+  exit 1
+fi
+
+# Parse rather than `source`. A .env file is not a shell script: a Neon URL ends
+# `?sslmode=require&channel_binding=require`, and `.` would read that `&` as a background
+# operator and silently truncate the value. Same for `$`, backticks, spaces and `#`. So
+# read it line by line and never let the shell evaluate a value.
+while IFS= read -r line || [ -n "$line" ]; do
+  line="${line%$'\r'}"                      # tolerate CRLF
+  case "$line" in '' | '#'*) continue ;; esac
+  case "$line" in *=*) ;; *) continue ;; esac
+  key="${line%%=*}"
+  val="${line#*=}"
+  case "$key" in [A-Za-z_][A-Za-z0-9_]*) ;; *) continue ;; esac
+  # Strip one layer of surrounding quotes if the author used them.
+  case "$val" in
+    \"*\") val="${val#\"}"; val="${val%\"}" ;;
+    \'*\') val="${val#\'}"; val="${val%\'}" ;;
+  esac
+  export "$key=$val"
+done < "$ENV_FILE"
+
+if [ -z "${DATABASE_URL:-}" ]; then
+  echo "dev:remote: no DATABASE_URL in $ENV_FILE" >&2
+  exit 1
+fi
+
+# Host only — never print the credential, this scrolls past in a shared terminal.
+HOST="$(printf '%s' "$DATABASE_URL" | sed -E 's#^[^:]+://[^@]*@?([^/:?]+).*#\1#')"
+
+case "$HOST" in
+  localhost | 127.0.0.1 | 0.0.0.0 | *.localhost)
+    echo "dev:remote: $ENV_FILE points at $HOST, which is local — use \`pnpm dev:all\`." >&2
+    exit 1
+    ;;
+esac
+
+export DERIVE_ALLOW_REMOTE_DB=1
+# Forced, not defaulted: this is the difference between reading production and becoming
+# a second writer against it. Overriding it in the env file will not take effect.
+export DERIVE_BACKGROUND_WORKERS=0
+
+# A server already on the API port is the quiet failure mode here: the web dev server
+# proxies to a fixed port, so a leftover process keeps answering the SPA and the server
+# you just started is ignored. It reads as "sign-in is broken" rather than as a conflict,
+# and the leftover is usually pointed at a different database.
+API_PORT="${PORT:-8090}"
+if command -v lsof >/dev/null 2>&1 && lsof -nP -iTCP:"$API_PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+  echo "dev:remote: something is already listening on port $API_PORT." >&2
+  echo "  The web app proxies there, so it would talk to that process, not this one." >&2
+  echo "  Stop it first:  lsof -nP -iTCP:$API_PORT -sTCP:LISTEN -t | xargs kill" >&2
+  exit 1
+fi
+
+printf '\n\033[41;97m  REMOTE DATABASE    \033[0m %s\n\n' "$HOST"
+printf '  Everything you do here writes to that database. That includes the things you\n'
+printf '  do not think of as writing: signing in creates a real session, opening an\n'
+printf '  artifact increments its view count and records presence.\n\n'
+if [ -z "${OBJECT_STORE_URL:-}" ]; then
+  printf '  Blobs are LOCAL, so artifact bodies and card thumbnails will be missing.\n'
+  printf '  Add OBJECT_STORE_URL to .env.neon-debug to read real content too.\n\n'
+fi
+printf '  Background workers are OFF, so this process will not deliver webhooks, run\n'
+printf '  automations, prune, or sweep. Your own reads and edits still hit it.\n\n'
+printf '  Confirm the startup lines say:\n'
+printf '    meta: postgres (%s)\n' "$HOST"
+printf '    workers: OFF (DERIVE_BACKGROUND_WORKERS=0)\n\n'
+printf '  Ctrl-C now if that is not what you meant.\n\n'
+
+if [ "${1:-}" = "--check" ]; then
+  printf '  --check: parsed and validated, not starting anything.\n\n'
+  exit 0
+fi
+
+cd "$ROOT"
+exec pnpm dev:all


### PR DESCRIPTION
Reproducing something against real data means pointing a dev server at the database that has it. Doing that naively is destructive, because this process runs shared background work the moment it boots.

Adds `pnpm dev:remote`, and the gate that makes it safe.

## The problem this is actually solving

Four background workers start unconditionally and write to whatever database the process is pointed at:

| Worker | Cadence | Writes |
|---|---|---|
| Webhook delivery | every 1.5s | delivers real webhooks and Slack messages |
| Prune | **on boot**, then daily | `DELETE`s view rows and stale OAuth clients |
| Expired-draft sweep | hourly | `DELETE`s draft rows |
| GitHub sync resume | **on boot**, then 60s | resumes syncs, writes artifacts |

Two of them fire on *boot*, not just on a timer. So starting a dev server against a shared database deletes rows in it and begins delivering its webhooks from a laptop — racing whichever deployment owns it for the same rows.

## `DERIVE_BACKGROUND_WORKERS`

On by default; a deployment never sets it. `0` stops all four. The script **forces** it rather than defaulting it, so an env file cannot re-enable it by accident.

## Three fixes that came out of building this

**The startup line now names the database host.** It read `meta: postgres` — identical for a local Postgres and a remote one, so you could not tell which had answered. Now `meta: postgres (<host>)`, plus a `workers:` field. Both facts are visible where you already look.

**The remote-DB guard covers the whole `dev*` family.** It matched `npm_lifecycle_event === "dev"` exactly, so any sibling script arrived with a different lifecycle event and walked straight past it — which the new script would have done. Deployments launch the entry directly with no lifecycle event and are unaffected either way.

**The script parses its env file rather than sourcing it.** A Postgres URL ending `?sslmode=require&channel_binding=require` makes the shell read `&` as a background operator and silently truncate the value. Same class of failure for `$`, backticks, spaces, `#`.

## Also in the script

- Refuses to start when something already holds the API port. The web dev server proxies to a fixed port, so a leftover process keeps answering the browser while the server you just started is ignored — that presents as broken auth, not as a port conflict.
- Refuses a `DATABASE_URL` that points at localhost (use `pnpm dev:all`).
- `--check` parses, validates, prints the banner and exits, so the setup can be verified without connecting to anything.
- A banner that names the host and states plainly that browsing writes — sign-in creates a session, opening an artifact bumps its view count and records presence.

The script's header documents which keys to set, which must stay local (`PORT`/`BASE_URL` — the web dev server proxies to a fixed port, and `BASE_URL` derives from it), and which to leave unset because they reach the real world: email, billing, Slack, and the custom-domain credentials that can mutate DNS.

## Verification

Both directions of the guard, exercised directly rather than assumed:

- remote `DATABASE_URL` under a `dev*` script, no override → **refuses**, naming the host
- with the shell override → **warns**, then proceeds
- `DERIVE_BACKGROUND_WORKERS` unset → `workers: 'on'`; `=0` → `workers: 'OFF (DERIVE_BACKGROUND_WORKERS=0)'`
- script guard paths: missing env file, localhost URL, occupied port — all refuse with a fix instruction

`pnpm verify` green. `.env.example` is generated (`pnpm --filter @derive/api gen:env`), not hand-edited — its snapshot test enforces that.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788189280&installation_model_id=428097&pr_number=613&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F613&signature=da605d1d604570fa950cd47678ec96afd2da45bffd7748a6176867104bfbead7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->