### PR TITLE
Fix member artifact return after sign-in

### DIFF
--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -38,6 +38,7 @@ import { EditBar } from "./edit-bar"
 import { FloatingControl } from "./floating-control"
 import { canCommentWithRole } from "./lib/comment-access"
 import { bucketThreads } from "./lib/layout"
+import { artifactLoginSearch } from "./lib/login-return"
 import { useArtifactChat } from "./lib/use-artifact-chat"
 import { parseRef, refFor } from "./parse-ref"
 import { PasswordGate } from "./password-gate"
@@ -478,7 +479,7 @@ export function Artifact() {
     error,
     onCanonical: (canonical) =>
       nav({ to: "/artifacts/$ref", params: { ref: canonical }, search: (s) => s, replace: true }),
-    onLoginBounce: () => nav({ to: "/login" }),
+    onLoginBounce: () => nav({ to: "/login", search: artifactLoginSearch(window.location) }),
     onOpenReview: (proposalId: string) => setReviewing({ proposalId }),
     post,
     setPanel,

--- a/apps/web/src/pages/artifact/lib/login-return.test.ts
+++ b/apps/web/src/pages/artifact/lib/login-return.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest"
+import { artifactLoginSearch } from "./login-return"
+
+describe("artifactLoginSearch", () => {
+  it("returns to the gated workspace artifact after sign-in", () => {
+    expect(
+      artifactLoginSearch({
+        pathname: "/artifacts/quarterly-plan-abc12345",
+        search: "",
+      }),
+    ).toEqual({ return_to: "/artifacts/quarterly-plan-abc12345" })
+  })
+
+  it("preserves version and collaboration deep links", () => {
+    expect(
+      artifactLoginSearch({
+        pathname: "/artifacts/quarterly-plan-abc12345@v3",
+        search: "?comment=thread_1&review=proposal_2",
+      }),
+    ).toEqual({
+      return_to: "/artifacts/quarterly-plan-abc12345@v3?comment=thread_1&review=proposal_2",
+    })
+  })
+})

--- a/apps/web/src/pages/artifact/lib/login-return.ts
+++ b/apps/web/src/pages/artifact/lib/login-return.ts
@@ -1,0 +1,8 @@
+/**
+ * Preserve the exact artifact deep link when an anonymous request is gated and
+ * bounced through sign-in. The login route validates this same-origin relative
+ * value before using it, then hard-navigates back after any auth method completes.
+ */
+export const artifactLoginSearch = (location: Pick<Location, "pathname" | "search">) => ({
+  return_to: `${location.pathname}${location.search}`,
+})


### PR DESCRIPTION
## What changed

- Preserve the gated artifact pathname and query string in the login `return_to`.
- Return members to the exact artifact after password, social, or SSO sign-in.
- Add regression coverage for base artifact URLs and version/comment/review deep links.

## Root cause

Member-only artifacts correctly return a non-disclosing 404 when there is no session. The artifact route then redirected anonymous visitors to `/login` but omitted `return_to`, so successful authentication landed in the library instead of back on the artifact.

That made valid workspace links opened from Slack, email, ChatGPT, or another browser surface without an existing Derive session look inaccessible—even though workspace membership and artifact authorization were correct.

## Impact

Workspace members opening member-only links without an existing browser session will sign in and return to the exact artifact URL they originally requested.

## Validation

- `pnpm verify` on Node 24.19.0
- 3,696 tests passed; 6 skipped

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/654"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788665594&installation_model_id=428097&pr_number=654&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F654&signature=e0f68b0cf9b5dba78fad6822106f3c2bf0bb93406064b2d804e8f44a7318bf61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->