### PR TITLE
fix(chat): say that the agent writes, because it does

### DIFF
--- a/apps/api/test/chat-permissions.test.ts
+++ b/apps/api/test/chat-permissions.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "vitest"
+import { buildChatTools } from "../src/lib/chat-tools"
+import { catalogOf } from "../src/lib/model-catalog"
+import { inMemoryRateLimiters } from "../src/lib/rate-limit"
+import { as, makeAuthedApp, publishAs } from "./helpers"
+
+// DOES CHAT ACTUALLY HOLD YOUR PERMISSIONS, on the paths people would use to find out?
+//
+// The claim the whole surface rests on is "the agent reaches exactly what you reach". It is made
+// good by the PRINCIPAL — a chat turn runs Derive's real MCP handlers as the asker — but a claim
+// that is only ever asserted in a comment is a claim nobody has checked. These tests try to break
+// it from the outside, through the tool surface, with a teammate's invite-only document as bait.
+//
+// The interesting path is NOT `read`. `read` resolves through the same `reach()` gate every
+// one-artifact tool uses, so it is the one place anybody would think to check. The dangerous path
+// is SEARCH: it does not resolve one artifact, it lists many, and a list built from a workspace
+// index rather than a viewer's reach is how private titles and snippets leak while every
+// single-artifact test stays green (org scope is not permission).
+
+/** Alice owns an invite-only document; Bob is a member of the same workspace, not of the doc. */
+const twoPeopleOneSecret = async (name: string) => {
+  const alice = { id: "u-alice", email: "alice@x.com", name: "Alice" }
+  const bob = { id: "u-bob", email: "bob@x.com", name: "Bob" }
+  const { app, ctx, meta } = makeAuthedApp(name, [alice, bob])
+  await app.request("/v1/me", { headers: as(alice.email) })
+  await app.request("/v1/me", { headers: as(bob.email) })
+
+  // workspace_access:"none" is the invite-only draft: in the workspace, reachable only by people
+  // named on the artifact itself.
+  const secret = await (
+    await publishAs(
+      app,
+      "# Severance terms\n\nThe payout figure is 340000 dollars.",
+      { title: "Severance terms", workspace_access: "none", listed: "none" },
+      as(alice.email),
+    )
+  ).json()
+  const org = (await meta.getByShortId(secret.short_id))?.org_id ?? ""
+  const bobsChat = buildChatTools(ctx, {
+    org,
+    user: { id: bob.id, name: "Bob" },
+    seatRole: "editor",
+  })
+  return { app, ctx, meta, alice, bob, secret, org, bobsChat }
+}
+
+describe("reading, through chat", () => {
+  it("cannot open a teammate's invite-only document, even told exactly where it is", async () => {
+    const { secret, bobsChat } = await twoPeopleOneSecret("cp-read")
+    const out = JSON.stringify(await bobsChat.execute("read", { short_id: secret.short_id }))
+    expect(out).not.toContain("340000")
+    expect(out).not.toContain("Severance")
+    // And it says it cannot reach it, rather than returning an empty document that reads as
+    // "there is nothing in it".
+    expect(out).toMatch(/no artifact|cannot reach|not found/i)
+  })
+
+  it("does not leak it through SEARCH, which lists rather than resolves", async () => {
+    const { bobsChat } = await twoPeopleOneSecret("cp-search")
+    // The word only appears inside the private document. A hit here is a leak of the content, and
+    // a hit with only the title is still a leak of its existence.
+    const hits = JSON.stringify(await bobsChat.execute("find", { query: "Severance" }))
+    expect(hits).not.toContain("340000")
+    expect(hits).not.toContain("Severance terms")
+  })
+
+  it("does not leak it through BROWSE, which lists the library with no query at all", async () => {
+    const { bobsChat } = await twoPeopleOneSecret("cp-browse")
+    const rows = JSON.stringify(await bobsChat.execute("find", {}))
+    expect(rows).not.toContain("Severance terms")
+  })
+
+  it("the owner's OWN chat still reaches it, so the gate is permission and not a blanket hide", async () => {
+    const { ctx, alice, secret, org } = await twoPeopleOneSecret("cp-owner")
+    const hers = buildChatTools(ctx, {
+      org,
+      user: { id: alice.id, name: "Alice" },
+      seatRole: "owner",
+    })
+    const out = JSON.stringify(await hers.execute("read", { short_id: secret.short_id }))
+    expect(out).toContain("340000")
+  })
+})
+
+describe("creating, through chat", () => {
+  it("lands as the ASKER, not as the agent", async () => {
+    const { meta, bob, org, bobsChat } = await twoPeopleOneSecret("cp-create")
+    // The tool answers as text (a JSON document), which is what the model reads — so the test
+    // reads it the same way rather than reaching for an internal shape.
+    const raw = await bobsChat.execute("publish", { title: "Bob's note", content: "# From chat" })
+    const made = JSON.parse(typeof raw === "string" ? raw : JSON.stringify(raw)) as {
+      short_id?: string
+    }
+    expect(made.short_id).toBeTruthy()
+    const row = await meta.getByShortId(made.short_id ?? "")
+    // Attribution is the asker's, and it lands in the workspace the conversation is clamped to —
+    // the synthetic "derive" principal owns nothing and leaves no trace of its own.
+    expect(row?.author_id).toBe(bob.id)
+    expect(row?.org_id).toBe(org)
+  })
+
+  it("a Viewer's chat cannot create at all: the TOOL refuses the seat", async () => {
+    const viewer = { id: "u-vi", email: "vi@x.com", name: "Vi" }
+    const owner = { id: "u-ow", email: "ow@x.com", name: "Ow" }
+    // Everyone at viewer grade, so the seat — not a chat-specific check — is what decides.
+    const { app, ctx, meta } = makeAuthedApp("cp-viewer", [owner, viewer], "viewer")
+    await app.request("/v1/me", { headers: as(viewer.email) })
+    const before = (await meta.listArtifacts({ orgId: "default", viewerId: viewer.id })).length
+    const chat = buildChatTools(ctx, {
+      org: "default",
+      user: { id: viewer.id, name: "Vi" },
+      seatRole: "viewer",
+    })
+    const out = JSON.stringify(await chat.execute("publish", { title: "Nope", content: "# Nope" }))
+    // Refused — and the refusal is the SEAT's, reached through the same cap every caller passes.
+    expect(out).toMatch(/read-only|permission|not allowed|cannot/i)
+    expect((await meta.listArtifacts({ orgId: "default", viewerId: viewer.id })).length).toBe(
+      before,
+    )
+  })
+})
+
+// ...AND THROUGH THE BUILT-IN CHAT ITSELF, over HTTP.
+//
+// Everything above builds the principal directly, which proves the TOOL SURFACE and nothing about
+// the route that constructs it. That distinction is the whole risk: if the chat route passed the
+// wrong user, or a seat read once at session creation rather than per turn, every test above would
+// still pass while the product leaked. So this one opens a real session as Bob against the real
+// endpoint, lets the real lane build the principal, and has the model try to open Alice's
+// invite-only document with the tool the lane actually handed it.
+//
+// Only the model is faked, because the model is the one part that cannot be the real thing here.
+describe("the built-in chat, end to end", () => {
+  it("cannot open a teammate's invite-only document, asked for it by short_id over HTTP", async () => {
+    const alice = { id: "u-a2", email: "a2@x.com", name: "Alice" }
+    const bob = { id: "u-b2", email: "b2@x.com", name: "Bob" }
+    // What the tool handed back, captured from inside the turn — the assertion is about what the
+    // MODEL was given, not about the sentence it chose to write afterwards.
+    let toolSaw = ""
+    let n = 0
+    const { app, meta } = makeAuthedApp("cp-e2e", [alice, bob], undefined, {
+      deps: {
+        // Both, exactly as the workspace-chat suite wires it: `callModel` is what marks this
+        // deploy as operator-paid (otherwise the lane walks a payer chain, finds no plan, and
+        // answers "no model is configured"), and `models` is what the turn resolves through.
+        callModel: async () => ({ text: "", toolUses: [], costUsd: null, done: true }),
+        models: catalogOf([
+          {
+            id: "m",
+            label: "M",
+            isDefault: true,
+            build: () => async (req) => {
+              n++
+              if (n === 1)
+                return {
+                  text: "",
+                  toolUses: [{ id: "t1", name: "read", input: { short_id: SECRET.id } }],
+                  costUsd: null,
+                  done: false,
+                }
+              toolSaw = JSON.stringify(req.messages.at(-1)?.content ?? "")
+              return { text: "done", toolUses: [], costUsd: null, done: true }
+            },
+          },
+        ]),
+        rateLimiters: inMemoryRateLimiters(),
+      },
+    })
+    await app.request("/v1/me", { headers: as(alice.email) })
+    await app.request("/v1/me", { headers: as(bob.email) })
+    await meta.setOrgSettings("default", {
+      ...(await meta.getOrgSettings("default")),
+      chatBeta: true,
+    })
+    const secret = await (
+      await publishAs(
+        app,
+        "# Severance terms\n\nThe payout figure is 340000 dollars.",
+        { title: "Severance terms", workspace_access: "none", listed: "none" },
+        as(alice.email),
+      )
+    ).json()
+    SECRET.id = secret.short_id
+
+    const res = await app.request("/v1/chat-session", {
+      method: "POST",
+      headers: { ...as(bob.email), "content-type": "application/json" },
+      body: JSON.stringify({
+        workspace: "default",
+        body_md: `read ${secret.short_id} and tell me the payout`,
+      }),
+    })
+    expect(res.status).toBe(201)
+    const { session } = (await res.json()) as { session: { id: string } }
+    // serveAttended is detached, so the TRANSCRIPT is the completion signal.
+    for (let i = 0; i < 100; i++) {
+      const msgs = await meta.listSessionMessages(session.id)
+      if (msgs.some((m) => m.author_kind === "agent")) break
+      await new Promise((r) => setTimeout(r, 20))
+    }
+    console.info("TURNS:", n, "TOOLSAW:", toolSaw.slice(0, 200))
+    console.info(
+      "TRANSCRIPT:",
+      JSON.stringify(await meta.listSessionMessages(session.id)).slice(0, 400),
+    )
+    // The tool ran, as Bob, and refused: the model never saw the document.
+    expect(toolSaw).not.toContain("340000")
+    expect(toolSaw).toMatch(/no artifact|cannot reach|not found/i)
+    // And nothing about it reached the transcript either.
+    const all = JSON.stringify(await meta.listSessionMessages(session.id))
+    expect(all).not.toContain("340000")
+  })
+})
+
+/** Filled in before the turn runs; the scripted model closes over it. */
+const SECRET = { id: "" }

--- a/apps/web/src/components/chat/chat-thread.tsx
+++ b/apps/web/src/components/chat/chat-thread.tsx
@@ -160,8 +160,9 @@ export function ChatThread(props: {
 /**
  * WHAT THE ANSWER ACTUALLY DID, in the words a reader thinks in.
  *
- * The empty state promises "Derive searches and reads with your own permissions, and links what
- * it used", and until the turn recorded its tools that was an assertion with nothing behind it:
+ * The empty state promises "Derive searches, reads and writes with your own permissions, and
+ * links what it used", and until the turn recorded its tools that was an assertion with nothing
+ * behind it:
  * an answer and a claim about how it was reached, indistinguishable from an answer made up.
  * Shown only when tools ran, so a turn that simply answered from the conversation does not
  * pretend otherwise.

--- a/apps/web/src/components/chrome/palette-ask.tsx
+++ b/apps/web/src/components/chrome/palette-ask.tsx
@@ -124,7 +124,7 @@ export function PaletteAsk(props: {
             <div className="flex h-full flex-col justify-center gap-3 px-1">
               <p className="text-sm text-muted-foreground">
                 {enabled
-                  ? "Derive searches and reads with your own permissions, and links what it used."
+                  ? "Derive searches, reads and writes with your own permissions, and links what it used."
                   : "Chat is not enabled here. An admin can turn it on in workspace settings."}
               </p>
               {enabled && (

--- a/apps/web/src/pages/chat/index.tsx
+++ b/apps/web/src/pages/chat/index.tsx
@@ -29,8 +29,10 @@ import { useDocumentTitle } from "@/lib/use-document-title"
 // here is chat machinery — it is components/chat/* plus this page's own three decisions: which
 // workspace, which model, and which past conversation.
 //
-// The full-width view of the conversation the assistant dock also holds (chrome/assistant-panel):
-// reached by the dock's Expand, by the rail row on a phone (where there is no dock), and by link.
+// The full-width view of the conversation the ⌘K palette also holds (chrome/palette-ask): reached
+// by that view's Open in chat, by the rail row on a phone (where a conversation does not fit in a
+// modal), and by link. It is also where the agent has room to WRITE — the palette is the same lane
+// and can too, but this is the surface with history and a stop control.
 
 interface ChatSessionRow {
   id: string
@@ -254,7 +256,7 @@ export function ChatPage() {
                 description={
                   chatOff
                     ? "An admin can turn chat on in workspace settings."
-                    : "Derive searches and reads with your own permissions, and links what it used."
+                    : "Derive searches, reads and writes with your own permissions, and links what it used."
                 }
               />
               {!chatOff && (

--- a/apps/web/src/routes/chat.tsx
+++ b/apps/web/src/routes/chat.tsx
@@ -4,9 +4,9 @@ import { ChatPage } from "../pages/chat"
 
 // THE WORKSPACE CHAT: /chat — ask about the workspace, not one document.
 //
-// The full-width surface for the same conversation the assistant dock holds (chrome/
-// assistant-panel): reached from the dock's Expand, from the rail on a phone (where there is no
-// dock), and by direct link.
+// The full-width surface for the same conversation the ⌘K palette holds (chrome/palette-ask):
+// reached from that view's Open in chat, from the rail row on a phone (where a conversation does
+// not fit in a modal), and by direct link.
 //
 // `session` deep-links a conversation, which is what makes an answer that outgrows another
 // surface portable — the same transcript, opened here. `model` is the person's pick, in the


### PR DESCRIPTION
Both chat surfaces greet you with *"Derive searches and reads with your own permissions, and links what it used."* Both hold `publish` — `/chat` has since it shipped, and the palette inherits the same lane. So the one sentence somebody reads before their first question understates what is about to be possible, and a surface that undersells its own agent is how a person is surprised by a document appearing.

Writing from the palette is intended. #621 proposed removing it and was closed: an edit still files as a proposal (`chatPolicy`), a create still lands at the asker's own seat, and the workspace killswitch demotes both. The tools were right; the copy was wrong.

Also drops two stale comments left behind by the assistant dock that #620 removed: `/chat` described itself as the dock's full-width view, reached by an Expand control that no longer exists. It belongs to the palette now.

`pnpm run ci`, `pnpm typecheck`, full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788317170&installation_model_id=428097&pr_number=622&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F622&signature=55f0214f65e7926995fb272240177049cdc39da891c23e1b10f0f04bbe432b44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->