### PR TITLE
fix(slack): the flexpane must identify which entity it describes

### DIFF
--- a/apps/api/src/lib/slack-work-object.ts
+++ b/apps/api/src/lib/slack-work-object.ts
@@ -172,6 +172,7 @@ export const artifactEntity = (a: WorkObjectArgs): Record<string, unknown> => {
  *  open-thread count and the review state are safe here for a reader who could open the doc
  *  anyway. */
 export const artifactDetails = (
+  artifact: Pick<ArtifactRecord, "short_id">,
   info: UnfurlInfo,
   status: ArtifactStatus,
   viewerId: string | null,
@@ -188,6 +189,14 @@ export const artifactDetails = (
   }
   const ago = agoLabel(status.updatedAt)
   return {
+    // `url` and `external_ref` are REQUIRED here, not optional identity decoration:
+    // entity.presentDetails answers `invalid_arguments` without them, with
+    // "missing required field: external_ref [json-pointer:/metadata]". The flexpane has to say
+    // WHICH entity it is describing — Slack does not infer it from the trigger — and the pair
+    // must match the unfurl's exactly, since it is the key behind search and the Conversations
+    // tab's aggregation.
+    url: info.pageUrl,
+    external_ref: { id: artifact.short_id, type: DERIVE_ENTITY_TYPE },
     entity_type: "slack#/entities/content_item",
     entity_payload: {
       // Mirrors the card's actions whenever a round is pending — see reviewActions.

--- a/apps/api/src/routes/slack.ts
+++ b/apps/api/src/routes/slack.ts
@@ -362,7 +362,10 @@ export const slackRoutes = (ctx: AppContext) => {
     const info = await unfurlInfoFor(meta, deps.baseUrl, artifact)
     const status = await artifactStatus(meta, artifact)
     return say(
-      { kind: "details", metadata: artifactDetails(info, status, userLink.user_id, iconUrl) },
+      {
+        kind: "details",
+        metadata: artifactDetails(artifact, info, status, userLink.user_id, iconUrl),
+      },
       "details",
     )
   }

--- a/apps/api/test/slack-work-object.test.ts
+++ b/apps/api/test/slack-work-object.test.ts
@@ -155,7 +155,7 @@ describe("artifactDetails (the flexpane)", () => {
       status: pending,
       withActions: true,
     })
-    const pane = artifactDetails(info, pending, "u-me", "https://d/i.png")
+    const pane = artifactDetails(artifact(), info, pending, "u-me", "https://d/i.png")
     const ids = (p: Record<string, unknown>) =>
       (
         (p.actions as { primary_actions?: { action_id: string }[] } | undefined)?.primary_actions ??
@@ -168,12 +168,25 @@ describe("artifactDetails (the flexpane)", () => {
   })
 
   it("offers no actions once the round is settled", () => {
-    const pane = artifactDetails(info, status(), "u-me", "https://d/i.png")
+    const pane = artifactDetails(artifact(), info, status(), "u-me", "https://d/i.png")
     expect((pane.entity_payload as Record<string, unknown>).actions).toBeUndefined()
+  })
+
+  // entity.presentDetails answers invalid_arguments without these — "missing required field:
+  // external_ref [json-pointer:/metadata]". The flexpane must say WHICH entity it describes;
+  // Slack does not infer it from the trigger. The pair must match the unfurl's, since it keys
+  // search and the Conversations tab.
+  it("identifies the entity, which presentDetails requires", () => {
+    const d = artifactDetails(artifact(), info, status(), "u", "https://d/i.png")
+    expect(d.url).toBe(info.pageUrl)
+    expect(d.external_ref).toEqual({ id: "abc123", type: "artifact" })
+    const card = artifactEntity({ ...base, artifact: artifact(), info, status: status() })
+    expect(d.external_ref).toEqual(card.external_ref)
   })
 
   it("describes the artifact for a viewer entitled to it, and says 'your review'", () => {
     const d = artifactDetails(
+      artifact(),
       info,
       status({ review: { state: "pending", reviewerId: "u-me", reviewerName: "Mert" } }),
       "u-me",


### PR DESCRIPTION
Clicking a Work Object card showed **"There was an issue and we couldn't display this item"**. `entity.presentDetails` rejected every details response with `invalid_arguments`.

The reason, once the error carried Slack's own messages:

```
missing required field: external_ref [json-pointer:/metadata]
missing required field: url          [json-pointer:/metadata]
```

Both are **required** on the flexpane metadata. Slack doesn't infer the subject from the trigger — the response has to name the entity it describes — and the pair must match the unfurl's, since it keys Work Object search and the Conversations tab's aggregation.

## Why this took two rounds

That shape was one of six I bisected offline against the live API. The test couldn't discriminate: **`trigger_id` validation runs first**, so a fabricated trigger returns `invalid_trigger_id` for every variant, correct or not. Triggers are one-shot and short-lived, so no offline probe could reach the shape check.

The only instrument that could answer was the error text from a real click — which the previous commit finally started carrying, after I'd spent the whole feature discarding `response_metadata.messages` and reading only the error code.

A test now pins the identity fields, and asserts the `external_ref` matches the card's rather than merely existing — drift between the two would silently break search and conversation aggregation while both payloads still validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/625"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788346220&installation_model_id=428097&pr_number=625&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F625&signature=6a896f4ed6609c3dee78e155f47bd94aa3021643ee1f593c52f1f96a5c81ec25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->