### PR TITLE
feat(unfurl): a one-time sweep for artifacts published before summaries existed

### DIFF
--- a/apps/api/src/lib/after-publish.ts
+++ b/apps/api/src/lib/after-publish.ts
@@ -120,8 +120,13 @@ const srcHash = async (text: string): Promise<string> => {
  *
  * Every exit logs its reason. "The card says nothing and I cannot tell why" is exactly the shape
  * of bug that cost a day on the unfurl ladder, and one line naming the rung is what prevents it.
+ *
+ * Exported for the one-time backfill (lib/summary-backfill.ts) so an artifact published before
+ * this existed is described by exactly the same code as one published after — same input
+ * shaping, same gate, same sanitizer, same skip reasons. Two paths producing different summaries
+ * for the same bytes is the drift this file's header exists to prevent.
  */
-const summarizeVersion = async (
+export const summarizeVersion = async (
   meta: Pick<MetaStore, "setVersionSummary" | "getVersion">,
   blobs: BlobStore,
   summarizer: Summarizer,

--- a/apps/api/src/lib/summary-backfill.ts
+++ b/apps/api/src/lib/summary-backfill.ts
@@ -1,0 +1,111 @@
+// The one-time sweep that gives artifacts published BEFORE summaries existed the description
+// every unfurl surface now shows.
+//
+// Sibling of `reindexSearchBatch` (lib/search.ts) and deliberately the same shape: publishing
+// keeps summaries current going forward (lib/after-publish.ts), so this exists only to close the
+// gap behind that wiring. Operator-triggered rather than a cron sweep, because unlike a preview
+// render — which costs our own browser — every summary here costs a model call, and spending that
+// across a whole corpus should be somebody's decision rather than a background job's.
+//
+// It calls the PUBLISH PATH's own `summarizeVersion`, so a backfilled artifact is described by
+// exactly the same code as a freshly published one.
+
+import type { ArtifactRecord, BlobStore, MetaStore, VersionRecord } from "@derive/core"
+import { log } from "../log"
+import type { Summarizer } from "../summarizer"
+import { summarizeVersion } from "./after-publish"
+
+export interface SummaryBackfillDeps {
+  blobs: BlobStore
+  meta: Pick<MetaStore, "listArtifacts" | "getVersion" | "setVersionSummary">
+  summarize: Summarizer
+}
+
+export interface SummaryBackfillResult {
+  /** Artifacts walked on this page. */
+  scanned: number
+  /** Artifacts whose current version already had one — the idempotency margin, so re-running
+   *  from cursor 0 after a partial sweep costs a read each rather than a model call each. */
+  alreadyHad: number
+  /** Artifacts handed to the summarizer. NOT all of these produce a summary: a non-text version
+   *  or one with too little prose is a legitimate skip, and `summarizeVersion` logs the reason. */
+  attempted: number
+  nextCursor: { key: string; id: string } | null
+}
+
+/**
+ * How many artifacts one call may walk.
+ *
+ * Much smaller than `search-reindex`'s 200, and for a different reason. That endpoint's per-item
+ * work is a blob read and a store write; this one's is a MODEL CALL, ~1–2 seconds of wall time
+ * each. Two hundred of those serially would exceed the invocation long before any subrequest
+ * ceiling. Bounded concurrency below recovers most of it — the calls are I/O, not CPU — but the
+ * page stays small so a slow model cannot wedge the operator's cursor.
+ */
+export const BACKFILL_MAX_LIMIT = 50
+export const BACKFILL_DEFAULT_LIMIT = 25
+
+/** How many summaries are in flight at once. Enough to hide per-call latency, low enough that a
+ *  page cannot flood a rate-limited model endpoint. */
+const CONCURRENCY = 5
+
+/** Run `work` over `items`, at most CONCURRENCY at a time. */
+const pooled = async <T>(items: T[], work: (item: T) => Promise<void>): Promise<void> => {
+  let next = 0
+  const runner = async (): Promise<void> => {
+    while (next < items.length) {
+      const item = items[next++]
+      if (item !== undefined) await work(item)
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(CONCURRENCY, items.length) }, runner))
+}
+
+export const backfillSummaryBatch = async (
+  deps: SummaryBackfillDeps,
+  opts: { orgId?: string; cursor?: { key: string; id: string }; limit: number },
+): Promise<SummaryBackfillResult> => {
+  const arts = await deps.meta.listArtifacts({
+    orgId: opts.orgId,
+    cursor: opts.cursor,
+    limit: opts.limit,
+    excludeRemoved: true,
+  })
+  let alreadyHad = 0
+  let attempted = 0
+  const todo: { artifact: ArtifactRecord; version: VersionRecord }[] = []
+  for (const a of arts) {
+    const version = await deps.meta.getVersion(a.id, a.current_version)
+    if (!version) continue // no current version to describe
+    // Skipping an artifact that already has one is what makes a re-sweep cheap: a partial run
+    // can be resumed from cursor 0 without paying the model twice for everything before it.
+    if (version.summary) {
+      alreadyHad++
+      continue
+    }
+    todo.push({ artifact: a, version })
+  }
+  await pooled(todo, async ({ artifact, version: v }) => {
+    attempted++
+    // Isolated per artifact: one unreadable blob or a single model failure must not abort the
+    // page and wedge the cursor. `summarizeVersion` already swallows its own skip cases and logs
+    // them; this catches the ones it cannot, so the sweep always makes forward progress.
+    try {
+      await summarizeVersion(deps.meta, deps.blobs, deps.summarize, artifact, v)
+    } catch (err) {
+      log.error("summary backfill skipped one artifact", {
+        artifact: artifact.id,
+        err: String(err),
+      })
+    }
+  })
+  const last = arts.at(-1)
+  return {
+    scanned: arts.length,
+    alreadyHad,
+    attempted,
+    // Identical to reindexSearchBatch's construction, so the operator loop is the one they
+    // already know: re-POST with nextCursor until it comes back null.
+    nextCursor: arts.length >= opts.limit && last ? { key: last.created_at, id: last.id } : null,
+  }
+}

--- a/apps/api/src/routes/system.ts
+++ b/apps/api/src/routes/system.ts
@@ -5,6 +5,11 @@ import type { AppContext } from "../context"
 import { fail, readJson } from "../lib/http"
 import { getInstanceChatModel, setInstanceChatModel } from "../lib/instance-settings"
 import { reindexSearchBatch } from "../lib/search"
+import {
+  BACKFILL_DEFAULT_LIMIT,
+  BACKFILL_MAX_LIMIT,
+  backfillSummaryBatch,
+} from "../lib/summary-backfill"
 import { log } from "../log"
 
 /** Operational endpoints: liveness (/healthz), readiness (/readyz — proves the datastore
@@ -138,6 +143,45 @@ export const systemRoutes = (ctx: AppContext) => {
       { orgId: body.orgId, cursor: body.cursor ?? undefined, limit },
     )
     return c.json(result)
+  })
+
+  // Backfill the one-line summary every unfurl surface describes an artifact with, over the
+  // EXISTING corpus. Publishing keeps it current going forward (lib/after-publish.ts); this
+  // closes the gap for artifacts published before that wiring. Same operator loop as
+  // search-reindex above — re-POST with `nextCursor` until it comes back null:
+  //   curl -XPOST -H "authorization: Bearer $DERIVE_TOKEN" .../v1/system/summary-backfill
+  //   # then repeat, passing {"cursor": <nextCursor>} until nextCursor is null
+  //
+  // Pages are far smaller than the reindex sweep's (25 vs 100) because the per-artifact work is
+  // a MODEL CALL rather than a blob read, so wall time — not the subrequest ceiling — is what
+  // bounds a page. Idempotent: an artifact that already has a summary costs one read, so a
+  // partial sweep can be resumed from cursor 0 rather than tracked.
+  //
+  // 404 rather than a no-op when no model is bound: on a deploy without one there is nothing
+  // this could ever do, and a silent 200 reporting "0 attempted" reads like an empty corpus.
+  app.post("/v1/system/summary-backfill", async (c) => {
+    if (!isToken(c) && !(await isSuperAdmin(c)))
+      return fail(c, 403, "operator access required (DERIVE_TOKEN or a super-admin account)")
+    if (!deps.summarize)
+      return fail(c, 404, "no summarizer is configured on this deployment (needs the AI binding)")
+    const body = await readJson(
+      c,
+      z.object({
+        orgId: z.string().optional(),
+        // `.nullish()` for the same reason as search-reindex: the natural resume loop echoes back
+        // the previous `nextCursor`, which is literally null on the final page.
+        cursor: z.object({ key: z.string(), id: z.string() }).nullish(),
+        limit: z.number().int().optional(),
+      }),
+    )
+    if (body instanceof Response) return body
+    const limit = Math.min(Math.max(body.limit ?? BACKFILL_DEFAULT_LIMIT, 1), BACKFILL_MAX_LIMIT)
+    return c.json(
+      await backfillSummaryBatch(
+        { meta, blobs, summarize: deps.summarize },
+        { orgId: body.orgId, cursor: body.cursor ?? undefined, limit },
+      ),
+    )
   })
 
   // A minimal API-origin landing, ONLY for deployments with no SPA at all. Skipped

--- a/apps/api/test/summary-backfill.test.ts
+++ b/apps/api/test/summary-backfill.test.ts
@@ -1,0 +1,202 @@
+/**
+ * THE ONE-TIME SWEEP for artifacts published before summaries existed.
+ *
+ * Publishing keeps them current going forward, so this closes a gap that shrinks on its own —
+ * which is exactly why it must be cheap to re-run and impossible to wedge. The tests are mostly
+ * about those two properties rather than about generation, which the publish path already owns.
+ */
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { SqliteMetaStore } from "@derive/db/sqlite"
+import { FsBlobStore } from "@derive/storage/fs"
+import { afterAll, describe, expect, it } from "vitest"
+import { createApp } from "../src/app"
+import { backfillSummaryBatch } from "../src/lib/summary-backfill"
+import type { Summarizer } from "../src/summarizer"
+
+const dir = mkdtempSync(join(tmpdir(), "derive-summary-backfill-"))
+afterAll(() => rmSync(dir, { recursive: true, force: true }))
+
+const TOKEN = "tok"
+const AUTH = { authorization: `Bearer ${TOKEN}` }
+const DOC =
+  "# Q4 rollout plan\n\nWe are moving the billing migration to November so the team can finish " +
+  "the invoicing work first. The cutover needs a maintenance window and a rollback rehearsal.\n"
+
+const counting = (reply: string | null = "Moves the billing migration to November.") => {
+  let calls = 0
+  return {
+    get calls() {
+      return calls
+    },
+    summarizer: {
+      summarize: async () => {
+        calls++
+        return reply
+      },
+    } satisfies Summarizer,
+  }
+}
+
+/** An app with NO summarizer, so publishing leaves the corpus exactly as it was before the
+ *  feature — which is the state a backfill exists to find. */
+const legacyApp = (name: string) => {
+  const meta = new SqliteMetaStore(join(dir, `${name}.db`))
+  const blobs = new FsBlobStore(join(dir, `blobs-${name}`))
+  return {
+    meta,
+    blobs,
+    app: createApp({ meta, blobs, baseUrl: "http://derive.test", token: TOKEN }),
+  }
+}
+
+const publish = async (app: ReturnType<typeof createApp>, title: string, content = DOC) => {
+  const form = new FormData()
+  form.append("file", new Blob([new TextEncoder().encode(content)]), "doc.md")
+  form.append("title", title)
+  const res = await app.request("/v1/artifacts", { method: "POST", body: form, headers: AUTH })
+  expect(res.status).toBeLessThan(300)
+  return (await res.json()) as { short_id: string }
+}
+
+const summaryOf = async (meta: SqliteMetaStore, shortId: string) => {
+  const a = await meta.getByShortId(shortId)
+  if (!a) throw new Error("not found")
+  return (await meta.getVersion(a.id, a.current_version))?.summary ?? null
+}
+
+describe("backfilling a corpus that predates summaries", () => {
+  it("describes artifacts the publish path never saw", async () => {
+    const { app, meta, blobs } = legacyApp("bf-basic")
+    const one = await publish(app, "One")
+    const two = await publish(app, "Two")
+    const ids = [one, two]
+    expect(await summaryOf(meta, one.short_id)).toBeNull()
+
+    // NOT destructured: object spread EVALUATES the `calls` getter, so `{...counting()}` would
+    // capture a snapshot of zero and the assertion would pass for the wrong reason.
+    const spy = counting()
+    const r = await backfillSummaryBatch({ meta, blobs, summarize: spy.summarizer }, { limit: 25 })
+    expect(r.scanned).toBe(2)
+    expect(r.attempted).toBe(2)
+    expect(spy.calls).toBe(2)
+    for (const i of ids)
+      expect(await summaryOf(meta, i.short_id)).toBe("Moves the billing migration to November.")
+  })
+
+  it("costs a read, not a model call, for anything already described", async () => {
+    // What makes a partial sweep resumable from cursor 0 instead of needing its progress tracked.
+    const { app, meta, blobs } = legacyApp("bf-idempotent")
+    await publish(app, "One")
+    const first = counting()
+    await backfillSummaryBatch({ meta, blobs, summarize: first.summarizer }, { limit: 25 })
+    expect(first.calls).toBe(1)
+
+    const second = counting()
+    const r = await backfillSummaryBatch(
+      { meta, blobs, summarize: second.summarizer },
+      { limit: 25 },
+    )
+    expect(second.calls).toBe(0)
+    expect(r.alreadyHad).toBe(1)
+    expect(r.attempted).toBe(0)
+  })
+
+  it("keeps walking when one artifact's model call fails", async () => {
+    // The sweep is the only driver, so an isolated failure must not wedge the operator's cursor
+    // — unlike the publish path, nothing else will come along and retry this row.
+    const { app, meta, blobs } = legacyApp("bf-partial")
+    await publish(app, "One")
+    await publish(app, "Two")
+    let n = 0
+    const flaky: Summarizer = {
+      summarize: async () => {
+        n++
+        if (n === 1) throw new Error("model exploded")
+        return "A second artifact."
+      },
+    }
+    const r = await backfillSummaryBatch({ meta, blobs, summarize: flaky }, { limit: 25 })
+    expect(r.scanned).toBe(2)
+    expect(r.attempted).toBe(2)
+    // One landed; the other is simply still null and will be picked up by a re-sweep.
+    const got = await Promise.all(
+      (await meta.listArtifacts({ limit: 10 })).map((a) =>
+        meta.getVersion(a.id, a.current_version).then((v) => v?.summary ?? null),
+      ),
+    )
+    expect(got.filter(Boolean)).toHaveLength(1)
+  })
+
+  it("pages, and reports a null cursor when the walk is done", async () => {
+    const { app, meta, blobs } = legacyApp("bf-pages")
+    for (const t of ["One", "Two", "Three"]) await publish(app, t)
+    const { summarizer } = counting()
+    const p1 = await backfillSummaryBatch({ meta, blobs, summarize: summarizer }, { limit: 2 })
+    expect(p1.scanned).toBe(2)
+    expect(p1.nextCursor).not.toBeNull()
+    const p2 = await backfillSummaryBatch(
+      { meta, blobs, summarize: summarizer },
+      { limit: 2, cursor: p1.nextCursor ?? undefined },
+    )
+    expect(p2.scanned).toBe(1)
+    expect(p2.nextCursor).toBeNull()
+  })
+})
+
+describe("the operator endpoint", () => {
+  const withSummarizer = (name: string, summarize: Summarizer) => {
+    const meta = new SqliteMetaStore(join(dir, `${name}.db`))
+    const blobs = new FsBlobStore(join(dir, `blobs-${name}`))
+    return {
+      meta,
+      app: createApp({ meta, blobs, baseUrl: "http://derive.test", token: TOKEN, summarize }),
+    }
+  }
+
+  it("refuses without operator credentials", async () => {
+    const { app } = withSummarizer("bf-authz", counting().summarizer)
+    const res = await app.request("/v1/system/summary-backfill", {
+      method: "POST",
+      body: JSON.stringify({}),
+      headers: { "content-type": "application/json" },
+    })
+    expect(res.status).toBe(403)
+  })
+
+  it("says so plainly when no model is bound, rather than reporting an empty sweep", async () => {
+    // A 200 with "0 attempted" on a deploy that can never summarize anything reads like an empty
+    // corpus — the operator would conclude the backfill had nothing to do and move on.
+    const { app } = legacyApp("bf-nomodel")
+    const res = await app.request("/v1/system/summary-backfill", {
+      method: "POST",
+      body: JSON.stringify({}),
+      headers: { ...AUTH, "content-type": "application/json" },
+    })
+    expect(res.status).toBe(404)
+    expect(JSON.stringify(await res.json())).toContain("AI binding")
+  })
+
+  it("runs a page and reports what it did", async () => {
+    const { app, meta } = withSummarizer("bf-endpoint", counting().summarizer)
+    // Published WITH a summarizer bound, so these already have summaries — the realistic state
+    // of a corpus after the feature shipped, where a backfill should report zero work.
+    const form = new FormData()
+    form.append("file", new Blob([new TextEncoder().encode(DOC)]), "doc.md")
+    form.append("title", "Live")
+    await app.request("/v1/artifacts", { method: "POST", body: form, headers: AUTH })
+
+    const res = await app.request("/v1/system/summary-backfill", {
+      method: "POST",
+      body: JSON.stringify({ limit: 5 }),
+      headers: { ...AUTH, "content-type": "application/json" },
+    })
+    expect(res.status).toBe(200)
+    const out = (await res.json()) as { scanned: number; alreadyHad: number; attempted: number }
+    expect(out.scanned).toBe(1)
+    expect(out.alreadyHad).toBe(1)
+    expect(out.attempted).toBe(0)
+    expect(await meta.getByShortId("nope")).toBeNull()
+  })
+})


### PR DESCRIPTION
Publishing keeps summaries current going forward, so the corpus self-heals — but only for
documents that get republished. A settled spec or onboarding page may never publish again, and
those are exactly the links people paste most.

Sibling of `reindexSearchBatch`, whose own comment describes this same situation for the search
index, and deliberately the same operator loop:

```
curl -XPOST -H "authorization: Bearer $DERIVE_TOKEN" .../v1/system/summary-backfill
# then repeat, passing {"cursor": <nextCursor>} until nextCursor is null
```

At ~250 live artifacts that is **10 calls at the default page size**, costing fractions of a cent
through a small model.

## The two decisions worth reviewing

**Operator-triggered, not a cron sweep.** Previews have a self-heal sweep because a missed render
costs our own browser. A missed summary costs a **model call**, and spending that across a whole
corpus should be somebody's decision rather than a background job's.

**Pages of 25, against search-reindex's 100.** That endpoint's per-item work is a blob read and a
store write; this one's is a model call at 1–2s each, so *wall time* bounds a page long before the
subrequest ceiling does. Bounded concurrency (5) recovers most of it — the calls are I/O, not CPU
— while keeping a slow model from wedging the operator's cursor.

## Reuse, so the two paths cannot drift

It calls the publish path's own `summarizeVersion`. An artifact backfilled today is described by
exactly the same code as one published tomorrow: same input shaping, same hash gate, same
sanitizer, same skip reasons in the log. Two paths producing different summaries for identical
bytes is precisely the drift `after-publish.ts`'s header exists to prevent.

## What the tests are actually about

Generation is already covered by the publish path, so these pin the two properties a sweep needs:

- **Re-running is cheap.** An artifact that already has a summary costs one read, so a partial
  sweep resumes from cursor 0 rather than needing its progress tracked.
- **One failure cannot wedge it.** This sweep is the only driver — unlike a publish, nothing else
  comes along and retries a row — so a bad blob or a model error is isolated and the page still
  advances.

Plus paging/cursor termination, operator authz, and a **404 when no model is bound**: a 200
reporting "0 attempted" on a deploy that can never summarize anything reads like an empty corpus.

## Verification

`pnpm verify` green — 2186 API, 330 db, 34 mcp. Guards proven load-bearing by deletion: removing
the idempotency skip fails 2 tests, removing per-item isolation fails 1.

Two of my own mistakes caught along the way: a test using `{...counting()}`, where object spread
**evaluates** the `calls` getter and captured a snapshot of zero — it would have reported success
whatever the code did; and a non-null assertion the repo forbids, caught by `verify` rather than
by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/648"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788529174&installation_model_id=428097&pr_number=648&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F648&signature=7ad074088861546381aac135a1cbd39b97e1ae8e508bf76f1d8c6e7ca09253b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->