### PR TITLE
feat(contexts): Output tab, paged Activity, and the Runner card's missing give step

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -8175,6 +8175,24 @@
             "required": true,
             "name": "id",
             "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Keyset cursor (`created_at|id`, from `next_cursor`) — return sessions strictly older than it. An offset would repeat rows as new sessions open; the id half keeps sessions that share a created_at from being skipped at the boundary."
+            },
+            "required": false,
+            "description": "Keyset cursor (`created_at|id`, from `next_cursor`) — return sessions strictly older than it. An offset would repeat rows as new sessions open; the id half keeps sessions that share a created_at from being skipped at the boundary.",
+            "name": "cursor",
+            "in": "query"
           }
         ],
         "responses": {
@@ -8190,10 +8208,16 @@
                       "items": {
                         "$ref": "#/components/schemas/Session"
                       }
+                    },
+                    "next_cursor": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Pass as `cursor` for the next page; null when this page reached the end."
                     }
                   },
                   "required": [
-                    "sessions"
+                    "sessions",
+                    "next_cursor"
                   ]
                 }
               }
@@ -8396,6 +8420,75 @@
                   },
                   "required": [
                     "sessions"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/contexts/{id}/outputs": {
+      "get": {
+        "tags": [
+          "Contexts"
+        ],
+        "summary": "The artifacts a context has produced, grouped by artifact with a run count.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The context's outputs, most recently produced first.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "outputs": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "short_id": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "Null when this viewer cannot read the artifact, or it is gone."
+                          },
+                          "version": {
+                            "type": "number",
+                            "nullable": true
+                          },
+                          "runs": {
+                            "type": "number",
+                            "description": "How many of this context's sessions bound it."
+                          },
+                          "last_run_at": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "short_id",
+                          "title",
+                          "version",
+                          "runs",
+                          "last_run_at"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "outputs"
                   ]
                 }
               }

--- a/apps/api/src/routes/contexts.ts
+++ b/apps/api/src/routes/contexts.ts
@@ -3,7 +3,9 @@ import { refRouter } from "@derive/broker"
 import {
   type ContextAskerRecord,
   type ContextRecord,
+  decodeCursor,
   effectiveRole,
+  encodeCursor,
   newId,
   normalizeSelector,
   parseSubject,
@@ -2044,11 +2046,34 @@ export const contextRoutes = (ctx: AppContext) => {
       path: "/v1/contexts/{id}/sessions",
       tags: ["Contexts"],
       summary: "A context's sessions (owner sees all; others only their own).",
-      request: { params: z.object({ id: z.string() }) },
+      request: {
+        params: z.object({ id: z.string() }),
+        query: z.object({
+          limit: z.string().optional(),
+          cursor: z
+            .string()
+            .optional()
+            .describe(
+              "Keyset cursor (`created_at|id`, from `next_cursor`) — return sessions strictly older than it. An offset would repeat rows as new sessions open; the id half keeps sessions that share a created_at from being skipped at the boundary.",
+            ),
+        }),
+      },
       responses: {
         200: {
           description: "The sessions.",
-          content: { "application/json": { schema: z.object({ sessions: z.array(Session) }) } },
+          content: {
+            "application/json": {
+              schema: z.object({
+                sessions: z.array(Session),
+                next_cursor: z
+                  .string()
+                  .nullable()
+                  .describe(
+                    "Pass as `cursor` for the next page; null when this page reached the end.",
+                  ),
+              }),
+            },
+          },
         },
       },
     }),
@@ -2059,17 +2084,23 @@ export const contextRoutes = (ctx: AppContext) => {
       if (!x || !(await canAskContext(c, x))) return bail(fail(c, 404, "not found"))
       const isOwner = x.created_by === me.id
       const limit = Math.min(100, Math.max(1, Number(c.req.query("limit")) || 50))
+      const cursor = decodeCursor(c.req.query("cursor"))
       const sessions = await meta.listSessions(x.id, {
         askerId: isOwner ? undefined : me.id,
         limit,
+        ...(cursor ? { cursor } : {}),
       })
+      // A full page MIGHT have more behind it; a short one is provably the end.
+      const last = sessions.at(-1)
+      const nextCursor =
+        sessions.length === limit && last ? encodeCursor(last.created_at, last.id) : null
       // The extra columns (who asked, whether the answer was recorded rather than
       // served) cost two more queries — worth it only on the OWNER's view: a non-owner
       // sees exclusively their own sessions, where "who asked" is a question with one
       // answer. Batched exactly like the runner queue's own transcript join (one
       // `listSessionMessagesFor` over every returned id, grouped after), not a
       // per-session round trip.
-      if (!isOwner) return c.json({ sessions: sessions.map(sessionJson) })
+      if (!isOwner) return c.json({ sessions: sessions.map(sessionJson), next_cursor: nextCursor })
       const users = new Map(
         (await meta.getUsers([...new Set(sessions.map((s) => s.asker_id))])).map((u) => [u.id, u]),
       )
@@ -2099,6 +2130,87 @@ export const contextRoutes = (ctx: AppContext) => {
           asker_username: users.get(s.asker_id)?.username ?? null,
           lane: laneOf(s),
         })),
+        next_cursor: nextCursor,
+      })
+    },
+  )
+
+  // WHAT THIS CONTEXT HAS PRODUCED — its body of work, not its conversation log.
+  //
+  // Derived entirely from result bindings that already exist (session.result_artifact_id);
+  // nothing new is written and nothing is inferred. Grouped by artifact, so a report
+  // republished nightly is ONE row carrying a run count rather than N identical rows —
+  // which is the whole reason this isn't just Activity with a filter.
+  //
+  // VISIBILITY: the store returns short ids only, and they are resolved here through
+  // `listArtifacts({ ids })` — the same gate the library uses. A viewer who can ask this
+  // context but cannot read one of its outputs gets that row back as `title: null`
+  // (unavailable) rather than the document: the RUN is not a secret (it is already in
+  // Activity), the document is.
+  app.openapi(
+    createRoute({
+      method: "get",
+      path: "/v1/contexts/{id}/outputs",
+      tags: ["Contexts"],
+      summary: "The artifacts a context has produced, grouped by artifact with a run count.",
+      request: { params: z.object({ id: z.string() }) },
+      responses: {
+        200: {
+          description: "The context's outputs, most recently produced first.",
+          content: {
+            "application/json": {
+              schema: z.object({
+                outputs: z.array(
+                  z.object({
+                    short_id: z.string(),
+                    title: z
+                      .string()
+                      .nullable()
+                      .describe("Null when this viewer cannot read the artifact, or it is gone."),
+                    version: z.number().nullable(),
+                    runs: z.number().describe("How many of this context's sessions bound it."),
+                    last_run_at: z.string(),
+                  }),
+                ),
+              }),
+            },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const me = await requireUser(c)
+      if (me instanceof Response) return bail(me)
+      const x = await meta.getContext(c.req.param("id"))
+      if (!x || !(await canAskContext(c, x))) return bail(fail(c, 404, "not found"))
+      const rows = await meta.contextOutputs(x.id)
+      if (rows.length === 0) return c.json({ outputs: [] })
+      // ONE batched resolve for every short id (not a fetch per row), then the SANCTIONED
+      // per-artifact gate — `getByShortIds` is a raw resolve with no visibility knowledge,
+      // exactly like getByShortId, so authorize() is what keeps this honest. Same pairing
+      // the bulk routes use (see bulkArtifactOp in routes/favorites.ts).
+      const resolved = await meta.getByShortIds(rows.map((r) => r.short_id))
+      const byShortId = new Map(resolved.map((a) => [a.short_id, a]))
+      const readable = new Map(
+        (
+          await Promise.all(
+            resolved.map(async (a) => ((await authorize(c, "read", a)) ? a.short_id : null)),
+          )
+        )
+          .filter((s): s is string => !!s)
+          .map((s) => [s, true]),
+      )
+      return c.json({
+        outputs: rows.map((r) => {
+          const a = readable.has(r.short_id) ? byShortId.get(r.short_id) : undefined
+          return {
+            short_id: r.short_id,
+            title: a?.title ?? null,
+            version: a?.current_version ?? null,
+            runs: r.runs,
+            last_run_at: r.last_run_at,
+          }
+        }),
       })
     },
   )

--- a/apps/api/test/contexts.test.ts
+++ b/apps/api/test/contexts.test.ts
@@ -932,3 +932,151 @@ describe("contexts: record a run that already happened locally", () => {
     expect((await res.json()).session.state).toBe("failed")
   })
 })
+
+// A context's OUTPUTS: what it produced, grouped by artifact — the console's Output tab.
+// Derived from result bindings that already exist; the interesting edges are the grouping
+// (a report republished nightly is one row with a run count) and the visibility gate (an
+// output you cannot read comes back titleless, never as the document).
+describe("contexts: outputs — what a context produced", () => {
+  const owner: TestUser = { id: "u_out_own", email: "outown@derive.test", name: "Owner" }
+  const asker: TestUser = { id: "u_out_ask", email: "outask@derive.test", name: "Asker" }
+  // A workspace member who is NOT on the asker roster — the 404 case.
+  const outsider: TestUser = { id: "u_out_no", email: "outno@derive.test", name: "Outsider" }
+  const { app } = makeAuthedApp("contexts-outputs", [owner, asker, outsider], "commenter")
+
+  let contextId: string
+  let dailyRun: string
+  let secret: string
+
+  const record = (headers: Record<string, string>, body: Record<string, unknown>) =>
+    app.request(`/v1/contexts/${contextId}/sessions/record`, jsonAs(headers, body))
+
+  it("setup: two runs bind the same report, one binds a private artifact", async () => {
+    await app.request("/v1/me", { headers: as(owner.email) })
+    await app.request("/v1/me", { headers: as(asker.email) })
+    const manifestShortId = (
+      await (await publishAs(app, "# Staging QA", {}, as(owner.email))).json()
+    ).short_id
+    const ag = await (
+      await app.request("/v1/agents", jsonAs(as(owner.email), { name: "QA Agent" }))
+    ).json()
+    contextId = (
+      await (
+        await app.request(
+          "/v1/contexts",
+          jsonAs(as(owner.email), {
+            name: "Staging QA",
+            agent_id: ag.id,
+            manifest_short_id: manifestShortId,
+          }),
+        )
+      ).json()
+    ).id
+    await app.request(
+      `/v1/contexts/${contextId}/askers`,
+      jsonAs(as(owner.email), { email: asker.email }),
+    )
+
+    dailyRun = (
+      await (await publishAs(app, "# Daily Run", { title: "Daily Run" }, as(owner.email))).json()
+    ).short_id
+    // Private to the owner: the asker can ask this context but must not read this doc.
+    secret = (
+      await (
+        await publishAs(
+          app,
+          "# Internal only",
+          { title: "Internal only", visibility: "private", link_role: "none" },
+          as(owner.email),
+        )
+      ).json()
+    ).short_id
+
+    // Two runs bind the SAME report — the grouping case.
+    for (const answer of ["run 1 done", "run 2 done"]) {
+      const res = await record(as(owner.email), {
+        instruction: "run smoke",
+        answer,
+        result_artifact_id: dailyRun,
+      })
+      expect(res.status).toBe(201)
+    }
+    // One run binds the private artifact, and one binds nothing at all.
+    expect(
+      (
+        await record(as(owner.email), {
+          instruction: "run internals",
+          answer: "done",
+          result_artifact_id: secret,
+        })
+      ).status,
+    ).toBe(201)
+    expect(
+      (await record(as(owner.email), { instruction: "just a question", answer: "no artifact" }))
+        .status,
+    ).toBe(201)
+  })
+
+  it("groups by artifact with a run count; a session that bound nothing is absent", async () => {
+    const res = await app.request(`/v1/contexts/${contextId}/outputs`, { headers: as(owner.email) })
+    expect(res.status).toBe(200)
+    const { outputs } = await res.json()
+    // Two distinct artifacts, NOT three rows — the report's two runs collapse into one.
+    expect(outputs).toHaveLength(2)
+    const report = outputs.find((o: { short_id: string }) => o.short_id === dailyRun)
+    expect(report).toMatchObject({ runs: 2, title: "Daily Run" })
+    expect(report.version).toBe(1)
+    expect(typeof report.last_run_at).toBe("string")
+    // Most recently produced first.
+    expect(outputs[0].short_id).toBe(secret)
+  })
+
+  it("an output the viewer cannot read comes back titleless, never as the document", async () => {
+    const { outputs } = await (
+      await app.request(`/v1/contexts/${contextId}/outputs`, { headers: as(asker.email) })
+    ).json()
+    // The RUN is not a secret — it is already in the transcript this asker can see — but
+    // the private document behind it is.
+    const hidden = outputs.find((o: { short_id: string }) => o.short_id === secret)
+    expect(hidden).toMatchObject({ title: null, version: null, runs: 1 })
+    // The readable one still resolves fully in the same response.
+    expect(outputs.find((o: { short_id: string }) => o.short_id === dailyRun)).toMatchObject({
+      title: "Daily Run",
+    })
+  })
+
+  it("a workspace member who may not ask gets 404 — outputs never leak the context's existence", async () => {
+    await app.request("/v1/me", { headers: as(outsider.email) })
+    expect(
+      (await app.request(`/v1/contexts/${contextId}/outputs`, { headers: as(outsider.email) }))
+        .status,
+    ).toBe(404)
+  })
+
+  // These four sessions were opened in a tight loop, so several genuinely SHARE a
+  // created_at — which is the case a timestamp-only cursor silently drops. Paging the
+  // whole list one row at a time is the assertion: every session must appear exactly
+  // once, in the same order the unpaged list returns.
+  it("pages the whole list with the keyset cursor — no row skipped, none repeated", async () => {
+    const all = await (
+      await app.request(`/v1/contexts/${contextId}/sessions`, { headers: as(owner.email) })
+    ).json()
+    expect(all.sessions).toHaveLength(4)
+    expect(all.next_cursor).toBeNull() // a short page is provably the end
+
+    const seen: string[] = []
+    let cursor: string | null = null
+    for (let guard = 0; guard < 10; guard++) {
+      const url: string = `/v1/contexts/${contextId}/sessions?limit=1${
+        cursor ? `&cursor=${encodeURIComponent(cursor)}` : ""
+      }`
+      const page = await (await app.request(url, { headers: as(owner.email) })).json()
+      if (page.sessions.length === 0) break
+      seen.push(...page.sessions.map((s: { id: string }) => s.id))
+      cursor = page.next_cursor
+      if (!cursor) break
+    }
+    expect(seen).toEqual(all.sessions.map((s: { id: string }) => s.id))
+    expect(new Set(seen).size).toBe(seen.length)
+  })
+})

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -4868,7 +4868,11 @@ export interface paths {
         /** A context's sessions (owner sees all; others only their own). */
         get: {
             parameters: {
-                query?: never;
+                query?: {
+                    limit?: string;
+                    /** @description Keyset cursor (`created_at|id`, from `next_cursor`) — return sessions strictly older than it. An offset would repeat rows as new sessions open; the id half keeps sessions that share a created_at from being skipped at the boundary. */
+                    cursor?: string;
+                };
                 header?: never;
                 path: {
                     id: string;
@@ -4885,6 +4889,8 @@ export interface paths {
                     content: {
                         "application/json": {
                             sessions: components["schemas"]["Session"][];
+                            /** @description Pass as `cursor` for the next page; null when this page reached the end. */
+                            next_cursor: string | null;
                         };
                     };
                 };
@@ -5109,6 +5115,54 @@ export interface paths {
                             sessions: (components["schemas"]["Session"] & {
                                 preview: string;
                             })[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/contexts/{id}/outputs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** The artifacts a context has produced, grouped by artifact with a run count. */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description The context's outputs, most recently produced first. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            outputs: {
+                                short_id: string;
+                                /** @description Null when this viewer cannot read the artifact, or it is gone. */
+                                title: string | null;
+                                version: number | null;
+                                /** @description How many of this context's sessions bound it. */
+                                runs: number;
+                                last_run_at: string;
+                            }[];
                         };
                     };
                 };

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -313,6 +313,10 @@ export type ContextInfo = components["schemas"]["ContextInfo"]
 export type ContextDetail =
   paths["/v1/contexts/{id}"]["get"]["responses"][200]["content"]["application/json"]
 export type ManifestSkillInfo = components["schemas"]["ManifestSkillInfo"]
+/** One artifact a context produced, grouped across every run that bound it. Generated
+ *  from the OpenAPI spec. */
+export type ContextOutput =
+  paths["/v1/contexts/{id}/outputs"]["get"]["responses"][200]["content"]["application/json"]["outputs"][number]
 /** The runner's structured payload on an agent message. Generated from the spec. */
 export type SessionMeta = components["schemas"]["SessionMeta"]
 export type SessionMessage = components["schemas"]["SessionMessage"]
@@ -1040,8 +1044,21 @@ export const api = {
     f(`/v1/contexts/${id}/askers`, opts({ email })).then(j),
   removeContextAsker: (id: string, userId: string): Promise<void> =>
     f(`/v1/contexts/${id}/askers/${userId}`, { ...opts(), method: "DELETE" }).then(() => undefined),
-  listContextSessions: (id: string): Promise<{ sessions: Session[] }> =>
-    f(`/v1/contexts/${id}/sessions`, opts()).then(j),
+  // `cursor` comes from the previous page's `next_cursor` (a `created_at|id` keyset);
+  // null there means the list is exhausted.
+  listContextSessions: (
+    id: string,
+    cursor?: string,
+  ): Promise<{ sessions: Session[]; next_cursor: string | null }> =>
+    f(
+      `/v1/contexts/${id}/sessions${cursor ? `?cursor=${encodeURIComponent(cursor)}` : ""}`,
+      opts(),
+    ).then(j),
+  // What the context has PRODUCED — result bindings grouped by artifact, so a report
+  // republished nightly is one row carrying a run count. `title`/`version` are null when
+  // the viewer can't read that artifact (the run isn't a secret; the document is).
+  listContextOutputs: (id: string): Promise<{ outputs: ContextOutput[] }> =>
+    f(`/v1/contexts/${id}/outputs`, opts()).then(j),
   getSession: (
     id: string,
   ): Promise<{

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -579,10 +579,23 @@ export const contextQuery = (id: string) =>
 
 // The caller's sessions on a context (the owner sees everyone's). Invalidated
 // when a new session opens.
+// Infinite: a context that has been run for months has more sessions than one page,
+// and Activity is the record of ALL of them. Keyset cursor (`created_at|id`), so a
+// session opening mid-scroll never repeats or hides a row the way an offset would.
 export const contextSessionsQuery = (id: string) =>
-  queryOptions({
+  infiniteQueryOptions({
     queryKey: ["context-sessions", id] as const,
-    queryFn: () => api.listContextSessions(id).then((r) => r.sessions),
+    queryFn: ({ pageParam }) => api.listContextSessions(id, pageParam || undefined),
+    initialPageParam: "",
+    getNextPageParam: (last) => last.next_cursor ?? undefined,
+  })
+
+// What a context has PRODUCED — one row per artifact with a run count, newest first.
+// Invalidated alongside the sessions list: a run that binds a result changes both.
+export const contextOutputsQuery = (id: string) =>
+  queryOptions({
+    queryKey: ["context-outputs", id] as const,
+    queryFn: () => api.listContextOutputs(id).then((r) => r.outputs),
   })
 
 // One session + transcript, polled the activeSyncsQuery way: fast while the

--- a/apps/web/src/pages/context/console.tsx
+++ b/apps/web/src/pages/context/console.tsx
@@ -1,4 +1,4 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query"
+import { useInfiniteQuery, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Link, useParams } from "@tanstack/react-router"
 import { Copy as CopyIcon, Cpu, Plug, TriangleAlert } from "lucide-react"
 import { useEffect, useState } from "react"
@@ -32,7 +32,13 @@ import { toast } from "@/components/ui/sonner"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Textarea } from "@/components/ui/textarea"
 import { useAuth } from "@/ctx"
-import { artifactQuery, contextQuery, contextSessionsQuery, sessionQuery } from "@/lib/queries"
+import {
+  artifactQuery,
+  contextOutputsQuery,
+  contextQuery,
+  contextSessionsQuery,
+  sessionQuery,
+} from "@/lib/queries"
 import { applyDelta, type DeltaState, EMPTY_DELTA } from "@/lib/session-delta"
 import { ago } from "@/lib/time"
 import { useApiMutation } from "@/lib/use-api-mutation"
@@ -41,7 +47,7 @@ import { usePageVisible } from "@/lib/use-page-visible"
 import { useUserEvent } from "@/lib/use-user-events"
 import { cn } from "@/lib/utils"
 import { mdToHtml } from "../artifact/lib/markdown"
-import { ConsolePending } from "./context-skeleton"
+import { ConsolePending, ContextRowsSkeleton } from "./context-skeleton"
 import { ANSWER_PROSE, answerMdToHtml } from "./lib/answer-md"
 
 // The context console: a context's HOME, not a bare chat widget — what it is (the
@@ -102,10 +108,16 @@ function Console({ id }: { id: string }) {
     refetchInterval: 60_000,
   })
   const {
-    data: sessions,
+    data: sessionPages,
     isError: sessionsFailed,
     refetch: refetchSessions,
-  } = useQuery(contextSessionsQuery(id))
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useInfiniteQuery(contextSessionsQuery(id))
+  // One flat list off the pages — the picker and Activity both read it, and neither
+  // cares where a page boundary fell.
+  const sessions = sessionPages?.pages.flatMap((p) => p.sessions)
   // The tab names the context; base title while it loads (or on no-access).
   useDocumentTitle(context?.name ?? null)
 
@@ -193,6 +205,9 @@ function Console({ id }: { id: string }) {
           </TabsTrigger>
           <TabsTrigger value="manifest" data-testid="console-tab-manifest">
             Manifest
+          </TabsTrigger>
+          <TabsTrigger value="output" data-testid="console-tab-output">
+            Output
           </TabsTrigger>
           {isOwner && (
             <TabsTrigger value="activity" data-testid="console-tab-activity">
@@ -308,6 +323,10 @@ function Console({ id }: { id: string }) {
           <ManifestTab context={context} />
         </TabsContent>
 
+        <TabsContent value="output" className="pt-4">
+          <OutputList contextId={id} />
+        </TabsContent>
+
         {isOwner && (
           <TabsContent value="activity" className="pt-4">
             <ActivityList
@@ -316,6 +335,8 @@ function Console({ id }: { id: string }) {
                 setPicked(sid)
                 setTab("chat")
               }}
+              onLoadMore={hasNextPage ? () => fetchNextPage() : undefined}
+              loadingMore={isFetchingNextPage}
             />
           </TabsContent>
         )}
@@ -941,11 +962,14 @@ function SessionThread({
   const [text, setText] = useState("")
   // The picker pills read the sessions LIST; the transcript polls its own key.
   // Sync the list whenever this session's state settles, so a pill never keeps
-  // saying "open" after the answer has already rendered below it.
+  // saying "open" after the answer has already rendered below it. Output goes with
+  // it: the turn that settles is the turn that may have bound a result artifact.
   const state = data?.session.state
   useEffect(() => {
-    if (state && state !== "open")
+    if (state && state !== "open") {
       qc.invalidateQueries({ queryKey: contextSessionsQuery(contextId).queryKey })
+      qc.invalidateQueries({ queryKey: contextOutputsQuery(contextId).queryKey })
+    }
   }, [state, contextId, qc])
   const refresh = () => qc.invalidateQueries({ queryKey: sessionQuery(sessionId).queryKey })
   // The server already publishes these on the same per-user SSE stream the notification
@@ -1306,8 +1330,21 @@ function MessageRow({ m, contextName }: { m: SessionMessage; contextName: string
   )
 }
 
-// The owner's view: every session on this context, most recent first.
-function ActivityList({ sessions, onOpen }: { sessions: Session[]; onOpen: (id: string) => void }) {
+// The owner's view: every session on this context, most recent first. Paged rather than
+// capped — a context that has been running for months has a record longer than one page,
+// and "the last 50" is not the record.
+function ActivityList({
+  sessions,
+  onOpen,
+  onLoadMore,
+  loadingMore,
+}: {
+  sessions: Session[]
+  onOpen: (id: string) => void
+  /** Undefined once the list is exhausted — the button disappears rather than no-ops. */
+  onLoadMore?: () => void
+  loadingMore?: boolean
+}) {
   if (sessions.length === 0)
     return <EmptyState title="No sessions yet" description="The first message starts the record." />
   return (
@@ -1351,6 +1388,100 @@ function ActivityList({ sessions, onOpen }: { sessions: Session[]; onOpen: (id: 
           )}
         </li>
       ))}
+      {onLoadMore && (
+        <li className="pt-3">
+          <Button
+            variant="outline"
+            size="sm"
+            data-testid="console-activity-more"
+            onClick={onLoadMore}
+            loading={loadingMore}
+            disabled={loadingMore}
+          >
+            Load more
+          </Button>
+        </li>
+      )}
+    </ul>
+  )
+}
+
+// WHAT THIS CONTEXT HAS PRODUCED — its body of work, not its conversation log. One row
+// per artifact however many runs bound it, so a report republished nightly reads as one
+// living document with a run count rather than fifty identical rows.
+function OutputList({ contextId }: { contextId: string }) {
+  const { data: outputs, isPending, isError, refetch } = useQuery(contextOutputsQuery(contextId))
+  if (isPending) return <ContextRowsSkeleton />
+  if (isError)
+    return (
+      <StatusPanel
+        layout="inline"
+        tone="danger"
+        title="Couldn't load this context's output"
+        description="Try again in a moment."
+        action={
+          <Button
+            variant="outline"
+            size="sm"
+            data-testid="console-output-retry"
+            onClick={() => refetch()}
+          >
+            Try again
+          </Button>
+        }
+      />
+    )
+  if (!outputs || outputs.length === 0)
+    return (
+      <EmptyState
+        icon={<Icon name="all" strokeWidth={1.75} />}
+        title="Nothing published yet"
+        description="When a run binds a result artifact, it shows up here — one row per document, however many runs it took."
+      />
+    )
+  return (
+    <ul className="flex flex-col">
+      {outputs.map((o) => {
+        // A run this viewer can see, on a document they can't: the row stays (the run
+        // is already in Activity) but it never becomes a link to something unreadable.
+        const unreadable = o.title === null
+        const body = (
+          <>
+            <Icon name="all" size={14} className="text-muted-foreground" />
+            <span className={cn("truncate", unreadable && "text-muted-foreground")}>
+              {o.title ?? o.short_id}
+            </span>
+            {unreadable && (
+              <Badge variant="outline" className="text-2xs">
+                unavailable
+              </Badge>
+            )}
+            <span className="ml-auto flex shrink-0 items-center gap-2.5 font-mono text-xs text-muted-foreground">
+              {o.version != null && <span>v{o.version}</span>}
+              <span>
+                {o.runs} {o.runs === 1 ? "run" : "runs"}
+              </span>
+              <span>{ago(o.last_run_at)}</span>
+            </span>
+          </>
+        )
+        return (
+          <li key={o.short_id} className="border-b last:border-0">
+            {unreadable ? (
+              <div className="flex items-center gap-3 px-1 py-2.5 text-sm">{body}</div>
+            ) : (
+              <Link
+                to="/artifacts/$ref"
+                params={{ ref: o.short_id }}
+                data-testid="console-output-row"
+                className="flex items-center gap-3 px-1 py-2.5 text-sm hover:bg-accent"
+              >
+                {body}
+              </Link>
+            )}
+          </li>
+        )
+      })}
     </ul>
   )
 }

--- a/apps/web/src/pages/context/console.tsx
+++ b/apps/web/src/pages/context/console.tsx
@@ -562,7 +562,16 @@ function RunnerCard({
         <div className="flex flex-col gap-2 border-t border-border-soft pt-2.5">
           <div>
             <p className="text-2xs text-muted-foreground">
-              Serve it from your own session — no token:
+              Give it work — from Chat above, or any coding session:
+            </p>
+            <code className="mt-1 block overflow-x-auto rounded-md bg-secondary px-2 py-1 font-mono text-2xs text-foreground">
+              use({"{"} context: "{context.name}", instruction: "…" {"}"})
+            </code>
+          </div>
+          <div>
+            <p className="text-2xs text-muted-foreground">
+              Then serve it from your own session — no token. This only claims what's already been
+              given; it does nothing on an empty queue:
             </p>
             <code className="mt-1 block overflow-x-auto rounded-md bg-secondary px-2 py-1 font-mono text-2xs text-foreground">
               use({"{"} context: "{context.name}" {"}"})
@@ -1304,12 +1313,19 @@ function ActivityList({ sessions, onOpen }: { sessions: Session[]; onOpen: (id: 
   return (
     <ul className="flex flex-col">
       {sessions.map((s) => (
-        <li key={s.id} className="border-b last:border-0">
+        <li
+          key={s.id}
+          className="flex items-center gap-3 border-b px-1 py-2.5 text-sm last:border-0 hover:bg-accent"
+        >
+          {/* A Link can't nest inside a button (invalid HTML, and the result link needs its
+              own navigation) — the row's open-chat click zone and the result link are siblings,
+              not parent/child; the result link stops propagation so it navigates instead of
+              also opening the thread underneath it. */}
           <button
             type="button"
             data-testid="console-activity-row"
             onClick={() => onOpen(s.id)}
-            className="flex w-full items-center gap-3 px-1 py-2.5 text-left text-sm hover:bg-accent"
+            className="flex min-w-0 flex-1 items-center gap-3 text-left"
           >
             <span className="text-foreground">{ago(s.created_at)}</span>
             {s.asker_username && <span className="text-muted-foreground">@{s.asker_username}</span>}
@@ -1319,13 +1335,20 @@ function ActivityList({ sessions, onOpen }: { sessions: Session[]; onOpen: (id: 
                 local
               </Badge>
             )}
-            <span className="ml-auto flex items-center gap-2.5">
-              <span className="font-mono text-xs text-muted-foreground">v{s.context_version}</span>
-              {s.result_artifact_id && (
-                <span className="font-mono text-xs text-muted-foreground">▤ result</span>
-              )}
-            </span>
           </button>
+          <span className="font-mono text-xs text-muted-foreground">v{s.context_version}</span>
+          {s.result_artifact_id && (
+            <Link
+              to="/artifacts/$ref"
+              params={{ ref: s.result_artifact_id }}
+              data-testid="console-activity-result"
+              onClick={(e) => e.stopPropagation()}
+              className="flex items-center gap-1 font-mono text-xs text-muted-foreground hover:text-foreground hover:underline"
+            >
+              <Icon name="all" size={12} />
+              result
+            </Link>
+          )}
         </li>
       ))}
     </ul>

--- a/apps/web/src/routes/contexts.$id.tsx
+++ b/apps/web/src/routes/contexts.$id.tsx
@@ -13,7 +13,9 @@ export const Route = createFileRoute("/contexts/$id")({
   loader: ({ context, params }) =>
     Promise.all([
       context.queryClient.prefetchQuery(contextQuery(params.id)),
-      context.queryClient.prefetchQuery(contextSessionsQuery(params.id)),
+      // Sessions are paged (Activity is the full record, not the last 50), so the
+      // warm-up is the infinite variant — prefetchQuery cannot seed a paged cache.
+      context.queryClient.prefetchInfiniteQuery(contextSessionsQuery(params.id)),
     ]),
   pendingComponent: ConsolePending,
   component: ContextConsole,

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -1431,11 +1431,25 @@ export interface ContextStore {
     state: SessionState,
   ): Promise<{ session: SessionRecord; message: SessionMessageRecord }>
   getSession(id: string): Promise<SessionRecord | null>
-  /** Sessions on a context, newest first; `askerId` narrows to one person's. */
+  /** Sessions on a context, newest first; `askerId` narrows to one person's.
+   *  `cursor` pages further back: a `(created_at, id)` keyset, exclusive. The id
+   *  tiebreak is load-bearing, not defensive — sessions ARE created in the same
+   *  millisecond (a script recording a batch of local runs), and a cursor on the
+   *  timestamp alone would silently drop every row sharing the boundary. Encode
+   *  and decode it with `encodeCursor`/`decodeCursor`, like `listArtifacts`. */
   listSessions(
     contextId: string,
-    opts?: { askerId?: string; limit?: number },
+    opts?: { askerId?: string; limit?: number; cursor?: { key: string; id: string } },
   ): Promise<SessionRecord[]>
+  /** What this context has PRODUCED: its sessions' bound result artifacts, GROUPED —
+   *  one row per artifact however many runs bound it, so a report republished nightly is
+   *  one output carrying a run count, not fifty rows of the same short id. Newest run
+   *  first. Sessions that bound nothing (a plain question) are simply absent.
+   *
+   *  Returns short ids only, deliberately: the caller resolves them through
+   *  `listArtifacts({ ids })`, so the visibility gate is the same one the library uses
+   *  and this can never widen what a viewer sees. */
+  contextOutputs(contextId: string, limit?: number): Promise<ContextOutput[]>
   /** One person's CONTEXTLESS sessions in a workspace, newest first — the chat history
    *  picker. Contextless IS the filter: a session with no context is one nobody packaged,
    *  which is exactly what the chat surfaces open. `listSessions` cannot answer this (it
@@ -2788,6 +2802,19 @@ export interface SessionRecord {
    *  opened before this column existed. */
   subject_ref: string | null
 }
+
+/** One artifact a context has produced, grouped across every session that bound it —
+ *  the row behind the console's Output tab. Carries no title or version on purpose:
+ *  those come from resolving `short_id` through the normal visibility-gated artifact
+ *  read, so an output can never show a viewer a document they cannot open. */
+export interface ContextOutput {
+  short_id: string
+  /** How many of this context's sessions bound this artifact as their result. */
+  runs: number
+  /** The most recent of those sessions' last activity (its `updated_at`). */
+  last_run_at: string
+}
+
 export interface NewSession {
   id: string
   context_id?: string | null

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -23,6 +23,7 @@ import type {
   ConnectionScope,
   ConnectionStatus,
   ContextAskerRecord,
+  ContextOutput,
   ContextRecord,
   DeliveryRecord,
   DeliveryStatus,
@@ -151,6 +152,7 @@ import {
   ne,
   notExists,
   or,
+  type SQL,
   sql,
 } from "drizzle-orm"
 import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres"
@@ -3803,17 +3805,44 @@ export class PgMetaStore implements MetaStore {
   }
   listSessions(
     contextId: string,
-    opts?: { askerId?: string; limit?: number },
+    opts?: { askerId?: string; limit?: number; cursor?: { key: string; id: string } },
   ): Promise<SessionRecord[]> {
-    const where = opts?.askerId
-      ? and(eq(contextSession.context_id, contextId), eq(contextSession.asker_id, opts.askerId))
-      : eq(contextSession.context_id, contextId)
+    const clauses = [eq(contextSession.context_id, contextId)]
+    if (opts?.askerId) clauses.push(eq(contextSession.asker_id, opts.askerId))
+    // Keyset, not offset (a session opened mid-paging would shift every offset and
+    // repeat a row), and the id tiebreak is required, not belt-and-braces: several
+    // sessions really do share a created_at, and `created_at < key` alone would skip
+    // every one of them at the page boundary.
+    const cur = opts?.cursor
+    if (cur)
+      clauses.push(
+        or(
+          lt(contextSession.created_at, cur.key),
+          and(eq(contextSession.created_at, cur.key), lt(contextSession.id, cur.id)),
+        ) as SQL,
+      )
     return this.db
       .select()
       .from(contextSession)
-      .where(where)
-      .orderBy(desc(contextSession.created_at))
+      .where(and(...clauses))
+      .orderBy(desc(contextSession.created_at), desc(contextSession.id))
       .limit(opts?.limit ?? 50)
+  }
+  contextOutputs(contextId: string, limit?: number): Promise<ContextOutput[]> {
+    const lastRun = sql<string>`max(coalesce(${contextSession.updated_at}, ${contextSession.created_at}))`
+    return this.db
+      .select({
+        short_id: sql<string>`${contextSession.result_artifact_id}`,
+        runs: count(),
+        last_run_at: lastRun,
+      })
+      .from(contextSession)
+      .where(
+        and(eq(contextSession.context_id, contextId), isNotNull(contextSession.result_artifact_id)),
+      )
+      .groupBy(contextSession.result_artifact_id)
+      .orderBy(desc(lastRun))
+      .limit(limit ?? 50)
   }
   listChatSessions(orgId: string, askerId: string, limit?: number): Promise<SessionRecord[]> {
     return this.db

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -18,6 +18,7 @@ import type {
   ConnectionScope,
   ConnectionStatus,
   ContextAskerRecord,
+  ContextOutput,
   ContextRecord,
   DeliveryRecord,
   DeliveryStatus,
@@ -3005,19 +3006,45 @@ export function makeRepos(db: SqliteDb) {
     (await db.select().from(contextSession).where(eq(contextSession.id, id)).get()) ?? null
   const listSessions = async (
     contextId: string,
-    opts?: { askerId?: string; limit?: number },
+    opts?: { askerId?: string; limit?: number; cursor?: { key: string; id: string } },
   ): Promise<SessionRecord[]> => {
-    const where = opts?.askerId
-      ? and(eq(contextSession.context_id, contextId), eq(contextSession.asker_id, opts.askerId))
-      : eq(contextSession.context_id, contextId)
+    const clauses = [eq(contextSession.context_id, contextId)]
+    if (opts?.askerId) clauses.push(eq(contextSession.asker_id, opts.askerId))
+    // Keyset, not offset (a session opened mid-paging would shift every offset and
+    // repeat a row), and the id tiebreak is required, not belt-and-braces: several
+    // sessions really do share a created_at, and `created_at < key` alone would skip
+    // every one of them at the page boundary.
+    const cur = opts?.cursor
+    if (cur)
+      clauses.push(
+        or(
+          lt(contextSession.created_at, cur.key),
+          and(eq(contextSession.created_at, cur.key), lt(contextSession.id, cur.id)),
+        ) as SQL,
+      )
     return db
       .select()
       .from(contextSession)
-      .where(where)
-      .orderBy(desc(contextSession.created_at))
+      .where(and(...clauses))
+      .orderBy(desc(contextSession.created_at), desc(contextSession.id))
       .limit(opts?.limit ?? 50)
       .all()
   }
+  const contextOutputs = async (contextId: string, limit?: number): Promise<ContextOutput[]> =>
+    db
+      .select({
+        short_id: contextSession.result_artifact_id,
+        runs: count(),
+        last_run_at: sql<string>`max(coalesce(${contextSession.updated_at}, ${contextSession.created_at}))`,
+      })
+      .from(contextSession)
+      .where(
+        and(eq(contextSession.context_id, contextId), isNotNull(contextSession.result_artifact_id)),
+      )
+      .groupBy(contextSession.result_artifact_id)
+      .orderBy(desc(sql`max(coalesce(${contextSession.updated_at}, ${contextSession.created_at}))`))
+      .limit(limit ?? 50)
+      .all() as Promise<ContextOutput[]>
   const listChatSessions = async (
     orgId: string,
     askerId: string,
@@ -4553,6 +4580,7 @@ export function makeRepos(db: SqliteDb) {
     createSessionWithMessage,
     getSession,
     listSessions,
+    contextOutputs,
     listChatSessions,
     pendingSessions,
     claimPendingSessions,

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -3154,6 +3154,62 @@ export function runStoreContract(
       expect(await store.pendingSessions(ctx.id, 1)).toHaveLength(1)
     })
 
+    it("pages sessions on a (created_at, id) keyset, surviving rows that share a timestamp", async () => {
+      const ctx = await newContext()
+      // Written in a tight loop, so several of these DO share a created_at at
+      // millisecond resolution — exactly the case a timestamp-only cursor drops
+      // at the page boundary.
+      for (let i = 0; i < 5; i++)
+        await store.createSession({
+          id: uuid(),
+          context_id: ctx.id,
+          org_id: ORG,
+          asker_id: "daniel",
+          context_version: 1,
+        })
+      const all = await store.listSessions(ctx.id)
+      expect(all).toHaveLength(5)
+      // Walk the whole list one row at a time: every session appears exactly once,
+      // in the same order the unpaged read returns.
+      const seen: string[] = []
+      let cursor: { key: string; id: string } | undefined
+      for (let guard = 0; guard < 10; guard++) {
+        const row = (await store.listSessions(ctx.id, { limit: 1, cursor }))[0]
+        if (!row) break
+        seen.push(row.id)
+        cursor = { key: row.created_at, id: row.id }
+      }
+      expect(seen).toEqual(all.map((s) => s.id))
+      expect(new Set(seen).size).toBe(5)
+    })
+
+    it("contextOutputs groups result bindings by artifact and counts the runs", async () => {
+      const ctx = await newContext()
+      const bind = async (artifact: string | null) => {
+        const s = await store.createSession({
+          id: uuid(),
+          context_id: ctx.id,
+          org_id: ORG,
+          asker_id: "daniel",
+          context_version: 1,
+        })
+        if (artifact) await store.setResultArtifact(s.id, artifact)
+        return s
+      }
+      await bind("rep0rt01")
+      await bind("rep0rt01") // the same report, a second run
+      await bind("other001")
+      await bind(null) // a plain question binds nothing and must not appear
+
+      const outputs = await store.contextOutputs(ctx.id)
+      expect(outputs).toHaveLength(2)
+      expect(outputs.find((o) => o.short_id === "rep0rt01")?.runs).toBe(2)
+      expect(outputs.find((o) => o.short_id === "other001")?.runs).toBe(1)
+      expect(typeof outputs[0]?.last_run_at).toBe("string")
+      // Another context's bindings are never mixed in.
+      expect(await store.contextOutputs((await newContext()).id)).toEqual([])
+    })
+
     it("lists a person's contextless chat sessions, newest first, and nobody else's", async () => {
       const ctx = await newContext()
       // A session WITH a context must never appear here: the chat history is the sessions


### PR DESCRIPTION
## Summary

Follow-ups to #638, all found by dogfooding it on production rather than re-reading the diff.

**1. The Runner card never showed the give step.** Confirmed live — pulling `use({context: "QA Derive"})` with nothing queued returns `claimed: 0` and does nothing, which is correct, but the card only ever showed that bare pull call. It reads like "run it" when it's actually "check the queue," so a manifest written like a task briefing sets you up to paste the snippet and watch nothing happen. The card now shows `use({context, instruction})` first and says plainly that serve alone no-ops on an empty queue.

**2. Activity's result indicator was dead text.** A plain `<span>` — visible, unreachable. Now a real `Link` (the row splits into a button for "open thread" and a sibling link for "open result," since a `Link` can't nest in a `<button>`).

**3. New Output tab — what a context has PRODUCED.** `GET /v1/contexts/:id/outputs` returns the artifacts a context produced, **grouped by artifact**, so a report republished nightly is one row carrying a run count rather than fifty identical rows. Derived entirely from result bindings that already exist (`session.result_artifact_id`); nothing new is written, and nothing is inferred from a publish.

**4. Activity pages instead of stopping at 50.** `listSessions` gains a `(created_at, id)` keyset cursor and the route returns `next_cursor`; the console's sessions query becomes infinite with a Load more that retires itself when a short page proves the end.

### Two things the tests caught, worth calling out

- **The id half of the cursor is load-bearing, not defensive.** Sessions genuinely share a `created_at` — a script recording a batch of local runs writes several per millisecond — and a timestamp-only cursor drops *every* row at that boundary. My first version had exactly that bug; the failing test is what surfaced it.
- **Visibility.** The first draft passed short_ids to `listArtifacts({ids})`, which takes *internal* ids and, with no `viewerId`, means "trusted caller sees everything." It's now `getByShortIds` + the sanctioned per-artifact `authorize()` gate (the pairing `bulkArtifactOp` uses). An output the viewer can't read comes back `title: null` and renders as "unavailable" rather than disappearing — the run is already visible in Activity; the document is what's private.

## Test plan

- [x] `pnpm verify` green (typecheck + full lint battery + `test:coverage`), plus the pre-push hook on every push.
- [x] New API tests: output grouping and run counts, a session that bound nothing stays absent, the unreadable-output case, 404 for a member who may not ask, and a full one-row-at-a-time keyset walk.
- [x] New store-contract tests on **both** dialects: `contextOutputs` grouping/scoping, and paging survives rows that share a timestamp.
- [x] Dogfooded live against local dev: 4 runs against one report collapse to a single row reading "4 runs"; an output row opens its artifact; walking 56 real sessions two at a time returns them in exactly the unpaged order with no repeats; Load more takes the list 50 → 56 and then disappears.

Not included: the *inferred* auto-record (treating any republish of a bound artifact as a run) — that one is noisy by construction and isn't scoped yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)