### PR TITLE
fix(slack): match content_item's real field schema, learned from the API

### DIFF
--- a/apps/api/src/lib/slack-work-object.ts
+++ b/apps/api/src/lib/slack-work-object.ts
@@ -34,16 +34,25 @@ export const SLACK_REVIEW_ACTION = {
  *  orphans every previously-unfurled card from its related conversations and search entries. */
 export const DERIVE_ENTITY_TYPE = "artifact"
 
-/** A review state as a Slack status tag. `tag_color` is the whole point of using a typed field —
- *  a blocked doc reads as blocked at a glance, without us rendering a single character. */
-const statusField = (s: ArtifactStatus): Record<string, unknown> | null => {
+/** The review state as a short label.
+ *
+ *  It rides `custom_fields`, not `fields`. `slack#/entities/content_item` accepts exactly five
+ *  typed fields — description, created_by, last_modified_by, date_created, date_updated — and
+ *  SILENTLY DROPS anything else with "The field X will be omitted due to an invalid type".
+ *  `status` (with its colour tag) and `assignee` belong to `task` and `incident`. Measured
+ *  against the live API, not inferred: sending all ten plausible names and reading back which
+ *  survived is the only way to learn this, since the schema is not published per type.
+ *
+ *  A custom field loses the coloured tag a `task` status would render. That is the price of the
+ *  type being honest — a Derive artifact is a document with review state, not a ticket — and the
+ *  information itself is unchanged. */
+const reviewLabel = (s: ArtifactStatus): string | null => {
   if (!s.review) return null
-  const byState = {
-    pending: { value: "Awaiting review", tag_color: "blue" },
-    sent_back: { value: "Answers sent back", tag_color: "yellow" },
-    approved: { value: "Approved", tag_color: "green" },
-  } as const
-  return byState[s.review.state]
+  return {
+    pending: "Awaiting review",
+    sent_back: "Answers sent back",
+    approved: "Approved",
+  }[s.review.state]
 }
 
 export interface WorkObjectArgs {
@@ -68,16 +77,34 @@ export interface WorkObjectArgs {
 /** The entity for one artifact, as `chat.unfurl`'s `metadata.entities[]` wants it. */
 export const artifactEntity = (a: WorkObjectArgs): Record<string, unknown> => {
   const { artifact, info, status } = a
-  const fields: Record<string, unknown> = {}
-  const st = statusField(status)
-  if (st) fields.status = st
-  if (status.review?.reviewerName)
-    // `{ text }` rather than `{ user_id }`: the reviewer is a DERIVE user, and we cannot assume
-    // their Slack id — only a linked account would give us one, and most reviewers are not the
-    // person who pasted the link.
-    fields.assignee = { type: "slack#/types/user", user: { text: status.review.reviewerName } }
+  // `fields` is REQUIRED — omitting it fails the whole payload with "missing required field:
+  // fields", which surfaces as a format error that looks like a wrapper problem. Only the five
+  // names content_item knows may go here; everything else belongs in custom_fields below.
+  const fields: Record<string, unknown> = {
+    description: {
+      value: statusPhrase(status)?.text
+        ? `${statusPhrase(status)?.text}${status.review?.reviewerName ? ` — ${status.review.reviewerName}` : ""}`
+        : unfurlDescription(info),
+      // "markdown", never "plain_text": the latter is not in the enum and rejects the payload.
+      format: "markdown",
+    },
+  }
+  if (status.updatedAt) {
+    const ms = Date.parse(status.updatedAt)
+    // A typed date, so Slack renders it in the reader's own locale and timezone.
+    if (!Number.isNaN(ms)) fields.date_updated = { value: Math.floor(ms / 1000) }
+  }
 
   const custom: Record<string, unknown>[] = []
+  const label = reviewLabel(status)
+  if (label) custom.push({ key: "review", label: "Review", value: label, type: "string" })
+  if (status.review?.reviewerName)
+    custom.push({
+      key: "reviewer",
+      label: "Waiting on",
+      value: status.review.reviewerName,
+      type: "string",
+    })
   if (status.openThreads > 0)
     custom.push({
       key: "open_threads",
@@ -142,17 +169,15 @@ export const artifactDetails = (
   viewerId: string | null,
   iconUrl: string,
 ): Record<string, unknown> => {
-  const fields: Record<string, unknown> = {
-    description: { value: unfurlDescription(info), format: "plain_text" },
-  }
-  const st = statusField(status)
-  if (st) fields.status = st
   const phrase = statusPhrase(status, viewerId)
-  if (phrase)
-    fields.waiting_on = {
-      type: "slack#/types/user",
-      user: { text: phrase.reviewerName ?? phrase.text },
-    }
+  const fields: Record<string, unknown> = {
+    description: {
+      value: phrase
+        ? `*${phrase.text}${phrase.reviewerName ? ` ${phrase.reviewerName}` : ""}*\n${unfurlDescription(info)}`
+        : unfurlDescription(info),
+      format: "markdown",
+    },
+  }
   const ago = agoLabel(status.updatedAt)
   return {
     entity_type: "slack#/entities/content_item",
@@ -165,6 +190,9 @@ export const artifactDetails = (
       },
       fields,
       custom_fields: [
+        ...(reviewLabel(status)
+          ? [{ key: "review", label: "Review", value: reviewLabel(status), type: "string" }]
+          : []),
         ...(status.openThreads > 0
           ? [
               {

--- a/apps/api/test/slack-work-object.test.ts
+++ b/apps/api/test/slack-work-object.test.ts
@@ -85,12 +85,18 @@ describe("artifactEntity", () => {
       }),
       withActions: true,
     })
-    const p = e.entity_payload as Record<string, never>
-    expect(p.fields).toMatchObject({
-      status: { value: "Awaiting review", tag_color: "blue" },
-      assignee: { type: "slack#/types/user", user: { text: "Mert" } },
-    })
-    expect(JSON.stringify(p.custom_fields)).toContain("Open threads")
+    const p = e.entity_payload as { fields: Record<string, never>; custom_fields: unknown[] }
+    // content_item accepts exactly five typed fields and silently DROPS the rest — `status` and
+    // `assignee` belong to `task`. Measured against the live API: sending them returns
+    // "The field status will be omitted due to an invalid type". So the review state rides
+    // custom_fields, and only `description` / `date_updated` go in `fields`.
+    expect(Object.keys(p.fields).sort()).toEqual(["date_updated", "description"])
+    expect(p.fields.description).toMatchObject({ format: "markdown" })
+    expect(JSON.stringify(p.fields)).not.toContain("tag_color")
+    const cf = JSON.stringify(p.custom_fields)
+    expect(cf).toContain("Awaiting review")
+    expect(cf).toContain("Mert")
+    expect(cf).toContain("Open threads")
   })
 
   // Buttons ride the BROADCAST card, so they appear only when there is something to settle.
@@ -134,7 +140,7 @@ describe("artifactEntity", () => {
 })
 
 describe("artifactDetails (the flexpane)", () => {
-  it("describes the artifact for a viewer entitled to it", () => {
+  it("describes the artifact for a viewer entitled to it, and says 'your review'", () => {
     const d = artifactDetails(
       info,
       status({ review: { state: "pending", reviewerId: "u-me", reviewerName: "Mert" } }),
@@ -142,7 +148,12 @@ describe("artifactDetails (the flexpane)", () => {
       "https://d/i.png",
     )
     expect(JSON.stringify(d)).toContain("Q4 plan")
-    expect((d.entity_payload as Record<string, never>).fields).toHaveProperty("status")
+    const f = (d.entity_payload as { fields: Record<string, never> }).fields
+    // Only content_item's own field names, and markdown — "plain_text" is not in the enum and
+    // rejects the entire payload.
+    expect(Object.keys(f)).toEqual(["description"])
+    expect(f.description).toMatchObject({ format: "markdown" })
+    expect(JSON.stringify(f.description)).toContain("Awaiting your review")
   })
 })
 


### PR DESCRIPTION
The entity was built from the shapes in Slack's docs examples — which are drawn from `task` and `file`. `slack#/entities/content_item` accepts a different set, and the difference is invisible until you send it:

```
The field status will be omitted due to an invalid type
The field assignee will be omitted due to an invalid type
```

## What content_item actually accepts

Measured, not inferred — sending ten plausible field names and reading back which survived:

| accepted | omitted |
|---|---|
| `description`, `created_by`, `last_modified_by`, `date_created`, `date_updated` | **`status`**, **`assignee`**, `preview`, `author`, `tags` |

`status` (with its colour tag) and `assignee` belong to `task` and `incident`. There is no published per-type schema, so the API is the only source.

## The fix

The review state moves to `custom_fields`, which take arbitrary typed key/label/value pairs and are accepted cleanly. The card loses the coloured status tag a `task` would render; it keeps every fact, and the type stays honest — a Derive artifact is a document with review state, not a ticket.

Two more faults the same probe surfaced, both of which rejected the *entire* payload:

- **`fields` is required.** Omitting it fails with `missing required field: fields`, which presents as a format error and reads like a wrapper problem — it cost me a round of bisecting the envelope shape.
- **`format: "plain_text"` is not in the enum.** Only `markdown`. The flexpane had this too.

## Verified against the live API

The real `artifactEntity` output, with a pending round and without:

```
pending+actions: ok=true err=- warn=-
no review     : ok=true err=- warn=-
```

Clean on both. That matters more than usual here: a warning is precisely how this API reports a card that will silently render wrong, which is why `unfurlSlackEntities` treats one as failure.

`pnpm ci` and `pnpm typecheck` clean; 96 Slack tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788343977&installation_model_id=428097&pr_number=623&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F623&signature=d9b839182af7f5743090e50b08f5b09ecfbe4e2eeac1ac5b9759d519d0169b54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->