### PR TITLE
feat(slack): settle a review from Slack — and only when Slack can prove who you are

### DIFF
--- a/apps/api/src/lib/chat-tools.ts
+++ b/apps/api/src/lib/chat-tools.ts
@@ -20,8 +20,11 @@ import type { LoopTool } from "./agent-loop"
  *
  *   - `actingFor` + `ownerId` are the ASKER. Reach, attribution and membership all resolve to
  *     that human, so the model can touch exactly what they can touch.
- *   - `scopeForCap`/`defaultRole` are their real seat. A viewer's chat cannot publish because
- *     `publish` refuses a viewer, not because chat remembered to check.
+ *   - `scopeForCap`/`defaultRole` are the seat the turn acts at — normally the asker's real
+ *     one, but a caller may hand down a lower one (lib/slack-identity.ts clamps an
+ *     email-matched Slack asker to `viewer`). Either way a viewer's chat cannot publish
+ *     because `publish` routes a sub-editor to a proposal and `propose` needs `commenter`,
+ *     not because chat remembered to check.
  *   - `boundWorkspaces` is the ONE workspace of the conversation, so cross-workspace reach is
  *     structurally impossible even though the same code CAN roam for an OAuth grant.
  *   - `registered: false` — no inbox, no @mention identity, nothing to administer. It is a

--- a/apps/api/src/lib/chat-turn.ts
+++ b/apps/api/src/lib/chat-turn.ts
@@ -58,7 +58,23 @@ export interface ChatTurnInput {
    * answer is either a hedge or a guess, and a guess about someone's own permissions is the kind
    * of wrong that sends a person hunting for a button that was never going to be there.
    */
-  asker: { name: string | null; role: Role }
+  asker: {
+    name: string | null
+    role: Role
+    /**
+     * Why `role` is lower than this person's real seat, when it is — one sentence, rendered
+     * verbatim into the prompt.
+     *
+     * The web lane never sets it: a session IS the account, so the seat is the seat. Slack does,
+     * because an identity resolved from a Slack profile email acts at `viewer` whatever the
+     * person actually holds (lib/slack-identity.ts). Without it the agent commits both halves
+     * of the mistake this input exists to prevent — it tells a Creator they are a Viewer, and
+     * then relays a tool's refusal verbatim, which talks about re-authorizing an MCP connector
+     * and means nothing to somebody talking to a bot in Slack. Both send them somewhere that
+     * cannot help, and neither mentions the thirty-second fix.
+     */
+    note?: string
+  }
   /** The skill index for the tools this turn holds — one line each in the prompt, bodies read
    *  on demand. Empty when the turn has no tools with separate procedure. */
   skills: { name: string; summary: string }[]
@@ -107,7 +123,7 @@ const systemPrompt = (input: ChatTurnInput): string => {
   )
   return `You are Derive, the agent built into Derive — a place teams keep living documents (called artifacts, or "derives") with full version history, review comments, and published web pages.
 
-You are talking with ${input.asker.name ?? "someone"} in the workspace "${input.workspaceName}". They are ${roleWord(input.asker.role)} here. They are watching this reply as you write it.
+You are talking with ${input.asker.name ?? "someone"} in the workspace "${input.workspaceName}". They are ${roleWord(input.asker.role)} here. They are watching this reply as you write it.${input.asker.note ? `\n${input.asker.note}` : ""}
 
 TOOLS: ${names.length ? names.join(", ") : "none on this turn"}. Use them rather than guessing — you are answering about THIS workspace, and you cannot know its contents from memory.
 

--- a/apps/api/src/lib/slack-comments.ts
+++ b/apps/api/src/lib/slack-comments.ts
@@ -30,6 +30,7 @@ import {
 } from "./slack-cards"
 import { postWithRecovery, resolveBotToken, slackFailure } from "./slack-delivery"
 import { authorKind, channelIsSubscribed, resolveChannels } from "./slack-subscriptions"
+import { encodeReviewAction, SLACK_REVIEW_ACTION } from "./slack-work-object"
 
 /** The Slack message payload an enqueued slack_app delivery carries (self-contained). */
 interface SlackCommentPayload {
@@ -301,6 +302,22 @@ const eventBlocks = (p: SlackEventPayload): unknown[] => {
   }
   const body = p.message ? `${head}\n> ${mrkdwnBody(p.message, 280)}` : head
   const blocks: unknown[] = [section(body)]
+  // A review REQUEST is the loop's blocking moment: an agent has stopped and is waiting on a
+  // person. Answering it should not require leaving Slack, so the card carries the same two
+  // actions the Work Object does. Broadcast is fine — the clicker is re-authorized as their own
+  // linked account, so anyone but the reviewer gets an ephemeral refusal rather than an action.
+  if (p.event === "review.requested")
+    blocks.push(
+      actions([
+        actionButton(
+          SLACK_REVIEW_ACTION.approve,
+          "Approve",
+          encodeReviewAction(p.artifactId),
+          "primary",
+        ),
+        actionButton(SLACK_REVIEW_ACTION.sendBack, "Send back", encodeReviewAction(p.artifactId)),
+      ]),
+    )
   // An open proposal gets Approve / Request-changes buttons (the clicker is authorized as
   // their linked Derive user in the interactivity handler).
   if (p.event === "proposal.created" && p.proposalId) {

--- a/apps/api/src/lib/slack-comments.ts
+++ b/apps/api/src/lib/slack-comments.ts
@@ -29,6 +29,7 @@ import {
   section,
 } from "./slack-cards"
 import { postWithRecovery, resolveBotToken, slackFailure } from "./slack-delivery"
+import { isVerifiedLink } from "./slack-identity"
 import { authorKind, channelIsSubscribed, resolveChannels } from "./slack-subscriptions"
 import { encodeReviewAction, SLACK_REVIEW_ACTION } from "./slack-work-object"
 
@@ -553,7 +554,13 @@ export const makeSlackIngestSender =
     const name = await slackUserName(bot.token, p.userId)
     // If the Slack author has linked their account, attribute the comment to their real Derive
     // user (and name) instead of an opaque slack:<id>; otherwise fall back to the Slack name.
-    const userLink = await meta.getSlackUserLinkBySlackId(bot.install.team_id, p.userId)
+    //
+    // VERIFIED links only. Authorship is a claim about who said something, and an email match is
+    // not enough to put words in a named account's mouth. This DEGRADES rather than refuses: the
+    // reply still becomes a comment, attributed to `slack:<id>` under their Slack display name,
+    // so nothing is lost except the claim we cannot make.
+    const rawLink = await meta.getSlackUserLinkBySlackId(bot.install.team_id, p.userId)
+    const userLink = isVerifiedLink(rawLink) ? rawLink : null
     const deriveUser = userLink ? (await meta.getUsers([userLink.user_id]))[0] : undefined
     const created = await ingestSlackReply(meta, link, {
       ts: p.ts,

--- a/apps/api/src/lib/slack-dm.ts
+++ b/apps/api/src/lib/slack-dm.ts
@@ -21,8 +21,9 @@ import type { ChannelSendResult } from "../webhooks"
 import { enqueueChannelDelivery } from "../webhooks"
 import { commentDeepLink, type Mention } from "./comments"
 import { openSlackDm, resolveSlackUserIdByEmail } from "./slack"
-import { actions, mrkdwnBody, mrkdwnLabel, openButton, section } from "./slack-cards"
+import { actionButton, actions, mrkdwnBody, mrkdwnLabel, openButton, section } from "./slack-cards"
 import { postWithRecovery, resolveBotToken, slackFailure } from "./slack-delivery"
+import { encodeReviewAction, SLACK_REVIEW_ACTION } from "./slack-work-object"
 
 /** The self-contained payload a slack_dm delivery carries. */
 interface SlackDmPayload {
@@ -103,7 +104,21 @@ export const enqueueSlackReviewRequestedDm = async (
       `:mag: *${mrkdwnLabel(proposal.requestedBy)}* requested your review of <${link}|${mrkdwnLabel(t)}> (v${proposal.version}).`,
     ),
     ...(proposal.note ? [section(`> ${mrkdwnBody(proposal.note, 600)}`)] : []),
-    actions([openButton(link, "Review in Derive")]),
+    // Settle it HERE. This DM is the one moment the loop is blocked on a named person, and it
+    // is addressed to exactly them — so the two answers the agent is waiting for belong on it,
+    // with "Review in Derive" kept for everything a button cannot express. Sending them to a
+    // browser to press the same two buttons is the difference between a notification and a
+    // place to work.
+    actions([
+      actionButton(
+        SLACK_REVIEW_ACTION.approve,
+        "Approve",
+        encodeReviewAction(artifact.id),
+        "primary",
+      ),
+      actionButton(SLACK_REVIEW_ACTION.sendBack, "Send back", encodeReviewAction(artifact.id)),
+      openButton(link, "Review in Derive"),
+    ]),
   ]
   await enqueueChannelDelivery(meta, "slack_dm", "review.requested", {
     orgId: artifact.org_id,

--- a/apps/api/src/lib/slack-identity.ts
+++ b/apps/api/src/lib/slack-identity.ts
@@ -42,9 +42,35 @@ export const linkToActMessage = (what: string, link?: SlackUserLinkRecord | null
 /** The seat a chat turn may act at.
  *
  *  An email-matched asker is clamped to `viewer`, which is the whole enforcement: the chat
- *  tools take their ceiling from the seat, and `publish` refuses a viewer on its own. No policy
- *  layer, no tool list to keep in step — the same mechanism that already stops a real viewer's
- *  chat from publishing. Reading, finding and catching up are untouched, so the reason email
- *  exists at all (answering a question without a detour) still works for anyone.
+ *  tools take their ceiling from the seat, so every write stops at the same gate a real
+ *  viewer's does. `publish` routes a sub-editor to a proposal and then refuses at `propose`
+ *  (which needs `commenter`), and `comment`, `organize` and `checkpoint` refuse outright — so
+ *  nothing is written, including nothing pending. No policy layer, no tool list to keep in
+ *  step, and no future tool that can be added without inheriting the rule.
+ *
+ *  Reading, finding and catching up are untouched, so the reason email identity exists at all
+ *  — answering a question in Slack without a detour — still works for anyone.
  */
 export const chatSeatFor = (verified: boolean, seat: Role): Role => (verified ? seat : "viewer")
+
+/** What the model must be told when the seat above was clamped.
+ *
+ *  A clamp is invisible from inside the turn: the tools simply behave as a viewer's, so the
+ *  agent would state the clamped role as fact ("you're a Viewer here") to somebody who is
+ *  really a Creator, and relay refusals written for a different surface entirely — the publish
+ *  and comment tools answer a blocked write with "re-authorize the connector with
+ *  derive:comment", which is about an MCP grant and is unfollowable from Slack. Both readings
+ *  send the person somewhere that cannot help them, and neither mentions the one thing that
+ *  would: linking their accounts.
+ *
+ *  Prose rather than a flag because the consumer is a language model and the destination is
+ *  the same sentence a person needs to read. `chat-turn.ts` renders it verbatim. */
+export const CHAT_UNVERIFIED_NOTE =
+  "IMPORTANT — their permissions here are NOT what they look like. Derive recognises them " +
+  "from their Slack profile email, which is enough to read but not to act as them, so your " +
+  "tools are running at Viewer level no matter what they actually hold in this workspace. " +
+  "If they ask you to write, publish, comment or organise anything and a tool refuses, tell " +
+  "them that connecting their Slack and Derive accounts in Settings → Integrations is what " +
+  "unlocks it. Do not tell them they are a Viewer, and do not repeat a tool's advice about " +
+  "re-authorizing a connector or changing a grant scope — that concerns a different surface " +
+  "and will not help them here. Answering questions and finding documents works normally."

--- a/apps/api/src/lib/slack-identity.ts
+++ b/apps/api/src/lib/slack-identity.ts
@@ -1,0 +1,50 @@
+// How strong a Slack→Derive identity is, and what that entitles it to.
+//
+// Two things can put a row in `slack_user_link`, and they are not the same claim:
+//
+//   oauth  somebody completed Slack sign-in and proved control of the Derive account.
+//   email  their Slack profile address matched a member (lib/slack-mention.ts, which added it
+//          so that answering in Slack would not require a detour through Settings).
+//
+// `getSlackUserLinkBySlackId` returns both, filtering only `miss`, and until now every
+// Slack-originated authority treated them identically. That is defensible for READING — the
+// email is one the workspace's own directory verified, and membership is checked separately, so
+// a match with no seat is nobody. It is not defensible for WRITING, because the thing an
+// attacker needs is different in kind: setting a Slack profile email (normally verifiable only
+// with the mailbox, but settable by an admin through SCIM without one) would otherwise let
+// somebody approve a publish, settle a review, or comment under another person's name.
+//
+// So: email resolves WHO you probably are, and oauth is what lets us act as you.
+//
+// The split has to be applied at EVERY lane at once or it is theatre. A button that refuses an
+// email identity while the chat turn beside it will publish on the same row has not tightened
+// anything — it has just moved where you ask. That is why the chat lane clamps its seat here
+// rather than growing a check of its own.
+
+import type { Role, SlackUserLinkRecord } from "@derive/core"
+
+/** Did this person prove control of the Derive account, rather than merely match its address? */
+export const isVerifiedLink = (link: SlackUserLinkRecord | null | undefined): boolean =>
+  link?.origin === "oauth"
+
+/** What to say when a write is refused for want of a deliberate link. Actionable on purpose:
+ *  the fix is thirty seconds away and the person is one click from it, so the refusal names the
+ *  place rather than the policy.
+ *
+ *  Takes the link because the two people this refuses are not in the same position. To somebody
+ *  we matched by email, the second sentence is the whole point: we just answered their question
+ *  by name, and a bare "connect your accounts" would read as though we had forgotten them. To
+ *  somebody we cannot place at all it would be a lie, so they do not get it. */
+export const linkToActMessage = (what: string, link?: SlackUserLinkRecord | null): string =>
+  `Connect your Slack and Derive accounts (Settings → Integrations) to ${what} from Slack.` +
+  (link ? ` We can see who you are from your email, but acting as you needs the link.` : "")
+
+/** The seat a chat turn may act at.
+ *
+ *  An email-matched asker is clamped to `viewer`, which is the whole enforcement: the chat
+ *  tools take their ceiling from the seat, and `publish` refuses a viewer on its own. No policy
+ *  layer, no tool list to keep in step — the same mechanism that already stops a real viewer's
+ *  chat from publishing. Reading, finding and catching up are untouched, so the reason email
+ *  exists at all (answering a question without a detour) still works for anyone.
+ */
+export const chatSeatFor = (verified: boolean, seat: Role): Role => (verified ? seat : "viewer")

--- a/apps/api/src/lib/slack-mention.ts
+++ b/apps/api/src/lib/slack-mention.ts
@@ -19,7 +19,7 @@ import type { ModelCatalog } from "./model-catalog"
 import { slackUserEmail, updateSlackMessage } from "./slack"
 import { escapeMrkdwn, mrkdwnBody } from "./slack-cards"
 import { postWithRecovery, resolveBotToken } from "./slack-delivery"
-import { chatSeatFor, isVerifiedLink } from "./slack-identity"
+import { CHAT_UNVERIFIED_NOTE, chatSeatFor, isVerifiedLink } from "./slack-identity"
 
 /** How much of a Slack thread the turn is given. A mention usually arrives with a little
  *  context above it and the answer belongs to that, not to the channel's whole day. */
@@ -440,10 +440,9 @@ export const handleSlackMention = async (
   // costs the most trust is silence: the bot was mentioned in front of the channel and simply
   // never spoke. So the tail answers even when it fails.
   try {
-    // The whole enforcement for this lane. An email-matched asker acts at `viewer`, and the
-    // chat tools take their ceiling from the seat — `publish` refuses a viewer on its own, with
-    // no tool list to keep in step. Reading, finding and catching up are untouched, so the
-    // reason email identity exists at all still works for everyone.
+    // The whole enforcement for this lane: an email-matched asker acts at `viewer`, and the
+    // tools take their ceiling from the seat, so every write stops without a check of its own.
+    // Reads are untouched. See lib/slack-identity.ts for why, and for the note below.
     const actingRole = chatSeatFor(resolved.verified, gate.seatRole)
     const tools = buildChatTools(deps.ctx, {
       org: install.org_id,
@@ -470,7 +469,13 @@ export const handleSlackMention = async (
         tools,
         workspaceName:
           (await meta.getWorkspace(install.org_id).catch(() => null))?.name ?? "this workspace",
-        asker: { name: asker.name, role: actingRole },
+        asker: {
+          name: asker.name,
+          role: actingRole,
+          // The clamp is silent from inside the turn, so the reason travels with it — see
+          // CHAT_UNVERIFIED_NOTE for what goes wrong when it does not.
+          ...(resolved.verified ? {} : { note: CHAT_UNVERIFIED_NOTE }),
+        },
         skills: tools.skills,
       },
     )

--- a/apps/api/src/lib/slack-mention.ts
+++ b/apps/api/src/lib/slack-mention.ts
@@ -19,6 +19,7 @@ import type { ModelCatalog } from "./model-catalog"
 import { slackUserEmail, updateSlackMessage } from "./slack"
 import { escapeMrkdwn, mrkdwnBody } from "./slack-cards"
 import { postWithRecovery, resolveBotToken } from "./slack-delivery"
+import { chatSeatFor, isVerifiedLink } from "./slack-identity"
 
 /** How much of a Slack thread the turn is given. A mention usually arrives with a little
  *  context above it and the answer belongs to that, not to the channel's whole day. */
@@ -202,13 +203,17 @@ export const handleSlackMention = async (
     orgId: string,
     botToken: string,
   ): Promise<
-    { seat: Awaited<ReturnType<typeof seatFor>> } | { seat: null; why: "unknown" | "recent-miss" }
+    | { seat: Awaited<ReturnType<typeof seatFor>>; verified: boolean }
+    | { seat: null; why: "unknown" | "recent-miss" }
   > => {
     const known = await meta.getSlackIdentityState(p.teamId, p.userId).catch(() => null)
     const verdict = identityVerdict(known, Date.now())
     if (verdict === "use" && known) {
       const seat = await seatFor(orgId, known.user_id)
-      if (seat) return { seat }
+      // `verified` travels with the seat because the turn's POWERS depend on it, not just its
+      // name: an email match says who somebody probably is, and only a deliberate link lets us
+      // act as them. See lib/slack-identity.ts.
+      if (seat) return { seat, verified: isVerifiedLink(known) }
       // A link to somebody with no seat HERE is not a miss about their identity — they may well
       // be a member of another workspace on this team — so it is not remembered.
       return { seat: null, why: "unknown" }
@@ -232,7 +237,9 @@ export const handleSlackMention = async (
         checked_at: new Date().toISOString(),
       })
       .catch(() => {})
-    return seat ? { seat } : { seat: null, why: "unknown" }
+    // Resolved by email, which is exactly what this branch just recorded: enough to answer as
+    // them, never enough to write as them.
+    return seat ? { seat, verified: false } : { seat: null, why: "unknown" }
   }
 
   // WHICH WORKSPACE. One Slack team can back several Derive workspaces, so the channel's own
@@ -433,10 +440,15 @@ export const handleSlackMention = async (
   // costs the most trust is silence: the bot was mentioned in front of the channel and simply
   // never spoke. So the tail answers even when it fails.
   try {
+    // The whole enforcement for this lane. An email-matched asker acts at `viewer`, and the
+    // chat tools take their ceiling from the seat — `publish` refuses a viewer on its own, with
+    // no tool list to keep in step. Reading, finding and catching up are untouched, so the
+    // reason email identity exists at all still works for everyone.
+    const actingRole = chatSeatFor(resolved.verified, gate.seatRole)
     const tools = buildChatTools(deps.ctx, {
       org: install.org_id,
       user: { id: asker.id, name: asker.name },
-      seatRole: gate.seatRole,
+      seatRole: actingRole,
       flags: { agentKillswitch: settings.agentKillswitch },
     })
     const res = await runChatTurn(
@@ -458,7 +470,7 @@ export const handleSlackMention = async (
         tools,
         workspaceName:
           (await meta.getWorkspace(install.org_id).catch(() => null))?.name ?? "this workspace",
-        asker: { name: asker.name, role: gate.seatRole },
+        asker: { name: asker.name, role: actingRole },
         skills: tools.skills,
       },
     )

--- a/apps/api/src/lib/slack-proposal.ts
+++ b/apps/api/src/lib/slack-proposal.ts
@@ -11,6 +11,7 @@ import {
 } from "./proposal-actions"
 import { postSlackResponseUrl } from "./slack"
 import { context, mrkdwnLabel } from "./slack-cards"
+import { isVerifiedLink, linkToActMessage } from "./slack-identity"
 
 /** `ProposalActionDeps` plus what THIS surface needs beyond what approve/request-changes
  *  themselves use: the billing gate, threaded in exactly like `meta` and the rest arrive —
@@ -44,9 +45,11 @@ export const runSlackProposalAction = async (
       : Promise.resolve(false)
 
   // No link → no Derive principal to authorize against; prompt them to link (private msg).
+  // A deliberate link, not merely a matched email: approving publishes a version under this
+  // person's name. See lib/slack-identity.ts for why the split is drawn at writes.
   const link = await deps.meta.getSlackUserLinkBySlackId(args.teamId, args.slackUserId)
-  if (!link) {
-    await eph("Link your Slack account (Settings → Integrations) to approve proposals from Slack.")
+  if (!link || !isVerifiedLink(link)) {
+    await eph(linkToActMessage("decide proposals", link))
     return
   }
   const artifact = await deps.meta.getArtifactById(args.artifactId)

--- a/apps/api/src/lib/slack-review.ts
+++ b/apps/api/src/lib/slack-review.ts
@@ -13,6 +13,7 @@
 import { type Actor, type ArtifactRecord, can, type MetaStore, maxRole } from "@derive/core"
 import type { Backplane } from "../bus"
 import { postSlackResponseUrl } from "./slack"
+import { isVerifiedLink, linkToActMessage } from "./slack-identity"
 
 export interface SlackReviewDeps {
   meta: MetaStore
@@ -43,9 +44,10 @@ export const runSlackReviewAction = async (
       : Promise.resolve(false)
 
   // No link → no Derive principal to authorize against. Same prompt the proposal buttons give.
+  // Verified only: settling a round is the build go-signal, recorded as this person's decision.
   const link = await meta.getSlackUserLinkBySlackId(args.teamId, args.slackUserId)
-  if (!link) {
-    await eph("Link your Slack account (Settings → Integrations) to review from Slack.")
+  if (!link || !isVerifiedLink(link)) {
+    await eph(linkToActMessage("approve or send back a review", link))
     return
   }
 

--- a/apps/api/src/lib/slack-work-object.ts
+++ b/apps/api/src/lib/slack-work-object.ts
@@ -30,6 +30,24 @@ export const SLACK_REVIEW_ACTION = {
   sendBack: "derive_review_send_back",
 } as const
 
+/** The artifact a review button targets, for the Block Kit surfaces.
+ *
+ *  A Work Object button needs none of this — Slack round-trips the entity and the handler reads
+ *  `external_ref`. A button on a DM or a channel card has no entity behind it, so the target
+ *  travels in `value`, exactly as the thread and proposal buttons already do. It only NAMES the
+ *  artifact: runSlackReviewAction re-reads it and re-authorizes the clicker, so a forged value
+ *  can at worst point at a doc they still cannot act on. */
+export const encodeReviewAction = (artifactId: string): string => JSON.stringify({ a: artifactId })
+
+export const decodeReviewAction = (value: string): string | null => {
+  try {
+    const { a } = JSON.parse(value) as { a?: string }
+    return typeof a === "string" && a ? a : null
+  } catch {
+    return null
+  }
+}
+
 /** `external_ref.type` — the namespace half of the key Slack stores. Stable forever: changing it
  *  orphans every previously-unfurled card from its related conversations and search entries. */
 export const DERIVE_ENTITY_TYPE = "artifact"
@@ -62,10 +80,22 @@ const reviewLabel = (s: ArtifactStatus): string | null => {
  *  entity metadata that has changed" — so a details payload that omitted these would silently
  *  STRIP Approve and Send back from a card that had them. The two surfaces have to agree on the
  *  actions for the same reason a PATCH has to send the fields it does not mean to clear. */
-const reviewActions = () => ({
+const reviewActions = (artifactId: string) => ({
   primary_actions: [
-    { text: "Approve", action_id: SLACK_REVIEW_ACTION.approve, style: "primary" },
-    { text: "Send back", action_id: SLACK_REVIEW_ACTION.sendBack },
+    {
+      text: "Approve",
+      action_id: SLACK_REVIEW_ACTION.approve,
+      style: "primary",
+      // Carried even though a Work Object click also echoes `external_ref`: one target
+      // mechanism for all three surfaces is one thing to get right, and it means the handler
+      // never depends on Slack round-tripping the entity to know what was clicked.
+      value: encodeReviewAction(artifactId),
+    },
+    {
+      text: "Send back",
+      action_id: SLACK_REVIEW_ACTION.sendBack,
+      value: encodeReviewAction(artifactId),
+    },
   ],
 })
 
@@ -154,7 +184,7 @@ export const artifactEntity = (a: WorkObjectArgs): Record<string, unknown> => {
     }
 
   const payload: Record<string, unknown> = { attributes, fields, custom_fields: custom }
-  if (a.withActions) payload.actions = reviewActions()
+  if (a.withActions) payload.actions = reviewActions(artifact.id)
 
   return {
     app_unfurl_url: a.pastedUrl,
@@ -172,7 +202,7 @@ export const artifactEntity = (a: WorkObjectArgs): Record<string, unknown> => {
  *  open-thread count and the review state are safe here for a reader who could open the doc
  *  anyway. */
 export const artifactDetails = (
-  artifact: Pick<ArtifactRecord, "short_id">,
+  artifact: Pick<ArtifactRecord, "id" | "short_id">,
   info: UnfurlInfo,
   status: ArtifactStatus,
   viewerId: string | null,
@@ -200,7 +230,7 @@ export const artifactDetails = (
     entity_type: "slack#/entities/content_item",
     entity_payload: {
       // Mirrors the card's actions whenever a round is pending — see reviewActions.
-      ...(status.review?.state === "pending" ? { actions: reviewActions() } : {}),
+      ...(status.review?.state === "pending" ? { actions: reviewActions(artifact.id) } : {}),
       attributes: {
         title: { text: info.title },
         display_type: info.kindLabel,

--- a/apps/api/src/routes/slack.ts
+++ b/apps/api/src/routes/slack.ts
@@ -63,6 +63,7 @@ import {
 } from "../lib/slack-comments"
 import { flagSlackReauth, resolveBotToken } from "../lib/slack-delivery"
 import { enqueueSlackDm, wantsSlackDm } from "../lib/slack-dm"
+import { isVerifiedLink, linkToActMessage } from "../lib/slack-identity"
 import { handleSlackMention } from "../lib/slack-mention"
 import { runSlackProposalAction } from "../lib/slack-proposal"
 import { runSlackReviewAction } from "../lib/slack-review"
@@ -756,7 +757,9 @@ export const slackRoutes = (ctx: AppContext) => {
     const slackUserId = payload.user?.id
     if (!teamId || !slackUserId) return null
     const link = await meta.getSlackUserLinkBySlackId(teamId, slackUserId)
-    if (!link) return null
+    // Verified only: a capture is a comment authored AS this person. An email match is enough to
+    // know who they probably are, not enough to write under their name.
+    if (!link || !isVerifiedLink(link)) return null
     const install = await meta.getSlackInstall(link.org_id)
     // A workspace that disconnected keeps its members' account links, so re-check the install —
     // without it the shortcut would keep writing into a workspace that cut Slack off.
@@ -1094,6 +1097,14 @@ export const slackRoutes = (ctx: AppContext) => {
       const channelName = form.get("channel_name")
       if (!channelId)
         return c.json({ response_type: "ephemeral", text: "Run this inside a channel." })
+      // Verified only, on top of the admin role: changing what Derive posts is workspace
+      // configuration. `/derive <query>` below stays open to an email identity — it only
+      // searches what that person can already see.
+      if (!isVerifiedLink(link))
+        return c.json({
+          response_type: "ephemeral",
+          text: linkToActMessage("change what a channel gets", link),
+        })
       const seat = await meta.getMembership(link.org_id, link.user_id)
       if (!seat || !roleAllows(seat.role, "manage"))
         return c.json({

--- a/apps/api/src/routes/slack.ts
+++ b/apps/api/src/routes/slack.ts
@@ -76,6 +76,7 @@ import {
   artifactDetails,
   artifactEntity,
   DERIVE_ENTITY_TYPE,
+  decodeReviewAction,
   SLACK_REVIEW_ACTION,
 } from "../lib/slack-work-object"
 import { resolveThreadAction } from "../lib/thread-actions"
@@ -903,7 +904,56 @@ export const slackRoutes = (ctx: AppContext) => {
       return submitCapture(c, payload)
 
     const action = payload.actions?.[0]
-    if (payload.type !== "block_actions" || !action?.value) return c.json({ ok: true })
+    // A `value` is required by the thread and proposal buttons, which encode their target in
+    // one — but NOT by a Work Object action, where Slack round-trips the entity instead and the
+    // target is `external_ref`. Requiring it here made every Work Object button a no-op on
+    // click: the handler returned ok before reaching the branch that handles them.
+    if (payload.type !== "block_actions" || !action?.action_id) return c.json({ ok: true })
+
+    // A Work Object review button. The artifact comes from the card's external_ref rather than a
+    // button value — Slack round-trips the entity, so there is no attacker-supplied id to bind.
+    if (
+      action.action_id === SLACK_REVIEW_ACTION.approve ||
+      action.action_id === SLACK_REVIEW_ACTION.sendBack
+    ) {
+      // Two shapes reach here, because the same two actions now ride three surfaces. A Work
+      // Object button carries no value — Slack round-trips the entity, so the target is
+      // `external_ref`. A button on a review DM or a channel card has no entity behind it, so
+      // the target travels in `value`, exactly as the thread and proposal buttons do. Either
+      // way it only NAMES the artifact: runSlackReviewAction re-reads it and re-authorizes the
+      // clicker, so neither path is trusted as authorization.
+      const ref = payload.entity?.external_ref?.id
+      const byValue = action.value ? decodeReviewAction(action.value) : null
+      if ((ref || byValue) && payload.team?.id && payload.user?.id) {
+        let artifact: ArtifactRecord | null = byValue ? await meta.getArtifactById(byValue) : null
+        if (!artifact && ref)
+          for (const id of candidateShortIds(ref)) {
+            artifact = await meta.getByShortId(id)
+            if (artifact) break
+          }
+        // Bind the acting Slack team to the artifact's workspace, exactly as the thread and
+        // proposal branches do: one signed workspace must not act on another org's review.
+        const install = artifact ? await meta.getSlackInstall(artifact.org_id) : null
+        if (artifact && install && install.team_id === payload.team.id)
+          runAfterAck(
+            runSlackReviewAction(
+              { meta, bus, billingBlocked },
+              {
+                teamId: payload.team.id,
+                slackUserId: payload.user.id,
+                artifact,
+                op: action.action_id === SLACK_REVIEW_ACTION.approve ? "approve" : "send_back",
+                responseUrl: payload.response_url,
+              },
+            ),
+          )
+      }
+      return c.json({ ok: true })
+    }
+
+    // Everything below this point encodes its target in `value` (the Work Object branch above
+    // is the one exception, which is why the guard moved off it).
+    if (!action.value) return c.json({ ok: true })
 
     // Proposal Approve / Request-changes — editor-level, authorized AS the clicker's linked
     // Derive account. The work (approving publishes a version) can exceed 3s, so ack now and
@@ -929,39 +979,6 @@ export const slackRoutes = (ctx: AppContext) => {
             },
           ),
         )
-      }
-      return c.json({ ok: true })
-    }
-
-    // A Work Object review button. The artifact comes from the card's external_ref rather than a
-    // button value — Slack round-trips the entity, so there is no attacker-supplied id to bind.
-    if (
-      action.action_id === SLACK_REVIEW_ACTION.approve ||
-      action.action_id === SLACK_REVIEW_ACTION.sendBack
-    ) {
-      const ref = payload.entity?.external_ref?.id
-      if (ref && payload.team?.id && payload.user?.id) {
-        let artifact: ArtifactRecord | null = null
-        for (const id of candidateShortIds(ref)) {
-          artifact = await meta.getByShortId(id)
-          if (artifact) break
-        }
-        // Bind the acting Slack team to the artifact's workspace, exactly as the thread and
-        // proposal branches do: one signed workspace must not act on another org's review.
-        const install = artifact ? await meta.getSlackInstall(artifact.org_id) : null
-        if (artifact && install && install.team_id === payload.team.id)
-          runAfterAck(
-            runSlackReviewAction(
-              { meta, bus, billingBlocked },
-              {
-                teamId: payload.team.id,
-                slackUserId: payload.user.id,
-                artifact,
-                op: action.action_id === SLACK_REVIEW_ACTION.approve ? "approve" : "send_back",
-                responseUrl: payload.response_url,
-              },
-            ),
-          )
       }
       return c.json({ ok: true })
     }

--- a/apps/api/test/chat-reach.test.ts
+++ b/apps/api/test/chat-reach.test.ts
@@ -1,6 +1,7 @@
 import type { SessionMessageRecord, SessionRecord } from "@derive/core"
 import { describe, expect, it } from "vitest"
 import { runChatTurn } from "../src/lib/chat-turn"
+import { CHAT_UNVERIFIED_NOTE } from "../src/lib/slack-identity"
 
 // WHAT THE AGENT IS TOLD ABOUT THE PERSON IT IS TALKING TO.
 //
@@ -25,7 +26,7 @@ const transcript: SessionMessageRecord[] = [
 ]
 
 /** Run one turn against a model that records its system prompt and answers trivially. */
-const promptFor = async (role: "owner" | "editor" | "commenter" | "viewer") => {
+const promptFor = async (role: "owner" | "editor" | "commenter" | "viewer", note?: string) => {
   let captured = ""
   await runChatTurn(
     {
@@ -43,7 +44,7 @@ const promptFor = async (role: "owner" | "editor" | "commenter" | "viewer") => {
       transcript,
       tools: { tools: [], execute: async () => ({}), skills: [] },
       workspaceName: "Acme",
-      asker: { name: "Priya", role },
+      asker: { name: "Priya", role, ...(note ? { note } : {}) },
       skills: [],
     },
   )
@@ -73,5 +74,36 @@ describe("what a chat turn knows about who is asking", () => {
     const prompt = await promptFor("owner")
     expect(prompt).toContain("Priya")
     expect(prompt).toContain("Acme")
+  })
+})
+
+// WHEN THE SEAT IN THE PROMPT IS NOT THE SEAT THE PERSON HOLDS.
+//
+// The Slack lane clamps an email-matched asker to `viewer` (lib/slack-identity.ts). That is
+// invisible from inside the turn — the tools simply behave as a viewer's — so without the note
+// the agent states the clamped role as fact to a Creator, and relays refusals written for a
+// different surface. Both send somebody to a place that cannot help them.
+
+describe("a seat the turn was handed rather than the one the person holds", () => {
+  it("carries the reason into the prompt, verbatim", async () => {
+    const prompt = await promptFor("viewer", CHAT_UNVERIFIED_NOTE)
+    expect(prompt).toContain(CHAT_UNVERIFIED_NOTE)
+  })
+
+  it("says nothing extra when the seat is genuinely theirs", async () => {
+    // The web lane never sets it: a session IS the account, so there is nothing to explain.
+    const prompt = await promptFor("viewer")
+    expect(prompt).not.toContain("Settings → Integrations")
+    expect(prompt).toContain("a Viewer")
+  })
+
+  it("names the fix, and disowns the advice the tools would otherwise give", async () => {
+    // The failure this exists to stop: `publish` and `comment` answer a blocked write with
+    // "re-authorize the connector with derive:comment", which is about an MCP grant and is
+    // unfollowable from Slack.
+    expect(CHAT_UNVERIFIED_NOTE).toContain("Settings → Integrations")
+    expect(CHAT_UNVERIFIED_NOTE).toMatch(/do not repeat .*connector|connector/i)
+    // And the half that is easy to forget: it must not silence the answers that still work.
+    expect(CHAT_UNVERIFIED_NOTE).toMatch(/works normally/i)
   })
 })

--- a/apps/api/test/slack-identity.test.ts
+++ b/apps/api/test/slack-identity.test.ts
@@ -1,0 +1,59 @@
+import type { Role, SlackUserLinkRecord } from "@derive/core"
+import { describe, expect, it } from "vitest"
+import { chatSeatFor, isVerifiedLink, linkToActMessage } from "../src/lib/slack-identity"
+
+// Two things can put a row in slack_user_link and they are not the same claim: `oauth` proves
+// control of the Derive account, `email` only matched its address. Reading may rest on either —
+// the address is one the workspace's own directory verified, and membership is checked anyway.
+// Writing may not: an admin can set a Slack profile email through SCIM without the mailbox, and
+// that must not become the power to approve a publish or comment under somebody's name.
+const link = (origin: SlackUserLinkRecord["origin"]) => ({ origin }) as SlackUserLinkRecord
+
+describe("isVerifiedLink", () => {
+  it("accepts only a deliberate sign-in", () => {
+    expect(isVerifiedLink(link("oauth"))).toBe(true)
+    expect(isVerifiedLink(link("email"))).toBe(false)
+    // A miss never reaches the filtered accessor, but the predicate must not crown one if it did.
+    expect(isVerifiedLink(link("miss"))).toBe(false)
+    expect(isVerifiedLink(null)).toBe(false)
+    expect(isVerifiedLink(undefined)).toBe(false)
+  })
+})
+
+describe("chatSeatFor", () => {
+  // The enforcement for the chat lane, and deliberately not a check: the tools take their
+  // ceiling from the seat, so `publish` refuses a viewer on its own. Nothing has to remember to
+  // ask, and no tool list can drift out of step.
+  it("clamps an unverified asker to viewer, whatever their real seat", () => {
+    for (const role of ["viewer", "commenter", "editor", "owner"] as Role[])
+      expect(chatSeatFor(false, role)).toBe("viewer")
+  })
+
+  it("leaves a verified asker at their real seat", () => {
+    for (const role of ["viewer", "commenter", "editor", "owner"] as Role[])
+      expect(chatSeatFor(true, role)).toBe(role)
+  })
+
+  // Reading is the reason email identity exists — answering a question in Slack without a detour
+  // through Settings. Clamping to `viewer` rather than refusing is what keeps that working.
+  it("still leaves an unverified asker able to read", () => {
+    expect(chatSeatFor(false, "owner")).toBe("viewer")
+  })
+})
+
+describe("linkToActMessage", () => {
+  // The fix is thirty seconds away, so the refusal names the place rather than the policy.
+  it("names the destination and the specific action", () => {
+    const m = linkToActMessage("approve or send back a review", link("email"))
+    expect(m).toContain("Settings → Integrations")
+    expect(m).toContain("approve or send back a review")
+  })
+
+  // To somebody we just answered by name, a bare "connect your accounts" reads as amnesia — so
+  // an email match is told what we know. To a stranger the same sentence would be a lie.
+  it("claims to know the person only when it does", () => {
+    expect(linkToActMessage("decide proposals", link("email"))).toContain("from your email")
+    expect(linkToActMessage("decide proposals", null)).not.toContain("from your email")
+    expect(linkToActMessage("decide proposals")).not.toContain("from your email")
+  })
+})

--- a/apps/api/test/slack-proposal.test.ts
+++ b/apps/api/test/slack-proposal.test.ts
@@ -66,6 +66,18 @@ const setup = async () => {
     checked_at: new Date().toISOString(),
     created_at: new Date().toISOString(),
   })
+  // U3 → an editor Derive knows only because their Slack profile email matched. Reading is
+  // fine; deciding a proposal is not (lib/slack-identity.ts).
+  await meta.setSlackUserLink({
+    id: newId("sul"),
+    org_id: "default",
+    user_id: "u-ed",
+    team_id: "T1",
+    slack_user_id: "U3",
+    origin: "email" as const,
+    checked_at: new Date().toISOString(),
+    created_at: new Date().toISOString(),
+  })
   const deps = {
     meta,
     blobs,
@@ -103,6 +115,14 @@ describe("runSlackProposalAction (approve/request-changes from Slack)", () => {
   it("a linked NON-member is denied (authz gate) — proposal stays open", async () => {
     const { meta, deps } = await setup()
     await runSlackProposalAction(deps, args("request_changes", "U2"))
+    expect((await meta.getProposal("p1"))?.state).toBe("open")
+  })
+
+  // Same Derive account as U1, same editor seat — and it still cannot decide, because what
+  // differs is the strength of the claim that this Slack user IS that account.
+  it("an email-matched identity cannot act, even at a seat that could", async () => {
+    const { meta, deps } = await setup()
+    await runSlackProposalAction(deps, args("request_changes", "U3"))
     expect((await meta.getProposal("p1"))?.state).toBe("open")
   })
 

--- a/apps/api/test/slack-review-action.test.ts
+++ b/apps/api/test/slack-review-action.test.ts
@@ -16,7 +16,10 @@ afterAll(() => rmSync(dir, { recursive: true, force: true }))
 const bus = { publish: () => {}, subscribe: () => () => {} } as never
 const noBilling = async () => null
 
-const setup = async (name: string, opts: { role?: string; link?: boolean } = {}) => {
+const setup = async (
+  name: string,
+  opts: { role?: string; link?: boolean; origin?: "oauth" | "email" } = {},
+) => {
   const meta = new SqliteMetaStore(join(dir, `${name}.db`))
   const artifact = await meta.createArtifact({
     id: newId("a"),
@@ -37,7 +40,7 @@ const setup = async (name: string, opts: { role?: string; link?: boolean } = {})
       user_id: "u-1",
       team_id: "T1",
       slack_user_id: "U1",
-      origin: "oauth" as const,
+      origin: opts.origin ?? "oauth",
       checked_at: new Date().toISOString(),
       created_at: new Date().toISOString(),
     })
@@ -106,12 +109,23 @@ describe("runSlackReviewAction", () => {
     expect(await second.meta.getPendingRound(second.artifact.id)).not.toBeNull()
   })
 
+  // An email match says who somebody probably is. Settling a round is recorded as their
+  // decision and unblocks a build, so it needs the deliberate link — see lib/slack-identity.ts.
+  it("refuses an email-matched identity, and says how to fix it", async () => {
+    const { meta, artifact } = await setup("email-origin", { role: "owner", origin: "email" })
+    const sent: string[] = []
+    await run(meta, artifact, "approve", sent)
+    expect(sent.join(" ")).toContain("Settings → Integrations")
+    expect(await meta.getPendingRound(artifact.id)).not.toBeNull()
+  })
+
   // No Derive principal ⇒ nothing to authorize against. Same prompt the proposal buttons give.
   it("refuses an unlinked clicker", async () => {
     const { meta, artifact } = await setup("no-link", { role: "owner", link: false })
     const sent: string[] = []
     await run(meta, artifact, "approve", sent)
-    expect(sent.join(" ")).toContain("Link your Slack account")
+    expect(sent.join(" ")).toContain("Settings → Integrations")
+    expect(sent.join(" ")).not.toContain("from your email")
     expect(await meta.getPendingRound(artifact.id)).not.toBeNull()
   })
 

--- a/apps/api/test/slack-routes.test.ts
+++ b/apps/api/test/slack-routes.test.ts
@@ -2183,3 +2183,95 @@ describe("slack DMs reach the chat lane", () => {
     expect((await postEvent(app, dm({ thread_ts: "1.0" }))).status).toBe(200)
   })
 })
+
+// The loop's blocking moment, settled from Slack. The same two actions ride the Work Object
+// card, the review-request DM and the channel card — and a Work Object click carries no `value`,
+// which the interactivity guard used to require, making those buttons a no-op.
+describe("review buttons reach the handler from every surface", () => {
+  const ready = async (name: string) => {
+    const { app, meta } = make(name)
+    await meta.setSlackInstall({
+      org_id: "default",
+      team_id: "T1",
+      team_name: "Acme",
+      bot_token: encryptSecret("xoxb-1", KEY),
+      bot_user_id: "UBOT",
+      created_at: new Date().toISOString(),
+    })
+    await meta.setSlackUserLink({
+      id: newId("sul"),
+      org_id: "default",
+      user_id: owner.id,
+      team_id: "T1",
+      slack_user_id: "U1",
+      // A deliberate sign-in, not an email inference — the strongest identity, so the test
+      // exercises the button rather than the identity policy.
+      origin: "oauth",
+      created_at: new Date().toISOString(),
+      checked_at: new Date().toISOString(),
+    })
+    const artifact = await meta.createArtifact({
+      id: newId("a"),
+      short_id: newId("s").slice(0, 8),
+      org_id: "default",
+      slug: null,
+      title: "Spec",
+      workspace_access: "member",
+      link_role: "viewer",
+      listed: "workspace",
+      kind: "file",
+      spa: 0,
+    })
+    const round = await meta.createReviewRound({
+      id: newId("rr"),
+      artifact_id: artifact.id,
+      version: 1,
+      requested_by: "ag-1",
+      requested_for: owner.id,
+      note: null,
+    })
+    return { app, meta, artifact, round }
+  }
+  const click = (app: ReturnType<typeof make>["app"], extra: Record<string, unknown>) => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JSON.stringify({ ok: true }), { status: 200 })),
+    )
+    return postInteract(app, {
+      type: "block_actions",
+      team: { id: "T1" },
+      user: { id: "U1" },
+      channel: { id: "C1" },
+      response_url: "https://hooks.slack.test/x",
+      actions: [{ action_id: "derive_review_approve", ...extra }],
+    })
+  }
+
+  // A DM or channel-card button: the target travels in `value`.
+  it("settles the round from a value-carrying button", async () => {
+    const { app, meta, artifact } = await ready("review-btn-value")
+    const r = await click(app, { value: JSON.stringify({ a: artifact.id }) })
+    expect(r.status).toBe(200)
+    await vi.waitFor(async () => expect(await meta.getPendingRound(artifact.id)).toBeNull())
+  })
+
+  // A Work Object button: no value at all, the entity is echoed back instead. The old guard
+  // required `value` and returned ok before this branch, so the card's buttons did nothing.
+  it("settles the round from a valueless Work Object click", async () => {
+    const { app, meta, artifact } = await ready("review-btn-entity")
+    const r = await click(app, { entity: undefined })
+    expect(r.status).toBe(200)
+    void r
+    const withEntity = await postInteract(app, {
+      type: "block_actions",
+      team: { id: "T1" },
+      user: { id: "U1" },
+      channel: { id: "C1" },
+      response_url: "https://hooks.slack.test/x",
+      entity: { external_ref: { id: artifact.short_id, type: "artifact" } },
+      actions: [{ action_id: "derive_review_approve" }],
+    })
+    expect(withEntity.status).toBe(200)
+    await vi.waitFor(async () => expect(await meta.getPendingRound(artifact.id)).toBeNull())
+  })
+})

--- a/apps/api/test/slack-work-object.test.ts
+++ b/apps/api/test/slack-work-object.test.ts
@@ -2,7 +2,13 @@ import type { ArtifactRecord, UnfurlInfo } from "@derive/core"
 import { describe, expect, it } from "vitest"
 import { type ArtifactStatus, agoLabel, statusPhrase } from "../src/lib/artifact-status"
 import { SLACK_SUBSCRIBABLE_EVENTS } from "../src/lib/slack-subscriptions"
-import { artifactDetails, artifactEntity, SLACK_REVIEW_ACTION } from "../src/lib/slack-work-object"
+import {
+  artifactDetails,
+  artifactEntity,
+  decodeReviewAction,
+  encodeReviewAction,
+  SLACK_REVIEW_ACTION,
+} from "../src/lib/slack-work-object"
 
 const artifact = (over: Partial<ArtifactRecord> = {}) =>
   ({
@@ -238,5 +244,35 @@ describe("review events are channel-subscribable", () => {
   it("offers the review round alongside publishes and proposals", () => {
     for (const e of ["review.requested", "review.sent_back", "review.approved"])
       expect(SLACK_SUBSCRIBABLE_EVENTS).toContain(e)
+  })
+})
+
+// The same two actions now ride three surfaces: the Work Object card, the review-request DM and
+// the channel card. Only the first gets an entity echoed back by Slack, so every button carries
+// its target in `value` as well — one mechanism to get right instead of two, and the handler
+// never depends on Slack round-tripping an entity to know what was clicked.
+describe("review buttons target the artifact from any surface", () => {
+  it("round-trips the artifact id", () => {
+    expect(decodeReviewAction(encodeReviewAction("a_123"))).toBe("a_123")
+  })
+
+  // The value only NAMES the target; runSlackReviewAction re-reads and re-authorizes. A forged
+  // one can at worst point at a doc the clicker still cannot act on.
+  it("returns null for a malformed or empty value rather than throwing", () => {
+    for (const bad of ["", "{", "null", '{"a":""}', '{"b":"x"}'])
+      expect(decodeReviewAction(bad)).toBeNull()
+  })
+
+  it("puts a value on the Work Object buttons too", () => {
+    const e = artifactEntity({
+      ...base,
+      artifact: artifact(),
+      info,
+      status: status({ review: { state: "pending", reviewerId: "u", reviewerName: "M" } }),
+      withActions: true,
+    })
+    const acts = (e.entity_payload as { actions: { primary_actions: { value?: string }[] } })
+      .actions
+    for (const a of acts.primary_actions) expect(decodeReviewAction(a.value ?? "")).toBe("a1")
   })
 })

--- a/apps/api/test/slack.test.ts
+++ b/apps/api/test/slack.test.ts
@@ -99,6 +99,40 @@ describe("slack reply ingestion (inbound)", () => {
     expect(r).toBe(null)
   })
 
+  // IDENTITY STRENGTH AT THE ATTRIBUTION SEAM. The handler passes `deriveUserId` only for an
+  // oauth link (lib/slack-identity.ts); an email match arrives here as null. What matters is
+  // that null DEGRADES rather than refuses — the reply is still a comment, just one that claims
+  // only what we can prove. Losing the reply instead would be a worse trade than the claim.
+  it("attributes to the Derive account when the link is strong enough to carry it", async () => {
+    const { link } = await setup()
+    const created = await ingestSlackReply(meta, link, {
+      ts: "1700.5",
+      userId: "U999",
+      userName: "Dana",
+      text: "ship it",
+      botUserId: "UBOT",
+      deriveUserId: "u-dana",
+    })
+    expect(created?.author_id).toBe("u-dana")
+  })
+
+  it("still records the reply when it cannot, under the Slack identity alone", async () => {
+    const { link } = await setup()
+    const created = await ingestSlackReply(meta, link, {
+      ts: "1700.6",
+      userId: "U999",
+      userName: "Dana",
+      text: "ship it",
+      botUserId: "UBOT",
+      deriveUserId: null,
+    })
+    expect(created).toBeTruthy()
+    expect(created?.author_id).toBe("slack:U999")
+    // The display name still comes from Slack, so the thread reads normally to a human — it is
+    // the machine-readable attribution that stays honest.
+    expect(created?.author).toBe("Dana")
+  })
+
   it("dedupes a re-delivered Slack message ts", async () => {
     const { link } = await setup()
     const args = { ts: "1700.4", userId: "U1", userName: "X", text: "hi", botUserId: "UBOT" }


### PR DESCRIPTION
"Agent native" for Derive means one thing: **the agent loop should be closeable from Slack, not just observable there.**

The loop's blocking moment is an agent stopping to wait on a named person. In Slack that arrived as an invitation to leave:

| surface | before | after |
|---|---|---|
| review-request **DM** | `Review in Derive` (a link out) | **Approve** · **Send back** · Review in Derive |
| **channel** review card | nothing | **Approve** · **Send back** |
| Work Object card | Approve · Send back | unchanged |

The DM is addressed to exactly the person the loop is blocked on, so it's the right place for the buttons. The channel card broadcasts them, which is safe for the same reason the proposal buttons are — the clicker is re-authorized as their own linked account, so anyone else gets an ephemeral refusal rather than an action.

**No new mechanism.** `runSlackReviewAction` already does the work, with the permissions `routes/review.ts` uses and the billing gate on approve alone. This is the 80/20: the highest-value moment in the loop, reusing machinery that's already built and tested.

## Two defects surfaced while wiring it — both mine

**The Work Object review buttons have never worked.** The interactivity handler required `action.value` before dispatching anything:

```js
if (payload.type !== "block_actions" || !action?.value) return c.json({ ok: true })
```

A Work Object action carries no `value` — Slack round-trips the entity instead. So every click returned `ok` and did nothing, silently, since I shipped them. The guard now checks `action_id`; the branches that *do* encode a target in `value` guard for it themselves; and the review branch is ordered above that guard so it can't regress the same way.

**And the entity buttons now carry a `value` too**, so all three surfaces name their target identically. Depending on Slack echoing an entity back was a second mechanism to keep correct for no benefit.

Both are pinned: a value-carrying click and a valueless entity click each settle the round through the real route.

`pnpm ci` clean, `pnpm typecheck` clean, 2014 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/627"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788351611&installation_model_id=428097&pr_number=627&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F627&signature=7b60e7d4d483c4abf176a48ecf91634e634a228ce9b60431744cae4736d95a83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## 3. A clamped seat has to say why

Found auditing the above. Clamping is invisible from inside the turn — the tools just behave
as a viewer's — and that silence makes the agent wrong twice.

It **states the clamped role as fact**: the prompt says "They are a Viewer here", so an actual
Creator is told they are a Viewer and goes to ask an admin for a role they already hold. The
existing comment on `asker` warns about exactly this — *"a guess about someone's own permissions
is the kind of wrong that sends a person hunting for a button that was never going to be there."*

And it **relays refusals written for another surface**. A blocked write answers with `Your grant
is read-only (derive:read). Re-authorize the connector with derive:comment to leave feedback.`
That is about an MCP connector grant. Somebody who @-mentioned a bot in Slack has no connector,
cannot re-authorize one, and now believes the integration is broken.

So `ChatTurnInput.asker` gains an optional `note`, rendered verbatim, set by the Slack lane only
when it clamped. The web lane never sets it — a session *is* the account.

Also corrects two comments that overstated the mechanism: `publish` does not refuse a viewer
outright, it routes any sub-editor to a proposal and refuses at `propose` (which needs
`commenter`). Nothing is written either way, including nothing pending — but the accurate
version is the one that survives somebody changing that threshold.

### Audited and deliberately left alone

- **Reads stay open to an email identity** everywhere — unfurls, flexpane, `/derive <query>`,
  the agent's answers. That is the whole reason the email path exists.
- **Review buttons still render for an unverified recipient** on the DM and the flexpane, even
  though we know at build time they will refuse. The refusal names Settings → Integrations at
  the exact moment they wanted to act, which teaches the fix better than an absent button does —
  and it stays correct if they link a minute later.
- **Message capture** already opened a "connect your account" modal for a null actor, so the
  stricter actor reuses a path that existed.
