### PR TITLE
feat(chat): on by default, Slack DMs, and a document conversation opens its document

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -881,7 +881,7 @@
           },
           "chatBeta": {
             "type": "boolean",
-            "description": "BETA: the Chat tab on a document. Off by default — the tab is hidden and the chat route refuses, so a workspace opts in deliberately."
+            "description": "The Chat tab on a document, and the workspace chat. ON by default; set it false to turn chat off for a workspace entirely (the tab hides and the chat routes refuse)."
           },
           "automateBeta": {
             "type": "boolean",

--- a/apps/api/src/lib/boot-shapes.ts
+++ b/apps/api/src/lib/boot-shapes.ts
@@ -43,7 +43,7 @@ export const OrgSettings = z
     chatBeta: z
       .boolean()
       .describe(
-        "BETA: the Chat tab on a document. Off by default — the tab is hidden and the chat route refuses, so a workspace opts in deliberately.",
+        "The Chat tab on a document, and the workspace chat. ON by default; set it false to turn chat off for a workspace entirely (the tab hides and the chat routes refuse).",
       ),
     automateBeta: z
       .boolean()

--- a/apps/api/src/lib/slack-mention.ts
+++ b/apps/api/src/lib/slack-mention.ts
@@ -182,7 +182,11 @@ export const handleSlackMention = async (
       // be a member of another workspace on this team — so it is not remembered.
       return { seat: null, why: "unknown" }
     }
-    if (known?.origin === "miss" && Date.now() - Date.parse(known.checked_at) < MISS_TTL_MS)
+    // A null or unparseable checked_at reads as "never checked", so we look again rather than
+    // stay silent for ever. Erring toward one extra lookup beats erring toward a person the
+    // bot has silently written off.
+    const checkedAt = known?.checked_at ? Date.parse(known.checked_at) : Number.NaN
+    if (known?.origin === "miss" && Date.now() - checkedAt < MISS_TTL_MS)
       return { seat: null, why: "recent-miss" }
 
     const email = await slackUserEmail(botToken, p.userId)

--- a/apps/api/src/lib/slack-mention.ts
+++ b/apps/api/src/lib/slack-mention.ts
@@ -24,9 +24,22 @@ import { postWithRecovery, resolveBotToken } from "./slack-delivery"
  *  context above it and the answer belongs to that, not to the channel's whole day. */
 const THREAD_CONTEXT = 12
 
-/** Slack users we have already told how to identify themselves, so the prompt is not repeated at
- *  somebody on every message. Deliberately in-memory and deliberately forgetful — see the use. */
-const promptedToLink = new Set<string>()
+/** The Slack message ts recorded on an asker message, or null. Tolerates unparseable meta:
+ *  a missing marker means "not seen", which costs a duplicate at worst and never a lost turn. */
+const parseSlackTs = (raw: string | null | undefined): string | null => {
+  if (!raw) return null
+  try {
+    return (JSON.parse(raw) as { slack?: { ts?: string } }).slack?.ts ?? null
+  } catch {
+    return null
+  }
+}
+
+/** How long a failed identity lookup is trusted before we ask Slack again. Long enough that
+ *  nobody gets a wall of identical prompts, short enough that somebody who joins Derive
+ *  tomorrow starts working without intervention. Linking short-circuits it entirely: a link
+ *  row replaces the miss and is checked first. */
+const MISS_TTL_MS = 24 * 60 * 60 * 1000
 
 export interface SlackMentionPayload {
   teamId: string
@@ -137,13 +150,59 @@ export const handleSlackMention = async (
    * still checked either way, so resolving an identity never grants access on its own — a
    * matched email with no seat in this workspace is still nobody here.
    */
-  const linkedFor = async (orgId: string, botToken: string) => {
-    const link = await meta.getSlackUserLinkBySlackId(p.teamId, p.userId).catch(() => null)
-    if (link) return await seatFor(orgId, link.user_id)
+  /**
+   * WHO IS ASKING — optimistically, and quietly once we know we cannot tell.
+   *
+   * An explicit link always wins: it is a deliberate statement about identity and survives an
+   * email change. Absent one, the Slack profile email resolves the seat, because the point of
+   * answering in Slack is that somebody is already there and "go to a settings page and come
+   * back" is exactly where they stop. Email is the identifier both systems already hold and the
+   * workspace's own directory verified. Never a display name — those are neither unique nor
+   * stable nor hard to set to somebody else's.
+   *
+   * A MISS IS REMEMBERED, on the same row, so a person we cannot place is asked once rather than
+   * on every message, and we stop calling Slack about them. It ages out (MISS_TTL_MS) so a Derive
+   * account created tomorrow starts working on its own, and any success replaces it outright —
+   * self-healing, no cleanup job.
+   *
+   * Returns the seat, or a reason: "unknown" (tell them how to fix it) vs "recent-miss" (already
+   * told them; say nothing).
+   */
+  const linkedFor = async (
+    orgId: string,
+    botToken: string,
+  ): Promise<
+    { seat: Awaited<ReturnType<typeof seatFor>> } | { seat: null; why: "unknown" | "recent-miss" }
+  > => {
+    const known = await meta.getSlackIdentityState(p.teamId, p.userId).catch(() => null)
+    if (known && known.origin !== "miss") {
+      const seat = await seatFor(orgId, known.user_id)
+      if (seat) return { seat }
+      // A link to somebody with no seat HERE is not a miss about their identity — they may well
+      // be a member of another workspace on this team — so it is not remembered.
+      return { seat: null, why: "unknown" }
+    }
+    if (known?.origin === "miss" && Date.now() - Date.parse(known.checked_at) < MISS_TTL_MS)
+      return { seat: null, why: "recent-miss" }
+
     const email = await slackUserEmail(botToken, p.userId)
-    if (!email) return null
-    const user = await meta.findUserByEmail(email).catch(() => null)
-    return user ? await seatFor(orgId, user.id) : null
+    const user = email ? await meta.findUserByEmail(email).catch(() => null) : null
+    const seat = user ? await seatFor(orgId, user.id) : null
+    await meta
+      .setSlackUserLink({
+        id: known?.id ?? newId("sul"),
+        org_id: orgId,
+        // Empty on a miss: there is nobody to point at, which is why the filtered accessors
+        // never hand this row to code that would try to use it.
+        user_id: seat?.id ?? "",
+        team_id: p.teamId,
+        slack_user_id: p.userId,
+        origin: seat ? "email" : "miss",
+        created_at: known?.created_at ?? new Date().toISOString(),
+        checked_at: new Date().toISOString(),
+      })
+      .catch(() => {})
+    return seat ? { seat } : { seat: null, why: "unknown" }
   }
 
   // WHICH WORKSPACE. One Slack team can back several Derive workspaces, so the channel's own
@@ -196,25 +255,20 @@ export const handleSlackMention = async (
     return quiet("ambiguous workspace")
   }
 
-  const asker = await linkedFor(install.org_id, bot.token)
+  const resolved = await linkedFor(install.org_id, bot.token)
+  const asker = resolved.seat
   if (!asker) {
-    // SAY IT ONCE. Somebody we cannot resolve will keep asking — that is the normal thing to do
-    // when a bot ignores you — and answering every message with the same paragraph turns a
-    // one-time setup step into a wall of identical text. They are told, clearly, with a link
-    // that works; after that, silence is kinder than repetition.
-    //
-    // Best-effort by construction: this lives in the isolate, so a deploy or a cold start says
-    // it again. That is the right failure direction. Forgetting means one extra prompt;
-    // remembering too well would mean somebody who linked and came back gets nothing.
-    if (!promptedToLink.has(`${p.teamId}:${p.userId}`)) {
-      promptedToLink.add(`${p.teamId}:${p.userId}`)
-      await say(
-        `I answer with *your* permissions, so I need to know who you are. ` +
-          `<${deps.baseUrl}/settings/integrations|Link your Derive account> and ask me again.\n\n` +
-          `If your Slack email already matches your Derive account, linking is not needed — ` +
-          `check that the two match.`,
-      )
-    }
+    if ("why" in resolved && resolved.why === "recent-miss") return quiet("asker not linked (told)")
+    // SAY IT ONCE. Somebody a bot ignores will keep asking — that is the normal thing to do —
+    // and answering every message with the same paragraph turns a one-time setup step into a
+    // wall of identical text. They are told, clearly, with a link that works; after that the
+    // miss row above keeps us quiet until it ages out or they fix it.
+    await say(
+      `I answer with *your* permissions, so I need to know who you are. ` +
+        `<${deps.baseUrl}/settings/integrations|Link your Derive account> and ask me again.\n\n` +
+        `If your Slack email already matches your Derive account, linking is not needed — ` +
+        `check that the two match.`,
+    )
     return quiet("asker not linked")
   }
 
@@ -252,12 +306,27 @@ export const handleSlackMention = async (
 
   let sessionId: string
   if (existing) {
+    // SLACK DELIVERS AT LEAST ONCE. A redelivery (30s/1min/5min later, routinely on another
+    // isolate) lands here, finds the live session, and would append the same question again —
+    // a second paid turn and a second answer posted into the thread. dedupe_key does not stop
+    // it: that key is per-THREAD, deliberately, so follow-ups continue one conversation.
+    //
+    // So the guard is the Slack message ts, scanned off the transcript — the same shape the
+    // ingest path uses (slack-comments.ts). It is DB state, which is what makes it survive the
+    // retry landing somewhere else. The marker is written IN THE SAME insert as the message,
+    // for the reason spelled out there: written afterwards, a retry racing the first attempt
+    // would not see it.
+    const already = (await meta.listSessionMessages(existing.id).catch(() => [])).some(
+      (m) => parseSlackTs(m.meta) === p.ts,
+    )
+    if (already) return quiet("duplicate slack delivery")
     await meta.appendFollowupReopen({
       id: newId("sm"),
       session_id: existing.id,
       author_kind: "asker",
       author_id: asker.id,
       body_md: question,
+      meta: JSON.stringify({ slack: { ts: p.ts } }),
     })
     sessionId = existing.id
   } else {
@@ -272,7 +341,13 @@ export const handleSlackMention = async (
         // A Derive link in the message pins the document; otherwise the workspace is the ground.
         subject_ref: null,
       },
-      { id: newId("sm"), author_kind: "asker", author_id: asker.id, body_md: question },
+      {
+        id: newId("sm"),
+        author_kind: "asker",
+        author_id: asker.id,
+        body_md: question,
+        meta: JSON.stringify({ slack: { ts: p.ts } }),
+      },
       "open",
     )
     sessionId = created.session.id

--- a/apps/api/src/lib/slack-mention.ts
+++ b/apps/api/src/lib/slack-mention.ts
@@ -24,6 +24,10 @@ import { postWithRecovery, resolveBotToken } from "./slack-delivery"
  *  context above it and the answer belongs to that, not to the channel's whole day. */
 const THREAD_CONTEXT = 12
 
+/** Slack users we have already told how to identify themselves, so the prompt is not repeated at
+ *  somebody on every message. Deliberately in-memory and deliberately forgetful — see the use. */
+const promptedToLink = new Set<string>()
+
 export interface SlackMentionPayload {
   teamId: string
   channel: string
@@ -194,9 +198,23 @@ export const handleSlackMention = async (
 
   const asker = await linkedFor(install.org_id, bot.token)
   if (!asker) {
-    await say(
-      `Link your Derive account to ask me here — I answer with *your* permissions, so I need to know who you are. ${deps.baseUrl}/settings/integrations`,
-    )
+    // SAY IT ONCE. Somebody we cannot resolve will keep asking — that is the normal thing to do
+    // when a bot ignores you — and answering every message with the same paragraph turns a
+    // one-time setup step into a wall of identical text. They are told, clearly, with a link
+    // that works; after that, silence is kinder than repetition.
+    //
+    // Best-effort by construction: this lives in the isolate, so a deploy or a cold start says
+    // it again. That is the right failure direction. Forgetting means one extra prompt;
+    // remembering too well would mean somebody who linked and came back gets nothing.
+    if (!promptedToLink.has(`${p.teamId}:${p.userId}`)) {
+      promptedToLink.add(`${p.teamId}:${p.userId}`)
+      await say(
+        `I answer with *your* permissions, so I need to know who you are. ` +
+          `<${deps.baseUrl}/settings/integrations|Link your Derive account> and ask me again.\n\n` +
+          `If your Slack email already matches your Derive account, linking is not needed — ` +
+          `check that the two match.`,
+      )
+    }
     return quiet("asker not linked")
   }
 

--- a/apps/api/src/lib/slack-mention.ts
+++ b/apps/api/src/lib/slack-mention.ts
@@ -26,7 +26,7 @@ const THREAD_CONTEXT = 12
 
 /** The Slack message ts recorded on an asker message, or null. Tolerates unparseable meta:
  *  a missing marker means "not seen", which costs a duplicate at worst and never a lost turn. */
-const parseSlackTs = (raw: string | null | undefined): string | null => {
+export const parseSlackTs = (raw: string | null | undefined): string | null => {
   if (!raw) return null
   try {
     return (JSON.parse(raw) as { slack?: { ts?: string } }).slack?.ts ?? null
@@ -39,7 +39,37 @@ const parseSlackTs = (raw: string | null | undefined): string | null => {
  *  nobody gets a wall of identical prompts, short enough that somebody who joins Derive
  *  tomorrow starts working without intervention. Linking short-circuits it entirely: a link
  *  row replaces the miss and is checked first. */
-const MISS_TTL_MS = 24 * 60 * 60 * 1000
+export const MISS_TTL_MS = 24 * 60 * 60 * 1000
+
+/**
+ * What a stored identity row tells us to do next.
+ *
+ * Pure, and exported, because these three branches are the whole behaviour and the lane around
+ * them needs Slack, a model and a store to exercise. The decision is the part that can be wrong
+ * in a way nobody notices: too eager and we re-ask Slack about somebody on every message, too
+ * sticky and a person who joined Derive yesterday is silently written off for ever.
+ *
+ *   "use"       a real link — resolve the seat from it.
+ *   "silent"    a miss we recorded recently. Say nothing; they have already been told.
+ *   "look"      no row, an aged-out miss, or a stamp we cannot read. Ask Slack again.
+ *
+ * A null or unparseable `checked_at` deliberately reads as "look": erring toward one extra
+ * lookup beats erring toward somebody the bot has quietly stopped answering.
+ */
+export const identityVerdict = (
+  known: { origin: string; checked_at: string | null } | null,
+  now: number,
+): "use" | "silent" | "look" => {
+  if (!known) return "look"
+  if (known.origin !== "miss") return "use"
+  const at = known.checked_at ? Date.parse(known.checked_at) : Number.NaN
+  const elapsed = now - at
+  // Bounded at BOTH ends. Only checking the upper bound means a stamp written ahead of us —
+  // clock skew between writer and reader, or a corrupt far-future date — reads as permanently
+  // fresh and silences this person for ever. A negative elapsed is not evidence of anything,
+  // so it costs one extra lookup instead.
+  return elapsed >= 0 && elapsed < MISS_TTL_MS ? "silent" : "look"
+}
 
 export interface SlackMentionPayload {
   teamId: string
@@ -175,19 +205,15 @@ export const handleSlackMention = async (
     { seat: Awaited<ReturnType<typeof seatFor>> } | { seat: null; why: "unknown" | "recent-miss" }
   > => {
     const known = await meta.getSlackIdentityState(p.teamId, p.userId).catch(() => null)
-    if (known && known.origin !== "miss") {
+    const verdict = identityVerdict(known, Date.now())
+    if (verdict === "use" && known) {
       const seat = await seatFor(orgId, known.user_id)
       if (seat) return { seat }
       // A link to somebody with no seat HERE is not a miss about their identity — they may well
       // be a member of another workspace on this team — so it is not remembered.
       return { seat: null, why: "unknown" }
     }
-    // A null or unparseable checked_at reads as "never checked", so we look again rather than
-    // stay silent for ever. Erring toward one extra lookup beats erring toward a person the
-    // bot has silently written off.
-    const checkedAt = known?.checked_at ? Date.parse(known.checked_at) : Number.NaN
-    if (known?.origin === "miss" && Date.now() - checkedAt < MISS_TTL_MS)
-      return { seat: null, why: "recent-miss" }
+    if (verdict === "silent") return { seat: null, why: "recent-miss" }
 
     const email = await slackUserEmail(botToken, p.userId)
     const user = email ? await meta.findUserByEmail(email).catch(() => null) : null

--- a/apps/api/src/lib/slack-mention.ts
+++ b/apps/api/src/lib/slack-mention.ts
@@ -16,7 +16,8 @@ import { chatArrival, refusalMessage } from "./chat-gate"
 import { buildChatTools } from "./chat-tools"
 import { runChatTurn } from "./chat-turn"
 import type { ModelCatalog } from "./model-catalog"
-import { escapeMrkdwn } from "./slack-cards"
+import { slackUserEmail } from "./slack"
+import { escapeMrkdwn, mrkdwnBody } from "./slack-cards"
 import { postWithRecovery, resolveBotToken } from "./slack-delivery"
 
 /** How much of a Slack thread the turn is given. A mention usually arrives with a little
@@ -112,13 +113,33 @@ export const handleSlackMention = async (
   // WHO. A Slack user id is not a Derive principal: the turn acts as the asker, reads with
   // their permissions and spends against their workspace, so an unlinked account has nobody to
   // act as. They are told how to fix it rather than ignored.
-  const linkedFor = async (orgId: string) => {
-    const link = await meta.getSlackUserLinkBySlackId(p.teamId, p.userId).catch(() => null)
-    if (!link) return null
-    const seat = await meta.getMembership(orgId, link.user_id).catch(() => null)
+  const seatFor = async (orgId: string, userId: string) => {
+    const seat = await meta.getMembership(orgId, userId).catch(() => null)
     if (!seat) return null
-    const user = (await meta.getUsers([link.user_id]).catch(() => []))[0]
-    return { id: link.user_id, name: user?.name ?? "someone", role: seat.role }
+    const user = (await meta.getUsers([userId]).catch(() => []))[0]
+    return { id: userId, name: user?.name ?? "someone", role: seat.role }
+  }
+
+  /**
+   * An EXPLICIT link wins, then the Slack profile's email.
+   *
+   * Requiring a link first was correct about the principal and wrong about the friction: the
+   * whole point of answering in Slack is that somebody is already there, and "go to a settings
+   * page and come back" is exactly the moment they stop. Email is the identifier both systems
+   * already hold, and a Slack profile email was verified by the workspace's own directory.
+   *
+   * It is a FALLBACK, not a replacement. An explicit link is a deliberate statement about who
+   * somebody is and survives an email change; this only runs when there is none. Membership is
+   * still checked either way, so resolving an identity never grants access on its own — a
+   * matched email with no seat in this workspace is still nobody here.
+   */
+  const linkedFor = async (orgId: string, botToken: string) => {
+    const link = await meta.getSlackUserLinkBySlackId(p.teamId, p.userId).catch(() => null)
+    if (link) return await seatFor(orgId, link.user_id)
+    const email = await slackUserEmail(botToken, p.userId)
+    if (!email) return null
+    const user = await meta.findUserByEmail(email).catch(() => null)
+    return user ? await seatFor(orgId, user.id) : null
   }
 
   // WHICH WORKSPACE. One Slack team can back several Derive workspaces, so the channel's own
@@ -171,7 +192,7 @@ export const handleSlackMention = async (
     return quiet("ambiguous workspace")
   }
 
-  const asker = await linkedFor(install.org_id)
+  const asker = await linkedFor(install.org_id, bot.token)
   if (!asker) {
     await say(
       `Link your Derive account to ask me here — I answer with *your* permissions, so I need to know who you are. ${deps.baseUrl}/settings/integrations`,
@@ -302,9 +323,23 @@ export const handleSlackMention = async (
       res.outcome === "failed" ? "failed" : "answered",
     )
 
-    // The reply is escaped; the continue-link is ours and is appended after, so it renders.
+    // AN ANSWER IS PROSE, not a label, so it goes through mrkdwnBody rather than escapeMrkdwn:
+    // the model writes markdown, and escaping alone left `**bold**` as asterisks and every
+    // citation as literal `[Title](/artifacts/x)` — the most useful part of an answer rendered
+    // as punctuation.
+    //
+    // Citations are ROOT-RELATIVE by design (the agent cites by path, knowing no hostname), and
+    // mrkdwnBody only linkifies absolute http(s) targets — correctly, since a relative href
+    // means nothing in Slack. So they are absolutised against this instance FIRST. The pattern
+    // stays strict for the same reason it is strict in the web renderer: a leading slash then an
+    // alphanumeric admits /artifacts/x and excludes both `javascript:` and the protocol-relative
+    // `//evil.com`.
+    const withLinks = res.reply.replace(
+      /\]\((\/[A-Za-z0-9][\w\-./?=&#%]*)\)/g,
+      (_m, path: string) => `](${deps.baseUrl}${path})`,
+    )
     await say(
-      `${escapeMrkdwn(res.reply)}\n\n<${deps.baseUrl}/chat?session=${sessionId}|Continue in Derive>`,
+      `${mrkdwnBody(withLinks)}\n\n<${deps.baseUrl}/chat?session=${sessionId}|Continue in Derive>`,
     )
   } catch (e) {
     log.error("slack mention turn failed", {

--- a/apps/api/src/lib/slack.ts
+++ b/apps/api/src/lib/slack.ts
@@ -590,9 +590,12 @@ export const openSlackDm = async (token: string, userId: string): Promise<string
  *    groups:history    delivery of message.groups — private-channel reply-back
  *    users:read        users.info, to name the author of an inbound Slack reply
  *    users:read.email  users.lookupByEmail, the DM fallback for a member who hasn't linked
- *    im:write          conversations.open, to DM a member. Reading DMs would need
- *                      im:history, which we deliberately do NOT request (see the
- *                      bot_events note in slack-app-setup.ts).
+ *    im:write          conversations.open, to DM a member
+ *    im:history        delivery of message.im — a DM to the app is a question, answered by
+ *                      the same chat lane a channel @mention uses. Requested only once
+ *                      something could actually answer one; before that the event was
+ *                      unreachable and the scope would have bought nothing but a scarier
+ *                      consent screen.
  *
  *  channels:read / groups:read back `conversations.list`, which is how the Settings channel
  *  picker offers channels to subscribe instead of asking an admin to paste an id. They were
@@ -622,6 +625,10 @@ export const SLACK_BOT_SCOPES = [
   "channels:history",
   "groups:read", // ditto, for private channels the bot is in
   "groups:history",
+  // DIRECT MESSAGES to the app. Slack refuses a manifest that subscribes `message.im` without
+  // this, which is why the event was dropped once before — see slack-app-setup.ts. Posting the
+  // answer back needs nothing extra: chat:write covers a DM the bot is already in.
+  "im:history",
   "users:read",
   "users:read.email",
   "im:write",

--- a/apps/api/src/lib/slack.ts
+++ b/apps/api/src/lib/slack.ts
@@ -527,6 +527,39 @@ export const joinSlackChannel = async (token: string, channel: string): Promise<
   }
 }
 
+/**
+ * A Slack user's EMAIL, which is what lets a mention resolve to a Derive account without the
+ * person having linked anything first.
+ *
+ * Email is the only identifier the two systems already share. Resolving by display NAME would
+ * be indefensible — names are not unique, not stable, and trivially set to somebody else's —
+ * whereas an email on a Slack profile was verified by the workspace admin's directory.
+ *
+ * Undefined on any failure, including the common one: a workspace whose admins hide profile
+ * email, where `users.info` returns a profile with no email at all. That is a legitimate
+ * configuration, not an error, and the caller falls back to asking the person to link.
+ */
+export const slackUserEmail = async (
+  token: string,
+  userId: string,
+): Promise<string | undefined> => {
+  try {
+    const res = await fetch(`${API}/users.info?user=${encodeURIComponent(userId)}`, {
+      headers: { authorization: `Bearer ${token}` },
+    })
+    const data = (await res.json()) as {
+      ok: boolean
+      user?: { profile?: { email?: string }; is_bot?: boolean }
+    }
+    // A bot's "email" is not a person's, so never resolve one to a seat.
+    if (!data.ok || data.user?.is_bot) return undefined
+    const email = data.user?.profile?.email?.trim().toLowerCase()
+    return email || undefined
+  } catch {
+    return undefined
+  }
+}
+
 /** A Slack user's display name (best-effort; falls back to the raw id on any error). */
 export const slackUserName = async (token: string, userId: string): Promise<string> => {
   try {

--- a/apps/api/src/routes/slack.ts
+++ b/apps/api/src/routes/slack.ts
@@ -655,6 +655,54 @@ export const slackRoutes = (ctx: AppContext) => {
         )
       return c.json({ ok: true })
     }
+    // A DIRECT MESSAGE to the app — the Messages tab, where there is nobody to @mention.
+    //
+    // Same lane as a mention, deliberately: a DM is the same question asked somewhere more
+    // private, so it gets the same gate, the same tools and the same turn. What differs is only
+    // that there is no mention to strip and no channel audience, both of which handleSlackMention
+    // already copes with (questionFrom leaves un-mentioned text alone, and a DM channel threads
+    // the same way).
+    //
+    // Ordered BEFORE the thread-reply branch because a DM can carry a thread_ts too, and that
+    // branch would otherwise try to mirror it as a comment on a document it has nothing to do
+    // with. The bot_id and subtype guards are what stop OUR OWN reply arriving back here as a new
+    // question, which is how a bot ends up talking to itself for ever.
+    if (
+      body.type === "event_callback" &&
+      ev?.type === "message" &&
+      ev.channel_type === "im" &&
+      !ev.bot_id &&
+      !ev.subtype &&
+      body.team_id &&
+      ev.channel &&
+      ev.user &&
+      ev.text
+    ) {
+      if (deps.models)
+        runAfterAck(
+          handleSlackMention(
+            {
+              meta,
+              bus,
+              baseUrl: deps.baseUrl,
+              models: deps.models,
+              encryptionKey: deps.encryptionKey,
+              ctx,
+              chatAllowlist: deps.chatAllowlist,
+              askLimiter: ctx.askLimiter,
+            },
+            {
+              teamId: body.team_id,
+              channel: ev.channel,
+              ts: ev.ts ?? "",
+              threadTs: ev.thread_ts,
+              userId: ev.user,
+              text: ev.text,
+            },
+          ),
+        )
+      return c.json({ ok: true })
+    }
     // Only human thread replies: a message with a thread_ts, no bot_id, not an edit/delete.
     if (
       body.type === "event_callback" &&
@@ -1498,6 +1546,8 @@ interface SlackEventPayload {
   type?: string
   subtype?: string
   bot_id?: string
+  /** "im" for a direct message to the app. Absent on channel messages. */
+  channel_type?: string
   user?: string
   text?: string
   channel?: string

--- a/apps/api/src/routes/slack.ts
+++ b/apps/api/src/routes/slack.ts
@@ -514,6 +514,11 @@ export const slackRoutes = (ctx: AppContext) => {
         user_id: state.uid,
         team_id: identity.teamId,
         slack_user_id: identity.slackUserId,
+        // DELIBERATE, so it outranks anything inferred — and this write replaces a `miss`
+        // row on the same (team_id, slack_user_id), which is exactly how linking fixes a
+        // person the email path could not place.
+        origin: "oauth" as const,
+        checked_at: new Date().toISOString(),
         created_at: new Date().toISOString(),
       })
       return c.redirect("/settings/integrations")

--- a/apps/api/src/slack-app-setup.ts
+++ b/apps/api/src/slack-app-setup.ts
@@ -29,6 +29,20 @@ export const buildSlackManifest = (baseUrl: string) => {
       background_color: "#1a1a2e",
     },
     features: {
+      // THE MESSAGES TAB, which is what makes the app DM-able at all.
+      //
+      // Omitting app_home does not leave Slack's default alone — applying a manifest without it
+      // turns the Messages tab OFF, so the app stops accepting direct messages and the person
+      // sees no way to write to it. Subscribing message.im and holding im:history buys nothing
+      // if nobody can open the conversation, which is exactly how this shipped broken: the event
+      // and the scope were right and the tab was gone.
+      //
+      // read_only must be false too — true renders a tab you can look at and cannot type into.
+      app_home: {
+        home_tab_enabled: false,
+        messages_tab_enabled: true,
+        messages_tab_read_only_enabled: false,
+      },
       bot_user: { display_name: "Derive", always_online: true },
       // The domains whose links this app unfurls. A registered domain matches all of its
       // SUBDOMAINS and paths, so one entry covers the instance host and every vanity

--- a/apps/api/src/slack-app-setup.ts
+++ b/apps/api/src/slack-app-setup.ts
@@ -79,20 +79,24 @@ export const buildSlackManifest = (baseUrl: string) => {
     settings: {
       event_subscriptions: {
         request_url: u("/v1/slack/events"),
-        // Public + private channels only. `message.im` was subscribed here but is
-        // unreachable by design: /v1/slack/events gates every reply on a slack_thread_link
-        // lookup (channel + thread_ts), and links are written ONLY by the channel
-        // comment-mirror — slack-dm.ts never writes one. So a DM could never match, while
-        // Slack still refused the manifest over it ("message.im event is missing scope(s):
-        // im:history"). Dropping the event fixes that without asking to READ users' DMs for
-        // a path that ignores them. When the assistant increment lands, add the event and
-        // im:history together.
+        // Channels, private channels, and DIRECT MESSAGES to the app.
+        //
+        // `message.im` was subscribed here once and removed: every reply was gated on a
+        // slack_thread_link lookup (channel + thread_ts) written only by the channel
+        // comment-mirror, so a DM could never match, while Slack still refused the manifest
+        // over the missing scope ("message.im event is missing scope(s): im:history"). The
+        // note left behind said to add the event and the scope together once something could
+        // actually answer a DM. That is this: /v1/slack/events now routes a DM straight into
+        // the chat lane instead of through the thread-link gate, so the event has a reader and
+        // im:history is in SLACK_BOT_SCOPES beside it.
+        //
         // app_uninstalled / tokens_revoked need no scope, and they are the only way to learn
         // that the stored bot token died without waiting for a delivery to fail — which never
         // happens on a workspace with no Slack traffic, leaving Settings claiming "connected".
         bot_events: [
           "message.channels",
           "message.groups",
+          "message.im",
           "link_shared",
           // @Derive, anywhere the bot is invited — the mention lane that does not need a
           // mirrored thread underneath it. Paired with the `app_mentions:read` scope in

--- a/apps/api/test/chat-attended.test.ts
+++ b/apps/api/test/chat-attended.test.ts
@@ -1,4 +1,4 @@
-import { newId } from "@derive/core"
+import { DEFAULT_ORG_SETTINGS, newId } from "@derive/core"
 import { describe, expect, it } from "vitest"
 import { createInProcessBackplane } from "../src/bus"
 import { inMemoryRateLimiters } from "../src/lib/rate-limit"
@@ -155,9 +155,10 @@ describe("the subject is authorized separately from the context", () => {
 })
 
 describe("the beta gate", () => {
-  it("REFUSES a workspace that has not opted in", async () => {
-    // A flag that only hides a button is not a gate: the route is reachable directly, and
-    // this is the lane that spends the operator's model key.
+  it("REFUSES a workspace that has explicitly turned chat OFF", async () => {
+    // Chat is ON by default now, so the case worth gating is the workspace that opted OUT.
+    // A flag that only hides a button is not a gate: the route is reachable directly, and this
+    // is the lane that spends the operator's model key.
     const users = [{ id: "u-ed", email: "ed@x.com", name: "Ed" }]
     const { app } = makeAuthedApp("chat-beta-off", users, undefined, {
       deps: { callModel: async () => ({ text: "hi", toolUses: [], costUsd: null, done: true }) },
@@ -173,12 +174,27 @@ describe("the beta gate", () => {
       })(),
     })
     const { short_id } = (await made.json()) as { short_id: string }
+    // Opt OUT, which is now the deliberate act.
+    await app.request("/v1/workspace/settings", {
+      method: "PATCH",
+      headers: { ...as("ed@x.com"), "content-type": "application/json" },
+      body: JSON.stringify({ chatBeta: false }),
+    })
     const res = await app.request("/v1/artifacts/chat-session", {
       method: "POST",
       headers: { ...as("ed@x.com"), "content-type": "application/json" },
       body: JSON.stringify({ short_id, body_md: "hello" }),
     })
     expect(res.status).toBe(404)
+  })
+
+  it("ANSWERS a workspace that has done nothing, because chat is on by default", () => {
+    // The default itself is the product decision: an opt-in everybody has to find is a feature
+    // nobody has. Asserted on the defaults rather than through a route so it cannot drift
+    // silently when the settings shape moves.
+    expect(DEFAULT_ORG_SETTINGS.chatBeta).toBe(true)
+    // Automations stay opt-in: they run unattended and can write while nobody is watching.
+    expect(DEFAULT_ORG_SETTINGS.automateBeta).toBe(false)
   })
 })
 

--- a/apps/api/test/integrations-settings.test.ts
+++ b/apps/api/test/integrations-settings.test.ts
@@ -28,7 +28,7 @@ describe("workspace integration settings", () => {
       hostedAgentsEnabled: true,
       // Chat ships BETA and OFF: a workspace opts in deliberately. This line failing is the
       // signal that someone flipped the default, which is the whole point of asserting it.
-      chatBeta: false,
+      chatBeta: true,
       // Automations ship the same way, and the same reasoning applies to this line.
       automateBeta: false,
       agentKillswitch: false,

--- a/apps/api/test/slack-app-setup.test.ts
+++ b/apps/api/test/slack-app-setup.test.ts
@@ -26,13 +26,20 @@ describe("buildSlackManifest", () => {
     )
   })
 
-  // Regression: message.im was subscribed but is unreachable — /v1/slack/events keys every
-  // reply on a slack_thread_link (channel + thread_ts) and only the channel comment-mirror
-  // writes those, never slack-dm.ts. Slack rejected the manifest over the missing im:history
-  // scope, and granting it would mean asking to READ users' DMs for a path that ignores them.
-  it("does not subscribe to DM messages it cannot act on (and so needs no im:history)", () => {
-    expect(m.settings.event_subscriptions.bot_events).not.toContain("message.im")
-    expect(m.oauth_config.scopes.bot).not.toContain("im:history")
+  // message.im and im:history travel TOGETHER, in both directions.
+  //
+  // Slack refuses a manifest that subscribes the event without the scope, which is how this was
+  // broken once before. It was then fixed by dropping the event, because nothing could answer a
+  // DM: every reply was keyed on a slack_thread_link (channel + thread_ts) that only the channel
+  // comment-mirror ever wrote. Now /v1/slack/events routes a DM straight into the chat lane, so
+  // the event has a reader and the scope earns its place on the consent screen.
+  //
+  // Asserted as a PAIR rather than individually: either one alone is a bug — the event without
+  // the scope is an app that cannot be created, and the scope without the event is asking to
+  // read people's DMs for nothing.
+  it("subscribes message.im and asks for im:history together", () => {
+    expect(m.settings.event_subscriptions.bot_events).toContain("message.im")
+    expect(m.oauth_config.scopes.bot).toContain("im:history")
   })
 
   it("declares the scopes posting, reply-back, and mention-DM email resolution need", () => {

--- a/apps/api/test/slack-dm.test.ts
+++ b/apps/api/test/slack-dm.test.ts
@@ -282,6 +282,8 @@ describe("makeSlackDmSender (delivery)", () => {
       user_id: linked.id,
       team_id: "T1",
       slack_user_id: "U-LINKED",
+      origin: "oauth" as const,
+      checked_at: new Date().toISOString(),
       created_at: new Date().toISOString(),
     })
     const { artifact, comment } = await artifactAndComment(meta)

--- a/apps/api/test/slack-mention.test.ts
+++ b/apps/api/test/slack-mention.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { SLACK_BOT_SCOPES } from "../src/lib/slack"
+import { mrkdwnBody } from "../src/lib/slack-cards"
 import { artifactRefIn, questionFrom } from "../src/lib/slack-mention"
 import { buildSlackManifest } from "../src/slack-app-setup"
 
@@ -81,5 +82,40 @@ describe("the Slack app manifest", () => {
 
   it("still declares chat:write — the mention lane answers by posting", () => {
     expect(manifest.oauth_config.scopes.bot).toContain("chat:write")
+  })
+})
+
+// HOW AN ANSWER LOOKS IN SLACK. The model writes markdown; Slack speaks mrkdwn. Escaping alone
+// left every citation as literal `[Title](/artifacts/x)` — the most useful part of an answer
+// rendered as punctuation — which no test caught because the STRING was correct.
+
+describe("an answer rendered for Slack", () => {
+  const BASE = "https://derive.example"
+  // The transform the lane applies before mrkdwnBody: citations are root-relative by design
+  // (the agent cites by path, knowing no hostname) and mean nothing to Slack until absolutised.
+  const absolutise = (md: string) =>
+    md.replace(/\]\((\/[A-Za-z0-9][\w\-./?=&#%]*)\)/g, (_m, p: string) => `](${BASE}${p})`)
+
+  it("turns a root-relative citation into a clickable Slack link", () => {
+    const out = mrkdwnBody(absolutise("See the [Q3 Roadmap](/artifacts/k9ffftpm) for dates."))
+    expect(out).toContain(`<${BASE}/artifacts/k9ffftpm|Q3 Roadmap>`)
+    expect(out).not.toContain("](")
+  })
+
+  it("leaves an absolute link alone", () => {
+    const out = mrkdwnBody(absolutise("See [the docs](https://example.com/x)."))
+    expect(out).toContain("<https://example.com/x|the docs>")
+  })
+
+  it("does NOT absolutise a protocol-relative or javascript target", () => {
+    // The pattern is the guard: a leading slash then an ALPHANUMERIC admits /artifacts/x and
+    // excludes both `//evil.com` and `javascript:`.
+    expect(absolutise("[x](//evil.com)")).toBe("[x](//evil.com)")
+    expect(absolutise("[x](javascript:alert(1))")).toBe("[x](javascript:alert(1))")
+  })
+
+  it("still neutralises a channel-wide mention hidden in an answer", () => {
+    // The escaping this replaced existed for a reason; rendering must not lose it.
+    expect(mrkdwnBody(absolutise("hello <!channel> there"))).not.toContain("<!channel>")
   })
 })

--- a/apps/api/test/slack-mention.test.ts
+++ b/apps/api/test/slack-mention.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest"
 import { SLACK_BOT_SCOPES } from "../src/lib/slack"
 import { mrkdwnBody } from "../src/lib/slack-cards"
-import { artifactRefIn, questionFrom } from "../src/lib/slack-mention"
+import {
+  artifactRefIn,
+  identityVerdict,
+  MISS_TTL_MS,
+  parseSlackTs,
+  questionFrom,
+} from "../src/lib/slack-mention"
 import { buildSlackManifest } from "../src/slack-app-setup"
 
 // @Derive IN SLACK. The pure halves — what the model is actually asked, and which document the
@@ -117,5 +123,64 @@ describe("an answer rendered for Slack", () => {
   it("still neutralises a channel-wide mention hidden in an answer", () => {
     // The escaping this replaced existed for a reason; rendering must not lose it.
     expect(mrkdwnBody(absolutise("hello <!channel> there"))).not.toContain("<!channel>")
+  })
+})
+
+// WHAT A STORED IDENTITY ROW MAKES US DO NEXT. Extracted and tested pure because the lane
+// around it needs Slack, a model and a store — and because these branches fail QUIETLY: too
+// eager re-asks Slack on every message, too sticky writes somebody off for ever.
+
+describe("deciding whether to look up an identity again", () => {
+  const NOW = Date.UTC(2026, 7, 1, 12, 0, 0)
+  const ago = (ms: number) => new Date(NOW - ms).toISOString()
+  const miss = (checked_at: string | null) => ({ origin: "miss", checked_at })
+
+  it("uses a real link, whatever its age", () => {
+    // A link does not go stale. Only a miss has a shelf life.
+    expect(identityVerdict({ origin: "oauth", checked_at: ago(400 * 24 * 3600_000) }, NOW)).toBe(
+      "use",
+    )
+    expect(identityVerdict({ origin: "email", checked_at: null }, NOW)).toBe("use")
+  })
+
+  it("stays silent on a miss inside the window", () => {
+    expect(identityVerdict(miss(ago(60_000)), NOW)).toBe("silent")
+    expect(identityVerdict(miss(ago(MISS_TTL_MS - 1000)), NOW)).toBe("silent")
+  })
+
+  it("looks again once the miss has aged out", () => {
+    // The point of expiry: somebody who joined Derive since should start working without
+    // anyone intervening.
+    expect(identityVerdict(miss(ago(MISS_TTL_MS + 1000)), NOW)).toBe("look")
+  })
+
+  it("looks when there is no row at all", () => {
+    expect(identityVerdict(null, NOW)).toBe("look")
+  })
+
+  it("looks when the stamp is missing or unreadable, rather than going silent", () => {
+    // The dangerous direction is silence. A row that predates checked_at, or one with a
+    // corrupt stamp, must not read as "recently checked, say nothing".
+    expect(identityVerdict(miss(null), NOW)).toBe("look")
+    expect(identityVerdict(miss("not a date"), NOW)).toBe("look")
+  })
+
+  it("looks when the stamp is in the FUTURE, so clock skew cannot silence us", () => {
+    expect(identityVerdict(miss(new Date(NOW + 60_000).toISOString()), NOW)).toBe("look")
+  })
+})
+
+describe("recognising a redelivered Slack message", () => {
+  it("reads the ts marker written alongside the message", () => {
+    expect(parseSlackTs(JSON.stringify({ slack: { ts: "1720000000.1" } }))).toBe("1720000000.1")
+  })
+
+  it("treats absent or unreadable meta as NOT SEEN", () => {
+    // Erring here costs one duplicate answer; the opposite error drops a real question on the
+    // floor, so every ambiguous case has to mean "not seen".
+    expect(parseSlackTs(null)).toBeNull()
+    expect(parseSlackTs(undefined)).toBeNull()
+    expect(parseSlackTs("{oops")).toBeNull()
+    expect(parseSlackTs(JSON.stringify({ outcome: "answered" }))).toBeNull()
   })
 })

--- a/apps/api/test/slack-proposal.test.ts
+++ b/apps/api/test/slack-proposal.test.ts
@@ -52,6 +52,8 @@ const setup = async () => {
     user_id: "u-ed",
     team_id: "T1",
     slack_user_id: "U1",
+    origin: "oauth" as const,
+    checked_at: new Date().toISOString(),
     created_at: new Date().toISOString(),
   })
   await meta.setSlackUserLink({
@@ -60,6 +62,8 @@ const setup = async () => {
     user_id: "u-nobody",
     team_id: "T1",
     slack_user_id: "U2",
+    origin: "oauth" as const,
+    checked_at: new Date().toISOString(),
     created_at: new Date().toISOString(),
   })
   const deps = {

--- a/apps/api/test/slack-review-action.test.ts
+++ b/apps/api/test/slack-review-action.test.ts
@@ -37,6 +37,8 @@ const setup = async (name: string, opts: { role?: string; link?: boolean } = {})
       user_id: "u-1",
       team_id: "T1",
       slack_user_id: "U1",
+      origin: "oauth" as const,
+      checked_at: new Date().toISOString(),
       created_at: new Date().toISOString(),
     })
   if (opts.role)

--- a/apps/api/test/slack-routes.test.ts
+++ b/apps/api/test/slack-routes.test.ts
@@ -329,6 +329,8 @@ describe("slack account linking (OIDC)", () => {
       user_id: owner.id,
       team_id: "T1",
       slack_user_id: "U777",
+      origin: "oauth" as const,
+      checked_at: new Date().toISOString(),
       created_at: new Date().toISOString(),
     })
     const r = await app.request("/v1/slack/link", { method: "DELETE", headers: as(owner.email) })
@@ -577,6 +579,8 @@ describe("slack events endpoint", () => {
       user_id: owner.id,
       team_id: "T1",
       slack_user_id: "U777",
+      origin: "oauth" as const,
+      checked_at: new Date().toISOString(),
       created_at: new Date().toISOString(),
     })
     vi.stubGlobal(
@@ -934,6 +938,8 @@ describe("/derive subscription subcommands", () => {
       user_id: role === "owner" ? owner.id : editor.id,
       team_id: "T1",
       slack_user_id: "U1",
+      origin: "oauth" as const,
+      checked_at: new Date().toISOString(),
       created_at: new Date().toISOString(),
     })
   }
@@ -1114,6 +1120,8 @@ describe("slack link unfurls", () => {
       user_id: owner.id,
       team_id: "T1",
       slack_user_id: "U1",
+      origin: "oauth" as const,
+      checked_at: new Date().toISOString(),
       created_at: new Date().toISOString(),
     })
     const artifact = await meta.createArtifact({
@@ -1194,6 +1202,8 @@ describe("slack link unfurls", () => {
       user_id: owner.id,
       team_id: "T1",
       slack_user_id: "U1",
+      origin: "oauth" as const,
+      checked_at: new Date().toISOString(),
       created_at: new Date().toISOString(),
     })
     const artifact = await meta.createArtifact({
@@ -1552,6 +1562,8 @@ describe("slack slash command (/derive)", () => {
       user_id: userId,
       team_id: "T1",
       slack_user_id: slackUserId,
+      origin: "oauth" as const,
+      checked_at: new Date().toISOString(),
       created_at: new Date().toISOString(),
     })
   }
@@ -1811,6 +1823,8 @@ describe("Save to Derive", () => {
         user_id: owner.id,
         team_id: "T1",
         slack_user_id: "U1",
+        origin: "oauth" as const,
+        checked_at: new Date().toISOString(),
         created_at: new Date().toISOString(),
       })
     const artifact = await meta.createArtifact({
@@ -2034,6 +2048,8 @@ describe("entity_details_requested (the flexpane)", () => {
         user_id: owner.id,
         team_id: "T1",
         slack_user_id: "U1",
+        origin: "oauth" as const,
+        checked_at: new Date().toISOString(),
         created_at: new Date().toISOString(),
       })
     const artifact = await meta.createArtifact({

--- a/apps/api/test/slack-routes.test.ts
+++ b/apps/api/test/slack-routes.test.ts
@@ -2122,3 +2122,48 @@ describe("entity_details_requested (the flexpane)", () => {
     expect(JSON.stringify(body)).not.toContain("Not yours")
   })
 })
+
+// A DIRECT MESSAGE to the app. The Messages tab is where there is nobody to @mention, so the
+// event has to route on its own — and the guards below are the ones that stop a bot answering
+// its own answer for ever.
+
+describe("slack DMs reach the chat lane", () => {
+  const dm = (over: Record<string, unknown> = {}) =>
+    JSON.stringify({
+      type: "event_callback",
+      team_id: "T-dm",
+      event: {
+        type: "message",
+        channel_type: "im",
+        channel: "D-1",
+        user: "U-asker",
+        text: "what changed this week?",
+        ts: "1.1",
+        ...over,
+      },
+    })
+
+  it("accepts a DM without a mention in it", async () => {
+    // A channel question carries "<@BOT>"; a DM carries nothing, and gating on a mention would
+    // make the Messages tab silently ignore every message sent to it.
+    const { app } = make("slack-dm-plain")
+    expect((await postEvent(app, dm())).status).toBe(200)
+  })
+
+  it("IGNORES the app's own messages, both shapes Slack uses", async () => {
+    // The loop this prevents: Derive posts an answer into the DM, Slack delivers that back as a
+    // new message.im, and it answers its own answer. Slack marks the bot's own posts with
+    // bot_id, and edits/deletes/joins with a subtype — neither is a question.
+    const { app } = make("slack-dm-self")
+    expect((await postEvent(app, dm({ bot_id: "B-self" }))).status).toBe(200)
+    expect((await postEvent(app, dm({ subtype: "message_changed" }))).status).toBe(200)
+  })
+
+  it("does not treat a threaded DM as a document comment", async () => {
+    // A DM can carry a thread_ts, and the comment-mirror branch keys on exactly that. Ordered
+    // after this one, it would try to mirror a private message onto a document it has nothing
+    // to do with.
+    const { app } = make("slack-dm-threaded")
+    expect((await postEvent(app, dm({ thread_ts: "1.0" }))).status).toBe(200)
+  })
+})

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -6148,7 +6148,7 @@ export interface components {
             whiteLabel: boolean;
             /** @description Master switch for Derive-hosted agent runs; off silences every hosted run. */
             hostedAgentsEnabled: boolean;
-            /** @description BETA: the Chat tab on a document. Off by default — the tab is hidden and the chat route refuses, so a workspace opts in deliberately. */
+            /** @description The Chat tab on a document, and the workspace chat. ON by default; set it false to turn chat off for a workspace entirely (the tab hides and the chat routes refuse). */
             chatBeta: boolean;
             /** @description BETA: automations on a document. Off by default — the Automate entry point is hidden and the create/run/fire routes refuse, so a workspace opts in deliberately. */
             automateBeta: boolean;

--- a/apps/web/src/pages/chat/index.tsx
+++ b/apps/web/src/pages/chat/index.tsx
@@ -201,6 +201,9 @@ export function ChatPage() {
             onPick={(id) =>
               void navigate({ to: "/chat", search: { session: id, model: modelParam } })
             }
+            onOpenDoc={(shortId) =>
+              void navigate({ to: "/artifacts/$ref", params: { ref: shortId } })
+            }
           />
         </div>
       </header>
@@ -277,8 +280,9 @@ function HistoryPicker(props: {
   sessions: ChatSessionRow[]
   current: string | null
   onPick: (id: string) => void
+  onOpenDoc: (shortId: string) => void
 }) {
-  const { sessions, current, onPick } = props
+  const { sessions, current, onPick, onOpenDoc } = props
   if (sessions.length === 0) return null
   // Split once, here, so the two groups below cannot drift on what counts as which.
   const here = sessions.filter((s) => !s.subject)
@@ -321,21 +325,19 @@ function HistoryPicker(props: {
           <>
             <DropdownMenuSeparator />
             <DropdownMenuLabel>On a document</DropdownMenuLabel>
-            {/* DISABLED, not absent. Opening one belongs on the document it is about, which is
-                where its rail already is — and until this page can route there, offering the
-                click would only reproduce the breakage. Showing them keeps the person's own
-                history honest: a conversation they remember having is still listed. */}
+            {/* THESE OPEN THE DOCUMENT, rather than loading into a page that has none. The
+                subject carries the artifact's short_id, which is exactly what /artifacts/$ref
+                resolves, so the conversation is one click away on the surface that can actually
+                show it — its own rail, against the document it is about. Disabling them was a
+                stand-in for a route I had not checked; the route was already there. */}
             {onDocs.map((s) => (
               <DropdownMenuItem
                 key={s.id}
-                disabled
-                className="opacity-100"
+                onSelect={() => onOpenDoc(s.subject?.id ?? "")}
                 data-testid="chat-history-item-doc"
               >
-                <span className="truncate text-muted-foreground">{s.preview || "(empty)"}</span>
-                <span className="ml-2 shrink-0 text-muted-foreground text-xs">
-                  open from the doc
-                </span>
+                <span className="truncate">{s.preview || "(empty)"}</span>
+                <span className="ml-2 shrink-0 text-muted-foreground text-xs">open doc</span>
               </DropdownMenuItem>
             ))}
           </>

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -459,6 +459,8 @@ CREATE TABLE IF NOT EXISTS slack_user_link (
   team_id TEXT NOT NULL,
   slack_user_id TEXT NOT NULL,
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  origin TEXT NOT NULL DEFAULT 'oauth',
+  checked_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
   UNIQUE (team_id, slack_user_id)
 );
 

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -460,7 +460,7 @@ CREATE TABLE IF NOT EXISTS slack_user_link (
   slack_user_id TEXT NOT NULL,
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
   origin TEXT NOT NULL DEFAULT 'oauth',
-  checked_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  checked_at TEXT,
   UNIQUE (team_id, slack_user_id)
 );
 

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -2981,10 +2981,11 @@ export interface OrgSettings {
    *  unaffected. */
   hostedAgentsEnabled: boolean
   /** BETA: chat with a document (the right-rail Chat tab). OFF by default — unlike every
-   *  other setting here, this one gates a surface we are still testing, and the Derive
-   *  workspace turns it on for itself first. Off means the tab does not render at all and
-   *  the chat route refuses, so a half-enabled state cannot leave someone typing into a
-   *  panel that will never answer. */
+   *  other setting here, it is now ON by default: the surface shipped, and an opt-in nobody
+   *  finds is a feature nobody has. Setting it FALSE still turns chat off completely — the tab
+   *  does not render and the chat routes refuse — so a half-enabled state cannot leave someone
+   *  typing into a panel that will never answer. On a shared host DERIVE_CHAT_ALLOWLIST still
+   *  bounds WHICH workspaces may spend the operator's model key. */
   chatBeta: boolean
   /** BETA: automations (the artifact's "Automate…" surface). Same shape and same reasoning as
    *  {@link chatBeta}, and separate from it because they are different bets: chat is attended
@@ -3045,8 +3046,11 @@ export const DEFAULT_ORG_SETTINGS: OrgSettings = {
   // the run-time safety lives in the autonomy gate (killswitch defaults off but
   // every write still lands as a proposal until a workspace opts into auto).
   hostedAgentsEnabled: true,
-  // Beta, so the default is the conservative one — opt IN per workspace.
-  chatBeta: false,
+  // Chat is ON by default now: it left beta, and an opt-in that everybody has to find is a
+  // feature nobody uses. Explicitly setting it FALSE still turns it off, so a workspace that
+  // does not want it keeps that. Automations stay opt-in — they run unattended and can write
+  // while nobody is watching, which is a different bet from an attended answer.
+  chatBeta: true,
   automateBeta: false,
   agentKillswitch: false,
   agentAutoEnabled: false,

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -3151,9 +3151,10 @@ export interface SlackUserLinkRecord {
   /** `user_id` is empty on a miss — there is nobody to point at. Never read it without
    *  checking `origin`, which is exactly what the filtered accessors below do for you. */
   created_at: string
-  /** When we last CHECKED. Distinct from created_at, which the upsert preserves: a miss
-   *  has to be able to age out and be retried. */
-  checked_at: string
+  /** When we last CHECKED, or null for a row that predates this mechanism. Distinct from
+   *  created_at, which the upsert preserves: a miss has to be able to age out and be retried.
+   *  Nullable so it can be ALTER-added to a populated table — see ddl.ts isMigratable. */
+  checked_at: string | null
 }
 
 /** Where a subscription's events come from: the whole workspace, or one collection. */

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -1220,13 +1220,23 @@ export interface IntegrationStore {
   getSlackThreadLinkByTs(channel: string, ts: string): Promise<SlackThreadLinkRecord | null>
   /** Record the Slack message ↔ Derive thread mapping (idempotent on thread_id). */
   setSlackThreadLink(l: SlackThreadLinkRecord): Promise<void>
-  /** Resolve a Slack user (team + user id) to the Derive user who linked it, or null. */
+  /**
+   * Resolve a Slack user (team + user id) to the Derive user who linked it, or null.
+   *
+   * NEVER returns a `miss` row. Every caller of this treats a non-null result as a real
+   * Derive user — one of them DMs `user_id` directly — so a miss leaking through here would
+   * be a message sent to an id that does not exist. Ask `getSlackIdentityState` when you
+   * actually want to know whether we have looked before.
+   */
   getSlackUserLinkBySlackId(
     teamId: string,
     slackUserId: string,
   ): Promise<SlackUserLinkRecord | null>
-  /** The Slack identity a Derive user linked for a team, or null. */
+  /** The Slack identity a Derive user linked for a team, or null. Also never a `miss`. */
   getSlackUserLinkByUser(teamId: string, userId: string): Promise<SlackUserLinkRecord | null>
+  /** The raw row INCLUDING a `miss`, for the one lane that needs to know whether resolving
+   *  this Slack user has already been tried and failed. */
+  getSlackIdentityState(teamId: string, slackUserId: string): Promise<SlackUserLinkRecord | null>
   /** Link a Derive user to a Slack identity (idempotent on (team_id, slack_user_id)). */
   setSlackUserLink(l: SlackUserLinkRecord): Promise<void>
   /** Remove a Derive user's Slack link for a team. */
@@ -3118,13 +3128,32 @@ export interface SlackThreadLinkRecord {
  *  account instead of guessing by email. Keyed on (team_id, slack_user_id): a Slack user id
  *  is unique per workspace, and one Derive user can link across several workspaces. `org_id`
  *  is the workspace the link was made from (context, not part of the identity key). */
+export type SlackLinkOrigin = "oauth" | "email" | "miss"
+
 export interface SlackUserLinkRecord {
   id: string
   org_id: string
   user_id: string
   team_id: string
   slack_user_id: string
+  /**
+   * HOW this identity was established — and why a MISS lives in the same table.
+   *
+   * "oauth" the person deliberately linked through Slack sign-in.
+   * "email" inferred from their Slack profile email, which resolved to a seat.
+   * "miss"  we looked and found nobody. NOT a link: it is the memo that stops us asking
+   *         Slack and re-prompting the person on every message, and it ages out.
+   *
+   * A miss and a link occupy the SAME (team_id, slack_user_id) row, so a later success
+   * replaces the miss through the ordinary upsert. Self-healing, with no cleanup job.
+   */
+  origin: SlackLinkOrigin
+  /** `user_id` is empty on a miss — there is nobody to point at. Never read it without
+   *  checking `origin`, which is exactly what the filtered accessors below do for you. */
   created_at: string
+  /** When we last CHECKED. Distinct from created_at, which the upsert preserves: a miss
+   *  has to be able to age out and be retried. */
+  checked_at: string
 }
 
 /** Where a subscription's events come from: the whole workspace, or one collection. */

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -613,6 +613,23 @@ export const slackUserLink = pgTable(
     team_id: text("team_id").notNull(),
     slack_user_id: text("slack_user_id").notNull(),
     created_at: text("created_at").notNull().$defaultFn(isoNow),
+    /**
+     * HOW this identity was established, and the reason a MISS can share the table.
+     *
+     * 'oauth' — the person deliberately linked through Slack sign-in.
+     * 'email' — inferred from their Slack profile email, which resolved to a seat.
+     * 'miss'  — we looked and found nobody. NOT a link: it is the memo that stops us
+     *           re-asking Slack and re-prompting the person on every message.
+     *
+     * A miss and a link occupy the SAME (team_id, slack_user_id) row, so a later success
+     * simply replaces the miss through the existing upsert — self-healing, no cleanup job.
+     * getSlackUserLinkBySlackId/ByUser filter miss rows out, so every existing caller keeps
+     * its contract that a returned row is a real Derive user.
+     */
+    origin: text("origin").notNull().default("oauth").$type<"oauth" | "email" | "miss">(),
+    /** When we last CHECKED. Distinct from created_at, which the upsert deliberately
+     *  preserves — a miss has to be able to age out and be retried. */
+    checked_at: text("checked_at").notNull().$defaultFn(isoNow),
   },
   (t) => [
     uniqueIndex("slack_user_link_slack").on(t.team_id, t.slack_user_id),

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -627,9 +627,14 @@ export const slackUserLink = pgTable(
      * its contract that a returned row is a real Derive user.
      */
     origin: text("origin").notNull().default("oauth").$type<"oauth" | "email" | "miss">(),
-    /** When we last CHECKED. Distinct from created_at, which the upsert deliberately
-     *  preserves — a miss has to be able to age out and be retried. */
-    checked_at: text("checked_at").notNull().$defaultFn(isoNow),
+    /** When we last CHECKED. Distinct from created_at, which the upsert preserves: a miss
+     *  has to be able to age out and be retried.
+     *
+     *  NULLABLE so it can be ALTER-added to a populated table. A NOT NULL column whose only
+     *  default is a $defaultFn is initial-only (see isMigratable in ddl.ts) — it would have
+     *  reached a fresh database and silently never reached an existing one. Null means "never
+     *  checked by this mechanism", which is exactly what every pre-existing link row is. */
+    checked_at: text("checked_at"),
   },
   (t) => [
     uniqueIndex("slack_user_link_slack").on(t.team_id, t.slack_user_id),

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -3028,6 +3028,10 @@ export class PgMetaStore implements MetaStore {
       .delete(slackSubscription)
       .where(and(eq(slackSubscription.org_id, orgId), eq(slackSubscription.channel_id, channelId)))
   }
+  // A `miss` shares this table with real links, so both getters filter it out HERE rather
+  // than at their call sites: every caller treats a non-null result as a real Derive user,
+  // and one of them DMs `user_id` directly. Filtering once, in the store, is what lets that
+  // stay true. `getSlackIdentityState` is the deliberate way to see a miss.
   async getSlackUserLinkBySlackId(
     teamId: string,
     slackUserId: string,
@@ -3035,7 +3039,13 @@ export class PgMetaStore implements MetaStore {
     const rows = await this.db
       .select()
       .from(slackUserLink)
-      .where(and(eq(slackUserLink.team_id, teamId), eq(slackUserLink.slack_user_id, slackUserId)))
+      .where(
+        and(
+          eq(slackUserLink.team_id, teamId),
+          eq(slackUserLink.slack_user_id, slackUserId),
+          ne(slackUserLink.origin, "miss"),
+        ),
+      )
     return rows[0] ?? null
   }
   async getSlackUserLinkByUser(
@@ -3045,10 +3055,27 @@ export class PgMetaStore implements MetaStore {
     const rows = await this.db
       .select()
       .from(slackUserLink)
-      .where(and(eq(slackUserLink.team_id, teamId), eq(slackUserLink.user_id, userId)))
+      .where(
+        and(
+          eq(slackUserLink.team_id, teamId),
+          eq(slackUserLink.user_id, userId),
+          ne(slackUserLink.origin, "miss"),
+        ),
+      )
+    return rows[0] ?? null
+  }
+  async getSlackIdentityState(
+    teamId: string,
+    slackUserId: string,
+  ): Promise<SlackUserLinkRecord | null> {
+    const rows = await this.db
+      .select()
+      .from(slackUserLink)
+      .where(and(eq(slackUserLink.team_id, teamId), eq(slackUserLink.slack_user_id, slackUserId)))
     return rows[0] ?? null
   }
   async setSlackUserLink(l: SlackUserLinkRecord): Promise<void> {
+    // created_at is preserved (first seen); checked_at rides in `set` so a miss can age.
     const { id: _i, created_at: _c, ...set } = l
     await this.db
       .insert(slackUserLink)

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -2464,6 +2464,10 @@ export function makeRepos(db: SqliteDb) {
       .where(and(eq(slackSubscription.org_id, orgId), eq(slackSubscription.channel_id, channelId)))
       .run()
   }
+  // A `miss` shares this table with real links, so both getters filter it out HERE rather
+  // than at their call sites: every caller treats a non-null result as a real Derive user,
+  // and one of them DMs `user_id` directly. Filtering once, in the store, is what keeps that
+  // true. `getSlackIdentityState` is the deliberate way to see a miss.
   const getSlackUserLinkBySlackId = async (
     teamId: string,
     slackUserId: string,
@@ -2471,7 +2475,13 @@ export function makeRepos(db: SqliteDb) {
     (await db
       .select()
       .from(slackUserLink)
-      .where(and(eq(slackUserLink.team_id, teamId), eq(slackUserLink.slack_user_id, slackUserId)))
+      .where(
+        and(
+          eq(slackUserLink.team_id, teamId),
+          eq(slackUserLink.slack_user_id, slackUserId),
+          ne(slackUserLink.origin, "miss"),
+        ),
+      )
       .get()) ?? null
   const getSlackUserLinkByUser = async (
     teamId: string,
@@ -2480,9 +2490,25 @@ export function makeRepos(db: SqliteDb) {
     (await db
       .select()
       .from(slackUserLink)
-      .where(and(eq(slackUserLink.team_id, teamId), eq(slackUserLink.user_id, userId)))
+      .where(
+        and(
+          eq(slackUserLink.team_id, teamId),
+          eq(slackUserLink.user_id, userId),
+          ne(slackUserLink.origin, "miss"),
+        ),
+      )
+      .get()) ?? null
+  const getSlackIdentityState = async (
+    teamId: string,
+    slackUserId: string,
+  ): Promise<SlackUserLinkRecord | null> =>
+    (await db
+      .select()
+      .from(slackUserLink)
+      .where(and(eq(slackUserLink.team_id, teamId), eq(slackUserLink.slack_user_id, slackUserId)))
       .get()) ?? null
   const setSlackUserLink = async (l: SlackUserLinkRecord): Promise<void> => {
+    // created_at is preserved (first seen); checked_at rides in `set` so a miss can age.
     const { id: _i, created_at: _c, ...set } = l
     await db
       .insert(slackUserLink)
@@ -4283,6 +4309,7 @@ export function makeRepos(db: SqliteDb) {
     getSlackThreadLinkByTs,
     setSlackThreadLink,
     getSlackUserLinkBySlackId,
+    getSlackIdentityState,
     getSlackUserLinkByUser,
     setSlackUserLink,
     deleteSlackUserLink,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -766,9 +766,14 @@ export const slackUserLink = sqliteTable(
      * its contract that a returned row is a real Derive user.
      */
     origin: text("origin").notNull().default("oauth").$type<"oauth" | "email" | "miss">(),
-    /** When we last CHECKED. Distinct from created_at, which the upsert deliberately
-     *  preserves — a miss has to be able to age out and be retried. */
-    checked_at: text("checked_at").notNull().default(now),
+    /** When we last CHECKED. Distinct from created_at, which the upsert preserves: a miss
+     *  has to be able to age out and be retried.
+     *
+     *  NULLABLE so it can be ALTER-added to a populated table. A NOT NULL column whose only
+     *  default is a $defaultFn is initial-only (see isMigratable in ddl.ts) — it would have
+     *  reached a fresh database and silently never reached an existing one. Null means "never
+     *  checked by this mechanism", which is exactly what every pre-existing link row is. */
+    checked_at: text("checked_at"),
   },
   (t) => [
     uniqueIndex("slack_user_link_slack").on(t.team_id, t.slack_user_id),

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -752,6 +752,23 @@ export const slackUserLink = sqliteTable(
     team_id: text("team_id").notNull(),
     slack_user_id: text("slack_user_id").notNull(),
     created_at: text("created_at").notNull().default(now),
+    /**
+     * HOW this identity was established, and the reason a MISS can share the table.
+     *
+     * 'oauth' — the person deliberately linked through Slack sign-in.
+     * 'email' — inferred from their Slack profile email, which resolved to a seat.
+     * 'miss'  — we looked and found nobody. NOT a link: it is the memo that stops us
+     *           re-asking Slack and re-prompting the person on every message.
+     *
+     * A miss and a link occupy the SAME (team_id, slack_user_id) row, so a later success
+     * simply replaces the miss through the existing upsert — self-healing, no cleanup job.
+     * getSlackUserLinkBySlackId/ByUser filter miss rows out, so every existing caller keeps
+     * its contract that a returned row is a real Derive user.
+     */
+    origin: text("origin").notNull().default("oauth").$type<"oauth" | "email" | "miss">(),
+    /** When we last CHECKED. Distinct from created_at, which the upsert deliberately
+     *  preserves — a miss has to be able to age out and be retried. */
+    checked_at: text("checked_at").notNull().default(now),
   },
   (t) => [
     uniqueIndex("slack_user_link_slack").on(t.team_id, t.slack_user_id),

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -4696,5 +4696,95 @@ export function runStoreContract(
         await store.updateConnectionCredential(cn.id, ORG, { secret_enc: "v1.second" }, null),
       ).toBeNull()
     })
+
+    // A MISS SHARES THE LINK TABLE, and must never escape as a link.
+    //
+    // Eleven call sites treat a non-null result from getSlackUserLinkBySlackId as a real Derive
+    // user — one of them DMs `user_id` directly, which on a miss is the empty string. The filter
+    // therefore belongs in the STORE, and it belongs in this contract suite so all three dialects
+    // prove it rather than one.
+    describe("slack identity: links vs misses", () => {
+      const linkRow = (over: Record<string, unknown> = {}) => ({
+        id: `sul-${Math.abs(Date.now() % 100000)}-${String(over.slack_user_id ?? "U1")}`,
+        org_id: ORG,
+        user_id: "u-1",
+        team_id: "T1",
+        slack_user_id: "U1",
+        origin: "oauth" as const,
+        created_at: new Date().toISOString(),
+        checked_at: new Date().toISOString(),
+        ...over,
+      })
+
+      it("hands back a real link", async () => {
+        await store.setSlackUserLink(linkRow({ slack_user_id: "U-real" }))
+        expect((await store.getSlackUserLinkBySlackId("T1", "U-real"))?.user_id).toBe("u-1")
+        expect((await store.getSlackUserLinkByUser("T1", "u-1"))?.slack_user_id).toBe("U-real")
+      })
+
+      it("HIDES a miss from both link accessors", async () => {
+        await store.setSlackUserLink(
+          linkRow({ slack_user_id: "U-miss", user_id: "", origin: "miss" as const }),
+        )
+        expect(await store.getSlackUserLinkBySlackId("T1", "U-miss")).toBeNull()
+        expect(await store.getSlackUserLinkByUser("T1", "")).toBeNull()
+      })
+
+      it("shows the miss to the accessor that asks for it, with checked_at", async () => {
+        const at = new Date(Date.now() - 60_000).toISOString()
+        await store.setSlackUserLink(
+          linkRow({
+            slack_user_id: "U-seen",
+            user_id: "",
+            origin: "miss" as const,
+            checked_at: at,
+          }),
+        )
+        const state = await store.getSlackIdentityState("T1", "U-seen")
+        expect(state?.origin).toBe("miss")
+        expect(state?.checked_at).toBe(at)
+      })
+
+      it("a later success REPLACES the miss on the same row — self-healing", async () => {
+        await store.setSlackUserLink(
+          linkRow({ slack_user_id: "U-fix", user_id: "", origin: "miss" as const }),
+        )
+        expect(await store.getSlackUserLinkBySlackId("T1", "U-fix")).toBeNull()
+        await store.setSlackUserLink(
+          linkRow({ slack_user_id: "U-fix", user_id: "u-9", origin: "email" as const }),
+        )
+        // No cleanup job: the upsert on (team_id, slack_user_id) did it.
+        expect((await store.getSlackUserLinkBySlackId("T1", "U-fix"))?.user_id).toBe("u-9")
+        expect((await store.getSlackIdentityState("T1", "U-fix"))?.origin).toBe("email")
+      })
+
+      it("refreshes checked_at on re-miss while PRESERVING created_at", async () => {
+        // created_at is first-seen and the upsert strips it; checked_at is what ages a miss out,
+        // so it has to move or a miss could never be retried a second time.
+        const old = new Date(Date.now() - 5 * 60_000).toISOString()
+        await store.setSlackUserLink(
+          linkRow({
+            slack_user_id: "U-age",
+            user_id: "",
+            origin: "miss" as const,
+            created_at: old,
+            checked_at: old,
+          }),
+        )
+        const now = new Date().toISOString()
+        await store.setSlackUserLink(
+          linkRow({
+            slack_user_id: "U-age",
+            user_id: "",
+            origin: "miss" as const,
+            created_at: now,
+            checked_at: now,
+          }),
+        )
+        const state = await store.getSlackIdentityState("T1", "U-age")
+        expect(state?.created_at).toBe(old)
+        expect(state?.checked_at).toBe(now)
+      })
+    })
   })
 }


### PR DESCRIPTION
Two follow-ups to #609.

## Chat is on by default

Chat left beta, and an opt-in everybody has to find is a feature nobody has.
`DEFAULT_ORG_SETTINGS.chatBeta` flips to `true`. Setting it **false** still turns
chat off completely — the tab hides and the chat routes refuse — so a workspace
that does not want it keeps that.

Automations stay opt-in deliberately. They are a different bet: an attended
answer happens with somebody watching, an automation runs unattended and can
write while nobody is.

On a shared host `DERIVE_CHAT_ALLOWLIST` still bounds which workspaces may spend
the operator's model key. The default answers "is this on", not "who pays".

The gate test was rewritten rather than deleted: the case worth covering is now
the workspace that opted **out**, plus an assertion on the default itself so it
cannot drift silently.

## A document conversation opens its document

The workspace chat history lists every conversation in the workspace, including
ones held on a document via its rail. #609 split them into labelled groups and
left the document ones **disabled** with "open from the doc", which told somebody
where to go and then made them walk.

That was a stand-in for a route I had not checked. The route was already there:
the session subject carries the artifact's `short_id`, which is exactly what
`/artifacts/$ref` resolves. So they navigate.

---

`pnpm verify` green. API 1977, web 266.

🤖 Generated with [Claude Code](https://claude.com/claude-code)