### PR TITLE
perf(chat): log where an attended turn's time actually went

### DIFF
--- a/apps/api/src/routes/contexts.ts
+++ b/apps/api/src/routes/contexts.ts
@@ -19,6 +19,7 @@ import type { Context } from "hono"
 import type { BlankEnv } from "hono/types"
 import type { AppContext } from "../context"
 import { isAbandoned } from "../lib/abandoned-turn"
+import type { AgentLoopInput } from "../lib/agent-loop"
 import { resolveActorBrandprint } from "../lib/brandprint"
 import {
   brokerFor,
@@ -205,6 +206,33 @@ export const contextRoutes = (ctx: AppContext) => {
   }
 
   /**
+   * WHERE A TURN'S TIME ACTUALLY WENT.
+   *
+   * A turn is a loop — model, tool, model — and the two halves have completely different fixes:
+   * time inside the model is the provider's, time outside it is ours (store round trips, tool
+   * work). Without splitting them, "chat feels slow" is unactionable, and the two are easy to
+   * confuse: the same turn measured 2.5s against a local disk store and 8s on the hosted tier,
+   * which says most of the gap is not the model at all.
+   *
+   * So: count the model calls and the milliseconds spent inside them, and log both next to the
+   * total when the turn settles. One line per turn, no sampling — a turn is already an expensive
+   * thing, and this is what makes the next round of work aimable.
+   */
+  const timedModel = (call: AgentLoopInput["callModel"]) => {
+    const stat = { calls: 0, ms: 0 }
+    const wrapped: AgentLoopInput["callModel"] = async (req) => {
+      stat.calls++
+      const t0 = Date.now()
+      try {
+        return await call(req)
+      } finally {
+        stat.ms += Date.now() - t0
+      }
+    }
+    return { stat, wrapped }
+  }
+
+  /**
    * One WORKSPACE chat turn: the model, this workspace's tools, and the transcript.
    *
    * The tools are Derive's own MCP tools, constructed for the ASKER (see lib/chat-tools.ts), so
@@ -266,9 +294,11 @@ export const contextRoutes = (ctx: AppContext) => {
       // the next write, not merely the next session.
       flags: { agentKillswitch: settings?.agentKillswitch ?? false },
     })
+    const timed = timedModel(stream.wrap(model.callModel))
+    const startedAt = Date.now()
     const res = await withinTurnBudget(
       runChatTurn(
-        { model: { ...model, callModel: stream.wrap(model.callModel) } },
+        { model: { ...model, callModel: timed.wrapped } },
         {
           session: s,
           transcript,
@@ -279,6 +309,17 @@ export const contextRoutes = (ctx: AppContext) => {
         },
       ),
     )
+    log.info("attended turn", {
+      session: s.id,
+      org: s.org_id,
+      total_ms: Date.now() - startedAt,
+      model_ms: timed.stat.ms,
+      // Everything that was NOT the model: store round trips, tool work, our own code. The half
+      // we can actually do something about.
+      other_ms: Date.now() - startedAt - timed.stat.ms,
+      model_calls: timed.stat.calls,
+      outcome: res.outcome,
+    })
     await reply(res.reply, res.outcome === "failed" ? "failed" : "answered", {
       outcome: res.outcome,
       // Absent on a turn that ran out of budget — it never got a cost or a model back, and

--- a/apps/api/src/routes/contexts.ts
+++ b/apps/api/src/routes/contexts.ts
@@ -219,14 +219,19 @@ export const contextRoutes = (ctx: AppContext) => {
    * thing, and this is what makes the next round of work aimable.
    */
   const timedModel = (call: AgentLoopInput["callModel"]) => {
-    const stat = { calls: 0, ms: 0 }
+    // Each call's own duration, not just the sum: three calls of 1.5s and one of 4.5s are the
+    // same total and completely different problems — the first is per-call latency to fix, the
+    // second is one pathological step to find.
+    const stat = { calls: 0, ms: 0, each: [] as number[] }
     const wrapped: AgentLoopInput["callModel"] = async (req) => {
       stat.calls++
       const t0 = Date.now()
       try {
         return await call(req)
       } finally {
-        stat.ms += Date.now() - t0
+        const took = Date.now() - t0
+        stat.ms += took
+        stat.each.push(took)
       }
     }
     return { stat, wrapped }
@@ -318,6 +323,7 @@ export const contextRoutes = (ctx: AppContext) => {
       // we can actually do something about.
       other_ms: Date.now() - startedAt - timed.stat.ms,
       model_calls: timed.stat.calls,
+      model_each_ms: timed.stat.each.join(","),
       outcome: res.outcome,
     })
     await reply(res.reply, res.outcome === "failed" ? "failed" : "answered", {


### PR DESCRIPTION
## Why

A turn is a loop — model, tool, model — and the two halves have different owners: time inside the model is the provider's, time outside it is ours (store round trips, tool work). Without splitting them, "chat feels slow" is unactionable.

## What this measured

One line per settled turn: `total_ms`, `model_ms`, `other_ms`, `model_calls`, and each call's own duration. Read off a real preview turn in QA Lab:

```
total=4965  model=4260  other=705  calls=3  each=[808, 406, 3046]
```

Three findings, two of which killed a plan I was about to build:

1. **The store is not the problem.** `other_ms` — every DB round trip, tool call and line of our own code — is 705ms of ~5s. A batching effort aimed at the store would have bought almost nothing.
2. **Round-trip count is nearly irrelevant.** Calls 1 and 2 cost 808ms and 406ms; they only emit tool calls. Cutting one saves ~400ms.
3. **Generating the answer is 71% of model time** (3046ms of 4260ms). That is the only thing worth attacking.

Model-side parameters were already exhausted separately — benchmarked against the real path, `max_tokens` caps and prompt caching all landed within noise of baseline (~2.5s locally, 3 calls).

## Config change made alongside (not in this diff)

Measured per-backend throughput for our model, n=6:

| Provider | tok/s median | worst | latency median |
|---|---|---|---|
| DeepInfra | 64.1 | 11.8 | 2.81s |
| Novita | 52.7 | 26.8 | 3.55s |
| GMICloud | 37.0 | 33.7 | 5.21s |
| Fireworks | 21.7 | 12 | — |

Fireworks was our third fallback and the slowest of six measured, so the order is now `DeepInfra,Novita,GMICloud`. Deployment config, not code.

## What is left, for whoever picks this up

The remaining lever is output length: 3s of generation at ~64 tok/s is roughly 190 tokens of answer. Shorter answers or a faster model are the only things that move it — not caching, not batching, not fewer round trips.

## Test plan
- [x] `pnpm typecheck` clean
- [x] chat/session suites pass (64 tests)
- [x] split read off real preview turns in QA Lab (numbers above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)