### PR TITLE
feat(library): the picker's Suggested tier learns from the dense index

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1523,6 +1523,23 @@
           "count"
         ]
       },
+      "CollectionSuggestion": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The suggested collection's id."
+          },
+          "score": {
+            "type": "number",
+            "description": "Summed neighbor-similarity votes — an ordering signal, not a probability."
+          }
+        },
+        "required": [
+          "id",
+          "score"
+        ]
+      },
       "Folder": {
         "type": "object",
         "properties": {
@@ -5613,6 +5630,47 @@
         "responses": {
           "204": {
             "description": "The artifact was removed."
+          }
+        }
+      }
+    },
+    "/v1/artifacts/{shortId}/collection-suggestions": {
+      "get": {
+        "tags": [
+          "Collections"
+        ],
+        "summary": "Collections where work similar to this artifact already lives (members only).",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "shortId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Suggested collections, best first. Empty whenever there's no signal.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "suggestions": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/CollectionSuggestion"
+                      }
+                    }
+                  },
+                  "required": [
+                    "suggestions"
+                  ]
+                }
+              }
+            }
           }
         }
       }

--- a/apps/api/src/lib/collection-suggest.ts
+++ b/apps/api/src/lib/collection-suggest.ts
@@ -1,0 +1,23 @@
+// Neighbor voting for the collection picker's semantic "Suggested" tier: the artifacts
+// most similar to the one being filed each vote — at their similarity score — for every
+// collection they already live in, and the heaviest collections win. Members vote, not
+// collection titles, so it works when the collections are named "Misc" and "Inbox".
+// Pure; the route owns the reads and every access gate.
+
+/** Rank collections by the summed similarity of the (already visibility-gated)
+ *  neighbors filed in them. Ties break by id so equal-scoring collections can't flap
+ *  between requests. */
+export const voteCollections = (
+  neighbors: { id: string; score: number }[],
+  collectionsByArtifact: Record<string, string[]>,
+  cap: number,
+): { id: string; score: number }[] => {
+  const votes = new Map<string, number>()
+  for (const n of neighbors)
+    for (const colId of collectionsByArtifact[n.id] ?? [])
+      votes.set(colId, (votes.get(colId) ?? 0) + n.score)
+  return [...votes]
+    .map(([id, score]) => ({ id, score }))
+    .sort((a, b) => b.score - a.score || a.id.localeCompare(b.id))
+    .slice(0, Math.max(cap, 0))
+}

--- a/apps/api/src/lib/collection-suggest.ts
+++ b/apps/api/src/lib/collection-suggest.ts
@@ -4,8 +4,9 @@
 // collection titles, so it works when the collections are named "Misc" and "Inbox".
 // Pure; the route owns the reads and every access gate.
 
-/** Rank collections by the summed similarity of the (already visibility-gated)
- *  neighbors filed in them. Ties break by id so equal-scoring collections can't flap
+/** Rank collections by the summed similarity of the neighbors filed in them. Callers
+ *  drop dead neighbors before voting and access-gate the RESULT per collection — this
+ *  sees only ids and scores. Ties break by id so equal-scoring collections can't flap
  *  between requests. */
 export const voteCollections = (
   neighbors: { id: string; score: number }[],

--- a/apps/api/src/routes/collections.ts
+++ b/apps/api/src/routes/collections.ts
@@ -19,8 +19,10 @@ import {
   sourceMaps,
 } from "../lib/boot-shapes"
 import { BULK_MAX, BulkSummarySchema, bulkArtifactOp } from "../lib/bulk"
+import { voteCollections } from "../lib/collection-suggest"
 import { bail, fail, readJson } from "../lib/http"
 import { resolveUserRef } from "../lib/resolve-user"
+import { log } from "../log"
 import { ArtifactMember } from "../schemas"
 
 /** Collections: shareable groups of artifacts. A member's role on a collection
@@ -28,6 +30,23 @@ import { ArtifactMember } from "../schemas"
  *  Collection response schema is the single source for the web client's type
  *  (generated from the OpenAPI spec). Member endpoints return the shared ArtifactMember
  *  shape (see ../schemas). */
+
+// The suggestions read's shape: a dozen neighbors is plenty of voting signal at
+// interactive latency; six candidates absorb role-gate drops while still resolving in a
+// handful of reads; three suggestions is all the picker shows.
+const SUGGEST_NEIGHBORS = 12
+const SUGGEST_CANDIDATES = 6
+const SUGGEST_CAP = 3
+
+const CollectionSuggestion = z
+  .object({
+    id: z.string().describe("The suggested collection's id."),
+    score: z
+      .number()
+      .describe("Summed neighbor-similarity votes — an ordering signal, not a probability."),
+  })
+  .openapi("CollectionSuggestion")
+
 export const collectionRoutes = (ctx: AppContext) => {
   const {
     meta,
@@ -352,6 +371,88 @@ export const collectionRoutes = (ctx: AppContext) => {
       if (!art || art.org_id !== col.org_id) return bail(fail(c, 404, "artifact not found"))
       await meta.removeCollectionItem(col.id, art.id)
       return c.body(null, 204)
+    },
+  )
+
+  // Where does work like this get filed? The picker's semantic "Suggested" tier: the
+  // artifact's nearest neighbors (by the dense index's stored vectors — no embed call
+  // at request time) each vote for the collections they already live in. Best-effort by
+  // design: no dense arm, no vector yet, or a dense hiccup all answer [] and the picker
+  // falls back to its client-side heuristics.
+  app.openapi(
+    createRoute({
+      method: "get",
+      path: "/v1/artifacts/{shortId}/collection-suggestions",
+      tags: ["Collections"],
+      summary: "Collections where work similar to this artifact already lives (members only).",
+      request: { params: z.object({ shortId: z.string() }) },
+      responses: {
+        200: {
+          description: "Suggested collections, best first. Empty whenever there's no signal.",
+          content: {
+            "application/json": {
+              schema: z.object({ suggestions: z.array(CollectionSuggestion) }),
+            },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const art = await meta.getByShortId(c.req.param("shortId"))
+      if (!art || art.current_version === 0 || !(await authorize(c, "read", art)))
+        return bail(fail(c, 404, "not found"))
+      const empty = { suggestions: [] as { id: string; score: number }[] }
+      // Members only — the same rule as GET /v1/collections, so this can't become a side
+      // channel that enumerates a workspace's collections off a public artifact.
+      if (!(await isMember(c, art.org_id))) return c.json(empty)
+      const search = ctx.search
+      if (!search?.similar) return c.json(empty)
+      const neighbors = await search
+        .similar(art.org_id, art.id, SUGGEST_NEIGHBORS)
+        .catch((err): { id: string; score: number }[] => {
+          // Best-effort on read, like every dense-arm consumer: a store hiccup degrades
+          // to "no suggestions", never a 500 on a picker open.
+          log.error("collection-suggestions dense lookup failed", {
+            artifact: art.id,
+            err: String(err),
+          })
+          return []
+        })
+      if (neighbors.length === 0) return c.json(empty)
+      // The access gate here is PER COLLECTION, not per neighbor — deliberately unlike
+      // workspace search's visibleArtifacts. The response reveals nothing about a
+      // neighbor except its presence in a collection, and collection visibility already
+      // implies enumerating its contents (collectionRole propagates to every item — the
+      // "no phantom-empty collections" rule), so a collection the caller may see leaks
+      // nothing when it votes. The LISTING gate would be wrong as well as redundant: it
+      // hides unlisted team drafts from everyone but their author, and team drafts are
+      // exactly what people file — the tier would almost never fire. The trusted read
+      // below only drops tombstones and cross-org strays a stale index could nominate;
+      // no field of it reaches the response.
+      const live = await meta.listArtifacts({
+        orgId: art.org_id,
+        ids: neighbors.map((n) => n.id),
+        excludeRemoved: true,
+      })
+      const liveIds = new Set(live.map((a) => a.id))
+      const byArtifact = await meta.collectionsForArtifacts([...liveIds])
+      const ranked = voteCollections(
+        neighbors.filter((n) => liveIds.has(n.id)),
+        byArtifact,
+        SUGGEST_CANDIDATES,
+      )
+      // The gate: collectionRole is the single source of truth (an invite-only
+      // collection a neighbor lives in must not surface for a non-member). Candidates
+      // are ≤ SUGGEST_CANDIDATES, so per-row resolution stays a handful of indexed
+      // reads.
+      const suggestions: { id: string; score: number }[] = []
+      for (const cand of ranked) {
+        if (suggestions.length >= SUGGEST_CAP) break
+        const col = await meta.getCollection(cand.id)
+        if (!col || !(await collectionRole(c, col))) continue
+        suggestions.push(cand)
+      }
+      return c.json({ suggestions })
     },
   )
 

--- a/apps/api/src/search-pgvector.ts
+++ b/apps/api/src/search-pgvector.ts
@@ -95,4 +95,27 @@ export class PgvectorSearchIndex implements SearchIndex {
     const matches = await this.store.query(orgId, vector, SEARCH_TOPK)
     return rollupBestChunk(matches, limit, this.embedder.minScore)
   }
+
+  // Nearest OTHER artifacts to one already-indexed artifact — same rollup, floor, and
+  // no-visibility contract as `search`, but the query vector is the artifact's stored
+  // LEAD chunk (chunk 0 = title + opening, the closest thing to a whole-doc summary
+  // vector), so no embed call happens at query time. The bare legacy id covers a
+  // pre-chunking vector that hasn't been re-indexed yet. Empty when the artifact has
+  // no vector (never indexed, or the dense arm was down at publish) — callers treat
+  // that as "no opinion", not an error.
+  async similar(
+    orgId: string,
+    artifactId: string,
+    limit: number,
+  ): Promise<{ id: string; score: number; chunk: string }[]> {
+    const vector =
+      (await this.store.getVector(`${artifactId}#0`)) ?? (await this.store.getVector(artifactId))
+    if (!vector) return []
+    const matches = await this.store.query(orgId, vector, SEARCH_TOPK)
+    return rollupBestChunk(
+      matches.filter((m) => m.artifactId !== artifactId),
+      limit,
+      this.embedder.minScore,
+    )
+  }
 }

--- a/apps/api/test/collection-suggest.test.ts
+++ b/apps/api/test/collection-suggest.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest"
+import { voteCollections } from "../src/lib/collection-suggest"
+
+// The voting math behind the picker's semantic tier: neighbors vote for the
+// collections they live in at their similarity score, so one very-close neighbor can
+// outrank several distant ones — a straight membership count couldn't.
+
+describe("voteCollections", () => {
+  it("sums neighbor scores per collection and ranks heaviest first", () => {
+    const out = voteCollections(
+      [
+        { id: "a1", score: 0.9 }, // in col_x
+        { id: "a2", score: 0.6 }, // in col_y
+        { id: "a3", score: 0.5 }, // in col_y
+      ],
+      { a1: ["col_x"], a2: ["col_y"], a3: ["col_y"] },
+      5,
+    )
+    // col_y collects 1.1 from two mid neighbors; col_x's single 0.9 loses.
+    expect(out).toEqual([
+      { id: "col_y", score: 1.1 },
+      { id: "col_x", score: 0.9 },
+    ])
+  })
+
+  it("a neighbor in several collections votes for each; unfiled neighbors vote for none", () => {
+    const out = voteCollections(
+      [
+        { id: "a1", score: 0.8 },
+        { id: "a2", score: 0.7 }, // no membership row at all
+      ],
+      { a1: ["col_x", "col_y"] },
+      5,
+    )
+    expect(out.map((s) => s.id).sort()).toEqual(["col_x", "col_y"])
+    expect(out[0]?.score).toBeCloseTo(0.8)
+  })
+
+  it("caps the list and breaks score ties by id so equal votes can't flap", () => {
+    const out = voteCollections([{ id: "a1", score: 0.5 }], { a1: ["col_z", "col_a", "col_m"] }, 2)
+    expect(out).toEqual([
+      { id: "col_a", score: 0.5 },
+      { id: "col_m", score: 0.5 },
+    ])
+  })
+})

--- a/apps/api/test/collection-suggestions.test.ts
+++ b/apps/api/test/collection-suggestions.test.ts
@@ -95,7 +95,8 @@ describe("collection suggestions", () => {
     expect(anas.map((s) => s.id)).toEqual([colY.id, colX.id])
     expect(anas[0]?.score).toBeCloseTo(1.1)
 
-    // Ben additionally sees his invite-only Z (0.9 + 0.9 tie between X and Z breaks by id).
+    // Ben additionally sees his invite-only Z. X and Z tie at 0.9 and collection ids
+    // are random here, so pin Y first and compare the rest as a set.
     const bens = await suggestionsFor(B)
     expect(bens.map((s) => s.id).sort()).toEqual([colX.id, colY.id, colZ.id].sort())
     expect(bens[0]?.id).toBe(colY.id)

--- a/apps/api/test/collection-suggestions.test.ts
+++ b/apps/api/test/collection-suggestions.test.ts
@@ -1,0 +1,116 @@
+import type { SearchIndex } from "@derive/core"
+import { describe, expect, it } from "vitest"
+import { as, makeAuthedApp, publishAs, type TestUser, app as tokenApp, upload } from "./helpers"
+
+// GET /v1/artifacts/{shortId}/collection-suggestions — the picker's semantic tier.
+// The dense index nominates neighbor ARTIFACTS with no access knowledge; these tests
+// pin what the route layers on top: vote aggregation into collections, the members-only
+// rule, and the per-collection role gate (an invite-only collection a neighbor lives in
+// must not surface for a non-member).
+
+const ana: TestUser = { id: "u_sug_ana", email: "ana@sug.test", name: "Ana", username: "anasug" }
+const ben: TestUser = { id: "u_sug_ben", email: "ben@sug.test", name: "Ben", username: "bensug" }
+
+/** A SearchIndex whose `similar` answers from a mutable map (internal artifact ids are
+ *  only known after publishing, so tests fill it in as they go). */
+const fakeSearch = (neighbors: Record<string, { id: string; score: number }[]>): SearchIndex => ({
+  indexArtifact: async () => {},
+  indexArtifacts: async () => {},
+  unindexArtifact: async () => {},
+  search: async () => [],
+  similar: async (_orgId, artifactId) =>
+    (neighbors[artifactId] ?? []).map((n) => ({ ...n, chunk: "" })),
+})
+
+describe("collection suggestions", () => {
+  it("aggregates neighbor votes per collection and hides invite-only collections from non-members", async () => {
+    const neighbors: Record<string, { id: string; score: number }[]> = {}
+    const { app, meta } = makeAuthedApp("colsug", [ana, ben], "editor", {
+      deps: { search: fakeSearch(neighbors) },
+    })
+    const A = as(ana.email)
+    const B = as(ben.email)
+    const json = { "content-type": "application/json" }
+
+    const publish = async (title: string, headers: Record<string, string>) => {
+      const r = await (await publishAs(app, `${title} body`, { title }, headers)).json()
+      const art = await meta.getByShortId(r.short_id)
+      if (!art) throw new Error(`missing ${title}`)
+      return { shortId: r.short_id as string, id: art.id }
+    }
+    const target = await publish("Target", A)
+    const n1 = await publish("Close neighbor", A)
+    const n2 = await publish("Mid neighbor", A)
+    const n3 = await publish("Far neighbor", A)
+
+    const collection = async (title: string, headers: Record<string, string>) =>
+      (await (
+        await app.request("/v1/collections", {
+          method: "POST",
+          headers: { ...json, ...headers },
+          body: JSON.stringify({ title }),
+        })
+      ).json()) as { id: string }
+    const add = (colId: string, shortId: string, headers: Record<string, string>) =>
+      app.request(`/v1/collections/${colId}/items/${shortId}`, {
+        method: "PUT",
+        headers: { ...json, ...headers },
+      })
+
+    // Ana's workspace-open collections: X holds the closest neighbor, Y holds the two
+    // mid ones — Y must outrank X on summed votes (0.6 + 0.5 > 0.9).
+    const colX = await collection("X", A)
+    const colY = await collection("Y", A)
+    await add(colX.id, n1.shortId, A)
+    await add(colY.id, n2.shortId, A)
+    await add(colY.id, n3.shortId, A)
+    // Ben's INVITE-ONLY collection also holds the closest neighbor. It must surface
+    // for Ben (creator = owner) and stay invisible to Ana (no role).
+    const colZ = await collection("Z", B)
+    expect(
+      (
+        await app.request(`/v1/collections/${colZ.id}/access`, {
+          method: "PATCH",
+          headers: { ...json, ...B },
+          body: JSON.stringify({ workspaceAccess: "none" }),
+        })
+      ).status,
+    ).toBe(200)
+    await add(colZ.id, n1.shortId, B)
+
+    neighbors[target.id] = [
+      { id: n1.id, score: 0.9 },
+      { id: n2.id, score: 0.6 },
+      { id: n3.id, score: 0.5 },
+    ]
+
+    const suggestionsFor = async (headers: Record<string, string>) =>
+      (
+        (await (
+          await app.request(`/v1/artifacts/${target.shortId}/collection-suggestions`, { headers })
+        ).json()) as { suggestions: { id: string; score: number }[] }
+      ).suggestions
+
+    const anas = await suggestionsFor(A)
+    expect(anas.map((s) => s.id)).toEqual([colY.id, colX.id])
+    expect(anas[0]?.score).toBeCloseTo(1.1)
+
+    // Ben additionally sees his invite-only Z (0.9 + 0.9 tie between X and Z breaks by id).
+    const bens = await suggestionsFor(B)
+    expect(bens.map((s) => s.id).sort()).toEqual([colX.id, colY.id, colZ.id].sort())
+    expect(bens[0]?.id).toBe(colY.id)
+  })
+
+  it("answers [] when no dense arm is bound, and 404s an unreadable artifact", async () => {
+    // The shared token app binds no SearchIndex — the endpoint degrades, never errors.
+    const { short_id } = await (await upload("sug-none.md", "x", { title: "No arm" })).json()
+    const res = await (
+      await tokenApp.request(`/v1/artifacts/${short_id}/collection-suggestions`)
+    ).json()
+    expect(res.suggestions).toEqual([])
+
+    expect((await tokenApp.request("/v1/artifacts/zzzzzzzz/collection-suggestions")).status).toBe(
+      404,
+    )
+  })
+})

--- a/apps/api/test/search-pgvector.test.ts
+++ b/apps/api/test/search-pgvector.test.ts
@@ -30,6 +30,7 @@ const makeStore = () => {
       for (const [k, r] of [...rows]) if (r.artifactId === id) rows.delete(k)
     },
     query: async () => queryResult,
+    getVector: async (vectorId) => rows.get(vectorId)?.embedding ?? null,
   }
   return {
     store,
@@ -211,6 +212,50 @@ describe("PgvectorSearchIndex", () => {
     const { embedder, calls } = makeEmbedder()
     expect(await new PgvectorSearchIndex(embedder, store).search("o1", "   ", 6)).toEqual([])
     expect(calls).toHaveLength(0)
+  })
+
+  it("similar queries FROM the stored lead vector — no embed call — and drops the artifact itself", async () => {
+    const { store, setQuery } = makeStore()
+    const { embedder, calls } = makeEmbedder()
+    const idx = new PgvectorSearchIndex(embedder, store)
+    await idx.indexArtifact("a1", "o1", "Pricing page", "the plans grid")
+    calls.length = 0 // forget the indexing embed; `similar` itself must not embed
+    setQuery([
+      { artifactId: "a1", chunk: "itself", score: 0.99 }, // the query doc is its own nearest hit
+      { artifactId: "a2", chunk: "pricing tiers doc", score: 0.71 },
+      { artifactId: "a3", chunk: "below floor", score: 0.3 },
+    ])
+    const hits = await idx.similar("o1", "a1", 6)
+    expect(calls).toHaveLength(0)
+    expect(hits.map((h) => h.id)).toEqual(["a2"]) // self excluded, floor applied
+  })
+
+  it("similar answers [] for an artifact with no stored vector", async () => {
+    const { store, setQuery } = makeStore()
+    const { embedder } = makeEmbedder()
+    setQuery([{ artifactId: "a2", chunk: "noise", score: 0.9 }])
+    expect(
+      await new PgvectorSearchIndex(embedder, store).similar("o1", "never-indexed", 6),
+    ).toEqual([])
+  })
+
+  it("similar falls back to a legacy bare-id vector from before chunking", async () => {
+    const { store, setQuery } = makeStore()
+    const { embedder } = makeEmbedder()
+    await store.upsert([
+      // A pre-chunking row: vectorId is the bare artifact id, no #0 twin exists.
+      {
+        vectorId: "a1",
+        artifactId: "a1",
+        orgId: "o1",
+        chunk: 0,
+        embedding: [1, 0, 0, 0],
+        snippet: "s",
+      },
+    ])
+    setQuery([{ artifactId: "a2", chunk: "neighbor", score: 0.8 }])
+    const hits = await new PgvectorSearchIndex(embedder, store).similar("o1", "a1", 6)
+    expect(hits.map((h) => h.id)).toEqual(["a2"])
   })
 
   it("throws (not misaligns) if the embedder returns a wrong vector count for a chunk group", async () => {

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -2585,6 +2585,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/artifacts/{shortId}/collection-suggestions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Collections where work similar to this artifact already lives (members only). */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    shortId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Suggested collections, best first. Empty whenever there's no signal. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            suggestions: components["schemas"]["CollectionSuggestion"][];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/bulk/collections": {
         parameters: {
             query?: never;
@@ -6429,6 +6469,12 @@ export interface components {
             prNumber?: number;
             /** @description For repo/PR collections: the "owner/name" slug. */
             repo?: string;
+        };
+        CollectionSuggestion: {
+            /** @description The suggested collection's id. */
+            id: string;
+            /** @description Summed neighbor-similarity votes — an ordering signal, not a probability. */
+            score: number;
         };
         Folder: {
             id: string;

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -85,6 +85,8 @@ export type Report = components["schemas"]["Report"]
  *  (kind = manual / repo / pr). Generated from the OpenAPI spec (apps/api/openapi.json)
  *  — a backend shape change surfaces here at `tsc`. */
 export type Collection = components["schemas"]["Collection"]
+/** A picker suggestion: a collection id plus its neighbor-vote score (ordering only). */
+export type CollectionSuggestion = components["schemas"]["CollectionSuggestion"]
 export type Folder = components["schemas"]["Folder"]
 /** The result of a /v1/bulk/* op: counts per artifact (skipped = not yours to touch). */
 export type BulkSummary = components["schemas"]["BulkSummary"]
@@ -1144,6 +1146,10 @@ export const api = {
   // Collections (shareable groups; sharing grants the role on every item)
   listCollections: (): Promise<{ collections: Collection[] }> =>
     f("/v1/collections", opts()).then(j),
+  /** Collections where semantically-similar artifacts already live — the picker's
+   *  Suggested tier. Best-effort by contract: empty whenever there's no signal. */
+  collectionSuggestions: (shortId: string): Promise<{ suggestions: CollectionSuggestion[] }> =>
+    f(`/v1/artifacts/${shortId}/collection-suggestions`, opts()).then(j),
   createCollection: (title: string): Promise<Collection> =>
     f("/v1/collections", opts({ title })).then(j),
   renameCollection: (id: string, title: string): Promise<Collection> =>

--- a/apps/web/src/components/shared/organize-dialogs.test.ts
+++ b/apps/web/src/components/shared/organize-dialogs.test.ts
@@ -88,6 +88,43 @@ describe("organizeList — browse (no query)", () => {
     ])
   })
 
+  it("semantic neighbors slot between your recent desks and title kinship", () => {
+    const cols = [
+      col({ title: "Mine", my_last_activity: "2026-08-01T00:00:00Z" }),
+      col({ title: "Neighborhood" }),
+      col({ title: "Pricing archive" }),
+      col({ title: "Inbox" }),
+      col({ title: "Misc" }),
+      col({ title: "Research" }),
+    ]
+    const hood = cols[1]
+    if (!hood) throw new Error("fixture")
+    const out = organizeList(cols, "", "Q3 pricing page", [hood.id])
+    if (out.mode !== "browse") throw new Error("expected browse")
+    expect(out.suggested.map((s) => [s.col.title, s.reason])).toEqual([
+      ["Mine", "recent"],
+      ["Neighborhood", "neighbors"],
+      ["Pricing archive", "similar"],
+    ])
+  })
+
+  it("semantic ids the list doesn't offer (mirrors, brandprint, unknown) are ignored", () => {
+    const cols = [
+      col({ title: "A" }),
+      col({ title: "B" }),
+      col({ title: "C" }),
+      col({ title: "D" }),
+      col({ title: "E" }),
+      col({ title: "Wiki", my_role: "viewer" }),
+    ]
+    const wiki = cols[5]
+    if (!wiki) throw new Error("fixture")
+    // A stale/foreign id and a view-only collection: neither may surface as suggested.
+    const out = organizeList(cols, "", undefined, ["col_gone", wiki.id])
+    if (out.mode !== "browse") throw new Error("expected browse")
+    expect(out.suggested).toEqual([])
+  })
+
   it("never suggests a collection the caller can't add to", () => {
     const cols = [
       col({ title: "Team wiki", my_role: "viewer", my_last_activity: "2026-08-02T00:00:00Z" }),

--- a/apps/web/src/components/shared/organize-dialogs.test.ts
+++ b/apps/web/src/components/shared/organize-dialogs.test.ts
@@ -89,16 +89,15 @@ describe("organizeList — browse (no query)", () => {
   })
 
   it("semantic neighbors slot between your recent desks and title kinship", () => {
+    const hood = col({ title: "Neighborhood" })
     const cols = [
       col({ title: "Mine", my_last_activity: "2026-08-01T00:00:00Z" }),
-      col({ title: "Neighborhood" }),
+      hood,
       col({ title: "Pricing archive" }),
       col({ title: "Inbox" }),
       col({ title: "Misc" }),
       col({ title: "Research" }),
     ]
-    const hood = cols[1]
-    if (!hood) throw new Error("fixture")
     const out = organizeList(cols, "", "Q3 pricing page", [hood.id])
     if (out.mode !== "browse") throw new Error("expected browse")
     expect(out.suggested.map((s) => [s.col.title, s.reason])).toEqual([
@@ -109,16 +108,15 @@ describe("organizeList — browse (no query)", () => {
   })
 
   it("semantic ids the list doesn't offer (mirrors, brandprint, unknown) are ignored", () => {
+    const wiki = col({ title: "Wiki", my_role: "viewer" })
     const cols = [
       col({ title: "A" }),
       col({ title: "B" }),
       col({ title: "C" }),
       col({ title: "D" }),
       col({ title: "E" }),
-      col({ title: "Wiki", my_role: "viewer" }),
+      wiki,
     ]
-    const wiki = cols[5]
-    if (!wiki) throw new Error("fixture")
     // A stale/foreign id and a view-only collection: neither may surface as suggested.
     const out = organizeList(cols, "", undefined, ["col_gone", wiki.id])
     if (out.mode !== "browse") throw new Error("expected browse")

--- a/apps/web/src/components/shared/organize-dialogs.tsx
+++ b/apps/web/src/components/shared/organize-dialogs.tsx
@@ -13,7 +13,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
-import { artifactQuery, collectionsQuery } from "@/lib/queries"
+import { artifactQuery, collectionSuggestionsQuery, collectionsQuery } from "@/lib/queries"
 import { ago } from "@/lib/time"
 import { useApiMutation } from "@/lib/use-api-mutation"
 import { useBrandprintCollectionIds } from "@/lib/use-brandprint-ids"
@@ -82,7 +82,7 @@ export const titleAffinity = (a: string, b: string): number => {
   return n
 }
 
-export type SuggestReason = "recent" | "similar"
+export type SuggestReason = "recent" | "neighbors" | "similar"
 export type OrganizeList =
   /** No query: a short Suggested tier above the full alphabetical index (deduped). */
   | { mode: "browse"; suggested: { col: Collection; reason: SuggestReason }[]; rest: Collection[] }
@@ -100,14 +100,16 @@ const SUGGESTED_MIN_LIST = 6
  * digest earned the same treatment — see digestFor).
  *
  * Suggested = the collections YOU touched most recently (filing runs in batches, so
- * your last desk is the best guess), then title kinship with the artifact being filed.
- * Only collections the caller can add to are suggested; the rest stay reachable in the
- * alphabetical index below.
+ * your last desk is the best guess), then where semantically-similar artifacts already
+ * live (`semanticIds`, the server's neighbor vote — already ranked), then title kinship
+ * with the artifact being filed. Only collections the caller can add to are suggested;
+ * the rest stay reachable in the alphabetical index below.
  */
 export function organizeList(
   pickable: Collection[],
   query: string,
   artifactTitle?: string,
+  semanticIds?: string[],
 ): OrganizeList {
   const q = query.trim().toLowerCase()
   if (q) {
@@ -135,6 +137,15 @@ export function organizeList(
     .filter((col) => col.my_last_activity)
     .sort((a, b) => (b.my_last_activity ?? "").localeCompare(a.my_last_activity ?? ""))
   for (const col of recent.slice(0, 2)) suggested.push({ col, reason: "recent" })
+  if (semanticIds?.length) {
+    const byId = new Map(addable.map((col) => [col.id, col]))
+    for (const id of semanticIds) {
+      if (suggested.length >= SUGGESTED_MAX) break
+      const col = byId.get(id)
+      if (col && !suggested.some((s) => s.col.id === col.id))
+        suggested.push({ col, reason: "neighbors" })
+    }
+  }
   if (artifactTitle) {
     const kin = addable
       .filter((col) => !suggested.some((s) => s.col.id === col.id))
@@ -254,7 +265,14 @@ export function CollectionsDialog({
   // an artifact's organize menu.
   const brandprintIds = useBrandprintCollectionIds()
   const pickable = pickableCollections(all, brandprintIds)
-  const list = organizeList(pickable, query, artifactTitle)
+  // The semantic tier — "collections where similar artifacts already live", from the
+  // dense index's neighbor vote. Best-effort garnish: a miss, an error, or an install
+  // with no dense arm all read as "no suggestions" and the local tiers carry the list.
+  const { data: semanticIds } = useQuery({
+    ...collectionSuggestionsQuery(shortId),
+    enabled: open,
+  })
+  const list = organizeList(pickable, query, artifactTitle, semanticIds)
   const inSet = new Set(inCollections)
 
   // Toggle membership optimistically (via onChange); the primitive rolls it back and
@@ -311,9 +329,11 @@ export function CollectionsDialog({
             ? "view only"
             : reason === "recent" && col.my_last_activity
               ? ago(col.my_last_activity)
-              : reason === "similar"
-                ? "similar title"
-                : undefined
+              : reason === "neighbors"
+                ? "similar artifacts"
+                : reason === "similar"
+                  ? "similar title"
+                  : undefined
         }
         onSelect={() => toggle(col)}
         onHover={() => setCursor(idx)}

--- a/apps/web/src/components/shared/organize-dialogs.tsx
+++ b/apps/web/src/components/shared/organize-dialogs.tsx
@@ -26,9 +26,10 @@ import { cn } from "@/lib/utils"
 // `onChange`; the caller keeps the cache writes.
 //
 // The list is a picker, so it answers "where do I file this" rather than inventorying:
-// a couple of suggestions (your recent desks, then title kinship) above an alphabetical
-// index, one filter-or-create input above both. Membership lives in the row's trailing
-// checkbox — bg-accent stays the pointer/keyboard wash, never a second meaning.
+// a couple of suggestions (your recent desks, where similar work already lives, title
+// kinship) above an alphabetical index, one filter-or-create input above both.
+// Membership lives in the row's trailing checkbox — bg-accent stays the
+// pointer/keyboard wash, never a second meaning.
 
 /** Collections an organize dialog offers at all: hand-made ones. Repo mirrors and PR
  *  previews fill themselves from GitHub, and Brandprint-pointed collections are managed
@@ -159,6 +160,15 @@ export function organizeList(
   return { mode: "browse", suggested, rest: rest.filter((col) => !picked.has(col.id)) }
 }
 
+// A row's small trailing note: why it's inert, or why the Suggested tier picked it.
+const rowHint = (col: Collection, addable: boolean, reason?: SuggestReason): string | undefined => {
+  if (!addable) return "view only"
+  if (reason === "recent" && col.my_last_activity) return ago(col.my_last_activity)
+  if (reason === "neighbors") return "similar artifacts"
+  if (reason === "similar") return "similar title"
+  return undefined
+}
+
 // The menu-row grammar (the dropdown item recipe): rounded-lg, bg-accent as the
 // pointer/keyboard wash only — membership renders in the checkbox, never as a wash.
 const ROW_CLASS =
@@ -265,9 +275,9 @@ export function CollectionsDialog({
   // an artifact's organize menu.
   const brandprintIds = useBrandprintCollectionIds()
   const pickable = pickableCollections(all, brandprintIds)
-  // The semantic tier — "collections where similar artifacts already live", from the
-  // dense index's neighbor vote. Best-effort garnish: a miss, an error, or an install
-  // with no dense arm all read as "no suggestions" and the local tiers carry the list.
+  // The neighbor-vote tier. `data` stays undefined on error or where no dense arm
+  // exists (see collectionSuggestionsQuery), and organizeList treats that as "no
+  // opinion" — the recency and kinship tiers carry the list.
   const { data: semanticIds } = useQuery({
     ...collectionSuggestionsQuery(shortId),
     enabled: open,
@@ -324,17 +334,7 @@ export function CollectionsDialog({
         checked={inSet.has(col.id)}
         disabled={!addable}
         highlighted={idx !== -1 && idx === cursor}
-        hint={
-          !addable
-            ? "view only"
-            : reason === "recent" && col.my_last_activity
-              ? ago(col.my_last_activity)
-              : reason === "neighbors"
-                ? "similar artifacts"
-                : reason === "similar"
-                  ? "similar title"
-                  : undefined
-        }
+        hint={rowHint(col, addable, reason)}
         onSelect={() => toggle(col)}
         onHover={() => setCursor(idx)}
         testId={`collections-menu-${col.id}`}

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -40,6 +40,18 @@ export const collectionsQuery = () =>
     queryFn: () => api.listCollections().then((r) => r.collections),
   })
 
+// The picker's semantic Suggested tier (see CollectionsDialog). Neighbors only move
+// when something similar is published, so a short staleTime just stops a close/reopen
+// from re-running the vector lookup. No retry: the tier is best-effort garnish, and
+// the picker reads a missing or failed answer as "no suggestions", never as an error.
+export const collectionSuggestionsQuery = (shortId: string) =>
+  queryOptions({
+    queryKey: ["collection-suggestions", shortId] as const,
+    queryFn: () => api.collectionSuggestions(shortId).then((r) => r.suggestions.map((s) => s.id)),
+    staleTime: 5 * 60_000,
+    retry: false,
+  })
+
 // A collection's folders (name order) + its artifact→folder assignment map — drives the
 // collection view's folder grouping and management. Keyed by collection.
 export const collectionFoldersQuery = (collectionId: string) =>

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -56,6 +56,18 @@ export interface SearchIndex {
     query: string,
     limit: number,
   ): Promise<{ id: string; score: number; chunk: string }[]>
+  /** The most semantically-similar OTHER artifacts to one already-indexed artifact,
+   *  ranked like {@link search} and with the same NO-visibility-filter contract. Reads
+   *  the artifact's stored lead vector — no embed call at query time — so it's cheap
+   *  enough for interactive surfaces (the collection picker's "filed with similar
+   *  work" suggestions). Empty when the artifact has no vector yet (never indexed, or
+   *  the dense arm was down at publish). Optional: a lexical-only install has no
+   *  vectors to compare. */
+  similar?(
+    orgId: string,
+    artifactId: string,
+    limit: number,
+  ): Promise<{ id: string; score: number; chunk: string }[]>
 }
 
 /**

--- a/packages/db/src/pgvector.ts
+++ b/packages/db/src/pgvector.ts
@@ -43,6 +43,9 @@ export interface VectorStore {
   deleteByIds(ids: string[]): Promise<void>
   deleteByArtifact(artifactId: string): Promise<void>
   query(orgId: string, vector: number[], topK: number): Promise<VectorMatch[]>
+  /** One stored embedding by its vector id, or null when absent — lets a caller run a
+   *  similarity query FROM an already-indexed chunk without re-embedding anything. */
+  getVector(vectorId: string): Promise<number[] | null>
 }
 
 // Serialize a JS number[] to a pgvector text literal `[1,2,3]`. Guards NaN/Infinity (a bad
@@ -157,6 +160,21 @@ export class PgVectorStore implements VectorStore {
   // Every chunk vector for an artifact, in one statement — the clean hard-delete path (unindex).
   async deleteByArtifact(artifactId: string): Promise<void> {
     await this.sql.query(`DELETE FROM ${this.table} WHERE artifact_id = $1`, [artifactId])
+  }
+
+  // One stored embedding, read back as a JS vector. pgvector's text form is `[0.1,0.2,…]` —
+  // valid JSON — so parse rather than hand-split. Null when the id has no row.
+  async getVector(vectorId: string): Promise<number[] | null> {
+    const { rows } = await this.sql.query(
+      `SELECT embedding::text AS embedding FROM ${this.table} WHERE vector_id = $1`,
+      [vectorId],
+    )
+    const text = rows[0]?.embedding
+    if (typeof text !== "string") return null
+    const parsed: unknown = JSON.parse(text)
+    if (!Array.isArray(parsed) || parsed.some((n) => typeof n !== "number"))
+      throw new Error(`stored vector ${vectorId} did not parse to a number array`)
+    return parsed as number[]
   }
 
   // Top-`topK` nearest chunks in ONE org by cosine similarity. Returns similarity (1 − distance)

--- a/packages/db/test/pgvector.test.ts
+++ b/packages/db/test/pgvector.test.ts
@@ -103,6 +103,28 @@ if (PG_URL) {
       expect(hits[0]?.score).toBeCloseTo(0.995, 2)
     })
 
+    it("getVector reads a stored embedding back as numbers; null for an absent id", async () => {
+      const store = await boot()
+      await store.upsert([
+        {
+          vectorId: "g1#0",
+          artifactId: "g1",
+          orgId: "o1",
+          chunk: 0,
+          embedding: [0.25, -1, 0, 0.5],
+          snippet: "s",
+        },
+      ])
+      const v = await store.getVector("g1#0")
+      expect(v).toHaveLength(DIM)
+      expect(v?.[0]).toBeCloseTo(0.25)
+      expect(v?.[1]).toBeCloseTo(-1)
+      expect(await store.getVector("g1#9")).toBeNull()
+      // Round-trip: the read-back vector is queryable — the `similar` path's exact shape.
+      const hits = await store.query("o1", v as number[], 5)
+      expect(hits[0]?.artifactId).toBe("g1")
+    })
+
     it("upsert is idempotent on vector_id (re-index overwrites, no duplicate rows)", async () => {
       const store = await boot()
       await store.upsert([


### PR DESCRIPTION
Follow-up to #631. The picker's "similar" suggestions shipped as client-side title-token overlap — the only signal available without new infrastructure. But every artifact already gets chunk-level bge-m3 embeddings in pgvector at publish time, so the much stronger signal was already sitting in the database: **which collections hold the artifacts most similar to the one being filed**.

## What changed

**`GET /v1/artifacts/{shortId}/collection-suggestions`** — neighbor voting:
- The artifact's nearest neighbors are queried **from its stored lead vector** (chunk 0 = title + opening), so there's no embed call at request time — one org-scoped HNSW lookup plus two indexed reads per picker open.
- Each neighbor votes for the collections it already lives in, at its similarity score; the heaviest collections win. Members vote, not collection titles, so it works when the collections are named "Misc" and "Inbox". The math is a pure function (`voteCollections`) with its own tests.

**Ports** (both optional, so lexical-only installs are untouched):
- `SearchIndex.similar?(orgId, artifactId, limit)` — same rollup, relevance floor, and no-visibility contract as `search`, implemented by `PgvectorSearchIndex`.
- `VectorStore.getVector(vectorId)` — read a stored embedding back (pgvector's text form is valid JSON).

**Access model** (the part worth reviewing closely): the route is **members-only** (same rule as `GET /v1/collections`), and the gate is **per collection via `collectionRole`**, not per neighbor. The response reveals nothing about a neighbor except its presence in a collection — and a collection you can see is one whose contents you can already enumerate (the "no phantom-empty collections" rule), so a visible collection's vote leaks nothing. The listing-level `visibleArtifacts` gate would be both wrong and too strict here: it hides unlisted team drafts from everyone but their author, and team drafts are exactly what people file — under it the tier would almost never fire. A trusted org-scoped read still drops tombstones and cross-org strays a stale index could nominate; no field of it reaches the response.

**Client**: the picker's Suggested tier now orders recent → **neighbor votes** ("similar artifacts") → title kinship, capped at three. The suggestions query is best-effort garnish — no retry, 5-minute staleTime, and a missing/failed answer reads as "no suggestions", so the picker can never gate or error on it. Semantic ids that aren't pickable (mirrors, Brandprint, view-only, stale) are ignored.

## Degradation

No dense arm bound, no vector yet (never indexed / dense arm down at publish), a store hiccup, or a non-member caller all answer `[]` — logged where it's a failure, silent where it's just absence. The client tiers from #631 carry the list.

## Tests

- Route-level (`collection-suggestions.test.ts`): vote aggregation end-to-end through a real app with an injected fake index, plus the invite-only case — a collection holding a neighbor surfaces for its owner and stays hidden from a workspace member with no role on it; no-dense-arm answers `[]`; unreadable artifact 404s.
- `voteCollections` (pure): score summing, multi-collection membership, cap + id tiebreak.
- `PgvectorSearchIndex.similar`: queries from the stored vector without embedding, excludes the artifact itself, applies the floor, falls back to the pre-chunking legacy vector id, answers `[]` when never indexed.
- `PgVectorStore.getVector`: round-trip against real pgvector (CI's Docker-gated db job).
- Picker policy: neighbor tier slots between recent and kinship; unofferable ids are ignored.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/632"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788373888&installation_model_id=428097&pr_number=632&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F632&signature=dfb5043d80adb00a56ef928d4acb1fc65d53b00ca0e5c753a7120007a9ab2c79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->