### PR TITLE
fix(chat): the palette asks, it does not write

### DIFF
--- a/apps/api/src/lib/chat-tools.ts
+++ b/apps/api/src/lib/chat-tools.ts
@@ -62,6 +62,27 @@ export const CHAT_TOOLS: ReadonlySet<string> = new Set(["find", "read", "publish
  */
 export const RAIL_CHAT_TOOLS: ReadonlySet<string> = new Set(["find", "read"])
 
+/**
+ * THE ASK SURFACE's subset: everything except the writer.
+ *
+ * The ⌘K palette answers in a dialog over whatever page you were on. Two reasons that surface
+ * should not hold `publish`, and the second is the load-bearing one:
+ *
+ *  - It says so. Its empty state promises "Derive searches and reads with your own permissions",
+ *    the control that opens it is labelled Ask, and a document appearing in the library because
+ *    of a sentence typed into a transient modal is not what either of those advertises.
+ *  - It removes a SECOND WRITE PATH for a document you are looking at. On /artifacts/… the rail
+ *    already writes, through the revision contract and the landing port that decide
+ *    publish-vs-propose and demote on a mid-turn race. The palette reaching the same document
+ *    through the `publish` tool instead means two answers to "how does this land", which is the
+ *    drift turn-core exists to prevent.
+ *
+ * Writing still has two homes, both of them surfaces you chose deliberately: /chat (full page,
+ * history, a stop control) and the document rail (its own contract). The palette's footer links
+ * to the first, so an ask that wants to become a write is one click from where it can.
+ */
+export const ASK_CHAT_TOOLS: ReadonlySet<string> = new Set(["find", "read", "use", "call"])
+
 export interface ChatToolSurface {
   /** The tools as the model is told about them. Empty when the subset is empty. */
   tools: LoopTool[]

--- a/apps/api/src/routes/contexts.ts
+++ b/apps/api/src/routes/contexts.ts
@@ -31,7 +31,7 @@ import {
 } from "../lib/broker"
 import { overBudget } from "../lib/budget"
 import { chatArrival } from "../lib/chat-gate"
-import { buildChatTools, RAIL_CHAT_TOOLS } from "../lib/chat-tools"
+import { ASK_CHAT_TOOLS, buildChatTools, RAIL_CHAT_TOOLS } from "../lib/chat-tools"
 import { runChatTurn } from "../lib/chat-turn"
 import { previewOf } from "../lib/comments"
 import { sha256 } from "../lib/crypto"
@@ -173,6 +173,9 @@ export const contextRoutes = (ctx: AppContext) => {
     reply: (body: string, state: SessionState, payload?: unknown) => Promise<void>,
     stream: DeltaStream,
     askedModelId: string | null,
+    /** Where the question was typed. "ask" (the palette) drops the writer for this turn; it can
+     *  only ever narrow, so a caller that says nothing gets what it always got. */
+    surface?: "ask",
   ) => {
     // The seat is re-read PER TURN, never trusted from session creation: someone removed from
     // the workspace still holds the session id, and their tools would otherwise keep working.
@@ -204,14 +207,18 @@ export const contextRoutes = (ctx: AppContext) => {
     }
     const ws = await meta.getWorkspace(s.org_id).catch(() => null)
     const settings = await meta.getOrgSettings(s.org_id).catch(() => null)
-    const tools = buildChatTools(ctx, {
-      org: s.org_id,
-      user: { id: me.id, name: me.name ?? me.username ?? null },
-      seatRole: seat.role,
-      // Read fresh for THIS turn: an operator who flips the killswitch mid-conversation stops
-      // the next write, not merely the next session.
-      flags: { agentKillswitch: settings?.agentKillswitch ?? false },
-    })
+    const tools = buildChatTools(
+      ctx,
+      {
+        org: s.org_id,
+        user: { id: me.id, name: me.name ?? me.username ?? null },
+        seatRole: seat.role,
+        // Read fresh for THIS turn: an operator who flips the killswitch mid-conversation stops
+        // the next write, not merely the next session.
+        flags: { agentKillswitch: settings?.agentKillswitch ?? false },
+      },
+      surface === "ask" ? ASK_CHAT_TOOLS : undefined,
+    )
     const res = await runChatTurn(
       { model: { ...model, callModel: stream.wrap(model.callModel) } },
       {
@@ -245,8 +252,14 @@ export const contextRoutes = (ctx: AppContext) => {
     /** The context's agent, or NULL for a contextless (default-agent) chat session. */
     agentId: string | null,
     /** What the caller asked for on THIS turn. `modelId` is the person's model pick; absent
-     *  means "whatever this conversation was already using", then the deploy's default. */
-    opts?: { modelId?: string | null },
+     *  means "whatever this conversation was already using", then the deploy's default.
+     *
+     *  `surface` narrows the tools, and ONLY ever narrows them: the palette says "ask" and loses
+     *  the writer (ASK_CHAT_TOOLS). It rides the request rather than the session because it is a
+     *  property of where the question was typed, not of the conversation — the same transcript
+     *  opened on /chat writes, which is what its Open-in-chat link is for. A caller that omits it
+     *  gets exactly what it got before, so this can add capability to nobody. */
+    opts?: { modelId?: string | null; surface?: "ask" },
   ) => {
     const subject = parseSubject(s.subject_ref)
     // WHAT THIS LANE WILL SERVE, and what it must leave alone.
@@ -324,7 +337,7 @@ export const contextRoutes = (ctx: AppContext) => {
       // writer, the settle wake — is shared with the document lane and deliberately not
       // duplicated; what differs is only what the turn is given and what it may do.
       if (!subject) {
-        await serveWorkspaceChat(s, me, reply, stream, opts?.modelId ?? null)
+        await serveWorkspaceChat(s, me, reply, stream, opts?.modelId ?? null, opts?.surface)
         return
       }
       const artifact = await meta.getByShortId(subject.id)
@@ -1628,6 +1641,12 @@ export const contextRoutes = (ctx: AppContext) => {
             .max(200)
             .optional()
             .describe("A model id from /v1/chat/models; omitted = this deploy's default."),
+          surface: z
+            .enum(["ask"])
+            .optional()
+            .describe(
+              'Where the question was typed. "ask" is the \u2318K palette, which loses the writer for this turn; omitted is the full chat surface. It can only ever narrow.',
+            ),
         }),
       )
       if (b instanceof Response) return bail(b)
@@ -1653,7 +1672,9 @@ export const contextRoutes = (ctx: AppContext) => {
       )
       // Detached, exactly like the document lane: the transcript is what the surface follows,
       // so closing the tab mid-turn loses nothing.
-      await ctx.background(serveAttended(created.session, me, null, { modelId: b.model ?? null }))
+      await ctx.background(
+        serveAttended(created.session, me, null, { modelId: b.model ?? null, surface: b.surface }),
+      )
       return c.json(
         { session: sessionJson(created.session), messages: [messageJson(created.message)] },
         201,
@@ -1837,6 +1858,12 @@ export const contextRoutes = (ctx: AppContext) => {
           z.object({
             body_md: z.string().trim().min(1).max(100_000),
             meta: z.unknown().optional(),
+            surface: z
+              .enum(["ask"])
+              .optional()
+              .describe(
+                'Where the question was typed. "ask" is the \u2318K palette, which loses the writer for this turn; omitted is the full chat surface. It can only ever narrow.',
+              ),
             state: z.enum(["answered", "escalated", "failed"]).optional(),
             // The asker message this answer addresses (from the runner's queue
             // snapshot) — the guard against the lost-turn race below.
@@ -1927,6 +1954,9 @@ export const contextRoutes = (ctx: AppContext) => {
           // the bigger one" is the whole use case, and it must not rewrite what already answered.
           // Absent = whatever this conversation was last answered with (see lastModelId).
           model: z.string().max(200).optional(),
+          // Per-turn for the same reason: the palette narrows ITS turns to the reading tools, and
+          // the same conversation reopened on /chat is not narrowed. Only ever narrows.
+          surface: z.enum(["ask"]).optional(),
         }),
       )
       if (b instanceof Response) return bail(b)
@@ -1974,7 +2004,10 @@ export const contextRoutes = (ctx: AppContext) => {
         if (!st?.chatBeta) return c.json({ message: messageJson(m) }, 201)
       }
       await ctx.background(
-        serveAttended(s, me, linked?.context.agent_id ?? null, { modelId: b.model ?? null }),
+        serveAttended(s, me, linked?.context.agent_id ?? null, {
+          modelId: b.model ?? null,
+          surface: b.surface,
+        }),
       )
       return c.json({ message: messageJson(m) }, 201)
     },

--- a/apps/api/test/chat-tools.test.ts
+++ b/apps/api/test/chat-tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { buildChatTools, CHAT_TOOLS } from "../src/lib/chat-tools"
+import { ASK_CHAT_TOOLS, buildChatTools, CHAT_TOOLS } from "../src/lib/chat-tools"
 import { catalogFromGateway, catalogOf } from "../src/lib/model-catalog"
 import { as, makeAuthedApp, publishAs } from "./helpers"
 
@@ -119,6 +119,27 @@ describe("the chat tool surface", () => {
     // returning an empty list that reads as "no work waiting".
     const out = JSON.stringify(await tools.execute("catch_up", {}))
     expect(out).toMatch(/no inbox/i)
+  })
+
+  it("the ASK surface holds every reading tool and no writer", async () => {
+    const { ctx } = makeAuthedApp("ct-ask", [{ id: "u1", email: "u1@x.com", name: "U" }])
+    const who = { org: "default", user: { id: "u1", name: "U" }, seatRole: "owner" } as const
+    const ask = buildChatTools(ctx, who, ASK_CHAT_TOOLS)
+    // The palette answers over the page you were on, and the document rail already writes to the
+    // document you are looking at. One writer per document is the point.
+    expect(ask.tools.map((t) => t.name)).not.toContain("publish")
+    // Everything that READS survives, so an ask is not a lesser answer — only a non-writing one.
+    for (const t of ["find", "read"]) expect(ask.tools.map((x) => x.name)).toContain(t)
+    // Not registered rather than refused: there is no handler to reach.
+    const out = JSON.stringify(await ask.execute("publish", { title: "x", content: "y" }))
+    expect(out).toMatch(/unknown tool/i)
+  })
+
+  it("the surface can only ever NARROW: it is a subset of the full set", () => {
+    // The narrowing rides the request, so a client picks it. That is safe only while it cannot
+    // ADD anything — this is the assertion that keeps it safe.
+    for (const t of ASK_CHAT_TOOLS) expect(CHAT_TOOLS.has(t)).toBe(true)
+    expect(ASK_CHAT_TOOLS.size).toBeLessThan(CHAT_TOOLS.size)
   })
 
   it("carries the app-help skill on EVERY lane, including one with no tools at all", async () => {

--- a/apps/web/src/components/chrome/palette-ask.tsx
+++ b/apps/web/src/components/chrome/palette-ask.tsx
@@ -63,15 +63,28 @@ export function PaletteAsk(props: {
   const { data: ws, isError: wsFailed } = useQuery({ ...workspaceQuery(), staleTime: 60_000 })
   const org = ws?.id ?? ""
 
+  // `surface: "ask"` on BOTH the open and every follow-up: it narrows this turn's tools to
+  // everything except the writer (ASK_CHAT_TOOLS). It travels with the request rather than
+  // living on the session, because it describes where the question was typed, not what the
+  // conversation is — the same transcript opened on /chat can write, which is what the
+  // Open-in-chat link below is for.
   const open = useCallback(
     (body: string) =>
       json<{ session: { id: string } }>("/v1/chat-session", {
         method: "POST",
-        body: JSON.stringify({ workspace: org, body_md: body }),
+        body: JSON.stringify({ workspace: org, body_md: body, surface: "ask" }),
       }),
     [org],
   )
-  const chat = useChatSession({ open, resetKey: org })
+  const followUp = useCallback(
+    (id: string, body: string) =>
+      json(`/v1/sessions/${id}/messages`, {
+        method: "POST",
+        body: JSON.stringify({ body_md: body, surface: "ask" }),
+      }),
+    [],
+  )
+  const chat = useChatSession({ open, followUp, resetKey: org })
 
   // ONE SHOT. A ref rather than state, because React's double mount would otherwise ask the same
   // question twice — two turns, two costs, two answers to read.


### PR DESCRIPTION
Follow-up to #620, which merged while this was in flight — so this one commit missed it.

## What was wrong

#620's description claimed "no writes from the palette: reach only, find and read". That was wrong, and reviewing my own PR body is what caught it. The palette runs the workspace chat lane, so it holds the full `CHAT_TOOLS` set including `publish`.

Which makes the overlap on a document page real rather than cosmetic: on `/artifacts/…` the rail already writes, through the revision contract and the landing port that decide publish-vs-propose and demote on a mid-turn race. The palette could reach the same document by another road. Two answers to "how does this land" is the drift `turn-core` exists to prevent.

## The change

`ASK_CHAT_TOOLS` is every reading tool and no `publish`. That also makes the surface honest: its empty state promises "searches and reads with your own permissions", and the control that opens it says **Ask**.

The narrowing rides the **request**, not the session, on both the open and every follow-up:

- It describes where a question was typed, not what a conversation is. The same transcript reopened on `/chat` writes, which is what the Open-in-chat link is for.
- Keeping it off the session means no migration and no new state to keep in step.
- It is safe because it can only ever **remove**. A caller that says nothing gets exactly what it got before, and a test asserts the ask set is a strict subset of the full one, so it can never grow into an escalation.

Writing still has two homes, both chosen deliberately: `/chat`, and the document rail for the document in front of you.

## Verification

`pnpm run ci`, `pnpm typecheck`, full suite green. Two new tests: the ask surface has no `publish` handler to reach (not a guard that could be skipped), and the ask set is a strict subset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/621"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788315362&installation_model_id=428097&pr_number=621&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F621&signature=93aefd22feadc47c2d81725af7fea1af2308bc8c18fea53a51608c576da83772"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->