### PR TITLE
feat(artifacts): use any readable artifact as a template

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -4913,6 +4913,92 @@
         }
       }
     },
+    "/v1/artifacts/{shortId}/use": {
+      "post": {
+        "tags": [
+          "Artifacts"
+        ],
+        "summary": "Copy this artifact into your workspace (or an anonymous claimable draft).",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "shortId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "The new copy: its workspace home (signed-in) or its draft + claim URLs (anonymous).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "short_id": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "url": {
+                          "type": "string",
+                          "description": "The copy's permanent URL in your workspace."
+                        },
+                        "org_id": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "short_id",
+                        "title",
+                        "url",
+                        "org_id"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "short_id": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "draft_url": {
+                          "type": "string",
+                          "description": "The live expiring page on the draft host."
+                        },
+                        "claim_url": {
+                          "type": "string",
+                          "description": "Sign in here to keep it."
+                        },
+                        "expires_at": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "short_id",
+                        "title",
+                        "draft_url",
+                        "claim_url",
+                        "expires_at"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/preview": {
       "post": {
         "tags": [

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -4918,7 +4918,7 @@
         "tags": [
           "Artifacts"
         ],
-        "summary": "Copy this artifact into your workspace (or an anonymous claimable draft).",
+        "summary": "Copy this artifact into your workspace (use it as a template).",
         "parameters": [
           {
             "schema": {
@@ -4931,66 +4931,32 @@
         ],
         "responses": {
           "201": {
-            "description": "The new copy: its workspace home (signed-in) or its draft + claim URLs (anonymous).",
+            "description": "The new copy's identity and workspace home.",
             "content": {
               "application/json": {
                 "schema": {
-                  "anyOf": [
-                    {
-                      "type": "object",
-                      "properties": {
-                        "short_id": {
-                          "type": "string"
-                        },
-                        "title": {
-                          "type": "string",
-                          "nullable": true
-                        },
-                        "url": {
-                          "type": "string",
-                          "description": "The copy's permanent URL in your workspace."
-                        },
-                        "org_id": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "short_id",
-                        "title",
-                        "url",
-                        "org_id"
-                      ]
+                  "type": "object",
+                  "properties": {
+                    "short_id": {
+                      "type": "string"
                     },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "short_id": {
-                          "type": "string"
-                        },
-                        "title": {
-                          "type": "string",
-                          "nullable": true
-                        },
-                        "draft_url": {
-                          "type": "string",
-                          "description": "The live expiring page on the draft host."
-                        },
-                        "claim_url": {
-                          "type": "string",
-                          "description": "Sign in here to keep it."
-                        },
-                        "expires_at": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "short_id",
-                        "title",
-                        "draft_url",
-                        "claim_url",
-                        "expires_at"
-                      ]
+                    "title": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "url": {
+                      "type": "string",
+                      "description": "The copy's permanent URL in your workspace."
+                    },
+                    "org_id": {
+                      "type": "string"
                     }
+                  },
+                  "required": [
+                    "short_id",
+                    "title",
+                    "url",
+                    "org_id"
                   ]
                 }
               }

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -400,7 +400,6 @@ export function createApp(deps: AppDeps): Hono {
     /^\/v1\/assets\/t\/[^/]+$/, // MCP-minted upload URL — the signed expiring token is the gate
     /^\/v1\/artifacts\/t\/[^/]+$/, // MCP-minted publish URL (create) — signed token is the gate
     /^\/v1\/drafts$/, // anonymous draft mint (the claim flow) — anonymous is the point; draftPublish IP cap + publish limiter are the gate
-    /^\/v1\/artifacts\/[^/]+\/use$/, // use-as-template: anonymous branch mints a claimable draft copy — source read gate + ip-keyed publish limiter bound it
     /^\/v1\/artifacts\/[^/]+\/versions\/t\/[^/]+$/, // MCP-minted publish URL (revise) — signed token is the gate
   ]
   app.use("/v1/*", async (c, next) => {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -400,6 +400,7 @@ export function createApp(deps: AppDeps): Hono {
     /^\/v1\/assets\/t\/[^/]+$/, // MCP-minted upload URL — the signed expiring token is the gate
     /^\/v1\/artifacts\/t\/[^/]+$/, // MCP-minted publish URL (create) — signed token is the gate
     /^\/v1\/drafts$/, // anonymous draft mint (the claim flow) — anonymous is the point; draftPublish IP cap + publish limiter are the gate
+    /^\/v1\/artifacts\/[^/]+\/use$/, // use-as-template: anonymous branch mints a claimable draft copy — source read gate + ip-keyed publish limiter bound it
     /^\/v1\/artifacts\/[^/]+\/versions\/t\/[^/]+$/, // MCP-minted publish URL (revise) — signed token is the gate
   ]
   app.use("/v1/*", async (c, next) => {

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -2042,10 +2042,12 @@ export const artifactRoutes = (ctx: AppContext) => {
   // Use an artifact as a template: copy its current version into the caller's own
   // space. The copy re-points at the source version's stored blob (content-addressed
   // and org-agnostic, so no bytes move — the `restore` recipe, one createArtifact
-  // earlier) and records lineage in `derived_from`. Two branches by principal:
-  // a signed-in caller lands it in their active workspace at the workspace's own
-  // access defaults; an anonymous caller gets an expiring draft on the usercontent
-  // host plus a claim URL (the POST /v1/drafts shape) — value first, signup after.
+  // earlier) and records lineage in `derived_from`. Signed-in only: the copy lands
+  // in the caller's active workspace at the workspace's own access defaults. An
+  // anonymous clicker is sent through login instead (`?use=1` on the viewer), and
+  // the page completes the copy the moment they can actually edit it — a draft
+  // copy an anonymous holder can't edit would deliver nothing the source page
+  // doesn't already show, so no copy is minted before auth.
   // Anyone who can READ the source can use it — the same standing that lets them
   // select-all-copy the rendered page; `requireArtifact(read)` folds in the world
   // link, membership, and the password unlock cookie.
@@ -2053,37 +2055,24 @@ export const artifactRoutes = (ctx: AppContext) => {
   // Embedded assets are NOT copied: /blob/:hash is org-blind with the (globally
   // unique, hash-keyed) asset row as allowlist, so images keep serving from the
   // copy. Same accepted semantics as the draft-claim move.
-  // authz-exempt: the anonymous branch is the point (mirrors /v1/drafts — the
-  // ANON_WRITE_ALLOW entry in app.ts + the ip-keyed publish limiter bound it), and
-  // the source's read gate still applies via requireArtifact.
   app.openapi(
     createRoute({
       method: "post",
       path: "/v1/artifacts/{shortId}/use",
       tags: ["Artifacts"],
-      summary: "Copy this artifact into your workspace (or an anonymous claimable draft).",
+      summary: "Copy this artifact into your workspace (use it as a template).",
       request: { params: z.object({ shortId: z.string() }) },
       responses: {
         201: {
-          description:
-            "The new copy: its workspace home (signed-in) or its draft + claim URLs (anonymous).",
+          description: "The new copy's identity and workspace home.",
           content: {
             "application/json": {
-              schema: z.union([
-                z.object({
-                  short_id: z.string(),
-                  title: z.string().nullable(),
-                  url: z.string().describe("The copy's permanent URL in your workspace."),
-                  org_id: z.string(),
-                }),
-                z.object({
-                  short_id: z.string(),
-                  title: z.string().nullable(),
-                  draft_url: z.string().describe("The live expiring page on the draft host."),
-                  claim_url: z.string().describe("Sign in here to keep it."),
-                  expires_at: z.string(),
-                }),
-              ]),
+              schema: z.object({
+                short_id: z.string(),
+                title: z.string().nullable(),
+                url: z.string().describe("The copy's permanent URL in your workspace."),
+                org_id: z.string(),
+              }),
             },
           },
         },
@@ -2101,74 +2090,12 @@ export const artifactRoutes = (ctx: AppContext) => {
       const srcVersion = await meta.getVersion(src.id, src.current_version)
       if (!srcVersion) return bail(fail(c, 404, "nothing published yet"))
       const me = await currentUser(c)
+      // The global anonymous-write gate refuses this route before it runs; this 401
+      // is defense in depth. The viewer routes a signed-out clicker through login
+      // with `?use=1` and completes the copy right after auth (deferred use).
+      if (!me) return bail(fail(c, 401, "sign in to use this artifact"))
 
-      if (!me) {
-        // ---- Anonymous: an expiring draft + claim URL (mirrors POST /v1/drafts). ----
-        if (!deps.subdomainBase || !deps.encryptionKey)
-          return bail(
-            fail(c, 501, "anonymous use needs DERIVE_SUBDOMAIN_BASE and DERIVE_AUTH_SECRET"),
-          )
-        await meta.setWorkspace(DRAFTS_ORG_ID, "Anonymous drafts")
-        const expiresAt = new Date(Date.now() + DRAFT_TTL_MS).toISOString()
-        const draft = await meta.createArtifact({
-          id: newId("a"),
-          short_id: newShortId(),
-          org_id: DRAFTS_ORG_ID,
-          slug: src.slug,
-          title: src.title,
-          // The fixed draft access shape (see /v1/drafts): the secret URL is the grant.
-          workspace_access: "none",
-          link_role: "viewer",
-          listed: "none",
-          kind: src.kind,
-          spa: src.spa,
-          expires_at: expiresAt,
-          derived_from: src.id,
-        })
-        const v = await meta.addVersion(draft.id, {
-          id: newId("v"),
-          blob_key: srcVersion.blob_key,
-          content_type: srcVersion.content_type,
-          size_bytes: srcVersion.size_bytes,
-          author: "anonymous",
-          author_id: null,
-          source: "api",
-          message: `Derived from ${src.short_id}`,
-          name: null,
-        })
-        const host = `${draft.short_id}.${deps.subdomainBase}`.toLowerCase()
-        const bound = await meta.setDomain({
-          host,
-          artifact_id: draft.id,
-          org_id: DRAFTS_ORG_ID,
-          kind: "subdomain",
-          status: "active",
-        })
-        const draftUrl = bound
-          ? `https://${host}/`
-          : `${deps.sandboxOrigin ?? deps.baseUrl}/raw/${draft.short_id}/v/1/index.html`
-        const claimToken = await signClaimToken(deps.encryptionKey, draft.id, Date.parse(expiresAt))
-        await afterPublish(
-          { meta, blobs, bus, notify, notifyRender, background, search, summarize },
-          draft,
-          v,
-          { isNew: true, onBehalf: null, actorId: null },
-        )
-        // The OAuth-reaper pattern: each mint reaps earlier expired drafts.
-        await background(sweepExpiredDrafts(meta, search))
-        return c.json(
-          {
-            short_id: draft.short_id,
-            title: draft.title,
-            draft_url: draftUrl,
-            claim_url: `${deps.baseUrl}/claim/${claimToken}`,
-            expires_at: expiresAt,
-          },
-          201,
-        )
-      }
-
-      // ---- Signed-in: land the copy in the active workspace at its own defaults. ----
+      // ---- Land the copy in the caller's active workspace at its own defaults. ----
       if (!(await workspaceCan(c, "publish")))
         return bail(fail(c, 403, "you need publish rights in this workspace"))
       const org = await activeWorkspace(c)

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -21,6 +21,7 @@ import {
   isMarkdownBundle,
   missingBlobAdvisory,
   newId,
+  newShortId,
   outlineOf,
   PublishError,
   pageText,
@@ -2032,6 +2033,196 @@ export const artifactRoutes = (ctx: AppContext) => {
           ...toJson(deps.baseUrl, fresh, versions),
           sessions: groupSessions(versions, versionWindowMs),
           published: version.n,
+        },
+        201,
+      )
+    },
+  )
+
+  // Use an artifact as a template: copy its current version into the caller's own
+  // space. The copy re-points at the source version's stored blob (content-addressed
+  // and org-agnostic, so no bytes move — the `restore` recipe, one createArtifact
+  // earlier) and records lineage in `derived_from`. Two branches by principal:
+  // a signed-in caller lands it in their active workspace at the workspace's own
+  // access defaults; an anonymous caller gets an expiring draft on the usercontent
+  // host plus a claim URL (the POST /v1/drafts shape) — value first, signup after.
+  // Anyone who can READ the source can use it — the same standing that lets them
+  // select-all-copy the rendered page; `requireArtifact(read)` folds in the world
+  // link, membership, and the password unlock cookie.
+  //
+  // Embedded assets are NOT copied: /blob/:hash is org-blind with the (globally
+  // unique, hash-keyed) asset row as allowlist, so images keep serving from the
+  // copy. Same accepted semantics as the draft-claim move.
+  // authz-exempt: the anonymous branch is the point (mirrors /v1/drafts — the
+  // ANON_WRITE_ALLOW entry in app.ts + the ip-keyed publish limiter bound it), and
+  // the source's read gate still applies via requireArtifact.
+  app.openapi(
+    createRoute({
+      method: "post",
+      path: "/v1/artifacts/{shortId}/use",
+      tags: ["Artifacts"],
+      summary: "Copy this artifact into your workspace (or an anonymous claimable draft).",
+      request: { params: z.object({ shortId: z.string() }) },
+      responses: {
+        201: {
+          description:
+            "The new copy: its workspace home (signed-in) or its draft + claim URLs (anonymous).",
+          content: {
+            "application/json": {
+              schema: z.union([
+                z.object({
+                  short_id: z.string(),
+                  title: z.string().nullable(),
+                  url: z.string().describe("The copy's permanent URL in your workspace."),
+                  org_id: z.string(),
+                }),
+                z.object({
+                  short_id: z.string(),
+                  title: z.string().nullable(),
+                  draft_url: z.string().describe("The live expiring page on the draft host."),
+                  claim_url: z.string().describe("Sign in here to keep it."),
+                  expires_at: z.string(),
+                }),
+              ]),
+            },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const over = await limited(c, publishLimiter)
+      if (over) return bail(over)
+      const src = await requireArtifact(c, "read")
+      if (src instanceof Response) return bail(src)
+      if (src.removed_at) return bail(fail(c, 410, "this artifact was removed"))
+      // A draft is itself an unclaimed copy mid-flight; templating one would let the
+      // claim funnel fork indefinitely. Claim it first.
+      if (src.expires_at) return bail(fail(c, 403, "claim this draft before using it"))
+      const srcVersion = await meta.getVersion(src.id, src.current_version)
+      if (!srcVersion) return bail(fail(c, 404, "nothing published yet"))
+      const me = await currentUser(c)
+
+      if (!me) {
+        // ---- Anonymous: an expiring draft + claim URL (mirrors POST /v1/drafts). ----
+        if (!deps.subdomainBase || !deps.encryptionKey)
+          return bail(
+            fail(c, 501, "anonymous use needs DERIVE_SUBDOMAIN_BASE and DERIVE_AUTH_SECRET"),
+          )
+        await meta.setWorkspace(DRAFTS_ORG_ID, "Anonymous drafts")
+        const expiresAt = new Date(Date.now() + DRAFT_TTL_MS).toISOString()
+        const draft = await meta.createArtifact({
+          id: newId("a"),
+          short_id: newShortId(),
+          org_id: DRAFTS_ORG_ID,
+          slug: src.slug,
+          title: src.title,
+          // The fixed draft access shape (see /v1/drafts): the secret URL is the grant.
+          workspace_access: "none",
+          link_role: "viewer",
+          listed: "none",
+          kind: src.kind,
+          spa: src.spa,
+          expires_at: expiresAt,
+          derived_from: src.id,
+        })
+        const v = await meta.addVersion(draft.id, {
+          id: newId("v"),
+          blob_key: srcVersion.blob_key,
+          content_type: srcVersion.content_type,
+          size_bytes: srcVersion.size_bytes,
+          author: "anonymous",
+          author_id: null,
+          source: "api",
+          message: `Derived from ${src.short_id}`,
+          name: null,
+        })
+        const host = `${draft.short_id}.${deps.subdomainBase}`.toLowerCase()
+        const bound = await meta.setDomain({
+          host,
+          artifact_id: draft.id,
+          org_id: DRAFTS_ORG_ID,
+          kind: "subdomain",
+          status: "active",
+        })
+        const draftUrl = bound
+          ? `https://${host}/`
+          : `${deps.sandboxOrigin ?? deps.baseUrl}/raw/${draft.short_id}/v/1/index.html`
+        const claimToken = await signClaimToken(deps.encryptionKey, draft.id, Date.parse(expiresAt))
+        await afterPublish(
+          { meta, blobs, bus, notify, notifyRender, background, search, summarize },
+          draft,
+          v,
+          { isNew: true, onBehalf: null, actorId: null },
+        )
+        // The OAuth-reaper pattern: each mint reaps earlier expired drafts.
+        await background(sweepExpiredDrafts(meta, search))
+        return c.json(
+          {
+            short_id: draft.short_id,
+            title: draft.title,
+            draft_url: draftUrl,
+            claim_url: `${deps.baseUrl}/claim/${claimToken}`,
+            expires_at: expiresAt,
+          },
+          201,
+        )
+      }
+
+      // ---- Signed-in: land the copy in the active workspace at its own defaults. ----
+      if (!(await workspaceCan(c, "publish")))
+        return bail(fail(c, 403, "you need publish rights in this workspace"))
+      const org = await activeWorkspace(c)
+      const blocked = await billingGate(c, org)
+      if (blocked) return bail(blocked)
+      // The copy meters real bytes against the destination (dedup'd blob or not).
+      if (await overStorage(org, srcVersion.size_bytes))
+        return bail(fail(c, 413, blockCopy.storage.message, { code: blockCopy.storage.code }))
+      const settings = await meta.getOrgSettings(org)
+      const copy = await meta.createArtifact({
+        id: newId("a"),
+        short_id: newShortId(),
+        org_id: org,
+        slug: src.slug,
+        title: src.title,
+        // The workspace's own default access (the team draft, unless configured wider) —
+        // NOT the source's: a public template must not make your copy public.
+        workspace_access: settings.defaultWorkspaceAccess,
+        link_role: settings.defaultLinkRole,
+        listed: settings.defaultListed,
+        kind: src.kind,
+        spa: src.spa,
+        derived_from: src.id,
+      })
+      const v = await meta.addVersion(copy.id, {
+        id: newId("v"),
+        blob_key: srcVersion.blob_key,
+        content_type: srcVersion.content_type,
+        size_bytes: srcVersion.size_bytes,
+        author: me.name ?? me.username ?? me.email,
+        author_id: me.id,
+        source: "web",
+        message: `Derived from ${src.short_id}`,
+        name: null,
+      })
+      await meta.setArtifactMember({
+        id: newId("am"),
+        artifact_id: copy.id,
+        user_id: me.id,
+        role: "owner",
+      })
+      await afterPublish(
+        { meta, blobs, bus, notify, notifyRender, background, search, summarize },
+        copy,
+        v,
+        { isNew: true, onBehalf: me.id, actorId: me.id },
+      )
+      const fresh = (await meta.getByShortId(copy.short_id)) as ArtifactRecord
+      return c.json(
+        {
+          short_id: fresh.short_id,
+          title: fresh.title,
+          url: artifactUrl(deps.baseUrl, fresh),
+          org_id: org,
         },
         201,
       )

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -2043,11 +2043,10 @@ export const artifactRoutes = (ctx: AppContext) => {
   // space. The copy re-points at the source version's stored blob (content-addressed
   // and org-agnostic, so no bytes move — the `restore` recipe, one createArtifact
   // earlier) and records lineage in `derived_from`. Signed-in only: the copy lands
-  // in the caller's active workspace at the workspace's own access defaults. An
-  // anonymous clicker is sent through login instead (`?use=1` on the viewer), and
-  // the page completes the copy the moment they can actually edit it — a draft
-  // copy an anonymous holder can't edit would deliver nothing the source page
-  // doesn't already show, so no copy is minted before auth.
+  // in the caller's active workspace at the workspace's own access defaults. The
+  // viewer defers a signed-out clicker through login (`?use=1`) rather than minting
+  // anything pre-auth — an anonymous holder couldn't edit a copy, so it would add
+  // nothing over the source page they're already reading.
   // Anyone who can READ the source can use it — the same standing that lets them
   // select-all-copy the rendered page; `requireArtifact(read)` folds in the world
   // link, membership, and the password unlock cookie.
@@ -2090,12 +2089,9 @@ export const artifactRoutes = (ctx: AppContext) => {
       const srcVersion = await meta.getVersion(src.id, src.current_version)
       if (!srcVersion) return bail(fail(c, 404, "nothing published yet"))
       const me = await currentUser(c)
-      // The global anonymous-write gate refuses this route before it runs; this 401
-      // is defense in depth. The viewer routes a signed-out clicker through login
-      // with `?use=1` and completes the copy right after auth (deferred use).
+      // The global anonymous-write gate already refused anonymous callers at the
+      // door; this 401 keeps the route safe on its own terms regardless.
       if (!me) return bail(fail(c, 401, "sign in to use this artifact"))
-
-      // ---- Land the copy in the caller's active workspace at its own defaults. ----
       if (!(await workspaceCan(c, "publish")))
         return bail(fail(c, 403, "you need publish rights in this workspace"))
       const org = await activeWorkspace(c)
@@ -2143,12 +2139,11 @@ export const artifactRoutes = (ctx: AppContext) => {
         v,
         { isNew: true, onBehalf: me.id, actorId: me.id },
       )
-      const fresh = (await meta.getByShortId(copy.short_id)) as ArtifactRecord
       return c.json(
         {
-          short_id: fresh.short_id,
-          title: fresh.title,
-          url: artifactUrl(deps.baseUrl, fresh),
+          short_id: copy.short_id,
+          title: copy.title,
+          url: artifactUrl(deps.baseUrl, copy),
           org_id: org,
         },
         201,

--- a/apps/api/test/use-artifact.test.ts
+++ b/apps/api/test/use-artifact.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest"
 import { as, makeAuthedApp, publishAs, type TestUser } from "./helpers"
 
-// POST /v1/artifacts/:shortId/use — "use this as a template". Anyone who can READ
-// the source gets a copy: signed-in callers land it in their active workspace at
-// the workspace's own defaults; anonymous callers get an expiring claimable draft
-// (the /v1/drafts shape). The copy re-points at the source blob (no bytes move)
-// and records lineage in `derived_from`.
+// POST /v1/artifacts/:shortId/use — "use this as a template". Signed-in only: any
+// caller who can READ the source lands a copy in their active workspace at the
+// workspace's own defaults. Anonymous clickers are deferred through login by the
+// viewer (`?use=1`) instead of minting anything pre-auth. The copy re-points at
+// the source blob (no bytes move) and records lineage in `derived_from`.
 
 const ana: TestUser = { id: "u_use_ana", email: "ana@use.test", name: "Ana" }
 const ben: TestUser = { id: "u_use_ben", email: "ben@use.test", name: "Ben" }
@@ -75,8 +75,11 @@ describe("signed-in use", () => {
   })
 })
 
-describe("anonymous use", () => {
-  it("mints an expiring claimable draft copy of a link-viewable source", async () => {
+describe("anonymous callers", () => {
+  it("is refused at the door even for a link-viewable source — no pre-auth copies", async () => {
+    // A draft copy an anonymous holder can't edit delivers nothing the source page
+    // doesn't already show, so the flow is deferred use (`?use=1` through login),
+    // and the global anonymous-write gate refuses the bare POST outright.
     const src = await (
       await publishAs(
         app,
@@ -85,35 +88,10 @@ describe("anonymous use", () => {
         as(ana.email),
       )
     ).json()
-
     const res = await use(src.short_id) // no auth headers at all
-    expect(res.status).toBe(201)
-    const draft = await res.json()
-    expect(draft.short_id).not.toBe(src.short_id)
-    expect(draft.draft_url).toBe(`https://${draft.short_id}.${BASE}/`)
-    expect(draft.claim_url).toContain("/claim/")
-    expect(Date.parse(draft.expires_at)).toBeGreaterThan(Date.now())
-
-    // The draft shape: held in the drafts org, link-viewer only, ownerless, lineage kept.
-    const row = await meta.getByShortId(draft.short_id)
-    const srcRow = await meta.getByShortId(src.short_id)
-    expect(row?.org_id).toBe("ws_sys_drafts")
-    expect(row?.workspace_access).toBe("none")
-    expect(row?.link_role).toBe("viewer")
-    expect(row?.listed).toBe("none")
-    expect(row?.expires_at).toBeTruthy()
-    expect(row?.derived_from).toBe(srcRow?.id)
-
-    // Live on its own draft host, same bytes as the source.
-    const served = await app.request(`http://${draft.short_id}.${BASE}/`)
-    expect(served.status).toBe(200)
-    expect(await served.text()).toContain("Public template")
-  })
-
-  it("cannot use a source that grants the world nothing (404)", async () => {
-    const teamOnly = await (await publishAs(app, "<p>team</p>", {}, as(ana.email))).json()
-    const res = await use(teamOnly.short_id)
-    expect(res.status).toBe(404)
+    expect(res.status).toBe(403)
+    // Nothing was minted anywhere for the click.
+    expect(await meta.countArtifacts("ws_sys_drafts")).toBe(0)
   })
 })
 

--- a/apps/api/test/use-artifact.test.ts
+++ b/apps/api/test/use-artifact.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest"
+import { as, makeAuthedApp, publishAs, type TestUser } from "./helpers"
+
+// POST /v1/artifacts/:shortId/use — "use this as a template". Anyone who can READ
+// the source gets a copy: signed-in callers land it in their active workspace at
+// the workspace's own defaults; anonymous callers get an expiring claimable draft
+// (the /v1/drafts shape). The copy re-points at the source blob (no bytes move)
+// and records lineage in `derived_from`.
+
+const ana: TestUser = { id: "u_use_ana", email: "ana@use.test", name: "Ana" }
+const ben: TestUser = { id: "u_use_ben", email: "ben@use.test", name: "Ben" }
+
+const BASE = "use-drafts.test"
+const SECRET = "0".repeat(64)
+const { app, meta } = makeAuthedApp("use-artifact", [ana, ben], "editor", {
+  deps: { subdomainBase: BASE, encryptionKey: SECRET },
+})
+
+const use = (shortId: string, headers: Record<string, string> = {}) =>
+  app.request(`/v1/artifacts/${shortId}/use`, { method: "POST", headers })
+
+describe("signed-in use", () => {
+  it("copies into the caller's workspace: same bytes, fresh identity, recorded lineage", async () => {
+    const src = await (
+      await publishAs(app, "<h1>Weekly deck</h1>", { title: "Weekly deck" }, as(ana.email))
+    ).json()
+
+    const res = await use(src.short_id, as(ben.email))
+    expect(res.status).toBe(201)
+    const copy = await res.json()
+    expect(copy.short_id).toBeTruthy()
+    expect(copy.short_id).not.toBe(src.short_id)
+    expect(copy.title).toBe("Weekly deck")
+    expect(copy.url).toContain(copy.short_id)
+
+    // Same stored blob — the content round-trips without any re-upload.
+    const served = await app.request(`/v1/artifacts/${copy.short_id}/content`, {
+      headers: as(ben.email),
+    })
+    expect(await served.text()).toContain("Weekly deck")
+
+    // Lineage: the copy knows which artifact it was derived from (by id, not short_id).
+    const srcRow = await meta.getByShortId(src.short_id)
+    const copyRow = await meta.getByShortId(copy.short_id)
+    expect(copyRow?.derived_from).toBe(srcRow?.id)
+    // Same blob key, so storage stays dedup'd.
+    const srcV = await meta.getVersion(srcRow?.id as string, 1)
+    const copyV = await meta.getVersion(copyRow?.id as string, 1)
+    expect(copyV?.blob_key).toBe(srcV?.blob_key)
+    expect(copyV?.message).toBe(`Derived from ${src.short_id}`)
+
+    // The copy takes the WORKSPACE's defaults (the team draft), never the source's
+    // access — and the copier owns it.
+    expect(copyRow?.workspace_access).toBe("member")
+    expect(copyRow?.link_role).toBe("none")
+    expect(copyRow?.listed).toBe("none")
+    const detail = await (
+      await app.request(`/v1/artifacts/${copy.short_id}`, { headers: as(ben.email) })
+    ).json()
+    expect(detail.my_role).toBe("owner")
+  })
+
+  it("refuses a source the caller cannot read (404, existence never leaks)", async () => {
+    // Invite-only: workspace gets nothing, no world link — Ben has no path in.
+    const hidden = await (
+      await publishAs(
+        app,
+        "<p>secret</p>",
+        { workspace_access: "none", link_role: "none" },
+        as(ana.email),
+      )
+    ).json()
+    const res = await use(hidden.short_id, as(ben.email))
+    expect(res.status).toBe(404)
+  })
+})
+
+describe("anonymous use", () => {
+  it("mints an expiring claimable draft copy of a link-viewable source", async () => {
+    const src = await (
+      await publishAs(
+        app,
+        "<h1>Public template</h1>",
+        { title: "Public template", link_role: "viewer" },
+        as(ana.email),
+      )
+    ).json()
+
+    const res = await use(src.short_id) // no auth headers at all
+    expect(res.status).toBe(201)
+    const draft = await res.json()
+    expect(draft.short_id).not.toBe(src.short_id)
+    expect(draft.draft_url).toBe(`https://${draft.short_id}.${BASE}/`)
+    expect(draft.claim_url).toContain("/claim/")
+    expect(Date.parse(draft.expires_at)).toBeGreaterThan(Date.now())
+
+    // The draft shape: held in the drafts org, link-viewer only, ownerless, lineage kept.
+    const row = await meta.getByShortId(draft.short_id)
+    const srcRow = await meta.getByShortId(src.short_id)
+    expect(row?.org_id).toBe("ws_sys_drafts")
+    expect(row?.workspace_access).toBe("none")
+    expect(row?.link_role).toBe("viewer")
+    expect(row?.listed).toBe("none")
+    expect(row?.expires_at).toBeTruthy()
+    expect(row?.derived_from).toBe(srcRow?.id)
+
+    // Live on its own draft host, same bytes as the source.
+    const served = await app.request(`http://${draft.short_id}.${BASE}/`)
+    expect(served.status).toBe(200)
+    expect(await served.text()).toContain("Public template")
+  })
+
+  it("cannot use a source that grants the world nothing (404)", async () => {
+    const teamOnly = await (await publishAs(app, "<p>team</p>", {}, as(ana.email))).json()
+    const res = await use(teamOnly.short_id)
+    expect(res.status).toBe(404)
+  })
+})
+
+describe("guards", () => {
+  it("refuses to use an unclaimed draft as a template (claim it first)", async () => {
+    const form = new FormData()
+    form.append("file", new Blob([new TextEncoder().encode("<p>draft</p>")]), "page.html")
+    const minted = await (await app.request("/v1/drafts", { method: "POST", body: form })).json()
+    const res = await use(minted.short_id, as(ana.email))
+    expect(res.status).toBe(403)
+  })
+
+  it("404s a source with no published content yet", async () => {
+    const res = await use("zzzzzzzz", as(ana.email))
+    expect(res.status).toBe(404)
+  })
+})

--- a/apps/api/test/use-artifact.test.ts
+++ b/apps/api/test/use-artifact.test.ts
@@ -76,10 +76,9 @@ describe("signed-in use", () => {
 })
 
 describe("anonymous callers", () => {
-  it("is refused at the door even for a link-viewable source — no pre-auth copies", async () => {
-    // A draft copy an anonymous holder can't edit delivers nothing the source page
-    // doesn't already show, so the flow is deferred use (`?use=1` through login),
-    // and the global anonymous-write gate refuses the bare POST outright.
+  it("is refused at the door even for a link-viewable source — nothing minted pre-auth", async () => {
+    // The viewer defers signed-out clickers through login (`?use=1`); the bare
+    // POST is refused by the global anonymous-write gate.
     const src = await (
       await publishAs(
         app,
@@ -88,10 +87,10 @@ describe("anonymous callers", () => {
         as(ana.email),
       )
     ).json()
+    const draftsBefore = await meta.countArtifacts("ws_sys_drafts")
     const res = await use(src.short_id) // no auth headers at all
     expect(res.status).toBe(403)
-    // Nothing was minted anywhere for the click.
-    expect(await meta.countArtifacts("ws_sys_drafts")).toBe(0)
+    expect(await meta.countArtifacts("ws_sys_drafts")).toBe(draftsBefore)
   })
 })
 

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -1705,7 +1705,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Copy this artifact into your workspace (or an anonymous claimable draft). */
+        /** Copy this artifact into your workspace (use it as a template). */
         post: {
             parameters: {
                 query?: never;
@@ -1717,7 +1717,7 @@ export interface paths {
             };
             requestBody?: never;
             responses: {
-                /** @description The new copy: its workspace home (signed-in) or its draft + claim URLs (anonymous). */
+                /** @description The new copy's identity and workspace home. */
                 201: {
                     headers: {
                         [name: string]: unknown;
@@ -1729,14 +1729,6 @@ export interface paths {
                             /** @description The copy's permanent URL in your workspace. */
                             url: string;
                             org_id: string;
-                        } | {
-                            short_id: string;
-                            title: string | null;
-                            /** @description The live expiring page on the draft host. */
-                            draft_url: string;
-                            /** @description Sign in here to keep it. */
-                            claim_url: string;
-                            expires_at: string;
                         };
                     };
                 };

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -1696,6 +1696,58 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/artifacts/{shortId}/use": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Copy this artifact into your workspace (or an anonymous claimable draft). */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    shortId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description The new copy: its workspace home (signed-in) or its draft + claim URLs (anonymous). */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            short_id: string;
+                            title: string | null;
+                            /** @description The copy's permanent URL in your workspace. */
+                            url: string;
+                            org_id: string;
+                        } | {
+                            short_id: string;
+                            title: string | null;
+                            /** @description The live expiring page on the draft host. */
+                            draft_url: string;
+                            /** @description Sign in here to keep it. */
+                            claim_url: string;
+                            expires_at: string;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/preview": {
         parameters: {
             query?: never;

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -848,6 +848,21 @@ export const api = {
     f(`/v1/drafts/claim/${encodeURIComponent(token)}`, opts()).then(j),
   claimDraft: (token: string): Promise<{ short_id: string; url: string; org_id: string }> =>
     f("/v1/drafts/claim", opts({ token })).then(j),
+  // "Use this as a template": copy the artifact. Signed-in → into the active
+  // workspace (`url` = its new home); anonymous → an expiring claimable draft
+  // (`claim_url` = sign in to keep it). The response shape says which happened.
+  deriveArtifact: (
+    id: string,
+  ): Promise<
+    | { short_id: string; title: string | null; url: string; org_id: string }
+    | {
+        short_id: string
+        title: string | null
+        draft_url: string
+        claim_url: string
+        expires_at: string
+      }
+  > => f(`/v1/artifacts/${encodeURIComponent(id)}/use`, opts({})).then(j),
 
   // Per-artifact vanity subdomains (`base` null when off) + the workspace's custom
   // domains shown read-only as the artifact's URL on each.

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -848,21 +848,12 @@ export const api = {
     f(`/v1/drafts/claim/${encodeURIComponent(token)}`, opts()).then(j),
   claimDraft: (token: string): Promise<{ short_id: string; url: string; org_id: string }> =>
     f("/v1/drafts/claim", opts({ token })).then(j),
-  // "Use this as a template": copy the artifact. Signed-in → into the active
-  // workspace (`url` = its new home); anonymous → an expiring claimable draft
-  // (`claim_url` = sign in to keep it). The response shape says which happened.
+  // "Use this as a template": copy the artifact into the active workspace (signed-in
+  // only — the viewer defers a signed-out clicker through login with `?use=1`).
   deriveArtifact: (
     id: string,
-  ): Promise<
-    | { short_id: string; title: string | null; url: string; org_id: string }
-    | {
-        short_id: string
-        title: string | null
-        draft_url: string
-        claim_url: string
-        expires_at: string
-      }
-  > => f(`/v1/artifacts/${encodeURIComponent(id)}/use`, opts({})).then(j),
+  ): Promise<{ short_id: string; title: string | null; url: string; org_id: string }> =>
+    f(`/v1/artifacts/${encodeURIComponent(id)}/use`, opts({})).then(j),
 
   // Per-artifact vanity subdomains (`base` null when off) + the workspace's custom
   // domains shown read-only as the artifact's URL on each.

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -39,6 +39,7 @@ import { FloatingControl } from "./floating-control"
 import { canCommentWithRole } from "./lib/comment-access"
 import { bucketThreads } from "./lib/layout"
 import { useArtifactChat } from "./lib/use-artifact-chat"
+import { takeUseIntent } from "./lib/use-intent"
 import { parseRef, refFor } from "./parse-ref"
 import { PasswordGate } from "./password-gate"
 import { PublicViewer } from "./public-viewer"
@@ -133,12 +134,12 @@ export function Artifact() {
     refetch,
   } = useQuery(artifactQuery(shortId, qc))
 
-  // Deferred use-as-template (`?use=1`): the public viewer's "Make your own" sends a
-  // signed-out clicker through login with this flag, and the copy fires HERE — the
-  // first moment the visitor can actually edit what they asked for. One-shot: fired
-  // at most once per mount; success replaces the URL with the copy's, and any
-  // refusal (still anonymous, no publish seat, source gone) strips the flag and
-  // shows the page normally.
+  // Deferred use-as-template: the public viewer's "Make your own" sends a signed-out
+  // clicker through login with `?use=1`, and the copy fires here, right after auth.
+  // The same-tab marker gates it — `?use=1` alone is a shareable URL, and a pasted
+  // link must not write into the clicker's workspace (see lib/use-intent.ts). Fired
+  // at most once per mount; success replaces the URL with the copy's, anything else
+  // (no marker, still anonymous, refused) strips the flag and shows the page as-is.
   const useFired = useRef(false)
   useEffect(() => {
     if (!search.use || loading || useFired.current) return
@@ -150,7 +151,7 @@ export function Artifact() {
         search: (s) => ({ ...s, use: undefined }),
         replace: true,
       })
-    if (!me) {
+    if (!me || !takeUseIntent(shortId)) {
       strip()
       return
     }

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -132,6 +132,42 @@ export function Artifact() {
     error,
     refetch,
   } = useQuery(artifactQuery(shortId, qc))
+
+  // Deferred use-as-template (`?use=1`): the public viewer's "Make your own" sends a
+  // signed-out clicker through login with this flag, and the copy fires HERE — the
+  // first moment the visitor can actually edit what they asked for. One-shot: fired
+  // at most once per mount; success replaces the URL with the copy's, and any
+  // refusal (still anonymous, no publish seat, source gone) strips the flag and
+  // shows the page normally.
+  const useFired = useRef(false)
+  useEffect(() => {
+    if (!search.use || loading || useFired.current) return
+    useFired.current = true
+    const strip = () =>
+      nav({
+        to: "/artifacts/$ref",
+        params: { ref },
+        search: (s) => ({ ...s, use: undefined }),
+        replace: true,
+      })
+    if (!me) {
+      strip()
+      return
+    }
+    api
+      .deriveArtifact(shortId)
+      .then((r) =>
+        nav({
+          to: "/artifacts/$ref",
+          params: { ref: refFor({ short_id: r.short_id, title: r.title }) },
+          replace: true,
+        }),
+      )
+      .catch(() => {
+        toast.error("Couldn't copy this artifact into your workspace")
+        strip()
+      })
+  }, [search.use, loading, me, shortId, ref, nav])
   // The tab is named after the document, like the workbench header (title, else id).
   useDocumentTitle(art ? (art.title ?? shortId) : null)
   // Comments are signed-in-only (the API 404s anon by design) — don't fire the

--- a/apps/web/src/pages/artifact/lib/use-intent.ts
+++ b/apps/web/src/pages/artifact/lib/use-intent.ts
@@ -1,0 +1,28 @@
+// The `?use=1` deferred-copy flag rides a shareable URL, and a copy that fired on
+// any GET navigation would let a pasted link write into the clicker's workspace.
+// The CLICK is what authorizes the copy — so the click leaves a same-tab marker
+// here, and the artifact page fires only when the URL flag and the marker agree
+// on the artifact. sessionStorage survives the login round-trip in the same tab
+// (external OAuth hops included) and never travels with a shared link.
+
+const KEY = "derive:use-intent"
+
+export const markUseIntent = (shortId: string): void => {
+  try {
+    sessionStorage.setItem(KEY, shortId)
+  } catch {
+    // Storage unavailable (private modes, hardened settings): the flag then never
+    // fires and the visitor simply lands on the page as a reader.
+  }
+}
+
+/** Consume the marker. True only for the artifact the click was on. */
+export const takeUseIntent = (shortId: string): boolean => {
+  try {
+    if (sessionStorage.getItem(KEY) !== shortId) return false
+    sessionStorage.removeItem(KEY)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/apps/web/src/pages/artifact/public-viewer.tsx
+++ b/apps/web/src/pages/artifact/public-viewer.tsx
@@ -1,7 +1,7 @@
 import { Link } from "@tanstack/react-router"
 import { X } from "lucide-react"
 import { type ReactNode, useState } from "react"
-import type { Artifact, Viewer } from "@/api"
+import { type Artifact, api, type Viewer } from "@/api"
 import { Icon } from "@/components/icons"
 import { Logo } from "@/components/shared/logo"
 import { Button } from "@/components/ui/button"
@@ -75,6 +75,8 @@ export function PublicViewer({
   const nudge = shouldPromptSignInToComment(art.link_role, !!art.removed)
   const copy = commentNudgeCopy(art.open_comment_count)
   const [nudgeOpen, setNudgeOpen] = useState(false)
+  // "Make your own" in flight — the click mints a copy server-side, then leaves the page.
+  const [making, setMaking] = useState(false)
   // Base ref for the version menu's links (current = bare, past = @vN).
   const baseRef = refFor({ short_id: art.short_id, title: art.title })
 
@@ -167,15 +169,30 @@ export function PublicViewer({
         <Presence viewers={viewers} selfId={selfId} compact={isMobile} />
 
         {/* The growth verb (the page's one filled primary) + a quiet sign-in. Clicks
-            refine the d_src stamp so the funnel knows WHICH surface converted. */}
-        <Button asChild variant="default" size="sm" data-testid="public-make-your-own">
-          <Link
-            to="/login"
-            search={{ signup: true, return_to: "/new" }}
-            onClick={() => stampSrc("make_your_own", art.short_id)}
-          >
-            {isMobile ? "Make yours" : "Make your own"}
-          </Link>
+            refine the d_src stamp so the funnel knows WHICH surface converted.
+            "Make your own" now means it: POST /use copies THIS artifact — an anon
+            visitor gets a claimable draft (value first, signup after), a signed-in
+            non-member gets it in their workspace. A source that refuses (nothing
+            published, read gate) falls back to the plain signup path. */}
+        <Button
+          variant="default"
+          size="sm"
+          data-testid="public-make-your-own"
+          disabled={making}
+          onClick={() => {
+            if (making) return
+            setMaking(true)
+            stampSrc("make_your_own", art.short_id)
+            api
+              .deriveArtifact(art.short_id)
+              // Leaves this page for the copy's home (the claim page, or the caller's
+              // ACTIVE workspace) — never a workspace switch, and the anonymous viewer
+              // has no persisted cache to restore.
+              .then((r) => window.location.assign("claim_url" in r ? r.claim_url : r.url)) // reload-ignore: not a workspace switch
+              .catch(() => window.location.assign("/login?signup=true&return_to=%2Fnew")) // reload-ignore: off-app auth page
+          }}
+        >
+          {isMobile ? "Make yours" : "Make your own"}
         </Button>
         <Button
           asChild

--- a/apps/web/src/pages/artifact/public-viewer.tsx
+++ b/apps/web/src/pages/artifact/public-viewer.tsx
@@ -17,6 +17,7 @@ import { ago } from "@/lib/time"
 import { cn } from "@/lib/utils"
 import { FloatingControl } from "./floating-control"
 import { commentNudgeCopy, shouldPromptSignInToComment } from "./lib/comment-access"
+import { markUseIntent } from "./lib/use-intent"
 import { refFor } from "./parse-ref"
 import { Presence } from "./rail-deck"
 
@@ -168,15 +169,19 @@ export function PublicViewer({
 
         {/* The growth verb (the page's one filled primary) + a quiet sign-in. Clicks
             refine the d_src stamp so the funnel knows WHICH surface converted.
-            "Make your own" means THIS artifact: `?use=1` rides return_to through
-            login, and the artifact page completes the copy the moment the visitor
-            can actually edit it (deferred use) — never a blank editor, never an
-            inert pre-auth copy. */}
+            "Make your own" copies THIS artifact, deferred through login: `?use=1`
+            carries the intent across the auth redirect, the same-tab marker proves
+            it originated from this click (a pasted ?use=1 link must not write —
+            see lib/use-intent.ts), and the artifact page fires the copy once the
+            visitor is signed in. */}
         <Button asChild variant="default" size="sm" data-testid="public-make-your-own">
           <Link
             to="/login"
             search={{ signup: true, return_to: `${returnTo}?use=1` }}
-            onClick={() => stampSrc("make_your_own", art.short_id)}
+            onClick={() => {
+              stampSrc("make_your_own", art.short_id)
+              markUseIntent(art.short_id)
+            }}
           >
             {isMobile ? "Make yours" : "Make your own"}
           </Link>

--- a/apps/web/src/pages/artifact/public-viewer.tsx
+++ b/apps/web/src/pages/artifact/public-viewer.tsx
@@ -1,7 +1,7 @@
 import { Link } from "@tanstack/react-router"
 import { X } from "lucide-react"
 import { type ReactNode, useState } from "react"
-import { type Artifact, api, type Viewer } from "@/api"
+import type { Artifact, Viewer } from "@/api"
 import { Icon } from "@/components/icons"
 import { Logo } from "@/components/shared/logo"
 import { Button } from "@/components/ui/button"
@@ -75,8 +75,6 @@ export function PublicViewer({
   const nudge = shouldPromptSignInToComment(art.link_role, !!art.removed)
   const copy = commentNudgeCopy(art.open_comment_count)
   const [nudgeOpen, setNudgeOpen] = useState(false)
-  // "Make your own" in flight — the click mints a copy server-side, then leaves the page.
-  const [making, setMaking] = useState(false)
   // Base ref for the version menu's links (current = bare, past = @vN).
   const baseRef = refFor({ short_id: art.short_id, title: art.title })
 
@@ -170,29 +168,18 @@ export function PublicViewer({
 
         {/* The growth verb (the page's one filled primary) + a quiet sign-in. Clicks
             refine the d_src stamp so the funnel knows WHICH surface converted.
-            "Make your own" now means it: POST /use copies THIS artifact — an anon
-            visitor gets a claimable draft (value first, signup after), a signed-in
-            non-member gets it in their workspace. A source that refuses (nothing
-            published, read gate) falls back to the plain signup path. */}
-        <Button
-          variant="default"
-          size="sm"
-          data-testid="public-make-your-own"
-          disabled={making}
-          onClick={() => {
-            if (making) return
-            setMaking(true)
-            stampSrc("make_your_own", art.short_id)
-            api
-              .deriveArtifact(art.short_id)
-              // Leaves this page for the copy's home (the claim page, or the caller's
-              // ACTIVE workspace) — never a workspace switch, and the anonymous viewer
-              // has no persisted cache to restore.
-              .then((r) => window.location.assign("claim_url" in r ? r.claim_url : r.url)) // reload-ignore: not a workspace switch
-              .catch(() => window.location.assign("/login?signup=true&return_to=%2Fnew")) // reload-ignore: off-app auth page
-          }}
-        >
-          {isMobile ? "Make yours" : "Make your own"}
+            "Make your own" means THIS artifact: `?use=1` rides return_to through
+            login, and the artifact page completes the copy the moment the visitor
+            can actually edit it (deferred use) — never a blank editor, never an
+            inert pre-auth copy. */}
+        <Button asChild variant="default" size="sm" data-testid="public-make-your-own">
+          <Link
+            to="/login"
+            search={{ signup: true, return_to: `${returnTo}?use=1` }}
+            onClick={() => stampSrc("make_your_own", art.short_id)}
+          >
+            {isMobile ? "Make yours" : "Make your own"}
+          </Link>
         </Button>
         <Button
           asChild

--- a/apps/web/src/routes/artifacts.$ref.tsx
+++ b/apps/web/src/routes/artifacts.$ref.tsx
@@ -15,13 +15,23 @@ export const Route = createFileRoute("/artifacts/$ref")({
   // context and falls back to the artifact's sole collection, if any).
   // `present=1` opens a deck straight into present mode, which is what you want from
   // the link you paste into the calendar invite for the meeting you're presenting in.
+  // `use=1` is deferred use-as-template: the public viewer's "Make your own" sends a
+  // signed-out clicker through login with it, and the page fires the copy once the
+  // visitor is authenticated (one-shot; stripped after firing either way).
   validateSearch: (
     s: Record<string, unknown>,
-  ): { comment?: string; review?: string; collection?: string; present?: boolean } => ({
+  ): {
+    comment?: string
+    review?: string
+    collection?: string
+    present?: boolean
+    use?: boolean
+  } => ({
     ...(typeof s.comment === "string" && s.comment ? { comment: s.comment } : {}),
     ...(typeof s.review === "string" && s.review ? { review: s.review } : {}),
     ...(typeof s.collection === "string" && s.collection ? { collection: s.collection } : {}),
     ...(s.present === true || s.present === "1" || s.present === "true" ? { present: true } : {}),
+    ...(s.use === true || s.use === "1" || s.use === "true" ? { use: true } : {}),
   }),
   // Warm the artifact + its comments so an intent-preloaded link opens instantly.
   // NOT the rendered HTML: a rel=prefetch of the viewer URL is never reused by the

--- a/apps/web/src/routes/artifacts.$ref.tsx
+++ b/apps/web/src/routes/artifacts.$ref.tsx
@@ -17,7 +17,9 @@ export const Route = createFileRoute("/artifacts/$ref")({
   // the link you paste into the calendar invite for the meeting you're presenting in.
   // `use=1` is deferred use-as-template: the public viewer's "Make your own" sends a
   // signed-out clicker through login with it, and the page fires the copy once the
-  // visitor is authenticated (one-shot; stripped after firing either way).
+  // visitor is authenticated. Gated by a same-tab click marker (a pasted ?use=1
+  // link must not write — see pages/artifact/lib/use-intent.ts) and stripped after
+  // firing either way.
   validateSearch: (
     s: Record<string, unknown>,
   ): {

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -29,7 +29,8 @@ CREATE TABLE IF NOT EXISTS artifact (
   author_login TEXT,
   author_avatar TEXT,
   author_gh_id TEXT,
-  author_id TEXT
+  author_id TEXT,
+  derived_from TEXT
 );
 
 CREATE TABLE IF NOT EXISTS version (

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -171,6 +171,9 @@ export interface ArtifactRecord {
    *  static-token publishes, and legacy rows. Lets a person's profile + people-follow
    *  surface their hand-published work. */
   author_id: string | null
+  /** Remix lineage: the artifact id this one was derived from ("use as template").
+   *  Null for ordinary artifacts. Not an FK — the copy outlives a deleted source. */
+  derived_from: string | null
 }
 
 export interface ListArtifactsOpts {
@@ -411,6 +414,9 @@ export interface NewArtifact {
   spa: 0 | 1
   /** Expiring anonymous draft: ISO expiry instant. Omit for ordinary artifacts. */
   expires_at?: string | null
+  /** Remix lineage: the artifact id this one was derived from ("use as template").
+   *  Omit for ordinary artifacts; never an FK — the copy outlives its source. */
+  derived_from?: string | null
 }
 
 /** Which surface created a version: the web app, the MCP publish tool, the HTTP API

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -78,6 +78,9 @@ export const artifact = pgTable("artifact", {
   // The Derive user who last published this by hand; null for sync/token/legacy. Mirrors
   // schema.ts — drives the profile work-list + people-follow.
   author_id: text("author_id"),
+  // Remix lineage: the artifact id this was derived from. Not an FK (the source may be
+  // deleted; the copy survives). Nullable, no default — ADD COLUMN IF NOT EXISTS clean.
+  derived_from: text("derived_from"),
 })
 
 export const version = pgTable(

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -106,6 +106,10 @@ export const artifact = sqliteTable("artifact", {
   // GitHub-synced versions (attributed via author_gh_id), static-token, and legacy rows.
   // Drives the profile work-list + people-follow. Nullable so it ALTER ADDs cleanly.
   author_id: text("author_id"),
+  // Remix lineage: the artifact id this one was derived from ("Use this as a
+  // template"). Deliberately not an FK — the source may be deleted later and the
+  // copy must survive it. Nullable, no default, so it ALTER ADDs cleanly.
+  derived_from: text("derived_from"),
 })
 
 export const version = sqliteTable(

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -129,6 +129,10 @@ export function runStoreContract(
       const list = await store.listArtifacts({ orgId: ORG })
       expect(list.some((x) => x.id === a.id)).toBe(true)
       expect(await store.countArtifacts(ORG)).toBeGreaterThan(0)
+      // Remix lineage: null unless stamped at create, and round-trips when it is.
+      expect(created.derived_from).toBeNull()
+      const derived = await store.createArtifact({ ...newArtifact(), derived_from: a.id })
+      expect((await store.getArtifactById(derived.id))?.derived_from).toBe(a.id)
     })
 
     it("sets source_path (the synced-file location) independently of the title", async () => {


### PR DESCRIPTION
## What

`POST /v1/artifacts/:shortId/use` — copy an artifact you can read into your workspace, one click:

- **Signed-in only.** The copy lands in your active workspace at the workspace's own access defaults (a public source never makes your copy public), with you as owner.
- **Signed-out clickers get deferred use**, not a pre-auth copy: the public viewer's "Make your own" routes through login with `?use=1`, and the artifact page completes the copy the moment the visitor can actually edit it. Never a blank editor.
- The copy re-points at the source's content-addressed blob, so no bytes move and storage stays dedup'd (the `restore` recipe, one `createArtifact` earlier).
- New nullable `artifact.derived_from` column records remix lineage (not an FK — the copy outlives a deleted source). Both dialects + d1 regen + store-contract parity.

## Why

Every template ecosystem that compounded (Notion, Figma, Webflow, Lovable, Gamma) has the same loop: public URL → one-click use → land in-product with something working. Our public viewer had the button but pointed it at a blank editor — this makes that step real. First slice of the templates plan; the library, gallery, and agent instantiation build on `derived_from` + this route.

An earlier revision of this branch minted an anonymous claimable draft on click. Cut after review: an anonymous holder can't edit a draft, so the pre-auth copy was byte-identical to the source page they were already reading — all cost (junk artifacts, an unauthenticated write endpoint), no value. Deferred use is strictly shorter (two steps, no expiring state).

## Notes for review

- No `ANON_WRITE_ALLOW` changes — the route sits behind the global anonymous-write gate, with an in-route 401 as defense in depth.
- Drafts can't be used as sources (claim first) — keeps the claim funnel from forking.
- Asset rows are NOT copied: `asset.hash` is the global PK and `/blob/:hash` is org-blind, so embedded images keep serving — same accepted semantics as draft-claim.
- `?use=1` is one-shot: fired at most once per mount, stripped on any refusal (still anonymous, no publish seat, source gone) with a toast.
- `pnpm verify` green locally (full suite).