### PR TITLE
fix(slack): @Derive in a mirrored thread never answered on the hosted tier

### DIFF
--- a/apps/api/src/webhook-do.ts
+++ b/apps/api/src/webhook-do.ts
@@ -1,9 +1,17 @@
-import type { D1Database, DurableObjectState, Hyperdrive } from "@cloudflare/workers-types"
+import type {
+  D1Database,
+  DurableObjectState,
+  Hyperdrive,
+  R2Bucket,
+} from "@cloudflare/workers-types"
 import type { MetaStore } from "@derive/core"
+import { R2BlobStore } from "@derive/storage"
 import { tickStore } from "./edge-pg"
 import { cloudflareEmailSender, type SendEmailBinding } from "./email-cf"
+import { answerDeriveMention } from "./lib/comment-turn"
 import { emailDeliverySender } from "./lib/email"
 import { makeGithubCommentSender } from "./lib/github-comments"
+import { catalogFromGateway } from "./lib/model-catalog"
 import { makeSlackIngestSender, makeSlackSender } from "./lib/slack-comments"
 import { makeSlackDmSender } from "./lib/slack-dm"
 import { type ChannelSenders, edgeGuard, runDeliveryTick } from "./webhooks"
@@ -29,6 +37,50 @@ export interface WebhookOutboxEnv {
   // The auth secret doubles as the at-rest encryption key for stored GitHub App
   // credentials — the GitHub comment sender needs it to mint installation tokens.
   DERIVE_AUTH_SECRET?: string
+  // Everything below is for answering an @Derive mention typed in a mirrored Slack thread. A
+  // Durable Object receives the SAME script-wide bindings the Worker does; they were simply
+  // never declared here, which is why that answer worked on self-host and silently did nothing
+  // on the hosted tier. See the slack_ingest sender below.
+  BUCKET?: R2Bucket
+  BASE_URL?: string
+  DERIVE_MODEL_BASE_URL?: string
+  DERIVE_MODEL_API_KEY?: string
+  DERIVE_MODEL_NAME?: string
+  DERIVE_MODEL_NAMES?: string
+  DERIVE_CHAT_ALLOWLIST?: string
+}
+
+/** The @Derive-in-a-thread answerer for this tier, or undefined when the deploy has no model.
+ *
+ *  Built here rather than injected because the DO is constructed by the runtime, not by the
+ *  Worker's request path — there is nowhere to hand it in from. `notify` is a no-op and there is
+ *  no bus: the DO is a separate isolate from the SSE handlers (see the sender's own note), so the
+ *  answer lands in the database and shows on the reader's next fetch rather than as a live push.
+ *  That is the same trade the surrounding ingest already makes. */
+const mentionAnswerer = (env: WebhookOutboxEnv, store: MetaStore) => {
+  const gw =
+    env.DERIVE_MODEL_BASE_URL && env.DERIVE_MODEL_API_KEY && env.DERIVE_MODEL_NAME
+      ? {
+          baseUrl: env.DERIVE_MODEL_BASE_URL,
+          apiKey: env.DERIVE_MODEL_API_KEY,
+          model: env.DERIVE_MODEL_NAME,
+          alsoModels: env.DERIVE_MODEL_NAMES,
+        }
+      : undefined
+  const models = catalogFromGateway(gw)
+  if (!models || !env.BUCKET || !env.BASE_URL) return undefined
+  return answerDeriveMention({
+    meta: store,
+    blobs: new R2BlobStore(env.BUCKET),
+    bus: { publish: () => {}, subscribe: () => () => {} } as never,
+    baseUrl: env.BASE_URL,
+    models,
+    notify: async () => {},
+    chatAllowlist: (env.DERIVE_CHAT_ALLOWLIST ?? "")
+      .split(",")
+      .map((x) => x.trim())
+      .filter(Boolean),
+  })
 }
 
 /**
@@ -67,7 +119,17 @@ export class WebhookOutbox {
       // Inbound Slack thread reply deferred by the events endpoint. No bus here: the DO
       // is a separate isolate from the SSE request handlers, so the comment lands and
       // shows on the viewer's next read rather than a live push.
-      slack_ingest: makeSlackIngestSender(store, env.DERIVE_AUTH_SECRET),
+      // The answerer is threaded in so an @Derive mention typed INSIDE a mirrored thread is
+      // answered as a Derive comment — the same turn the web app runs. node.ts has always
+      // passed it; this tier never did, so the hosted product quietly ignored those mentions
+      // while self-host answered them. A deploy with no model gateway still passes nothing,
+      // which stays the honest "nothing answers" state rather than a failure.
+      slack_ingest: makeSlackIngestSender(
+        store,
+        env.DERIVE_AUTH_SECRET,
+        undefined,
+        mentionAnswerer(env, store),
+      ),
     }
   }
 

--- a/apps/api/test/slack-ingest-parity.test.ts
+++ b/apps/api/test/slack-ingest-parity.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+
+// The two runtimes must wire the slack_ingest sender the same way.
+//
+// They did not. `makeSlackIngestSender` takes an optional `answerDeriveMention`, which is what
+// answers an @Derive mention typed INSIDE a mirrored Slack thread. node.ts passed it; the
+// Durable Object that drains the outbox on the hosted tier did not — so that answer worked on
+// self-host and silently did nothing in production. Nothing failed, nothing logged: the comment
+// was ingested and the mention simply went unanswered.
+//
+// Asserted against the source because there is no seam to observe it through. Both call sites
+// construct their deps from their own runtime's bindings, and a test that stubbed those would be
+// asserting the stub. What can be checked is that neither entry point drops the argument.
+const src = (p: string) => readFileSync(join(__dirname, "..", "src", p), "utf8")
+
+describe("both runtimes wire the Slack ingest sender the same", () => {
+  it("the edge Durable Object passes a mention answerer", () => {
+    const s = src("webhook-do.ts")
+    expect(s).toMatch(/slack_ingest:\s*makeSlackIngestSender\([\s\S]{0,400}mentionAnswerer/)
+  })
+
+  it("the Node worker passes one too", () => {
+    expect(src("node.ts")).toMatch(
+      /slack_ingest:\s*makeSlackIngestSender\([\s\S]{0,400}answerDeriveMention/,
+    )
+  })
+
+  // The answerer needs a model, a blob store and a base URL. A deploy missing any of them must
+  // pass NOTHING rather than a half-built one — "nothing answers" is honest; a turn that throws
+  // inside the outbox is a dead-lettered delivery.
+  it("the edge degrades to undefined when the deploy has no model", () => {
+    const s = src("webhook-do.ts")
+    expect(s).toMatch(/if \(!models \|\| !env\.BUCKET \|\| !env\.BASE_URL\) return undefined/)
+  })
+
+  // The bindings a Durable Object needs must be declared on its own env interface, even though
+  // the runtime hands it the same script-wide set. Undeclared meant unused, which is the whole
+  // bug: the capability was present and never reached for.
+  it("declares the bindings the answerer needs", () => {
+    const s = src("webhook-do.ts")
+    for (const key of ["BUCKET?", "BASE_URL?", "DERIVE_MODEL_NAME?"]) expect(s).toContain(key)
+  })
+})

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -1227,6 +1227,26 @@ export interface IntegrationStore {
    * Derive user — one of them DMs `user_id` directly — so a miss leaking through here would
    * be a message sent to an id that does not exist. Ask `getSlackIdentityState` when you
    * actually want to know whether we have looked before.
+   *
+   * IT RETURNS BOTH `oauth` AND `email` ROWS, and every Slack-originated authority in the
+   * product rests on that. Worth stating plainly, because the two are not the same claim: an
+   * `oauth` row means somebody completed Slack sign-in and proved control of the Derive
+   * account; an `email` row means their Slack profile address matched a member (lib/
+   * slack-mention.ts, which introduced it so that answering in Slack would not require a
+   * detour through Settings).
+   *
+   * The accepted policy is that BOTH are identities, workspace-wide. It is not an accident of
+   * this filter, and code should not quietly assume otherwise. Membership and role are checked
+   * separately in every case, so resolving an identity grants nothing on its own — a matched
+   * email with no seat is nobody. What it does mean is that an actor able to set a Slack
+   * profile email can act as the matching member: normally that requires verifying the address
+   * (so, control of their mailbox — at which point Derive's own password reset is open too),
+   * and the residual path is a workspace admin setting emails through SCIM without one.
+   *
+   * If that trade is ever revisited, revisit it HERE and for every lane at once. Tightening one
+   * caller alone would be incoherent while the chat turn — which already acts as the asker's
+   * seat with `publish` and `comment` in its tool surface — accepts the same row: somebody
+   * refused at a button could simply ask the agent to do it instead.
    */
   getSlackUserLinkBySlackId(
     teamId: string,


### PR DESCRIPTION
Found auditing the Slack surface as a whole rather than any one lane. Both call sites read correctly in isolation; only comparing them showed one dropping an argument.

| entry point | `answerDeriveMention` |
|---|---|
| `node.ts:363` (self-host) | ✅ passed |
| `webhook-do.ts:70` (**hosted edge**) | ❌ omitted |

`makeSlackIngestSender` takes an optional answerer for an `@Derive` mention typed *inside* a mirrored Slack thread — the same turn the web app runs. The Durable Object that drains the outbox on Workers never passed it, so **that answer worked on self-host and silently did nothing in production.** Nothing failed, nothing logged: the reply was ingested as a comment and the mention went unanswered.

## The capability was already there

A Durable Object receives the same script-wide bindings the Worker does. They were simply never declared on `WebhookOutboxEnv`, so nothing reached for them. Declaring `BUCKET`, `BASE_URL` and the model-gateway vars is most of the fix.

A deploy without a model, bucket or base URL still passes **nothing** — the honest "nothing answers" state, rather than a turn that throws inside the outbox and dead-letters a delivery. No bus and a no-op `notify`, matching the trade the surrounding ingest already documents: the DO is a separate isolate from the SSE handlers, so the answer lands in the database and appears on the reader's next fetch.

The test asserts parity between the two runtimes, because there's no seam to observe this through — both construct deps from their own bindings, and stubbing those would only assert the stub. Verified it fails when the argument is dropped again.

## Also: the identity policy, written down

`getSlackUserLinkBySlackId` returns **both `oauth` and `email` rows**, and every Slack-originated authority rests on that — unfurl visibility, the flexpane's read gate, proposal approve, review approve/send-back, Save to Derive.

The two are not the same claim. `oauth` means somebody completed Slack sign-in and proved control of the Derive account; `email` means their Slack profile address matched a member — introduced by the mention lane so answering in Slack wouldn't require a detour through Settings.

I considered gating the write actions on `oauth` and **decided against it**: the chat turn already acts as the asker's seat with `publish` and `comment` in its tool surface and accepts the same row, so somebody refused at a button could just ask the agent instead. Tightening one caller would be incoherent, not safer.

So the policy is now stated on the accessor, with its actual risk boundary (an actor able to set a Slack profile email can act as the matching member; that normally needs mailbox control, and the residual path is an admin setting emails via SCIM). If it's revisited, it should be revisited for every lane at once — which is why the reasoning lives there and not in one consumer.

`pnpm ci` clean, 2013 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788350061&installation_model_id=428097&pr_number=626&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F626&signature=62fcd91d7a075ba49cef1f97c0ee61c0f2f8fab29bf003923aa3fd98fbc62991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->