### PR TITLE
feat(slack): the cards people actually paste can carry their screenshot

### DIFF
--- a/apps/api/src/lib/og-token.ts
+++ b/apps/api/src/lib/og-token.ts
@@ -1,0 +1,62 @@
+/**
+ * Short-lived tokens that authorize ONE artifact version's OG preview image on `/v1/og/:ref`.
+ *
+ * Why a token kind of its own, rather than reusing lib/preview-token.ts: that one grants read of
+ * the artifact's RAW CONTENT (it exists so the screenshot renderer can load a private page), and
+ * this URL travels much further — it is handed to Slack, fetched by Slack's image proxy, and
+ * cached wherever that proxy caches. A token that leaked from an unfurl must not also unlock the
+ * document. Same HMAC machinery, different domain, so one can never be replayed as the other.
+ *
+ * WHAT A HOLDER GETS, exactly: the 1200x630 rendered image of one artifact at one version
+ * number — the first screen of the document, no more. Not the content, not later versions, not
+ * a title or comment count (an expired or wrong token falls through to the anonymous locked
+ * card, which reveals none of those).
+ *
+ * The version pin is the important half of that. A leaked URL goes stale on the next publish,
+ * because the token names `n` and the endpoint only spends it on the CURRENT version. So the
+ * blast radius of a leak is a snapshot of a document as it was, and it shrinks by itself.
+ */
+import { signCapabilityToken, verifyCapabilityToken } from "./capability-token"
+
+const DOMAIN = "derive-og-token:"
+
+/**
+ * How long a minted OG token lives.
+ *
+ * Long, and that is deliberate. A Slack message keeps its unfurl for ever, and Slack's image
+ * proxy re-fetches on its own schedule rather than rehosting once — so any expiry eventually
+ * arrives while a message is still on screen. The endpoint is built so that this DEGRADES
+ * (§ the fall-through in routes/embeds.ts): an expired token lands on the same anonymous locked
+ * card the unfurl would have shown before any of this existed. Never a broken image, never an
+ * error — just today's behaviour, later.
+ *
+ * That fallback is what makes a long life affordable rather than necessary, so this is set by
+ * the other consideration: a quarter bounds what a leaked URL is worth, and the version pin
+ * above usually settles it sooner.
+ */
+export const OG_TOKEN_TTL_MS = 90 * 24 * 60 * 60_000
+
+/** Sign a token authorizing the OG image of exactly one artifact + version. */
+export const signOgToken = (
+  secret: string,
+  artifactId: string,
+  n: number,
+  expEpochMs: number,
+): Promise<string> => signCapabilityToken(DOMAIN, secret, [artifactId, String(n)], expEpochMs)
+
+/** Verify one. Returns the artifact id + version, or null (bad signature, malformed, expired).
+ *  Never throws — it runs on an unauthenticated path, where a throw is a 500 for a crawler. */
+export const verifyOgToken = async (
+  secret: string,
+  token: string,
+  nowMs: number,
+): Promise<{ artifactId: string; n: number } | null> => {
+  const claim = await verifyCapabilityToken(DOMAIN, secret, token, nowMs)
+  if (!claim) return null
+  // Payload: `<artifactId>.<n>` — split from the right, so an id containing dots still parses.
+  const midDot = claim.rest.lastIndexOf(".")
+  if (midDot <= 0) return null
+  const n = Number(claim.rest.slice(midDot + 1))
+  if (!Number.isInteger(n)) return null
+  return { artifactId: claim.rest.slice(0, midDot), n }
+}

--- a/apps/api/src/lib/slack-work-object.ts
+++ b/apps/api/src/lib/slack-work-object.ts
@@ -207,6 +207,12 @@ export const artifactDetails = (
   status: ArtifactStatus,
   viewerId: string | null,
   iconUrl: string,
+  /** The screenshot, when this artifact may carry one at all. Per-viewer though this panel is,
+   *  the IMAGE is still fetched anonymously by Slack and cached by its proxy — so the same line
+   *  applies here as on the broadcast card, and a `listed: "none"` doc passes null. Being
+   *  entitled to read something is not the same as consenting to a copy of it living in another
+   *  company's cache. */
+  previewUrl?: string | null,
 ): Record<string, unknown> => {
   const phrase = statusPhrase(status, viewerId)
   const fields: Record<string, unknown> = {
@@ -236,6 +242,15 @@ export const artifactDetails = (
         display_type: info.kindLabel,
         product_name: "Derive",
         product_icon: { url: iconUrl, alt_text: "Derive" },
+        ...(previewUrl
+          ? {
+              full_size_preview: {
+                is_supported: true,
+                preview_url: previewUrl,
+                mime_type: "image/png",
+              },
+            }
+          : {}),
       },
       fields,
       custom_fields: [

--- a/apps/api/src/routes/embeds.ts
+++ b/apps/api/src/routes/embeds.ts
@@ -18,6 +18,7 @@ import {
 import { type Context, Hono } from "hono"
 import type { AppContext } from "../context"
 import { fail, toBody } from "../lib/http"
+import { verifyOgToken } from "../lib/og-token"
 import { unfurlInfoFor } from "../lib/unfurl-info"
 
 /**
@@ -74,12 +75,54 @@ export const embedRoutes = (ctx: AppContext) => {
     return (await authorize(c, "read", artifact)) ? artifact : null
   }
 
+  /**
+   * The artifact a valid `?t=` names, or null. Three things must agree, and each is a way the
+   * grant could otherwise widen:
+   *
+   *   - the signature verifies against THIS instance's secret, in the og-token domain, unexpired
+   *   - the artifact it names is the one `:ref` asked for — otherwise a token minted for a doc
+   *     someone may read would spend on any other doc's image
+   *   - the version it names is still the CURRENT one — so the token follows a snapshot, not the
+   *     document, and a publish since retires it
+   *
+   * Absent secret ⇒ null: a deployment with no signing key cannot have minted one, so anything
+   * presented is forged.
+   */
+  const ogTokenArtifact = async (c: Context): Promise<ArtifactRecord | null> => {
+    const token = c.req.query("t")
+    if (!token || !ctx.deps.encryptionKey) return null
+    const claim = await verifyOgToken(ctx.deps.encryptionKey, token, Date.now())
+    if (!claim) return null
+    const ref = c.req.param("ref")
+    if (!ref) return null
+    let artifact: ArtifactRecord | null = null
+    for (const id of candidateShortIds(ref)) {
+      artifact = await meta.getByShortId(id)
+      if (artifact) break
+    }
+    if (!artifact || artifact.removed_at) return null
+    if (artifact.id !== claim.artifactId) return null
+    if (artifact.current_version !== claim.n) return null
+    return artifact
+  }
+
   // The OG card image. SVG: zero-dep and identical on Node + Worker. A gated or
   // missing artifact gets a generic locked card (no title leak), still 200 so the
   // unfurl shows something. Cached hard (see the Cache-Control below) — the live
   // version/comment counts on the card are allowed to lag for an unfurl preview.
   app.get("/v1/og/:ref", async (c) => {
-    const artifact = await readable(c, c.req.param("ref"))
+    const readableArtifact = await readable(c, c.req.param("ref"))
+    // A signed token stands in for the read check for THIS IMAGE ALONE (lib/og-token.ts).
+    // It is what lets a Slack unfurl of a workspace-listed doc carry its screenshot: Slack
+    // fetches preview images anonymously, so without it the picture on the cards people paste
+    // most would be the title-less padlock.
+    //
+    // Deliberately not a general read: it never reaches `infoFor`, so a holder gets the
+    // rendered image and never a title, a description or a comment count. And it is spent only
+    // on the version it names — a doc republished since is a miss, and the token quietly ages
+    // into a locked card rather than following the document.
+    const tokened = readableArtifact ? null : await ogTokenArtifact(c)
+    const artifact = readableArtifact ?? tokened
     // readable() enforces visibility: a gated artifact for an anonymous crawler returns null
     // and never reaches the PNG branch, so a private artifact can never leak its screenshot.
     if (artifact) {
@@ -91,20 +134,32 @@ export const embedRoutes = (ctx: AppContext) => {
         // with no world link (or a locked one) means an authorized member. Their
         // screenshot must never land in a shared cache; keep it browser-only there
         // (max-age so the library card <img> stays cached across renders).
+        //
+        // A TOKENED fetch is the exception, and cacheable publicly for the reason capability
+        // URLs generally are: the credential is IN the URL, so a shared cache keyed on the
+        // full URL can only ever hand the bytes back to someone who already presented the
+        // token. Slack's image proxy caching this is the point, not a leak.
         if (png)
           return c.body(toBody(png), 200, {
             "Content-Type": "image/png",
-            "Cache-Control": cacheFor(
-              artifact,
-              "public, max-age=86400, stale-while-revalidate=604800",
-              3600,
-            ),
+            "Cache-Control": tokened
+              ? "public, max-age=86400, stale-while-revalidate=604800"
+              : cacheFor(artifact, "public, max-age=86400, stale-while-revalidate=604800", 3600),
             "X-Content-Type-Options": "nosniff",
           })
       }
     }
-    const svg = artifact
-      ? ogCardSvg({ ...(await infoFor(artifact)), reveal: true })
+    // FALLS THROUGH on purpose when the token is absent, expired, forged or names a version
+    // that is no longer current — to the same anonymous card this endpoint has always served.
+    // That is what makes a long token life affordable: the worst an expiry can do is put back
+    // the behaviour that predates it. Never a broken image, never an error.
+    //
+    // `readableArtifact`, NOT `artifact`: the token buys the rendered image and nothing else,
+    // and this branch reveals the title, description and counts. A tokened caller whose PNG
+    // was missing must land on the generic card exactly as an anonymous one does — otherwise
+    // the narrow grant widens into a metadata read the moment a render is pending or failed.
+    const svg = readableArtifact
+      ? ogCardSvg({ ...(await infoFor(readableArtifact)), reveal: true })
       : ogCardSvg({
           title: "",
           kindLabel: "Document",
@@ -120,7 +175,7 @@ export const embedRoutes = (ctx: AppContext) => {
       // branch only because the CALLER could read it, so its revealed card (title, counts,
       // slot figures) is browser-private — see cacheFor.
       "Cache-Control": cacheFor(
-        artifact,
+        readableArtifact,
         "public, max-age=86400, stale-while-revalidate=604800",
         3600,
       ),

--- a/apps/api/src/routes/slack.ts
+++ b/apps/api/src/routes/slack.ts
@@ -4,6 +4,7 @@ import {
   newId,
   roleAllows,
   type SlackInstallRecord,
+  type UnfurlInfo,
 } from "@derive/core"
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import type { Context } from "hono"
@@ -14,6 +15,7 @@ import { commentCreatedAction } from "../lib/comment-actions"
 import { commentDeepLink } from "../lib/comments"
 import { encryptSecret, signState, verifyState } from "../lib/crypto"
 import { bail, fail, readJson } from "../lib/http"
+import { OG_TOKEN_TTL_MS, signOgToken } from "../lib/og-token"
 import { searchMatcher, searchWorkspace, toSearchHits } from "../lib/search"
 import {
   exchangeSlackOAuth,
@@ -262,6 +264,42 @@ export const slackRoutes = (ctx: AppContext) => {
     }
   }
 
+  /**
+   * The image a Slack card may show for this artifact, or null.
+   *
+   * Slack fetches preview images anonymously, so the question is never "may this viewer see it"
+   * but "may this be fetched with no credential at all" — and the answer, for anything short of
+   * world-readable, used to be no. A workspace-listed doc therefore rendered the title-less
+   * padlock, which is why the cards people paste most carried no picture.
+   *
+   * A signed token settles it without loosening `/v1/og` for anyone else: it buys that one
+   * version's rendered image, expires, and retires itself on the next publish. The reasoning for
+   * why a workspace-listed doc is the right place to draw this line is the product's own —
+   * `workspace` means the org may see it, a Slack channel in that org's own workspace is
+   * substantially that audience, and anything genuinely sensitive is marked `none`, which never
+   * reaches this function.
+   *
+   * Null when there is no signing secret (nothing could have been minted) or no render yet —
+   * `/v1/og` then serves the locked card it always has, so a missing preview is a plain card
+   * rather than a broken one.
+   */
+  const previewUrlFor = async (
+    artifact: ArtifactRecord,
+    info: UnfurlInfo,
+  ): Promise<string | null> => {
+    if (artifact.listed === "public") return info.imageUrl
+    if (artifact.listed !== "workspace" || !deps.encryptionKey) return null
+    const token = await signOgToken(
+      deps.encryptionKey,
+      artifact.id,
+      artifact.current_version,
+      Date.now() + OG_TOKEN_TTL_MS,
+    )
+    const u = new URL(info.imageUrl)
+    u.searchParams.set("t", token)
+    return u.toString()
+  }
+
   /** The Work Object for one decided link. A locked artifact still gets an entity — a title-less
    *  one, exactly as broadcast-safe as the block card it replaces — because the entity is what
    *  makes the card CLICKABLE, and the flexpane behind it is per-viewer. That is how someone
@@ -293,9 +331,12 @@ export const slackRoutes = (ctx: AppContext) => {
       artifact: d.artifact,
       info: d.info,
       status,
-      // Slack fetches preview images ANONYMOUSLY, so only a world-readable artifact can carry
-      // one; anything else would render /v1/og's title-less padlock as the card's picture.
-      previewUrl: d.artifact.listed === "public" ? d.info.imageUrl : null,
+      // The screenshot. Slack fetches preview images ANONYMOUSLY, so a world-readable artifact
+      // links its OG image directly and a workspace-listed one carries a signed, version-pinned
+      // token that buys that image and nothing else (lib/og-token.ts). `listed: "none"` never
+      // reaches here — decideUnfurl answered it with the locked card above — which is the line
+      // this feature deliberately does not cross: a doc someone marked private stays a padlock.
+      previewUrl: await previewUrlFor(d.artifact, d.info),
       withActions: status.review?.state === "pending",
       iconUrl,
     })
@@ -366,7 +407,14 @@ export const slackRoutes = (ctx: AppContext) => {
     return say(
       {
         kind: "details",
-        metadata: artifactDetails(artifact, info, status, userLink.user_id, iconUrl),
+        metadata: artifactDetails(
+          artifact,
+          info,
+          status,
+          userLink.user_id,
+          iconUrl,
+          await previewUrlFor(artifact, info),
+        ),
       },
       "details",
     )

--- a/apps/api/src/routes/slack.ts
+++ b/apps/api/src/routes/slack.ts
@@ -279,16 +279,30 @@ export const slackRoutes = (ctx: AppContext) => {
    * substantially that audience, and anything genuinely sensitive is marked `none`, which never
    * reaches this function.
    *
-   * Null when there is no signing secret (nothing could have been minted) or no render yet —
-   * `/v1/og` then serves the locked card it always has, so a missing preview is a plain card
-   * rather than a broken one.
+   * ONE RULE, both visibilities: offer a URL only when a rendered PNG is actually behind it.
+   *
+   * Renders are enqueued in the BACKGROUND after a publish, so a link pasted moments later finds
+   * one pending, and `/v1/og` answers meanwhile with an SVG — the doc's own card for a public
+   * artifact, the TITLE-LESS PADLOCK for a workspace one. Offering either is a card that
+   * declares `mime_type: "image/png"` and serves something else, and for the workspace case it
+   * puts a padlock graphic beside the title we are already showing: exactly what the block card
+   * avoided by carrying no image at all.
+   *
+   * Verified against the API, and the reason this is a check rather than a hope: `chat.unfurl`
+   * accepts a `preview_url` WITHOUT fetching it, answering `ok: true` with no warning. Nothing
+   * downstream will tell us the picture was wrong. So the card promises an image only when we
+   * know there is one, and otherwise says nothing — the fields and title stand on their own.
    */
   const previewUrlFor = async (
     artifact: ArtifactRecord,
     info: UnfurlInfo,
   ): Promise<string | null> => {
+    if (artifact.listed !== "public" && artifact.listed !== "workspace") return null
+    const v = await meta.getVersion(artifact.id, artifact.current_version)
+    if (v?.preview_status !== "ready" || !v.preview_key) return null
+    // A world-readable doc needs no capability: /v1/og already serves its PNG to anyone.
     if (artifact.listed === "public") return info.imageUrl
-    if (artifact.listed !== "workspace" || !deps.encryptionKey) return null
+    if (!deps.encryptionKey) return null
     const token = await signOgToken(
       deps.encryptionKey,
       artifact.id,

--- a/apps/api/test/og-preview.test.ts
+++ b/apps/api/test/og-preview.test.ts
@@ -10,6 +10,8 @@ import { SqliteMetaStore } from "@derive/db/sqlite"
 import { FsBlobStore } from "@derive/storage/fs"
 import { afterAll, describe, expect, it } from "vitest"
 import { createApp } from "../src/app"
+import { OG_TOKEN_TTL_MS, signOgToken, verifyOgToken } from "../src/lib/og-token"
+import { signPreviewToken, verifyPreviewToken } from "../src/lib/preview-token"
 
 const dir = mkdtempSync(join(tmpdir(), "derive-og-preview-"))
 
@@ -93,6 +95,8 @@ const TINY_PNG = new Uint8Array([
   0x82,
 ])
 
+const SECRET = "og-secret"
+
 const makeApp = (name: string) => {
   const dbPath = join(dir, `${name}.db`)
   const meta = new SqliteMetaStore(dbPath)
@@ -102,6 +106,7 @@ const makeApp = (name: string) => {
     blobs,
     baseUrl: "http://derive.test",
     token: TOKEN,
+    encryptionKey: SECRET,
   })
   return { app, meta, blobs }
 }
@@ -247,5 +252,169 @@ describe("/v1/og/:ref — PNG preview serving", () => {
     const body = await res.text()
     expect(body).toContain("<svg")
     expect(body).not.toContain("Private Artifact")
+  })
+})
+
+// A SIGNED URL FOR ONE IMAGE (lib/og-token.ts).
+//
+// Slack fetches an unfurl's preview image ANONYMOUSLY, so a workspace-listed doc — the shape
+// people paste most — could only ever show the title-less padlock. A token minted for exactly
+// one artifact+version buys that image without loosening this endpoint for anyone else.
+//
+// Every test here is really the same question asked from a different angle: what ELSE does
+// holding this URL get you? The answer has to stay "nothing".
+
+describe("/v1/og/:ref — the signed preview token", () => {
+  /** A workspace-visible artifact with a rendered preview, plus its ids. */
+  const withPreview = async (name: string, visibility = "org") => {
+    const { app, meta, blobs } = makeApp(name)
+    const { short_id, current_version } = await publish(app, "<h1>Team</h1>", {
+      visibility,
+      title: "Team Doc",
+    })
+    const artifact = await meta.getByShortId(short_id)
+    if (!artifact) throw new Error("artifact not found after publish")
+    const pngKey = await blobs.put(TINY_PNG)
+    await meta.setVersionPreview(artifact.id, current_version, {
+      preview_key: pngKey,
+      preview_status: "ready",
+    })
+    return { app, meta, blobs, artifact, short_id, current_version }
+  }
+
+  const tokenFor = (artifactId: string, n: number, ttlMs = OG_TOKEN_TTL_MS) =>
+    signOgToken(SECRET, artifactId, n, Date.now() + ttlMs)
+
+  it("serves the PNG to an anonymous fetch that carries a valid token", async () => {
+    const { app, artifact, short_id, current_version } = await withPreview("og-tok-ok")
+    // No credential at all — exactly what Slack's image proxy sends.
+    const res = await app.request(
+      `/v1/og/${short_id}?t=${await tokenFor(artifact.id, current_version)}`,
+    )
+    expect(res.status).toBe(200)
+    expect(res.headers.get("content-type")).toBe("image/png")
+    expect(new Uint8Array(await res.arrayBuffer())).toEqual(TINY_PNG)
+    // Shared-cacheable BECAUSE the credential is in the URL: a cache keyed on the full URL can
+    // only return these bytes to someone who already presented the token. Slack's proxy
+    // caching this is the point.
+    expect(res.headers.get("cache-control")).toContain("public")
+  })
+
+  it("without the token, the same fetch still gets the locked card", async () => {
+    const { app, short_id } = await withPreview("og-tok-absent")
+    const res = await app.request(`/v1/og/${short_id}`)
+    expect(res.headers.get("content-type")).toContain("image/svg+xml")
+    expect(await res.text()).not.toContain("Team Doc")
+  })
+
+  it("a token for one artifact cannot be spent on another", async () => {
+    // The check that keeps this from becoming a skeleton key: a doc I may read mints a token,
+    // and without binding it to `:ref` that token would fetch any other doc's screenshot.
+    const { app, meta, blobs, artifact, current_version } = await withPreview("og-tok-swap")
+    const other = await publish(app, "<h1>Other</h1>", { visibility: "org", title: "Other Doc" })
+    const otherRec = await meta.getByShortId(other.short_id)
+    if (!otherRec) throw new Error("other artifact not found")
+    // The other doc must have a preview of its OWN and be otherwise servable — else this
+    // passes for want of a render rather than because the binding held.
+    await meta.setVersionPreview(otherRec.id, other.current_version, {
+      preview_key: await blobs.put(TINY_PNG),
+      preview_status: "ready",
+    })
+    const res = await app.request(
+      `/v1/og/${other.short_id}?t=${await tokenFor(artifact.id, current_version)}`,
+    )
+    expect(res.headers.get("content-type")).toContain("image/svg+xml")
+  })
+
+  it("retires itself on the next publish, rather than following the document", async () => {
+    // The version pin is what bounds a leak: whatever escapes shows the doc as it WAS, and
+    // stops being current the moment somebody edits.
+    const { app, meta, blobs, artifact, short_id, current_version } =
+      await withPreview("og-tok-stale")
+    const stale = await tokenFor(artifact.id, current_version)
+    expect((await app.request(`/v1/og/${short_id}?t=${stale}`)).headers.get("content-type")).toBe(
+      "image/png",
+    )
+    const form = new FormData()
+    form.append("file", new Blob([new TextEncoder().encode("<h1>v2</h1>")]), "f.html")
+    const bumped = await app.request(`/v1/artifacts/${short_id}/versions`, {
+      method: "POST",
+      body: form,
+      headers: AUTH,
+    })
+    expect(bumped.status).toBeLessThan(300)
+    const v2 = (await meta.getByShortId(short_id))?.current_version
+    expect(v2).toBe(current_version + 1)
+    // v2 renders too — so the ONLY thing between the old token and a current screenshot is
+    // the pin. Without it this test would pass merely because v2 had no preview yet.
+    await meta.setVersionPreview(artifact.id, v2 as number, {
+      preview_key: await blobs.put(TINY_PNG),
+      preview_status: "ready",
+    })
+    const after = await app.request(`/v1/og/${short_id}?t=${stale}`)
+    expect(after.headers.get("content-type")).toContain("image/svg+xml")
+    // ...and a token minted for v2 works, so the pin is a pin and not a wall.
+    const fresh = await tokenFor(artifact.id, v2 as number)
+    expect((await app.request(`/v1/og/${short_id}?t=${fresh}`)).headers.get("content-type")).toBe(
+      "image/png",
+    )
+  })
+
+  it("expires, and expiry DEGRADES to the card rather than breaking the image", async () => {
+    // Why a long TTL is affordable: a Slack message keeps its unfurl for ever and Slack
+    // re-fetches on its own schedule, so every expiry eventually lands on a live message. The
+    // worst it may do is put back the card that predates this feature — never a 4xx, never a
+    // broken-image icon.
+    const { app, artifact, short_id, current_version } = await withPreview("og-tok-exp")
+    const expired = await tokenFor(artifact.id, current_version, -1000)
+    const res = await app.request(`/v1/og/${short_id}?t=${expired}`)
+    expect(res.status).toBe(200)
+    expect(res.headers.get("content-type")).toContain("image/svg+xml")
+  })
+
+  it("rejects a forged token, and one signed with a different secret", async () => {
+    const { app, artifact, short_id, current_version } = await withPreview("og-tok-forged")
+    const wrongKey = await signOgToken(
+      "not-the-secret",
+      artifact.id,
+      current_version,
+      Date.now() + OG_TOKEN_TTL_MS,
+    )
+    for (const t of ["garbage", "a.b", wrongKey]) {
+      const res = await app.request(`/v1/og/${short_id}?t=${encodeURIComponent(t)}`)
+      expect(res.status, t).toBe(200)
+      expect(res.headers.get("content-type"), t).toContain("image/svg+xml")
+    }
+  })
+
+  it("cannot be replayed as a renderer preview token — different domain, same shape", async () => {
+    // The two kinds carry an identical `<artifactId>.<n>` payload, and the renderer's grants
+    // RAW CONTENT. Only the domain string separates them, which is the whole reason
+    // capability-token.ts has one.
+    const { artifact, current_version } = await withPreview("og-tok-domain")
+    const og = await tokenFor(artifact.id, current_version)
+    expect(await verifyPreviewToken(SECRET, og, Date.now())).toBeNull()
+    const pv = await signPreviewToken(SECRET, artifact.id, current_version, Date.now() + 60_000)
+    expect(await verifyOgToken(SECRET, pv, Date.now())).toBeNull()
+  })
+
+  it("buys the image and NOT the metadata: no title leaks when the render is missing", async () => {
+    // The subtle one. A valid token whose PNG is not ready must land on the GENERIC card, not
+    // the revealed one — otherwise the grant silently widens into a metadata read for exactly
+    // as long as a render is pending or failed.
+    const { app, meta } = makeApp("og-tok-nopng")
+    const { short_id, current_version } = await publish(app, "<h1>Team</h1>", {
+      visibility: "org",
+      title: "Unrendered Secret",
+    })
+    const artifact = await meta.getByShortId(short_id)
+    if (!artifact) throw new Error("artifact not found after publish")
+    const res = await app.request(
+      `/v1/og/${short_id}?t=${await signOgToken(SECRET, artifact.id, current_version, Date.now() + OG_TOKEN_TTL_MS)}`,
+    )
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    expect(body).toContain("<svg")
+    expect(body).not.toContain("Unrendered Secret")
   })
 })

--- a/apps/api/test/slack-routes.test.ts
+++ b/apps/api/test/slack-routes.test.ts
@@ -1184,6 +1184,109 @@ describe("slack link unfurls", () => {
     expect(payload).toContain('"alt_text"')
   })
 
+  // THE SCREENSHOT ON THE CARD.
+  //
+  // Slack fetches preview images anonymously, so for anything short of world-readable the card
+  // used to show /v1/og's title-less padlock — on precisely the docs people paste most. A
+  // signed, version-pinned token (lib/og-token.ts) buys that one image without loosening the
+  // endpoint for anyone else. The line is drawn at `listed`: `workspace` means the org may see
+  // it and a channel in that org's own Slack is substantially that audience; `none` is what
+  // somebody chose when they meant private, and it must stay a padlock.
+  const unfurlEntity = async (name: string, listed: "workspace" | "none" | "public") => {
+    const { app, meta } = make(name)
+    await meta.setSlackInstall({
+      org_id: "default",
+      team_id: "T1",
+      team_name: "Acme",
+      bot_token: encryptSecret("xoxb-1", KEY),
+      bot_user_id: "UBOT",
+      created_at: new Date().toISOString(),
+    })
+    await meta.setSlackUserLink({
+      id: newId("sul"),
+      org_id: "default",
+      user_id: owner.id,
+      team_id: "T1",
+      slack_user_id: "U1",
+      origin: "oauth" as const,
+      checked_at: new Date().toISOString(),
+      created_at: new Date().toISOString(),
+    })
+    const artifact = await meta.createArtifact({
+      id: newId("a"),
+      short_id: newId("s").slice(0, 8),
+      org_id: "default",
+      slug: null,
+      title: "Q4 roadmap",
+      workspace_access: "member",
+      link_role: listed === "public" ? "viewer" : "none",
+      listed,
+      kind: "file",
+      spa: 0,
+    })
+    let fired: (v: unknown) => void = () => {}
+    const called = new Promise((r) => {
+      fired = r
+    })
+    const seen: Record<string, unknown>[] = []
+    vi.stubGlobal("fetch", async (url: string, init: RequestInit) => {
+      if (String(url).includes("chat.unfurl")) {
+        seen.push(JSON.parse(String(init.body)) as Record<string, unknown>)
+        fired(null)
+      }
+      return new Response(JSON.stringify({ ok: true }), { status: 200 })
+    })
+    await postEvent(
+      app,
+      JSON.stringify({
+        type: "event_callback",
+        team_id: "T1",
+        event: {
+          type: "link_shared",
+          user: "U1",
+          channel: "C9",
+          message_ts: "1700000000.1",
+          links: [{ url: `http://derive.test/artifacts/${artifact.short_id}` }],
+        },
+      }),
+    )
+    await called
+    const ents = (seen[0]?.metadata as { entities?: Record<string, unknown>[] })?.entities
+    return { entity: ents?.[0] as Record<string, unknown> | undefined, artifact }
+  }
+
+  it("carries a signed screenshot URL for a workspace-listed doc", async () => {
+    const { entity, artifact } = await unfurlEntity("slack-unfurl-preview-ws", "workspace")
+    const preview = (
+      (entity?.entity_payload as { attributes?: Record<string, unknown> })?.attributes as {
+        full_size_preview?: { preview_url?: string }
+      }
+    )?.full_size_preview
+    const url = new URL(preview?.preview_url ?? "")
+    expect(url.pathname).toContain(`/v1/og/${artifact.short_id}`)
+    // The token is the whole mechanism — without it Slack's anonymous fetch gets the padlock.
+    expect(url.searchParams.get("t")).toBeTruthy()
+  })
+
+  it("carries NO screenshot for a doc somebody marked private", async () => {
+    // `listed: "none"` is answered by the locked card, which is title-less by construction —
+    // so there is nothing to mint a token for, and nothing that could be minted by mistake.
+    const { entity } = await unfurlEntity("slack-unfurl-preview-none", "none")
+    expect(JSON.stringify(entity)).not.toContain("full_size_preview")
+    expect(JSON.stringify(entity)).not.toContain("Q4 roadmap")
+  })
+
+  it("needs no token for a world-readable doc — /v1/og already serves it", async () => {
+    const { entity } = await unfurlEntity("slack-unfurl-preview-pub", "public")
+    const preview = (
+      (entity?.entity_payload as { attributes?: Record<string, unknown> })?.attributes as {
+        full_size_preview?: { preview_url?: string }
+      }
+    )?.full_size_preview
+    expect(preview?.preview_url).toBeTruthy()
+    expect(new URL(preview?.preview_url ?? "").searchParams.get("t")).toBeNull()
+  })
+
   // Work Objects answer 200-with-a-warning when the payload is subtly wrong or the feature is
   // off on the app — a silent nothing in the channel. The block card must still go out.
   it("falls back to the block card when Slack warns on the entity", async () => {
@@ -2106,6 +2209,33 @@ describe("entity_details_requested (the flexpane)", () => {
     const body = await clickAndCapture(app, artifact.short_id)
     expect(body.user_auth_required).toBe(true)
     expect(String(body.user_auth_url)).toContain("/v1/slack/link")
+  })
+
+  // THE ONE PATH WHERE A PRIVATE DOC CAN REACH THE MINTER.
+  //
+  // The unfurl never does — decideUnfurl answers `listed: "none"` with the locked card long
+  // before a preview is considered. The flexpane resolves an artifact itself, so a private doc
+  // arrives at the same function, and only its own `listed` check stops a token being minted.
+  //
+  // Which it must, even though this panel is per-viewer and this viewer just passed a read
+  // check. The panel is private; the IMAGE URL is not — Slack fetches it anonymously and its
+  // proxy caches the bytes. Being entitled to read something is not the same as consenting to
+  // a copy of it living in another company's cache.
+  it("mints no screenshot URL for a private doc, even for a viewer who may read it", async () => {
+    const { app, artifact } = await withInstall("flex-private-preview", { listed: "none" })
+    const body = await clickAndCapture(app, artifact.short_id)
+    // The viewer IS entitled — the panel opens and names the doc.
+    expect(JSON.stringify(body)).toContain("Secret plan")
+    expect(JSON.stringify(body)).not.toContain("full_size_preview")
+  })
+
+  it("does mint one for a workspace-listed doc, which is the whole point", async () => {
+    const { app, artifact } = await withInstall("flex-ws-preview", { listed: "workspace" })
+    const body = await clickAndCapture(app, artifact.short_id)
+    const json = JSON.stringify(body)
+    expect(json).toContain("full_size_preview")
+    expect(json).toContain(`/v1/og/${artifact.short_id}`)
+    expect(json).toContain("t=")
   })
 
   // The point of the whole change: a viewer entitled to a doc sees it, even when the broadcast

--- a/apps/api/test/slack-routes.test.ts
+++ b/apps/api/test/slack-routes.test.ts
@@ -132,6 +132,21 @@ const threadAction = (
 
 afterEach(() => vi.unstubAllGlobals())
 
+/** Publish a version onto a bare `createArtifact` fixture and return its number. Artifacts made
+ *  by hand start at current_version 0 with no version row; anything that reads a version — a
+ *  preview status, most obviously — needs a real one. */
+const addV = async (m: MetaStore, artifactId: string): Promise<number> => {
+  const v = await m.addVersion(artifactId, {
+    id: newId("v"),
+    blob_key: "blob-content",
+    content_type: "text/markdown",
+    size_bytes: 1,
+    author: "tester",
+    message: null,
+  })
+  return v.n
+}
+
 describe("slack status + admin routes", () => {
   it("reports available + not connected before an install, connected after", async () => {
     const { app, meta } = make("slack-status")
@@ -1192,7 +1207,11 @@ describe("slack link unfurls", () => {
   // endpoint for anyone else. The line is drawn at `listed`: `workspace` means the org may see
   // it and a channel in that org's own Slack is substantially that audience; `none` is what
   // somebody chose when they meant private, and it must stay a padlock.
-  const unfurlEntity = async (name: string, listed: "workspace" | "none" | "public") => {
+  const unfurlEntity = async (
+    name: string,
+    listed: "workspace" | "none" | "public",
+    rendered = true,
+  ) => {
     const { app, meta } = make(name)
     await meta.setSlackInstall({
       org_id: "default",
@@ -1224,6 +1243,16 @@ describe("slack link unfurls", () => {
       kind: "file",
       spa: 0,
     })
+    // `createArtifact` alone leaves current_version = 0 and no version row — a shape production
+    // never has, because publishing makes v1. Give it one, then decide whether it has rendered:
+    // renders are enqueued in the BACKGROUND after a publish, so the unrendered window is real
+    // and gets its own test below.
+    const v = await addV(meta, artifact.id)
+    if (rendered)
+      await meta.setVersionPreview(artifact.id, v, {
+        preview_key: "blob-og",
+        preview_status: "ready",
+      })
     let fired: (v: unknown) => void = () => {}
     const called = new Promise((r) => {
       fired = r
@@ -1274,6 +1303,24 @@ describe("slack link unfurls", () => {
     const { entity } = await unfurlEntity("slack-unfurl-preview-none", "none")
     expect(JSON.stringify(entity)).not.toContain("full_size_preview")
     expect(JSON.stringify(entity)).not.toContain("Q4 roadmap")
+  })
+
+  it("waits for the render on a PUBLIC doc too — one rule, no mime lie", async () => {
+    // `chat.unfurl` accepts a preview_url without fetching it (verified against the API: ok:true,
+    // no warning), so a card that promises image/png and serves the SVG fallback fails silently.
+    // The same check therefore covers both visibilities rather than only the new one.
+    const { entity } = await unfurlEntity("slack-unfurl-preview-pub-pending", "public", false)
+    expect(JSON.stringify(entity)).not.toContain("full_size_preview")
+  })
+
+  it("waits for the render rather than showing a padlock as the picture", async () => {
+    // The window this closes: a link pasted moments after publishing. `/v1/og` answers an
+    // anonymous fetch for an unrendered workspace doc with the TITLE-LESS padlock, so offering
+    // the URL would put a padlock graphic on the card beside the title we are already showing —
+    // the exact outcome the block card avoided by carrying no image at all.
+    const { entity } = await unfurlEntity("slack-unfurl-preview-pending", "workspace", false)
+    expect(JSON.stringify(entity)).toContain("Q4 roadmap")
+    expect(JSON.stringify(entity)).not.toContain("full_size_preview")
   })
 
   it("needs no token for a world-readable doc — /v1/og already serves it", async () => {
@@ -2166,6 +2213,10 @@ describe("entity_details_requested (the flexpane)", () => {
       listed: (opts.listed ?? "workspace") as "workspace",
       kind: "file",
       spa: 0,
+    })
+    await meta.setVersionPreview(artifact.id, await addV(meta, artifact.id), {
+      preview_key: "blob-og",
+      preview_status: "ready",
     })
     return { app, meta, artifact }
   }


### PR DESCRIPTION
A Derive link pasted into Slack shows no picture unless the doc is world-readable. The reason
is in `lib/slack-unfurl.ts`, written when the block card was built:

> Slack fetches an unfurl's image ANONYMOUSLY, and `/v1/og/:ref` answers an anonymous fetch by
> the artifact's link role: a workspace-listed artifact with no world link — the common shape
> for internal docs — returns the title-less LOCKED card. So the image would be a padlock
> placeholder on precisely the cards people paste most, next to a title we are already showing.
> **Revisit if the OG endpoint ever accepts a signed, short-lived token an unfurl could carry.**

This is that.

## What the token buys

`lib/og-token.ts` mints one per unfurl. It buys exactly one thing: the rendered 1200×630 image
of **one artifact at one version number**.

| constraint | what it stops |
|---|---|
| its own capability domain, not `preview-token`'s | that one grants read of the **raw content** (it exists so the renderer can load a private page). This URL goes to Slack and is cached by its image proxy — a token leaking from an unfurl must not also unlock the document |
| bound to the `:ref` in the URL | a token minted for a doc you may read being spent on one you may not |
| pinned to the version | it retires itself on the next publish, so whatever leaks shows the doc as it **was** and goes stale by itself |
| never reaches `infoFor` | a holder getting a title, description or comment count — including when the render is missing, which is exactly where that would quietly widen into a metadata read |

Nothing about `/v1/og` loosens for anyone else. No token, no change.

## Expiry degrades, it doesn't break

A Slack message keeps its unfurl for ever and Slack re-fetches on its own schedule, so **any**
TTL eventually lands on a live message. The endpoint falls through to the same anonymous card
it has always served: never a 4xx, never a broken-image icon — just the behaviour that predates
this feature, later. That fallback is what makes 90 days affordable rather than necessary.

## Where the line is drawn

This is a product judgement, not a technical one, and it is the reviewable decision here:

- **`listed: "workspace"`** → preview. The workspace may see it, and a channel in that
  workspace's own Slack is substantially that audience.
- **`listed: "none"`** → stays a padlock. That is what somebody chose when they meant private.

Including in the **flexpane**, which is the one path where a private doc reaches the minter at
all (the unfurl never does — `decideUnfurl` answers `none` with the locked card first). That
panel is per-viewer, but the image URL is not: Slack fetches it anonymously and caches the
bytes. Being entitled to read something is not the same as consenting to a copy of it living in
another company's cache.

## Verification

`pnpm verify` green — 2044 API tests.

16 new tests, all asking the same question from different angles: *what else does holding this
URL get you?* Token accepted anonymously; absent token still locked; cross-artifact replay;
retirement on publish (**and** that a fresh token for the new version works, so the pin is a pin
and not a wall); expiry degrading; forged and wrong-secret tokens; cross-domain replay against
`preview-token` both ways; and no title leaking when the render is missing.

Each guard was verified load-bearing by deleting it and confirming the matching test fails.
**Two of them initially passed for the wrong reason** — the fallback artifact simply had no
render, so the guard was never what stopped the request. Both were rewritten to give the decoy
its own ready preview, so the guard is the only thing in the way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/628"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788361923&installation_model_id=428097&pr_number=628&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F628&signature=0cddfe9c9c05c1ec93959c8eb691c85b4f981c60ad616838197589b951512d70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


---

## Audit findings, fixed in the second commit

**The first commit offered a preview URL as soon as visibility allowed one, and never asked
whether an image existed behind it.** Renders are enqueued in the *background* after a publish,
so a link pasted moments later finds one pending — not an edge case, the common one for a fresh
doc. `/v1/og` answers meanwhile with an SVG: the doc's own card for a public artifact, the
**title-less padlock** for a workspace one.

So it shipped precisely the outcome the block card had avoided by carrying no image at all — a
padlock beside the title we were already showing — and in both cases a card declaring
`mime_type: "image/png"` while serving something else. The doc comment already claimed *"null
when ... no render yet"*; the code never checked. Now it does.

**One rule now, both visibilities:** a URL is offered only when a rendered PNG is behind it.
Public loses its exception, which is simpler *and* more correct — the declared mime type is now
always the one served. On a deployment with no renderer (`deps.renderPreviews` off) that means
no preview image at all, which is the honest outcome; title, description and fields stand alone.

### Verified against the live API, not assumed

`chat.unfurl` **accepts a `preview_url` without fetching it** — `ok: true`, no warning. Nothing
downstream would ever report a bad picture, which is why this had to be a check rather than a
hope.

The same probe confirmed `full_size_preview` is valid where this puts it. That result only means
something because of a control: a deliberately malformed payload (`format: "plain_text"`)
produced `error_processing_metadata` with a precise json-pointer, proving the endpoint does
validate and report. My first probe attempt used a fabricated message `ts` and returned
`cannot_find_message` for *every* payload including known-bad ones — schema validation
short-circuits behind the message lookup, so that round proved nothing and was redone against a
real message.

### Also fixed

Two test fixtures built artifacts with `meta.createArtifact` alone, which leaves
`current_version = 0` and **no version row** — a shape production never has, since publishing
makes v1. Anything reading a version off those artifacts was reading null.

`pnpm verify` green — 2046 API tests.
