### PR TITLE
fix(slack): a skipped unfurl says which rung skipped it

### DIFF
--- a/apps/api/src/lib/slack-unfurl.ts
+++ b/apps/api/src/lib/slack-unfurl.ts
@@ -100,7 +100,12 @@ export const lockedUnfurlBlocks = (baseUrl: string, shortId: string): unknown[] 
  *  before — but the flexpane is per-viewer, so a reader entitled to the artifact can be shown the
  *  real thing there. Keeping the distinction in the type is what lets the caller honour both. */
 export type UnfurlDecision =
-  | { kind: "skip" }
+  /** Nothing to show, and WHICH rung decided that. The reason is not decoration: five different
+   *  states all end here and look identical from the channel, and from outside the server they
+   *  are indistinguishable — a workspace-listed artifact answers an anonymous probe exactly as a
+   *  non-existent one does, so "I pasted a link and got no card" cannot be diagnosed by trying
+   *  the URL. The caller logs this. */
+  | { kind: "skip"; why: string }
   | { kind: "auth" }
   | { kind: "card"; url: string; blocks: unknown[]; artifact: ArtifactRecord; info: UnfurlInfo }
   | { kind: "locked"; url: string; blocks: unknown[]; artifact: ArtifactRecord }
@@ -136,15 +141,20 @@ export const decideUnfurl = async (
 ): Promise<UnfurlDecision> => {
   if (!viewerId) return { kind: "auth" }
   const ref = artifactRefFromUrl(deps.baseUrl, url)
-  if (!ref) return { kind: "skip" }
+  if (!ref) return { kind: "skip", why: "url is not an artifact link on this instance" }
   let artifact: ArtifactRecord | null = null
   for (const id of candidateShortIds(ref)) {
     artifact = await deps.meta.getByShortId(id)
     if (artifact) break
   }
-  if (!artifact || artifact.removed_at) return { kind: "skip" }
-  if (artifact.org_id !== deps.orgId) return { kind: "skip" }
-  if (!(await deps.canRead(viewerId, artifact))) return { kind: "skip" }
+  if (!artifact) return { kind: "skip", why: "no artifact with that short id" }
+  if (artifact.removed_at) return { kind: "skip", why: "artifact is removed" }
+  // The likeliest cause of a silent miss in a team with more than one Derive workspace, and
+  // the one hardest to guess at: the link works for the sharer and the channel shows nothing.
+  if (artifact.org_id !== deps.orgId)
+    return { kind: "skip", why: "artifact belongs to a different Derive workspace" }
+  if (!(await deps.canRead(viewerId, artifact)))
+    return { kind: "skip", why: "sharer has no read standing on it" }
 
   // Build the locked card BEFORE unfurlInfoFor: it needs none of that, and the whole point is
   // to touch as little of the artifact as possible.

--- a/apps/api/src/routes/slack.ts
+++ b/apps/api/src/routes/slack.ts
@@ -224,11 +224,17 @@ export const slackRoutes = (ctx: AppContext) => {
         l.url,
         userLink.user_id,
       )
-      // `skip` is the ladder's catch-all — not ours, gone, another workspace, or not readable by
-      // this viewer — and it is the rung that most often surprises someone. Naming the URL is
-      // what makes it actionable.
+      // `skip` has five rungs behind it — not an artifact link, no such short id, removed,
+      // another workspace, or not readable by this sharer — and from the channel they are one
+      // silent nothing. Naming the URL was not enough: a workspace-listed artifact answers an
+      // anonymous probe exactly as a non-existent one does, so the rung cannot be recovered
+      // afterwards by trying the URL. It has to be said here, at the moment it is known.
       if (d.kind === "skip" || d.kind === "auth") {
-        why(`decision: ${d.kind}`, { url: l.url, viewer: userLink.user_id })
+        why(`decision: ${d.kind}`, {
+          url: l.url,
+          viewer: userLink.user_id,
+          ...(d.kind === "skip" ? { rung: d.why, org: install.org_id } : {}),
+        })
         continue
       }
       unfurls[d.url] = { blocks: d.blocks }

--- a/apps/api/test/slack-unfurl.test.ts
+++ b/apps/api/test/slack-unfurl.test.ts
@@ -139,3 +139,77 @@ describe("decideUnfurl — the broadcast gate", () => {
     expect((await decideUnfurl(deps, `${BASE}/artifacts/nope404`, "u-1")).kind).toBe("skip")
   })
 })
+
+// WHY A SKIP HAPPENED, WHICH IS THE ONLY THING THAT MAKES ONE DIAGNOSABLE.
+//
+// Five rungs end in `skip` and the channel shows the same silent nothing for all of them. They
+// cannot be told apart afterwards either: a workspace-listed artifact answers an anonymous probe
+// exactly as a non-existent one does, so "try the URL yourself" resolves nothing. The reason has
+// to be recorded at the moment it is known.
+
+describe("a skip names the rung that caused it", () => {
+  const artifactIn = (org: string, over: Partial<ArtifactRecord> = {}) =>
+    ({
+      id: "a1",
+      short_id: "abc12345",
+      org_id: org,
+      title: "T",
+      listed: "workspace",
+      link_role: "none",
+      workspace_access: "member",
+      removed_at: null,
+      current_version: 1,
+      ...over,
+    }) as ArtifactRecord
+
+  const deps = (artifact: ArtifactRecord | null, canRead = true) => ({
+    meta: { getByShortId: async () => artifact } as never,
+    baseUrl: "https://derive.to",
+    orgId: "org-connected",
+    canRead: async () => canRead,
+  })
+
+  const skipWhy = async (
+    d: ReturnType<typeof deps>,
+    url = "https://derive.to/artifacts/abc12345",
+  ) => (await decideUnfurl(d, url, "u-sharer")) as { kind: string; why?: string }
+
+  it("distinguishes a link that is not ours at all", async () => {
+    const r = await skipWhy(deps(artifactIn("org-connected")), "https://example.com/whatever")
+    expect(r.kind).toBe("skip")
+    expect(r.why).toMatch(/not an artifact link/i)
+  })
+
+  it("distinguishes a short id nothing answers to", async () => {
+    const r = await skipWhy(deps(null))
+    expect(r.why).toMatch(/no artifact/i)
+  })
+
+  it("distinguishes a removed artifact from a missing one", async () => {
+    const r = await skipWhy(deps(artifactIn("org-connected", { removed_at: "2026-01-01" })))
+    expect(r.why).toMatch(/removed/i)
+  })
+
+  // The one worth naming most: the link works for the sharer, the channel shows nothing, and
+  // nothing about either fact points at the cause.
+  it("distinguishes an artifact living in another workspace", async () => {
+    const r = await skipWhy(deps(artifactIn("org-elsewhere")))
+    expect(r.why).toMatch(/different Derive workspace/i)
+  })
+
+  it("distinguishes a sharer without read standing", async () => {
+    const r = await skipWhy(deps(artifactIn("org-connected"), false))
+    expect(r.why).toMatch(/read standing/i)
+  })
+
+  it("gives every rung a distinct reason, or the log cannot tell them apart", async () => {
+    const reasons = [
+      (await skipWhy(deps(artifactIn("org-connected")), "https://example.com/x")).why,
+      (await skipWhy(deps(null))).why,
+      (await skipWhy(deps(artifactIn("org-connected", { removed_at: "2026-01-01" })))).why,
+      (await skipWhy(deps(artifactIn("org-elsewhere")))).why,
+      (await skipWhy(deps(artifactIn("org-connected"), false))).why,
+    ]
+    expect(new Set(reasons).size).toBe(5)
+  })
+})


### PR DESCRIPTION
Diagnosing a real report — *"I pasted a link and no card appeared"* — took a Cloudflare log
query, a Slack API read and three anonymous probes, and still ended in a **hypothesis rather
than an answer**.

`decideUnfurl` has five ways to return `skip`:

| rung | what it looks like from the channel |
|---|---|
| url isn't an artifact link | nothing |
| no artifact with that short id | nothing |
| artifact is removed | nothing |
| **belongs to a different Derive workspace** | nothing |
| sharer has no read standing | nothing |

The caller logged only `decision: skip` — the aggregate. And the rung **cannot be recovered
afterwards**: a workspace-listed artifact answers an anonymous probe *exactly* as a non-existent
one does. Confirmed against three URLs, including one I invented — identical responses. So "try
the link yourself" resolves nothing.

The fourth rung is the one that matters most in a team with several Derive workspaces, and the
cruellest to guess at: the link works perfectly for the sharer, the channel shows nothing, and
neither fact points at the cause.

The reason now travels with the decision. A test asserts all five are **distinct** — two rungs
sharing a phrase would be this same bug again.

## Scope

Logging only, no behaviour change. **~15 lines of production code.**

An earlier revision also counted whether each card carried a preview image. Dropped on review:
that existed to answer a question I had while debugging, not one users will ask.

`pnpm verify` green — 2134 API tests, 6 new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
