### PR TITLE
fix(slack): opening the flexpane no longer strips the card's buttons

### DIFF
--- a/apps/api/src/lib/slack-work-object.ts
+++ b/apps/api/src/lib/slack-work-object.ts
@@ -55,6 +55,20 @@ const reviewLabel = (s: ArtifactStatus): string | null => {
   }[s.review.state]
 }
 
+/** The review buttons.
+ *
+ *  Shared by the card and the flexpane ON PURPOSE. Opening a flexpane updates the unfurl from
+ *  the metadata the app answers with — Slack's words: "the unfurl will also be updated given the
+ *  entity metadata that has changed" — so a details payload that omitted these would silently
+ *  STRIP Approve and Send back from a card that had them. The two surfaces have to agree on the
+ *  actions for the same reason a PATCH has to send the fields it does not mean to clear. */
+const reviewActions = () => ({
+  primary_actions: [
+    { text: "Approve", action_id: SLACK_REVIEW_ACTION.approve, style: "primary" },
+    { text: "Send back", action_id: SLACK_REVIEW_ACTION.sendBack },
+  ],
+})
+
 export interface WorkObjectArgs {
   /** The URL exactly as pasted — Slack matches the unfurl back to the message by this, so it is
    *  NOT interchangeable with the canonical url below. */
@@ -140,13 +154,7 @@ export const artifactEntity = (a: WorkObjectArgs): Record<string, unknown> => {
     }
 
   const payload: Record<string, unknown> = { attributes, fields, custom_fields: custom }
-  if (a.withActions)
-    payload.actions = {
-      primary_actions: [
-        { text: "Approve", action_id: SLACK_REVIEW_ACTION.approve, style: "primary" },
-        { text: "Send back", action_id: SLACK_REVIEW_ACTION.sendBack },
-      ],
-    }
+  if (a.withActions) payload.actions = reviewActions()
 
   return {
     app_unfurl_url: a.pastedUrl,
@@ -182,6 +190,8 @@ export const artifactDetails = (
   return {
     entity_type: "slack#/entities/content_item",
     entity_payload: {
+      // Mirrors the card's actions whenever a round is pending — see reviewActions.
+      ...(status.review?.state === "pending" ? { actions: reviewActions() } : {}),
       attributes: {
         title: { text: info.title },
         display_type: info.kindLabel,

--- a/apps/api/src/lib/slack.ts
+++ b/apps/api/src/lib/slack.ts
@@ -403,6 +403,24 @@ export const unfurlSlackLinks = async (
   if (!data.ok) throw new SlackApiError(data.error ?? "unknown")
 }
 
+/** Slack's real diagnosis lives in `response_metadata.messages`, not in `error`.
+ *
+ *  `error` is a category — `invalid_arguments`, `error_processing_metadata` — while the messages
+ *  name the field: "The field status will be omitted due to an invalid type", "must be a valid
+ *  enum value (pointer: …/format)". Every Work Object bug in this integration was diagnosed from
+ *  that array and none from the code, so it belongs in the thrown error rather than the floor. */
+interface SlackApiResponse {
+  ok: boolean
+  error?: string
+  warning?: string
+  response_metadata?: { messages?: string[] }
+}
+
+const slackDetail = (d: SlackApiResponse): string => {
+  const parts = [d.error ?? d.warning ?? "unknown", ...(d.response_metadata?.messages ?? [])]
+  return parts.join(" | ").slice(0, 600)
+}
+
 /** Unfurl one or more links as WORK OBJECTS — typed entities rather than rendered blocks.
  *
  *  Throws on a warning as well as on `ok: false`, which is not paranoia: this API's documented
@@ -430,9 +448,8 @@ export const unfurlSlackEntities = async (
       metadata: { entities },
     }),
   })
-  const data = (await res.json()) as { ok: boolean; error?: string; warning?: string }
-  if (!data.ok) throw new SlackApiError(data.error ?? "unknown")
-  if (data.warning) throw new SlackApiError(`warning: ${data.warning}`)
+  const data = (await res.json()) as SlackApiResponse
+  if (!data.ok || data.warning) throw new SlackApiError(slackDetail(data))
 }
 
 /** Fill the flexpane for one viewer, in response to `entity_details_requested`.
@@ -460,7 +477,9 @@ export const presentSlackEntityDetails = async (
               status: "custom_partial_view",
               custom_title: body.title,
               custom_message: body.message,
-              message_format: "plain_text",
+              // "markdown" — `plain_text` is not in Slack's enum, the same trap that rejected
+              // a description earlier in this work.
+              message_format: "markdown",
             },
           }
   const res = await fetch(`${API}/entity.presentDetails`, {
@@ -471,9 +490,8 @@ export const presentSlackEntityDetails = async (
     },
     body: JSON.stringify(payload),
   })
-  const data = (await res.json()) as { ok: boolean; error?: string; warning?: string }
-  if (!data.ok) throw new SlackApiError(data.error ?? "unknown")
-  if (data.warning) throw new SlackApiError(`warning: ${data.warning}`)
+  const data = (await res.json()) as SlackApiResponse
+  if (!data.ok || data.warning) throw new SlackApiError(slackDetail(data))
 }
 
 /** The public channels the bot can see, for the subscription picker — so nobody has to paste a

--- a/apps/api/test/slack-work-object.test.ts
+++ b/apps/api/test/slack-work-object.test.ts
@@ -140,6 +140,38 @@ describe("artifactEntity", () => {
 })
 
 describe("artifactDetails (the flexpane)", () => {
+  // Opening a flexpane UPDATES the card from the metadata the app answers with — Slack: "the
+  // unfurl will also be updated given the entity metadata that has changed". So a details
+  // payload that omitted the actions would silently strip Approve and Send back from a card
+  // that had them, and the only symptom would be buttons quietly disappearing after a click.
+  it("carries the same actions as the card, so opening it cannot strip them", () => {
+    const pending = status({
+      review: { state: "pending", reviewerId: "u-me", reviewerName: "Mert" },
+    })
+    const card = artifactEntity({
+      ...base,
+      artifact: artifact(),
+      info,
+      status: pending,
+      withActions: true,
+    })
+    const pane = artifactDetails(info, pending, "u-me", "https://d/i.png")
+    const ids = (p: Record<string, unknown>) =>
+      (
+        (p.actions as { primary_actions?: { action_id: string }[] } | undefined)?.primary_actions ??
+        []
+      ).map((x) => x.action_id)
+    expect(ids(pane.entity_payload as Record<string, unknown>)).toEqual(
+      ids(card.entity_payload as Record<string, unknown>),
+    )
+    expect(ids(pane.entity_payload as Record<string, unknown>)).toHaveLength(2)
+  })
+
+  it("offers no actions once the round is settled", () => {
+    const pane = artifactDetails(info, status(), "u-me", "https://d/i.png")
+    expect((pane.entity_payload as Record<string, unknown>).actions).toBeUndefined()
+  })
+
   it("describes the artifact for a viewer entitled to it, and says 'your review'", () => {
     const d = artifactDetails(
       info,


### PR DESCRIPTION
Opening a flexpane **updates the unfurl** from whatever metadata the app answers with — Slack's words:

> When a user opens, edits, or refreshes the flexpane and your app responds using the `entity.presentDetails` API method, **the unfurl will also be updated** given the entity metadata that has changed.

`artifactDetails` carried no `actions`, while `artifactEntity` does. So opening the flexpane would have quietly removed **Approve** and **Send back** from a card that had them — buttons disappearing at the exact moment someone showed interest in the doc, with no error and nothing logged.

Both surfaces now emit the same actions from one helper, for the same reason a PATCH has to resend the fields it doesn't mean to clear.

The test compares the two payloads against each other rather than asserting either in isolation, because the bug *is* that they can drift:

```js
expect(ids(pane.entity_payload)).toEqual(ids(card.entity_payload))
```

## How it surfaced

From the question "if you create a new version, does the card update itself?" The answer is **no** — the card is a static snapshot, refreshed lazily by three triggers:

| trigger | behaviour |
|---|---|
| hover → refresh button | fires a fresh `link_shared`; our existing handler re-unfurls |
| **opening the flexpane** | **updates the card from the details metadata** ← this one |
| clicking an action | a refresh is scheduled to pick up what the action changed |

Chasing the second row is what exposed the defect. Worth noting a passive reader isn't stranded either: the channel now receives a `review.approved` card as its own message, so state changes arrive even if nobody touches the old unfurl.

Verified the corrected payload against the live API — accepted with no error and no warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788345072&installation_model_id=428097&pr_number=624&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F624&signature=1fb03d05c3b3640eea047a73a4dbf689770bef4dd62c7a367a0228e6db8c9120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->