### PR TITLE
feat(library): the collection picker suggests, sorts, and tells the truth

### DIFF
--- a/apps/api/src/lib/boot-shapes.ts
+++ b/apps/api/src/lib/boot-shapes.ts
@@ -266,34 +266,44 @@ export const collectionsJson = (
   }
   const roleFor = (col: CollectionRecord): Role | null =>
     operator ? "owner" : col.created_by === meId ? "owner" : (roleMap[col.id] ?? null)
-  return cols
-    .map((col) => ({ col, role: roleFor(col) }))
-    .filter(({ role }) => role !== null)
-    .map(({ col, role }) =>
-      enrich(
-        {
-          ...col,
-          my_role: role,
-          starred: starredIds.has(col.id),
-          active: workedIn.has(col.id),
-          my_last_activity: workedIn.get(col.id),
-          // Everything the Collections digest renders per cover: the caption (title),
-          // the window check (updated_at), and the recent-editor avatars (byline).
-          // Only the internal id stays server-side.
-          preview: (previews[col.id] ?? []).map((p) => ({
-            short_id: p.short_id,
-            title: p.title,
-            current_version: p.current_version,
-            has_preview: p.has_preview,
-            updated_at: p.updated_at,
-            author_name: healedName(p),
-            author_login: p.author_login,
-            author_avatar: p.author_avatar,
-          })),
-          last_activity: previews[col.id]?.[0]?.updated_at,
-        },
-        srcByCollection,
-        branchByRepo,
-      ),
-    )
+  return (
+    cols
+      .map((col) => ({ col, role: roleFor(col) }))
+      .filter(({ role }) => role !== null)
+      // Pin the wire order: the Postgres overview read is a bare UNION ALL (heap order,
+      // free to shift between requests), while the SQLite store lists newest-first. Sort
+      // here so every store serves the same contract and no client inherits plan order.
+      .sort(
+        (a, b) =>
+          new Date(b.col.created_at).getTime() - new Date(a.col.created_at).getTime() ||
+          a.col.id.localeCompare(b.col.id),
+      )
+      .map(({ col, role }) =>
+        enrich(
+          {
+            ...col,
+            my_role: role,
+            starred: starredIds.has(col.id),
+            active: workedIn.has(col.id),
+            my_last_activity: workedIn.get(col.id),
+            // Everything the Collections digest renders per cover: the caption (title),
+            // the window check (updated_at), and the recent-editor avatars (byline).
+            // Only the internal id stays server-side.
+            preview: (previews[col.id] ?? []).map((p) => ({
+              short_id: p.short_id,
+              title: p.title,
+              current_version: p.current_version,
+              has_preview: p.has_preview,
+              updated_at: p.updated_at,
+              author_name: healedName(p),
+              author_login: p.author_login,
+              author_avatar: p.author_avatar,
+            })),
+            last_activity: previews[col.id]?.[0]?.updated_at,
+          },
+          srcByCollection,
+          branchByRepo,
+        ),
+      )
+  )
 }

--- a/apps/api/test/collections-order.test.ts
+++ b/apps/api/test/collections-order.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+import { collectionsJson } from "../src/lib/boot-shapes"
+
+// The Postgres collections-overview read is a bare UNION ALL — heap order, free to
+// shift between requests — while the SQLite store lists newest-first. collectionsJson
+// is the one funnel both stores pass through, so the wire order is pinned there:
+// newest-first, id as the tiebreak. Every client sorts for display; this guarantees
+// they all start from the same deterministic list.
+
+const rec = (id: string, title: string, created_at: string) => ({
+  id,
+  org_id: "org1",
+  title,
+  created_by: "u1",
+  created_at,
+  workspace_access: "member" as const,
+  folder_id: null,
+  count: 0,
+})
+
+describe("collectionsJson", () => {
+  it("serves newest-first regardless of the store's row order", () => {
+    const scrambled = [
+      rec("col_b", "Middle", "2026-07-15T00:00:00.000Z"),
+      rec("col_a", "Oldest", "2026-07-01T00:00:00.000Z"),
+      rec("col_c", "Newest", "2026-08-01T00:00:00.000Z"),
+    ]
+    const out = collectionsJson(scrambled, [], {}, "u1", false)
+    expect(out.map((c) => c.title)).toEqual(["Newest", "Middle", "Oldest"])
+  })
+
+  it("breaks created_at ties by id, so equal timestamps can't flap between requests", () => {
+    const t = "2026-08-01T00:00:00.000Z"
+    const out = collectionsJson([rec("col_z", "Z", t), rec("col_a", "A", t)], [], {}, "u1", false)
+    expect(out.map((c) => c.id)).toEqual(["col_a", "col_z"])
+  })
+})

--- a/apps/web/src/components/shared/organize-dialogs.test.ts
+++ b/apps/web/src/components/shared/organize-dialogs.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest"
+import type { Collection } from "@/api"
+import { canAddTo, organizeList, pickableCollections, titleAffinity } from "./organize-dialogs"
+
+// The picker's ordering is the redesign: the old dialog served the list in raw API
+// order (heap order on Postgres — genuinely arbitrary), and "suggested then A–Z" is a
+// promise the UI can't keep unless it's pinned here as data, not eyeballed as JSX.
+
+let seq = 0
+const col = (over: Partial<Collection>): Collection =>
+  ({
+    id: `col_${seq++}`,
+    title: "Shelf",
+    count: 1,
+    my_role: "owner",
+    ...over,
+  }) as Collection
+
+const titles = (cols: Collection[]) => cols.map((c) => c.title)
+
+describe("pickableCollections", () => {
+  it("offers hand-made collections only — mirrors and Brandprint stay out", () => {
+    const manual = col({ title: "Launch assets" })
+    const untagged = col({ title: "Old row", kind: undefined }) // pre-kind payloads are manual
+    const repo = col({ title: "derive/derive", kind: "repo" })
+    const pr = col({ title: "PR 618 — library rail", kind: "pr" })
+    const brand = col({ title: "Brandprint docs" })
+    const out = pickableCollections([manual, untagged, repo, pr, brand], new Set([brand.id]))
+    expect(titles(out)).toEqual(["Launch assets", "Old row"])
+  })
+})
+
+describe("canAddTo", () => {
+  it("mirrors the add route's demand: publish on the collection (editor or better)", () => {
+    expect(canAddTo(col({ my_role: "owner" }))).toBe(true)
+    expect(canAddTo(col({ my_role: "editor" }))).toBe(true)
+    expect(canAddTo(col({ my_role: "commenter" }))).toBe(false)
+    expect(canAddTo(col({ my_role: "viewer" }))).toBe(false)
+    expect(canAddTo(col({ my_role: null }))).toBe(false)
+  })
+})
+
+describe("organizeList — browse (no query)", () => {
+  it("a short list is just A–Z, case-insensitive — no section chrome", () => {
+    const cols = [
+      col({ title: "screenshots", my_last_activity: "2026-08-01T00:00:00Z" }),
+      col({ title: "Brand" }),
+      col({ title: "Pricing" }),
+    ]
+    const out = organizeList(cols, "")
+    expect(out.mode).toBe("browse")
+    if (out.mode !== "browse") return
+    expect(out.suggested).toEqual([])
+    expect(titles(out.rest)).toEqual(["Brand", "Pricing", "screenshots"])
+  })
+
+  it("your latest desks lead the suggestions, newest touch first", () => {
+    const cols = [
+      col({ title: "Alpha" }),
+      col({ title: "Beta", my_last_activity: "2026-08-01T00:00:00Z" }),
+      col({ title: "Gamma", my_last_activity: "2026-08-02T00:00:00Z" }),
+      col({ title: "Delta" }),
+      col({ title: "Epsilon" }),
+      col({ title: "Zeta" }),
+    ]
+    const out = organizeList(cols, "")
+    if (out.mode !== "browse") throw new Error("expected browse")
+    expect(out.suggested.map((s) => s.col.title)).toEqual(["Gamma", "Beta"])
+    expect(out.suggested.map((s) => s.reason)).toEqual(["recent", "recent"])
+    // Suggested rows don't repeat in the index below.
+    expect(titles(out.rest)).toEqual(["Alpha", "Delta", "Epsilon", "Zeta"])
+  })
+
+  it("title kinship fills the remaining slots, and never duplicates a recent pick", () => {
+    const cols = [
+      col({ title: "Pricing work", my_last_activity: "2026-08-02T00:00:00Z" }),
+      col({ title: "Pricing archive" }),
+      col({ title: "Brand" }),
+      col({ title: "Research" }),
+      col({ title: "Inbox" }),
+      col({ title: "Misc" }),
+    ]
+    const out = organizeList(cols, "", "Q3 pricing page")
+    if (out.mode !== "browse") throw new Error("expected browse")
+    expect(out.suggested.map((s) => [s.col.title, s.reason])).toEqual([
+      ["Pricing work", "recent"],
+      ["Pricing archive", "similar"],
+    ])
+  })
+
+  it("never suggests a collection the caller can't add to", () => {
+    const cols = [
+      col({ title: "Team wiki", my_role: "viewer", my_last_activity: "2026-08-02T00:00:00Z" }),
+      col({ title: "Mine", my_last_activity: "2026-08-01T00:00:00Z" }),
+      col({ title: "A" }),
+      col({ title: "B" }),
+      col({ title: "C" }),
+      col({ title: "D" }),
+    ]
+    const out = organizeList(cols, "")
+    if (out.mode !== "browse") throw new Error("expected browse")
+    expect(out.suggested.map((s) => s.col.title)).toEqual(["Mine"])
+    // Still reachable — just not promoted.
+    expect(titles(out.rest)).toContain("Team wiki")
+  })
+})
+
+describe("organizeList — filter (typed query)", () => {
+  const cols = [
+    col({ title: "Brand kit" }),
+    col({ title: "Rebrand 2026" }),
+    col({ title: "Launch brand assets" }),
+    col({ title: "Pricing" }),
+  ]
+
+  it("ranks title-prefix over word-prefix over substring, then A–Z", () => {
+    const out = organizeList(cols, "bran")
+    if (out.mode !== "filter") throw new Error("expected filter")
+    expect(titles(out.matches)).toEqual(["Brand kit", "Launch brand assets", "Rebrand 2026"])
+  })
+
+  it("offers to create the draft unless a collection already has exactly that name", () => {
+    const fresh = organizeList(cols, "  brand book ")
+    if (fresh.mode !== "filter") throw new Error("expected filter")
+    expect(fresh.create).toBe("brand book")
+
+    const taken = organizeList(cols, "brand KIT")
+    if (taken.mode !== "filter") throw new Error("expected filter")
+    expect(taken.create).toBeNull()
+  })
+
+  it("no match still offers create — the empty state is an invitation, not a wall", () => {
+    const out = organizeList(cols, "zzz")
+    if (out.mode !== "filter") throw new Error("expected filter")
+    expect(out.matches).toEqual([])
+    expect(out.create).toBe("zzz")
+  })
+})
+
+describe("titleAffinity", () => {
+  it("counts meaningful shared words — case, plurals, and connectives don't", () => {
+    expect(titleAffinity("Q3 pricing page", "Pricing work")).toBe(1)
+    expect(titleAffinity("Screenshots of the launch", "launch screenshot")).toBe(2)
+    expect(titleAffinity("The plan for launch", "Plan of the launch")).toBe(2)
+    expect(titleAffinity("Brand", "Pricing")).toBe(0)
+    // Stopwords and short tokens alone never bind two titles together.
+    expect(titleAffinity("The A to Z", "The Z of A")).toBe(0)
+  })
+})

--- a/apps/web/src/components/shared/organize-dialogs.tsx
+++ b/apps/web/src/components/shared/organize-dialogs.tsx
@@ -1,16 +1,20 @@
-import { useEffect, useState } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { type KeyboardEvent, type ReactNode, useEffect, useRef, useState } from "react"
 import { api, type Collection } from "@/api"
 import { Icon } from "@/components/icons"
+import { StatusPanel } from "@/components/shared/status-panel"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
   DialogContent,
   DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
-import { artifactQuery } from "@/lib/queries"
+import { artifactQuery, collectionsQuery } from "@/lib/queries"
+import { ago } from "@/lib/time"
 import { useApiMutation } from "@/lib/use-api-mutation"
 import { useBrandprintCollectionIds } from "@/lib/use-brandprint-ids"
 import { cn } from "@/lib/utils"
@@ -20,38 +24,245 @@ import { cn } from "@/lib/utils"
 // collections, or create one on the fly. Adding to a shared collection grants its members
 // their role on this artifact too. Owns its API calls and reports the new state through
 // `onChange`; the caller keeps the cache writes.
+//
+// The list is a picker, so it answers "where do I file this" rather than inventorying:
+// a couple of suggestions (your recent desks, then title kinship) above an alphabetical
+// index, one filter-or-create input above both. Membership lives in the row's trailing
+// checkbox — bg-accent stays the pointer/keyboard wash, never a second meaning.
+
+/** Collections an organize dialog offers at all: hand-made ones. Repo mirrors and PR
+ *  previews fill themselves from GitHub, and Brandprint-pointed collections are managed
+ *  on /brandprint — offering any of them here is a row you shouldn't press. */
+export function pickableCollections(
+  all: Collection[],
+  excludeIds: ReadonlySet<string>,
+): Collection[] {
+  return all.filter((col) => (col.kind ?? "manual") === "manual" && !excludeIds.has(col.id))
+}
+
+/** Whether the caller can file an artifact into this collection. The add route demands
+ *  `publish` on the collection, so a viewer/commenter row renders inert instead of
+ *  optimistically checking and bouncing back as an error toast. */
+export const canAddTo = (col: Collection): boolean =>
+  col.my_role === "editor" || col.my_role === "owner"
+
+const byTitle = (a: Collection, b: Collection) =>
+  a.title.localeCompare(b.title, undefined, { sensitivity: "base" })
+
+// Title kinship, for the "similar" suggestion tier: meaningful words two titles share.
+// Lowercased, split on non-word runs, articles/connectives dropped, a trailing plural-s
+// stripped so "screenshots" meets "screenshot". Deliberately dumb — it only has to rank
+// a workspace's handful of collections, not search a corpus.
+const STOPWORDS = new Set([
+  "the",
+  "a",
+  "an",
+  "and",
+  "or",
+  "of",
+  "for",
+  "to",
+  "in",
+  "on",
+  "with",
+  "from",
+])
+const titleTokens = (s: string): Set<string> => {
+  const out = new Set<string>()
+  for (const raw of s.toLowerCase().split(/[^\p{L}\p{N}]+/u)) {
+    const t = raw.length > 3 && raw.endsWith("s") ? raw.slice(0, -1) : raw
+    if (t.length >= 3 && !STOPWORDS.has(t)) out.add(t)
+  }
+  return out
+}
+export const titleAffinity = (a: string, b: string): number => {
+  const ta = titleTokens(a)
+  let n = 0
+  for (const t of titleTokens(b)) if (ta.has(t)) n++
+  return n
+}
+
+export type SuggestReason = "recent" | "similar"
+export type OrganizeList =
+  /** No query: a short Suggested tier above the full alphabetical index (deduped). */
+  | { mode: "browse"; suggested: { col: Collection; reason: SuggestReason }[]; rest: Collection[] }
+  /** A query: matches ranked prefix → word-prefix → substring, then A–Z; `create`
+   *  carries the draft title unless a collection already has exactly that name. */
+  | { mode: "filter"; matches: Collection[]; create: string | null }
+
+const SUGGESTED_MAX = 3
+/** Below this many collections the whole list fits in one glance — section labels
+ *  would be chrome, not help. */
+const SUGGESTED_MIN_LIST = 6
+
+/**
+ * The picker's whole ordering policy, pure so tests pin it (the Collections page's
+ * digest earned the same treatment — see digestFor).
+ *
+ * Suggested = the collections YOU touched most recently (filing runs in batches, so
+ * your last desk is the best guess), then title kinship with the artifact being filed.
+ * Only collections the caller can add to are suggested; the rest stay reachable in the
+ * alphabetical index below.
+ */
+export function organizeList(
+  pickable: Collection[],
+  query: string,
+  artifactTitle?: string,
+): OrganizeList {
+  const q = query.trim().toLowerCase()
+  if (q) {
+    const rank = (col: Collection): number => {
+      const t = col.title.toLowerCase()
+      if (t.startsWith(q)) return 0
+      if (t.split(/\s+/).some((w) => w.startsWith(q))) return 1
+      return t.includes(q) ? 2 : 3
+    }
+    const matches = pickable
+      .map((col) => ({ col, rank: rank(col) }))
+      .filter((r) => r.rank < 3)
+      .sort((a, b) => a.rank - b.rank || byTitle(a.col, b.col))
+      .map((r) => r.col)
+    const exact = pickable.some((col) => col.title.trim().toLowerCase() === q)
+    return { mode: "filter", matches, create: exact ? null : query.trim() }
+  }
+
+  const rest = [...pickable].sort(byTitle)
+  if (pickable.length < SUGGESTED_MIN_LIST) return { mode: "browse", suggested: [], rest }
+
+  const suggested: { col: Collection; reason: SuggestReason }[] = []
+  const addable = pickable.filter(canAddTo)
+  const recent = addable
+    .filter((col) => col.my_last_activity)
+    .sort((a, b) => (b.my_last_activity ?? "").localeCompare(a.my_last_activity ?? ""))
+  for (const col of recent.slice(0, 2)) suggested.push({ col, reason: "recent" })
+  if (artifactTitle) {
+    const kin = addable
+      .filter((col) => !suggested.some((s) => s.col.id === col.id))
+      .map((col) => ({ col, score: titleAffinity(artifactTitle, col.title) }))
+      .filter((s) => s.score > 0)
+      .sort((a, b) => b.score - a.score || byTitle(a.col, b.col))
+    for (const { col } of kin.slice(0, SUGGESTED_MAX - suggested.length))
+      suggested.push({ col, reason: "similar" })
+  }
+  const picked = new Set(suggested.map((s) => s.col.id))
+  return { mode: "browse", suggested, rest: rest.filter((col) => !picked.has(col.id)) }
+}
+
+// The menu-row grammar (the dropdown item recipe): rounded-lg, bg-accent as the
+// pointer/keyboard wash only — membership renders in the checkbox, never as a wash.
+const ROW_CLASS =
+  "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm font-medium text-foreground outline-none hover:bg-accent focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-60"
+
+/** One picker row — also the bulk dialog's row, so the grammar can't drift. */
+export function CollectionToggleRow({
+  col,
+  checked,
+  disabled,
+  highlighted,
+  hint,
+  onSelect,
+  onHover,
+  testId,
+  rowIndex,
+}: {
+  col: Collection
+  checked: boolean
+  disabled?: boolean
+  highlighted?: boolean
+  /** Small trailing note: a suggestion's reason, or "view only" on an inert row. */
+  hint?: string
+  onSelect: () => void
+  onHover?: () => void
+  testId: string
+  rowIndex?: number
+}) {
+  return (
+    <button
+      type="button"
+      data-testid={testId}
+      data-idx={rowIndex}
+      aria-pressed={checked}
+      disabled={disabled}
+      onClick={onSelect}
+      onMouseMove={onHover}
+      className={cn(ROW_CLASS, highlighted && "bg-accent")}
+    >
+      <Icon name="collection" size={16} className="shrink-0 text-muted-foreground" />
+      <span className={cn("min-w-0 flex-1 truncate", checked && "font-semibold")}>{col.title}</span>
+      {hint && <span className="shrink-0 text-2xs text-muted-foreground">{hint}</span>}
+      <span className="shrink-0 font-mono text-2xs tabular-nums text-muted-foreground">
+        {col.count}
+      </span>
+      <span
+        aria-hidden
+        className={cn(
+          "grid size-4 shrink-0 place-items-center rounded border",
+          checked ? "border-foreground bg-foreground text-background" : "border-input",
+        )}
+      >
+        {checked && <Icon name="check" size={12} />}
+      </span>
+    </button>
+  )
+}
+
+function SectionLabel({ children }: { children: string }) {
+  return (
+    <div className="px-2 pt-2.5 pb-1 font-medium text-2xs tracking-wide text-muted-foreground uppercase first:pt-0.5">
+      {children}
+    </div>
+  )
+}
+
 export function CollectionsDialog({
   shortId,
+  artifactTitle,
   inCollections,
   onChange,
   open,
   onOpenChange,
 }: {
   shortId: string
+  /** Feeds the "similar title" suggestion tier; the picker works without it. */
+  artifactTitle?: string
   inCollections: string[]
   onChange: (ids: string[]) => void
   open: boolean
   onOpenChange: (o: boolean) => void
 }) {
-  const [all, setAll] = useState<Collection[]>([])
-  const [draft, setDraft] = useState("")
+  const {
+    data: all = [],
+    isPending,
+    isError,
+    refetch,
+  } = useQuery({ ...collectionsQuery(), enabled: open })
+  const [query, setQuery] = useState("")
+  // Keyboard position among the actionable rows (null = nowhere: a bare Enter must not
+  // toggle a collection the user never aimed at). Typing aims at the first match.
+  const [cursor, setCursor] = useState<number | null>(null)
+  const listRef = useRef<HTMLDivElement>(null)
+  // The workbench keeps this dialog mounted; a reopen must not inherit last time's
+  // filter. Reset on close so the exit animation carries the old list out.
   useEffect(() => {
-    if (open)
-      api
-        .listCollections()
-        .then((r) => setAll(r.collections))
-        .catch(() => {})
+    if (!open) {
+      setQuery("")
+      setCursor(null)
+    }
   }, [open])
+
   // Brandprint-pointed collections take docs through Settings → Brandprint only, not from
   // an artifact's organize menu.
   const brandprintIds = useBrandprintCollectionIds()
-  const pickable = all.filter((col) => !brandprintIds.has(col.id))
+  const pickable = pickableCollections(all, brandprintIds)
+  const list = organizeList(pickable, query, artifactTitle)
   const inSet = new Set(inCollections)
+
   // Toggle membership optimistically (via onChange); the primitive rolls it back and
   // toasts if the write fails. The settle-time invalidation reconciles the artifact
   // detail (`collections` AND the server-computed `collection_access` disclosure rows)
   // against the server once the write lands — never during the optimistic phase, where
-  // a refetch would race the in-flight PUT and repaint pre-mutation state.
+  // a refetch would race the in-flight PUT and repaint pre-mutation state. The
+  // collections list rides along so the rows' item counts stay honest.
   const toggleCol = useApiMutation({
     mutationFn: ({ col, isIn }: { col: Collection; isIn: boolean }) =>
       isIn ? api.removeFromCollection(col.id, shortId) : api.addToCollection(col.id, shortId),
@@ -60,7 +271,7 @@ export function CollectionsDialog({
       onChange(isIn ? inCollections.filter((id) => id !== col.id) : [...inCollections, col.id])
       return () => onChange(prev)
     },
-    invalidate: [artifactQuery(shortId).queryKey],
+    invalidate: [artifactQuery(shortId).queryKey, collectionsQuery().queryKey],
   })
   const toggle = (col: Collection) => toggleCol.mutate({ col, isIn: inSet.has(col.id) })
   // Create a collection and drop this artifact into it in one gesture.
@@ -71,16 +282,107 @@ export function CollectionsDialog({
       return col
     },
     onSuccess: (col) => {
-      setAll((a) => [col, ...a])
       onChange([...inCollections, col.id])
+      setQuery("")
+      setCursor(null)
     },
-    invalidate: [artifactQuery(shortId).queryKey],
+    invalidate: [artifactQuery(shortId).queryKey, collectionsQuery().queryKey],
   })
   const create = () => {
-    const t = draft.trim()
-    setDraft("")
-    if (t) createCol.mutate(t)
+    if (list.mode === "filter" && list.create && !createCol.isPending) createCol.mutate(list.create)
   }
+
+  // The rows in visual order, with what Enter on each would do — the keyboard walks
+  // exactly what the eye sees, skipping inert (view-only) rows.
+  const actions: (() => void)[] = []
+  const register = (run: () => void): number => actions.push(run) - 1
+  const rowFor = (col: Collection, reason?: SuggestReason) => {
+    const addable = canAddTo(col)
+    const idx = addable ? register(() => toggle(col)) : -1
+    return (
+      <CollectionToggleRow
+        key={col.id}
+        col={col}
+        checked={inSet.has(col.id)}
+        disabled={!addable}
+        highlighted={idx !== -1 && idx === cursor}
+        hint={
+          !addable
+            ? "view only"
+            : reason === "recent" && col.my_last_activity
+              ? ago(col.my_last_activity)
+              : reason === "similar"
+                ? "similar title"
+                : undefined
+        }
+        onSelect={() => toggle(col)}
+        onHover={() => setCursor(idx)}
+        testId={`collections-menu-${col.id}`}
+        rowIndex={idx === -1 ? undefined : idx}
+      />
+    )
+  }
+  const body: ReactNode[] = []
+  if (list.mode === "browse") {
+    if (list.suggested.length > 0) {
+      body.push(<SectionLabel key="l-suggested">Suggested</SectionLabel>)
+      body.push(...list.suggested.map(({ col, reason }) => rowFor(col, reason)))
+      body.push(<SectionLabel key="l-all">All collections</SectionLabel>)
+    }
+    body.push(...list.rest.map((col) => rowFor(col)))
+  } else {
+    body.push(...list.matches.map((col) => rowFor(col)))
+    if (list.create) {
+      const idx = register(create)
+      body.push(
+        <button
+          key="create"
+          type="button"
+          data-testid="collections-create"
+          data-idx={idx}
+          disabled={createCol.isPending}
+          onClick={create}
+          onMouseMove={() => setCursor(idx)}
+          className={cn(ROW_CLASS, idx === cursor && "bg-accent")}
+        >
+          <Icon name="plus" size={16} className="shrink-0 text-muted-foreground" />
+          <span className="min-w-0 flex-1 truncate">Create “{list.create}”</span>
+        </button>,
+      )
+    }
+  }
+
+  const move = (delta: number) => {
+    if (actions.length === 0) return
+    const next =
+      cursor === null
+        ? delta > 0
+          ? 0
+          : actions.length - 1
+        : Math.min(actions.length - 1, Math.max(0, cursor + delta))
+    setCursor(next)
+    requestAnimationFrame(() =>
+      listRef.current?.querySelector(`[data-idx="${next}"]`)?.scrollIntoView({ block: "nearest" }),
+    )
+  }
+  const onInputKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+      e.preventDefault()
+      move(e.key === "ArrowDown" ? 1 : -1)
+    } else if (e.key === "Enter") {
+      e.preventDefault()
+      // A bare Enter acts only where the user has aimed: the cursor row, or — while
+      // filtering — the first match (the combobox default).
+      const at = cursor ?? (query.trim() ? 0 : null)
+      if (at !== null) actions[at]?.()
+    }
+  }
+
+  const membership =
+    inCollections.length === 0
+      ? "Not in any collection"
+      : `In ${inCollections.length} ${inCollections.length === 1 ? "collection" : "collections"}`
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
@@ -91,54 +393,58 @@ export function CollectionsDialog({
             members.
           </DialogDescription>
         </DialogHeader>
-        {pickable.length === 0 && (
-          <div className="text-sm text-muted-foreground">
-            No collections yet — create one below.
-          </div>
-        )}
-        {pickable.length > 0 && (
-          <div className="flex max-h-64 flex-col gap-px overflow-auto">
-            {pickable.map((col) => (
-              <button
-                key={col.id}
-                type="button"
-                data-testid={`collections-menu-${col.id}`}
-                onClick={() => toggle(col)}
-                className={cn(
-                  // Menu-row grammar (the dropdown item recipe): rounded-lg,
-                  // neutral bg-accent hover — never a second wash token.
-                  "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm font-medium text-foreground outline-none hover:bg-accent focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-ring",
-                  inSet.has(col.id) && "bg-accent",
-                )}
+        <Input
+          autoFocus
+          value={query}
+          placeholder="Filter or create…"
+          aria-label="Filter collections, or type a new name"
+          data-testid="collections-filter"
+          onChange={(e) => {
+            setQuery(e.target.value)
+            setCursor(e.target.value.trim() ? 0 : null)
+          }}
+          onKeyDown={onInputKeyDown}
+        />
+        {/* A failed load is NOT "no collections yet" — saying so would invite you to
+            create a duplicate of one you already have. */}
+        {isError && (
+          <StatusPanel
+            tone="danger"
+            title="Couldn’t load your collections"
+            description="This is usually temporary."
+            action={
+              <Button
+                variant="outline"
+                size="sm"
+                data-testid="collections-retry"
+                onClick={() => refetch()}
               >
-                <span className="grid w-3.5 shrink-0 place-items-center">
-                  {inSet.has(col.id) && <Icon name="check" size={16} />}
-                </span>
-                <span className="flex-1 truncate">{col.title}</span>
-              </button>
-            ))}
+                Try again
+              </Button>
+            }
+          />
+        )}
+        {!isError && isPending && (
+          <div className="text-sm text-muted-foreground">Loading collections…</div>
+        )}
+        {!isError && !isPending && body.length === 0 && (
+          <div className="text-sm text-muted-foreground">
+            {query.trim()
+              ? "No collection matches."
+              : "No collections yet — type a name above to create one."}
           </div>
         )}
-        <div className="flex gap-1.5">
-          <Input
-            value={draft}
-            placeholder="New collection…"
-            data-testid="collection-new-input"
-            onChange={(e) => setDraft(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") create()
-            }}
-          />
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={create}
-            disabled={!draft.trim()}
-            data-testid="collection-add"
-          >
-            Add
+        {body.length > 0 && (
+          <div ref={listRef} className="flex max-h-64 flex-col gap-px overflow-auto">
+            {body}
+          </div>
+        )}
+        <DialogFooter className="items-center">
+          <span className="mr-auto text-xs text-muted-foreground">{membership}</span>
+          <Button size="sm" data-testid="collections-done" onClick={() => onOpenChange(false)}>
+            Done
           </Button>
-        </div>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   )

--- a/apps/web/src/pages/artifact/artifact-top-bar.tsx
+++ b/apps/web/src/pages/artifact/artifact-top-bar.tsx
@@ -32,6 +32,8 @@ import { ShareButton } from "./share-dialog"
  */
 export function ArtifactTopBar(props: {
   shortId: string
+  /** Feeds the collections picker's "similar title" suggestions. */
+  artifactTitle?: string
   /** The artifact's current workspace — threaded to the move dialog so it can
    *  exclude the current workspace from the destination picker. */
   orgId?: string
@@ -254,6 +256,7 @@ export function ArtifactTopBar(props: {
       {/* Portaled dialogs — invisible until opened from the ⋯ menu. */}
       <CollectionsDialog
         shortId={shortId}
+        artifactTitle={props.artifactTitle}
         inCollections={props.collections}
         onChange={props.onCollections}
         open={collectionsOpen}

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -868,6 +868,7 @@ export function Artifact() {
           {!isAnon && (
             <ArtifactTopBar
               shortId={shortId}
+              artifactTitle={art.title ?? undefined}
               orgId={art.org_id}
               myRole={art.my_role}
               workspaceAccess={art.workspace_access}

--- a/apps/web/src/pages/library/bulk-organize.tsx
+++ b/apps/web/src/pages/library/bulk-organize.tsx
@@ -3,6 +3,11 @@ import { useQuery } from "@tanstack/react-query"
 import { useState } from "react"
 import { type Artifact, api, type Folder } from "@/api"
 import { Icon } from "@/components/icons"
+import {
+  CollectionToggleRow,
+  canAddTo,
+  pickableCollections,
+} from "@/components/shared/organize-dialogs"
 import { StatusPanel } from "@/components/shared/status-panel"
 import { Button } from "@/components/ui/button"
 import {
@@ -153,10 +158,12 @@ export function BulkCollectionsDialog({
   const { data: all = [], isError, refetch } = useQuery({ ...collectionsQuery(), enabled: open })
   const [draft, setDraft] = useState("")
   const [picked, setPicked] = useState<string[]>([])
-  // Brandprint-pointed collections take docs through /brandprint only — same exclusion
-  // the single-artifact dialog makes.
+  // Same offer policy as the single-artifact dialog (manual collections only, Brandprint
+  // excluded), alphabetized — this list has no suggestion tier, so A–Z is the whole order.
   const brandprintIds = useBrandprintCollectionIds()
-  const pickable = all.filter((col) => !brandprintIds.has(col.id))
+  const pickable = pickableCollections(all, brandprintIds).sort((a, b) =>
+    a.title.localeCompare(b.title, undefined, { sensitivity: "base" }),
+  )
 
   const apply = useApiMutation({
     // One call: the server folds the whole selection into every picked collection,
@@ -226,27 +233,19 @@ export function BulkCollectionsDialog({
         {pickable.length > 0 && (
           <div className="flex max-h-64 flex-col gap-px overflow-auto">
             {pickable.map((col) => (
-              <button
+              <CollectionToggleRow
                 key={col.id}
-                type="button"
-                data-testid={`bulk-collection-${col.id}`}
-                aria-pressed={picked.includes(col.id)}
-                onClick={() =>
+                col={col}
+                checked={picked.includes(col.id)}
+                disabled={!canAddTo(col)}
+                hint={!canAddTo(col) ? "view only" : undefined}
+                onSelect={() =>
                   setPicked((prev) =>
                     prev.includes(col.id) ? prev.filter((id) => id !== col.id) : [...prev, col.id],
                   )
                 }
-                className={cn(
-                  // The menu-row recipe, shared with the single-artifact dialog.
-                  "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm font-medium text-foreground outline-none hover:bg-accent focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-ring",
-                  picked.includes(col.id) && "bg-accent",
-                )}
-              >
-                <span className="grid w-3.5 shrink-0 place-items-center">
-                  {picked.includes(col.id) && <Icon name="check" size={16} />}
-                </span>
-                <span className="flex-1 truncate">{col.title}</span>
-              </button>
+                testId={`bulk-collection-${col.id}`}
+              />
             ))}
           </div>
         )}

--- a/apps/web/src/pages/library/quick-organize.tsx
+++ b/apps/web/src/pages/library/quick-organize.tsx
@@ -41,6 +41,7 @@ export function LibraryCollectionsDialog({
   return (
     <CollectionsDialog
       shortId={artifact.short_id}
+      artifactTitle={artifact.title ?? undefined}
       inCollections={ids ?? data?.collections ?? []}
       onChange={(next) => {
         setIds(next)


### PR DESCRIPTION
## Why

The add-to-collection dialog served its list in raw API order — on Postgres the overview read is a bare `UNION ALL`, so the order was genuinely arbitrary and could shift between opens — with membership painted in the same `bg-accent` wash as hover, no filtering, rows that carried nothing but a title, and a failed fetch rendering as "No collections yet — create one below."

## What changed

**The picker** (`CollectionsDialog`):
- One **filter-or-create input** replaces the separate input + "Add" bar: typing filters (ranked title-prefix → word-prefix → substring, then A–Z), and a name no collection has offers *Create "…"* in place — creating still files the artifact in one gesture.
- A **Suggested tier** above the full A–Z index: the collections you touched most recently, then title kinship with the artifact being filed. Both signals already ride the `/v1/collections` payload — no new endpoint. The tier only appears once the list is long enough to need it.
- **Membership is the row's trailing checkbox** (plus `aria-pressed`); `bg-accent` now means exactly one thing — pointer/keyboard position. Rows carry the collection glyph and item count.
- **View-only rows render inert** with a "view only" hint instead of optimistically checking and bouncing back as an error toast (the add route requires `publish` on the collection).
- **Repo/PR mirror collections stay out** — they fill themselves from GitHub; hand-filing into them was never meaningful.
- **Keyboard**: ↓/↑ walk the rows, Enter toggles (or creates); a bare Enter with no aim does nothing.
- **Honest states**: the dialog joins the `collectionsQuery` cache instead of a raw fetch-per-open, so it has a real loading state and a real error panel with retry — an error no longer masquerades as an empty library. Footer states the result ("In 2 collections") with a Done button.

**Shared grammar**: `BulkCollectionsDialog` reuses the same row component and offer policy (manual collections only, alphabetized, view-only inert), so the two dialogs can't drift.

**Server**: `collectionsJson` now pins the wire order newest-first (created_at desc, id tiebreak). The Postgres overview read has no `ORDER BY`; this is the one funnel both stores pass through, so no client inherits heap order again.

## Tests

- `organize-dialogs.test.ts` — the ordering policy is a pure function (`organizeList`, `pickableCollections`, `canAddTo`, `titleAffinity`) pinned by 10 tests, same treatment as the Collections page's `digestFor`.
- `collections-order.test.ts` — `collectionsJson` serves newest-first regardless of store row order, ties broken by id.
- Existing e2e (`library-multi-select`) keeps its testids and passes unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/631"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788372250&installation_model_id=428097&pr_number=631&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F631&signature=c41b3bb2244267e7660dad2a0bbba620dbfe73b31f1b5d88efa2df8fc4729230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->