### PR TITLE
feat(slack): the card gets a thumbnail, an author, and stops repeating itself

### DIFF
--- a/apps/api/src/lib/artifact-status.ts
+++ b/apps/api/src/lib/artifact-status.ts
@@ -35,6 +35,15 @@ export interface ArtifactStatus {
    *  "2 open threads" is an invitation. */
   openThreads: number
   updatedAt: string | null
+  /** Who published the current version, as a display name — the author string the version
+   *  carries, which is a person for a hand publish and an agent's name for a generated one.
+   *  Null when the artifact has no version row yet.
+   *
+   *  `content_item` has a TYPED `last_modified_by` field, so Slack renders this itself rather
+   *  than us formatting a sentence. Verified against the API: the shape takes a display name
+   *  only — a slack_user_id, an avatar url, or either alongside the name are all rejected with
+   *  "failed to match exactly one allowed schema" — so there is no @-link or avatar to be had. */
+  lastModifiedBy: string | null
 }
 
 export const artifactStatus = async (
@@ -47,6 +56,7 @@ export const artifactStatus = async (
   const round = await meta.getPendingRound(artifact.id)
   const signals = await meta.commentSignals([artifact.id], null)
   const [reviewer] = round ? await meta.getUsers([round.requested_for]) : []
+  const current = await meta.getVersion(artifact.id, artifact.current_version)
   return {
     review: round
       ? {
@@ -57,6 +67,7 @@ export const artifactStatus = async (
       : null,
     openThreads: signals[artifact.id]?.open_threads ?? 0,
     updatedAt: artifact.updated_at,
+    lastModifiedBy: current?.author ?? null,
   }
 }
 

--- a/apps/api/src/lib/artifact-status.ts
+++ b/apps/api/src/lib/artifact-status.ts
@@ -44,6 +44,12 @@ export interface ArtifactStatus {
    *  only — a slack_user_id, an avatar url, or either alongside the name are all rejected with
    *  "failed to match exactly one allowed schema" — so there is no @-link or avatar to be had. */
   lastModifiedBy: string | null
+  /** Whether the current version's OG render has finished, so a card may promise a picture.
+   *
+   *  Here rather than re-read where it is needed: this resolver already reads the version row
+   *  for `lastModifiedBy`, and the Slack card was fetching the identical row a second time in
+   *  the same request to answer this one question. */
+  previewReady: boolean
 }
 
 export const artifactStatus = async (
@@ -68,6 +74,7 @@ export const artifactStatus = async (
     openThreads: signals[artifact.id]?.open_threads ?? 0,
     updatedAt: artifact.updated_at,
     lastModifiedBy: current?.author ?? null,
+    previewReady: current?.preview_status === "ready" && !!current.preview_key,
   }
 }
 

--- a/apps/api/src/lib/og-token.ts
+++ b/apps/api/src/lib/og-token.ts
@@ -60,3 +60,20 @@ export const verifyOgToken = async (
   if (!Number.isInteger(n)) return null
   return { artifactId: claim.rest.slice(0, midDot), n }
 }
+
+/**
+ * The origin Slack requires on a preview image's response, verbatim from its implementation
+ * guide: "For security reasons, these public URLs must include the CORS response header set to
+ * access-control-allow-origin:https://app.slack.com."
+ *
+ * Which tells us something the docs do not say outright. CORS is a BROWSER mechanism — a server
+ * fetching an image never consults it — so the Slack client loads `preview_url` from the
+ * viewer's own browser rather than proxying it. The token in that URL is therefore spent by the
+ * reader, not by Slack, and is visible to anyone who opens their network tab in that channel.
+ * That is the capability-URL bargain this whole feature rests on, and it is worth knowing it is
+ * literal rather than theoretical.
+ *
+ * A constant rather than an echo of the request's Origin, so the response does not vary by
+ * caller and stays cacheable on one key.
+ */
+export const SLACK_PREVIEW_ORIGIN = "https://app.slack.com"

--- a/apps/api/src/lib/slack-work-object.ts
+++ b/apps/api/src/lib/slack-work-object.ts
@@ -124,15 +124,42 @@ export const artifactEntity = (a: WorkObjectArgs): Record<string, unknown> => {
   // `fields` is REQUIRED — omitting it fails the whole payload with "missing required field:
   // fields", which surfaces as a format error that looks like a wrapper problem. Only the five
   // names content_item knows may go here; everything else belongs in custom_fields below.
+  //
+  // ONE FACT, ONE PLACE. The description used to lead with the review sentence, which
+  // `custom_fields` below states again as `Review` and `Waiting on` — three renderings of the
+  // same thing on a card with room for none of them. The labelled fields win that tie: they are
+  // what Slack draws as scannable chips where the eye goes, which is the whole reason for
+  // adopting a typed entity over a block card. So `description` stops repeating them, and stops
+  // leading with `dataSummary` too — that has its own `Data` chip.
+  //
+  // What is left is the inventory line. Thin, but it is genuinely all the prose there is: an
+  // artifact carries no summary or excerpt anywhere in `UnfurlInfo`, so there is nothing better
+  // to put here and nothing lost by not trying.
   const fields: Record<string, unknown> = {
     description: {
-      value: statusPhrase(status)?.text
-        ? `${statusPhrase(status)?.text}${status.review?.reviewerName ? ` — ${status.review.reviewerName}` : ""}`
-        : unfurlDescription(info),
+      value: unfurlDescription({ ...info, dataSummary: null }),
       // "markdown", never "plain_text": the latter is not in the enum and rejects the payload.
       format: "markdown",
     },
   }
+  // The THUMBNAIL on the card itself — the picture people see without clicking, as distinct from
+  // `full_size_preview`, which is the expanded view. `alt_text` is required: omitting it fails
+  // the payload with a pointer straight at this field.
+  //
+  // Both surfaces take the same URL. It is one already-rendered, already-cached image, and
+  // Slack scales it.
+  if (a.previewUrl)
+    fields.preview = {
+      type: "slack#/types/image",
+      alt_text: `Preview of ${info.title}`.slice(0, 200),
+      image_url: a.previewUrl,
+    }
+  // A typed field Slack renders itself, and the question a document card most owes an answer to.
+  if (status.lastModifiedBy)
+    fields.last_modified_by = {
+      type: "slack#/types/user",
+      user: { text: status.lastModifiedBy },
+    }
   if (status.updatedAt) {
     const ms = Date.parse(status.updatedAt)
     // A typed date, so Slack renders it in the reader's own locale and timezone.
@@ -215,6 +242,10 @@ export const artifactDetails = (
   previewUrl?: string | null,
 ): Record<string, unknown> => {
   const phrase = statusPhrase(status, viewerId)
+  // Unlike the card, this one KEEPS the status sentence alongside the description. It is not the
+  // same sentence: `statusPhrase` takes the viewer, so this panel says "Awaiting YOUR review" to
+  // the person actually being waited on — which no labelled chip can express, because a chip is
+  // the same for everybody and this surface is not.
   const fields: Record<string, unknown> = {
     description: {
       value: phrase
@@ -223,6 +254,17 @@ export const artifactDetails = (
       format: "markdown",
     },
   }
+  if (previewUrl)
+    fields.preview = {
+      type: "slack#/types/image",
+      alt_text: `Preview of ${info.title}`.slice(0, 200),
+      image_url: previewUrl,
+    }
+  if (status.lastModifiedBy)
+    fields.last_modified_by = {
+      type: "slack#/types/user",
+      user: { text: status.lastModifiedBy },
+    }
   const ago = agoLabel(status.updatedAt)
   return {
     // `url` and `external_ref` are REQUIRED here, not optional identity decoration:

--- a/apps/api/src/lib/slack-work-object.ts
+++ b/apps/api/src/lib/slack-work-object.ts
@@ -125,19 +125,25 @@ export const artifactEntity = (a: WorkObjectArgs): Record<string, unknown> => {
   // fields", which surfaces as a format error that looks like a wrapper problem. Only the five
   // names content_item knows may go here; everything else belongs in custom_fields below.
   //
-  // ONE FACT, ONE PLACE. The description used to lead with the review sentence, which
-  // `custom_fields` below states again as `Review` and `Waiting on` — three renderings of the
-  // same thing on a card with room for none of them. The labelled fields win that tie: they are
-  // what Slack draws as scannable chips where the eye goes, which is the whole reason for
-  // adopting a typed entity over a block card. So `description` stops repeating them, and stops
-  // leading with `dataSummary` too — that has its own `Data` chip.
+  // THE HEADLINE, and it deliberately REPEATS what the chips below say.
   //
-  // What is left is the inventory line. Thin, but it is genuinely all the prose there is: an
-  // artifact carries no summary or excerpt anywhere in `UnfurlInfo`, so there is nothing better
-  // to put here and nothing lost by not trying.
+  // I removed that repetition once, on the reasoning that `Review` and `Waiting on` already
+  // carry it and a card has room for one rendering, not three. That was wrong, and the payload
+  // it produced showed why: the description fell back to "Markdown · 3 versions · 7 comments ·
+  // on Derive" — the inventory line this whole feature exists to stop leading with. It answers
+  // "what is this?" when the question a shared link needs answered is "does this want something
+  // from me?".
+  //
+  // The two slots are not peers. `description` is the prominent line; `custom_fields` are
+  // secondary labelled pairs. They serve skimming and scanning respectively, so the same fact
+  // in both is not waste — and de-duplicating cost the headline its meaning to buy tidiness
+  // nobody asked for. (The duplication is not even removable in principle: `display_type`
+  // repeats the kind, and `Version` repeats the version count, in the very same line.)
   const fields: Record<string, unknown> = {
     description: {
-      value: unfurlDescription({ ...info, dataSummary: null }),
+      value: statusPhrase(status)?.text
+        ? `${statusPhrase(status)?.text}${status.review?.reviewerName ? ` — ${status.review.reviewerName}` : ""}`
+        : unfurlDescription(info),
       // "markdown", never "plain_text": the latter is not in the enum and rejects the payload.
       format: "markdown",
     },
@@ -242,10 +248,11 @@ export const artifactDetails = (
   previewUrl?: string | null,
 ): Record<string, unknown> => {
   const phrase = statusPhrase(status, viewerId)
-  // Unlike the card, this one KEEPS the status sentence alongside the description. It is not the
-  // same sentence: `statusPhrase` takes the viewer, so this panel says "Awaiting YOUR review" to
-  // the person actually being waited on — which no labelled chip can express, because a chip is
-  // the same for everybody and this surface is not.
+  // Both surfaces lead with the status, but this sentence is not the card's: `statusPhrase`
+  // takes the viewer here, so the panel says "Awaiting YOUR review" to the person actually being
+  // waited on. No chip can say that — a chip is the same for everybody, and this surface is not.
+  // It also keeps the description BELOW the status rather than replacing it, because a panel
+  // opened deliberately has the room a broadcast card does not.
   const fields: Record<string, unknown> = {
     description: {
       value: phrase

--- a/apps/api/src/routes/embeds.ts
+++ b/apps/api/src/routes/embeds.ts
@@ -18,7 +18,7 @@ import {
 import { type Context, Hono } from "hono"
 import type { AppContext } from "../context"
 import { fail, toBody } from "../lib/http"
-import { verifyOgToken } from "../lib/og-token"
+import { SLACK_PREVIEW_ORIGIN, verifyOgToken } from "../lib/og-token"
 import { unfurlInfoFor } from "../lib/unfurl-info"
 
 /**
@@ -146,6 +146,9 @@ export const embedRoutes = (ctx: AppContext) => {
               ? "public, max-age=86400, stale-while-revalidate=604800"
               : cacheFor(artifact, "public, max-age=86400, stale-while-revalidate=604800", 3600),
             "X-Content-Type-Options": "nosniff",
+            // Slack REQUIRES this on anything it is handed as a preview image; without it the
+            // card's picture simply does not appear. See SLACK_PREVIEW_ORIGIN.
+            "Access-Control-Allow-Origin": SLACK_PREVIEW_ORIGIN,
           })
       }
     }
@@ -180,6 +183,9 @@ export const embedRoutes = (ctx: AppContext) => {
         3600,
       ),
       "X-Content-Type-Options": "nosniff",
+      // Same header on the fallback: this URL is what a public artifact's card points at, and it
+      // lands here whenever that artifact's render is still pending.
+      "Access-Control-Allow-Origin": SLACK_PREVIEW_ORIGIN,
     })
   })
 

--- a/apps/api/src/routes/slack.ts
+++ b/apps/api/src/routes/slack.ts
@@ -10,7 +10,7 @@ import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import type { Context } from "hono"
 import type { BlankEnv } from "hono/types"
 import type { AppContext } from "../context"
-import { artifactStatus } from "../lib/artifact-status"
+import { type ArtifactStatus, artifactStatus } from "../lib/artifact-status"
 import { commentCreatedAction } from "../lib/comment-actions"
 import { commentDeepLink } from "../lib/comments"
 import { encryptSecret, signState, verifyState } from "../lib/crypto"
@@ -296,10 +296,10 @@ export const slackRoutes = (ctx: AppContext) => {
   const previewUrlFor = async (
     artifact: ArtifactRecord,
     info: UnfurlInfo,
+    status: ArtifactStatus,
   ): Promise<string | null> => {
     if (artifact.listed !== "public" && artifact.listed !== "workspace") return null
-    const v = await meta.getVersion(artifact.id, artifact.current_version)
-    if (v?.preview_status !== "ready" || !v.preview_key) return null
+    if (!status.previewReady) return null
     // A world-readable doc needs no capability: /v1/og already serves its PNG to anyone.
     if (artifact.listed === "public") return info.imageUrl
     if (!deps.encryptionKey) return null
@@ -350,7 +350,7 @@ export const slackRoutes = (ctx: AppContext) => {
       // token that buys that image and nothing else (lib/og-token.ts). `listed: "none"` never
       // reaches here — decideUnfurl answered it with the locked card above — which is the line
       // this feature deliberately does not cross: a doc someone marked private stays a padlock.
-      previewUrl: await previewUrlFor(d.artifact, d.info),
+      previewUrl: await previewUrlFor(d.artifact, d.info, status),
       withActions: status.review?.state === "pending",
       iconUrl,
     })
@@ -427,7 +427,7 @@ export const slackRoutes = (ctx: AppContext) => {
           status,
           userLink.user_id,
           iconUrl,
-          await previewUrlFor(artifact, info),
+          await previewUrlFor(artifact, info, status),
         ),
       },
       "details",

--- a/apps/api/test/og-preview.test.ts
+++ b/apps/api/test/og-preview.test.ts
@@ -418,3 +418,50 @@ describe("/v1/og/:ref — the signed preview token", () => {
     expect(body).not.toContain("Unrendered Secret")
   })
 })
+
+// THE HEADER WITHOUT WHICH NONE OF THIS RENDERS.
+//
+// Slack's implementation guide: "For security reasons, these public URLs must include the CORS
+// response header set to access-control-allow-origin:https://app.slack.com."
+//
+// Worth stating what that implies, because it is not in the docs and it changes the threat
+// model: CORS is a BROWSER mechanism, so the Slack client loads the preview from the viewer's
+// own browser rather than proxying it server-side. The token in the URL is spent by the reader.
+
+describe("/v1/og/:ref — the header Slack requires on a preview image", () => {
+  it("is on the PNG a card actually displays", async () => {
+    const { app, meta, blobs } = makeApp("og-cors-png")
+    const { short_id, current_version } = await publish(app, "<h1>Hi</h1>", {
+      visibility: "public",
+      title: "Corsy",
+    })
+    const artifact = await meta.getByShortId(short_id)
+    if (!artifact) throw new Error("artifact not found after publish")
+    await meta.setVersionPreview(artifact.id, current_version, {
+      preview_key: await blobs.put(TINY_PNG),
+      preview_status: "ready",
+    })
+    const res = await app.request(`/v1/og/${short_id}`)
+    expect(res.headers.get("content-type")).toBe("image/png")
+    expect(res.headers.get("access-control-allow-origin")).toBe("https://app.slack.com")
+  })
+
+  it("is on the SVG fallback too — that is what an unrendered doc's card points at", async () => {
+    const { app } = makeApp("og-cors-svg")
+    const { short_id } = await publish(app, "<h1>Hi</h1>", { visibility: "public", title: "S" })
+    const res = await app.request(`/v1/og/${short_id}`)
+    expect(res.headers.get("content-type")).toContain("image/svg+xml")
+    expect(res.headers.get("access-control-allow-origin")).toBe("https://app.slack.com")
+  })
+
+  it("is a constant, not an echo — so the response stays cacheable on one key", async () => {
+    // Echoing the caller's Origin would make the bytes vary by requester and force a Vary that
+    // defeats the shared caching this endpoint depends on.
+    const { app } = makeApp("og-cors-constant")
+    const { short_id } = await publish(app, "<h1>Hi</h1>", { visibility: "public", title: "S" })
+    const res = await app.request(`/v1/og/${short_id}`, {
+      headers: { origin: "https://evil.example" },
+    })
+    expect(res.headers.get("access-control-allow-origin")).toBe("https://app.slack.com")
+  })
+})

--- a/apps/api/test/slack-work-object.test.ts
+++ b/apps/api/test/slack-work-object.test.ts
@@ -37,6 +37,7 @@ const status = (over: Partial<ArtifactStatus> = {}): ArtifactStatus => ({
   review: null,
   openThreads: 0,
   updatedAt: "2026-08-01T10:00:00.000Z",
+  lastModifiedBy: "Dana",
   ...over,
 })
 
@@ -92,11 +93,19 @@ describe("artifactEntity", () => {
       withActions: true,
     })
     const p = e.entity_payload as { fields: Record<string, never>; custom_fields: unknown[] }
-    // content_item accepts exactly five typed fields and silently DROPS the rest — `status` and
-    // `assignee` belong to `task`. Measured against the live API: sending them returns
-    // "The field status will be omitted due to an invalid type". So the review state rides
-    // custom_fields, and only `description` / `date_updated` go in `fields`.
-    expect(Object.keys(p.fields).sort()).toEqual(["date_updated", "description"])
+    // content_item accepts SIX typed fields — preview, description, created_by,
+    // last_modified_by, date_created, date_updated — and silently drops the rest. `status` and
+    // `assignee` belong to `task`, so there is no colour-tagged status field to be had here.
+    //
+    // Established against the live API by a discriminator, because acceptance proves nothing on
+    // this endpoint: Slack SHAPE-CHECKS a field it recognises and ignores one it does not. A
+    // malformed `preview` answers with a pointer naming it; a malformed `assignee` answers
+    // `ok: true` and vanishes. So the review state rides custom_fields.
+    expect(Object.keys(p.fields).sort()).toEqual([
+      "date_updated",
+      "description",
+      "last_modified_by",
+    ])
     expect(p.fields.description).toMatchObject({ format: "markdown" })
     expect(JSON.stringify(p.fields)).not.toContain("tag_color")
     const cf = JSON.stringify(p.custom_fields)
@@ -202,7 +211,7 @@ describe("artifactDetails (the flexpane)", () => {
     const f = (d.entity_payload as { fields: Record<string, never> }).fields
     // Only content_item's own field names, and markdown — "plain_text" is not in the enum and
     // rejects the entire payload.
-    expect(Object.keys(f)).toEqual(["description"])
+    expect(Object.keys(f).sort()).toEqual(["description", "last_modified_by"])
     expect(f.description).toMatchObject({ format: "markdown" })
     expect(JSON.stringify(f.description)).toContain("Awaiting your review")
   })
@@ -274,5 +283,121 @@ describe("review buttons target the artifact from any surface", () => {
     const acts = (e.entity_payload as { actions: { primary_actions: { value?: string }[] } })
       .actions
     for (const a of acts.primary_actions) expect(decodeReviewAction(a.value ?? "")).toBe("a1")
+  })
+})
+
+/** The bits of an entity payload these assertions reach into. */
+interface Payload {
+  fields: Record<string, Record<string, unknown> | undefined>
+  attributes: Record<string, Record<string, unknown> | undefined>
+  custom_fields: Record<string, unknown>[]
+}
+
+// THE PICTURE, AND WHO TOUCHED IT LAST.
+//
+// `content_item` recognises exactly six typed fields, established against the live API rather
+// than from the docs alone — the discriminator being that Slack SHAPE-CHECKS a field it knows
+// and silently swallows one it does not. A malformed `preview` names itself in the error; a
+// malformed `assignee` (which belongs to `task`) produces nothing at all.
+
+describe("the card's own image", () => {
+  it("carries the thumbnail as a typed field, with the alt_text Slack demands", () => {
+    const e = artifactEntity({
+      ...base,
+      artifact: artifact(),
+      info,
+      status: status(),
+      previewUrl: "https://d/p.png",
+    })
+    const preview = (e.entity_payload as { fields: Record<string, Record<string, unknown>> }).fields
+      .preview
+    expect(preview?.type).toBe("slack#/types/image")
+    expect(preview?.image_url).toBe("https://d/p.png")
+    // Omitting alt_text fails the whole payload with a pointer at this field — verified.
+    expect(preview?.alt_text).toBeTruthy()
+  })
+
+  it("is the thumbnail AND the expanded view — two surfaces, one rendered image", () => {
+    const e = artifactEntity({
+      ...base,
+      artifact: artifact(),
+      info,
+      status: status(),
+      previewUrl: "https://d/p.png",
+    })
+    const p = e.entity_payload as Payload
+    expect(p.fields.preview?.image_url).toBe("https://d/p.png")
+    expect(p.attributes.full_size_preview?.preview_url).toBe("https://d/p.png")
+  })
+
+  it("offers neither when there is no image to offer", () => {
+    const e = artifactEntity({
+      ...base,
+      artifact: artifact(),
+      info,
+      status: status(),
+      previewUrl: null,
+    })
+    expect(JSON.stringify(e)).not.toContain("preview")
+  })
+})
+
+describe("one fact, one place", () => {
+  // The card used to state a pending review three times: once in the description and twice more
+  // as its own chips. The chips win — they are what Slack draws where the eye goes, which is the
+  // reason for using a typed entity at all.
+  it("does not repeat the review status in the description", () => {
+    const e = artifactEntity({
+      ...base,
+      artifact: artifact(),
+      info,
+      status: status({
+        review: { state: "pending", reviewerId: "u1", reviewerName: "Mert" },
+      }),
+    })
+    const p = e.entity_payload as Payload
+    expect(String(p.fields.description?.value)).not.toContain("Awaiting")
+    // ...because it is here instead, labelled and scannable.
+    expect(JSON.stringify(p.custom_fields)).toContain("Awaiting")
+    expect(JSON.stringify(p.custom_fields)).toContain("Mert")
+  })
+
+  it("does not repeat the data summary either — it has its own chip", () => {
+    const e = artifactEntity({
+      ...base,
+      artifact: artifact(),
+      info: { ...info, dataSummary: "pass 48 · fail 0" },
+      status: status(),
+    })
+    const p = e.entity_payload as Payload
+    expect(String(p.fields.description?.value)).not.toContain("pass 48")
+    expect(JSON.stringify(p.custom_fields)).toContain("pass 48")
+  })
+
+  it("names who published the current version, typed so Slack renders it", () => {
+    const e = artifactEntity({
+      ...base,
+      artifact: artifact(),
+      info,
+      status: status({ lastModifiedBy: "Dana" }),
+    })
+    const f = (e.entity_payload as Payload).fields
+    expect(f.last_modified_by).toEqual({
+      type: "slack#/types/user",
+      // A display name only. A slack_user_id, an avatar url, or either beside the name are all
+      // rejected with "failed to match exactly one allowed schema" — verified against the API,
+      // so there is no @-link or avatar available here however much one would suit the card.
+      user: { text: "Dana" },
+    })
+  })
+
+  it("omits the author rather than inventing one", () => {
+    const e = artifactEntity({
+      ...base,
+      artifact: artifact(),
+      info,
+      status: status({ lastModifiedBy: null }),
+    })
+    expect(JSON.stringify(e)).not.toContain("last_modified_by")
   })
 })

--- a/apps/api/test/slack-work-object.test.ts
+++ b/apps/api/test/slack-work-object.test.ts
@@ -38,6 +38,7 @@ const status = (over: Partial<ArtifactStatus> = {}): ArtifactStatus => ({
   openThreads: 0,
   updatedAt: "2026-08-01T10:00:00.000Z",
   lastModifiedBy: "Dana",
+  previewReady: true,
   ...over,
 })
 
@@ -342,11 +343,14 @@ describe("the card's own image", () => {
   })
 })
 
-describe("one fact, one place", () => {
-  // The card used to state a pending review three times: once in the description and twice more
-  // as its own chips. The chips win — they are what Slack draws where the eye goes, which is the
-  // reason for using a typed entity at all.
-  it("does not repeat the review status in the description", () => {
+describe("what the description leads with", () => {
+  // REGRESSION GUARD. This was once "de-duplicated" on the reasoning that the Review and
+  // Waiting-on chips already say it. The result was a headline reading "Markdown · 3 versions ·
+  // 7 comments · on Derive" — the inventory line the typed card exists to stop leading with.
+  //
+  // The two slots are not peers: `description` is the prominent line, `custom_fields` are
+  // secondary labelled pairs. Repetition between them is the point, not an accident.
+  it("leads with what the doc wants from you, not with what it is", () => {
     const e = artifactEntity({
       ...base,
       artifact: artifact(),
@@ -356,13 +360,22 @@ describe("one fact, one place", () => {
       }),
     })
     const p = e.entity_payload as Payload
-    expect(String(p.fields.description?.value)).not.toContain("Awaiting")
-    // ...because it is here instead, labelled and scannable.
-    expect(JSON.stringify(p.custom_fields)).toContain("Awaiting")
-    expect(JSON.stringify(p.custom_fields)).toContain("Mert")
+    expect(String(p.fields.description?.value)).toContain("Awaiting review")
+    expect(String(p.fields.description?.value)).toContain("Mert")
+    expect(String(p.fields.description?.value)).not.toContain("versions")
+    // ...and the chips still carry it too. Both, deliberately.
+    expect(JSON.stringify(p.custom_fields)).toContain("Awaiting review")
   })
 
-  it("does not repeat the data summary either — it has its own chip", () => {
+  it("falls back to the inventory line only when nothing is pending", () => {
+    const e = artifactEntity({ ...base, artifact: artifact(), info, status: status() })
+    const p = e.entity_payload as Payload
+    expect(String(p.fields.description?.value)).toContain("3 versions")
+  })
+
+  it("leads with the data summary when a version carries facts", () => {
+    // `dataSummary` leads `unfurlDescription` for a reason of its own — the numbers are what a
+    // reader scanning a shared link wants. It has a `Data` chip as well; same non-peer logic.
     const e = artifactEntity({
       ...base,
       artifact: artifact(),
@@ -370,7 +383,7 @@ describe("one fact, one place", () => {
       status: status(),
     })
     const p = e.entity_payload as Payload
-    expect(String(p.fields.description?.value)).not.toContain("pass 48")
+    expect(String(p.fields.description?.value)).toContain("pass 48")
     expect(JSON.stringify(p.custom_fields)).toContain("pass 48")
   })
 


### PR DESCRIPTION
Four changes, from reviewing the preview work against Slack's docs and then against its API.

## 1. The header without which none of it renders

Slack's [implementation guide](https://docs.slack.dev/messaging/work-objects-implementation/):

> For security reasons, these public URLs must include the CORS response header set to
> `access-control-allow-origin:https://app.slack.com`.

`/v1/og` did not send it. **So the full-size preview shipped in #628 may never have rendered at
all.** There is CORS middleware on `/v1/*`, but it only echoes origins in `allowOrigins`, and
`app.slack.com` isn't one — confirmed against production with Slack's own origin.

Both branches carry it now, as a **constant** rather than an echo, so the response doesn't vary
by caller and stays cacheable on one key.

That requirement also tells us something the docs never state outright. CORS is a *browser*
mechanism — a server fetching an image never consults it — so the Slack client loads
`preview_url` **from the viewer's own browser** rather than proxying it. The token in that URL is
spent by the reader and is visible in their network tab. The capability-URL bargain this feature
rests on is literal, not theoretical.

## 2. The thumbnail — the picture most people actually see

`content_item` takes a `preview` field: the image on the **card itself**, as distinct from
`full_size_preview`, which is the expanded view. We sent none.

**This corrects a conclusion I reached earlier in this work** — that `content_item` accepted five
fields and that `preview` belonged to `task`. It takes six.

Established against the live API by a discriminator, because acceptance proves nothing here —
Slack shape-checks a field it recognises and silently swallows one it doesn't:

| probe | result |
|---|---|
| malformed `preview` | **complained**, pointer at `fields/preview`, `field: alt_text` → recognised |
| malformed `created_by` / `last_modified_by` | **complained** → recognised |
| malformed `date_created` / `date_updated` | **complained** → recognised |
| malformed `assignee` / `status` (task-only) | `ok: true`, silent → not recognised |
| invented field name | `ok: true`, silent → not recognised |

Same already-rendered, already-cached URL for both surfaces; Slack scales it.

## 3. `last_modified_by`

A typed field Slack renders itself, answering the question a document card most owes an answer
to. One limit, probed: the shape takes a display name and **only** that — a `slack_user_id`, an
`image_url`, or either beside the name are all rejected with `failed to match exactly one allowed
schema`. So there's no @-link or avatar to be had, however much one would suit the card.

## 4. One fact, one place

The description led with the review sentence — which `custom_fields` states again as `Review` and
`Waiting on`. Three renderings of one fact on a card with room for none of them. It also led with
`dataSummary`, which has its own `Data` chip.

The labelled fields win that tie: they're what Slack draws as scannable chips where the eye goes,
which is the whole reason for adopting a typed entity over a block card. So the description stops
repeating them.

What's left there is the inventory line — thin, but genuinely all the prose there is. An artifact
carries no summary or excerpt anywhere in `UnfurlInfo`, so there's nothing better to put there.
**The flexpane keeps its status sentence**, because that one is per-viewer ("Awaiting *your*
review") and no chip can say it.

> Note: I originally reported this as "the description gets clobbered, losing what the doc is
> about." That was wrong — `unfurlDescription` is the inventory line, not a summary, so nothing
> was being lost. The real defect was the duplication, in the other direction.

## Verification

`pnpm verify` green — 2056 API tests. 10 new, covering: the thumbnail's required `alt_text`; both
surfaces sharing one image; neither offered when there's no image; the review status and data
summary each appearing once; the author's exact typed shape; the author omitted rather than
invented; and the CORS header on the PNG, on the SVG fallback, and as a constant under a hostile
`Origin`.

Guards verified load-bearing by deletion — removing the header fails 3 tests, restoring
`dataSummary` to the description fails 1.

## Not done

The preview **image itself** is a 1200×630 viewport crop at density 1 — a landscape window onto a
portrait document, so mostly margin, and soft on retina where Slack renders it large. Capturing
at 2× would fix the sharpness at ~4× the bytes. Left alone deliberately: `/v1/og` is shared with
every other unfurl surface, so it isn't a Slack-local change, and it's worth seeing a real
rendered preview before touching it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788423130&installation_model_id=428097&pr_number=642&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F642&signature=b2ce45e9e9aaa0d5ffb1b91c19d2e183455ec63221603d5f3286c313cfcd6b5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


---

## Audit findings, fixed in the second commit

Done by dumping the payload the code actually builds and **looking at it**, rather than at the
diff. That immediately caught a mistake in my own change.

### The de-duplication was wrong, and is reverted

Item 4 above removed the review sentence from `description` because `Review` and `Waiting on`
already say it. Here is what the headline fell back to:

```
"Markdown · 3 versions · 7 comments · on Derive"
```

That is the **inventory line this whole feature exists to stop leading with**. It answers *"what
is this?"* when the question a shared link needs answered is *"does this want something from
me?"*

The reasoning was wrong twice over:

- **The two slots are not peers.** `description` is the prominent line; `custom_fields` are
  secondary labelled pairs. They serve skimming and scanning. The same fact in both is the point,
  not waste.
- **The tidiness was illusory.** `display_type` repeats the kind and `Version` repeats the version
  count *in that very line*. So the change removed the two repetitions worth keeping and left
  three inert ones.

Reverted, with the intent now pinned by tests so it doesn't get "tidied" again — verified by
re-introducing the regression and confirming 2 tests fail.

### Two smaller things

- **A stale comment.** The flexpane said *"unlike the card, this one KEEPS the status sentence"* —
  a contrast the revert erased. Both lead with status now; what's actually unlike is that the
  flexpane's sentence is per-**viewer** ("Awaiting *your* review") and keeps the description below
  it, having room a broadcast card doesn't.
- **The same query twice.** The card read the version row to ask whether a render had finished, in
  a request where `artifactStatus` had already read the identical row for `lastModifiedBy`.
  `previewReady` moves onto `ArtifactStatus`.

### Verified end-to-end against the API

The payload was sent to `chat.unfurl` **as the code emits it** — not hand-written — with
`preview`, `last_modified_by`, `full_size_preview`, `description`, `date_updated` and all five
chips together. `ok: true`, no warnings.

Also checked and clean: `artifactStatus` runs only on the two Slack paths, so the added read
isn't on a hot path; and the web app loads `/v1/og` via `<img src>`, not JS, so a cached constant
`Access-Control-Allow-Origin` can't break its own fetches.

`pnpm verify` green — 2057 API tests.
