### PR TITLE
fix(library): drop the sibling pager arrows and the top-bar Ask button

### DIFF
--- a/apps/web/src/pages/artifact/artifact-breadcrumb.tsx
+++ b/apps/web/src/pages/artifact/artifact-breadcrumb.tsx
@@ -4,15 +4,12 @@ import { useCallback, useEffect, useState } from "react"
 import { type Artifact, api } from "@/api"
 import { Icon } from "@/components/icons"
 import { Breadcrumb, CrumbSep, crumbClass } from "@/components/shared/breadcrumb"
-import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import { Kbd } from "@/components/ui/kbd"
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { canRenameArtifact } from "@/lib/artifact"
 import {
   artifactQuery,
@@ -285,57 +282,6 @@ export function ArtifactBreadcrumb({ art, focusMode }: { art: Artifact; focusMod
         <h1 className={cn(TITLE_CLASS, "flex min-w-0 flex-1")}>
           <EditableTitle art={art} />
         </h1>
-      )}
-      {hasSwitcher && (
-        <div className="flex shrink-0 items-center gap-0.5 pl-1">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon-xs"
-                aria-label="Previous artifact in collection"
-                data-testid="sibling-prev"
-                disabled={!prev}
-                onClick={() => goto(prev)}
-              >
-                <Icon name="chevron-left" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              Previous <Kbd>[</Kbd>
-            </TooltipContent>
-          </Tooltip>
-          <span
-            // The scope is otherwise invisible: the denominator is the FOLDER count when
-            // filed, the whole-collection count when not. The tooltip names it so the
-            // number never looks like it jumped for no reason.
-            title={
-              folderName
-                ? `${index + 1} of ${total} in ${folderName}`
-                : `${index + 1} of ${total} in the collection`
-            }
-            className="px-0.5 font-mono text-2xs tabular-nums text-muted-foreground"
-          >
-            {index + 1} / {total}
-          </span>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon-xs"
-                aria-label="Next artifact in collection"
-                data-testid="sibling-next"
-                disabled={!next}
-                onClick={() => goto(next)}
-              >
-                <Icon name="chevron-right" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              Next <Kbd>]</Kbd>
-            </TooltipContent>
-          </Tooltip>
-        </div>
       )}
     </Breadcrumb>
   )

--- a/apps/web/src/pages/library/index.tsx
+++ b/apps/web/src/pages/library/index.tsx
@@ -6,7 +6,6 @@ import { useEffect, useRef, useState } from "react"
 import { type Artifact, api } from "@/api"
 import { useShell } from "@/components/chrome/shell-context"
 import { Icon } from "@/components/icons"
-import { AskButton } from "@/components/shared/ask-button"
 import { ConfirmDialog } from "@/components/shared/confirm-dialog"
 import { ConnectAgentButton } from "@/components/shared/connect-agent"
 import { EmptyState } from "@/components/shared/empty-state"
@@ -476,7 +475,6 @@ function LibraryBody({ view }: { view: LibraryView }) {
             tools={
               <>
                 {filterField}
-                <AskButton text={query} testId="library-ask" />
                 <DisplayMenu
                   layout={layout}
                   onLayout={setLayout}
@@ -552,7 +550,6 @@ function LibraryBody({ view }: { view: LibraryView }) {
               </>
             )}
             {filterField}
-            <AskButton text={query} testId="library-ask" />
             {/* Feeds have no view row, so Display stays up here for them; home's moves
                 down beside Filter — the two are one kind of control and sit together. */}
             {view !== "all" && (

--- a/apps/web/src/pages/library/index.tsx
+++ b/apps/web/src/pages/library/index.tsx
@@ -1,6 +1,6 @@
 import type { SortMode } from "@derive/core"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
-import { Link, useNavigate, useSearch } from "@tanstack/react-router"
+import { useNavigate, useSearch } from "@tanstack/react-router"
 import { FolderTree, List } from "lucide-react"
 import { useEffect, useRef, useState } from "react"
 import { type Artifact, api } from "@/api"
@@ -119,8 +119,8 @@ function LibraryBody({ view }: { view: LibraryView }) {
   const scrollRef = useRef<HTMLDivElement>(null)
 
   const { openAssistant } = useShell()
-  // ⌘↵ in the filter box and the Ask button beside it are one action, so they go through one
-  // call: whatever is typed, handed to the agent (empty simply opens the conversation).
+  // ⌘↵ in the filter box hands whatever is typed to the agent (empty simply opens the
+  // conversation).
   const askFromField = (v: string) => openAssistant(v.trim() || undefined)
 
   const [shareCol, setShareCol] = useState<(typeof collections)[number] | null>(null)
@@ -641,103 +641,74 @@ function LibraryBody({ view }: { view: LibraryView }) {
 
       {/* The artifact body. Absent in the Collections view — that view IS the page, and
           rendering the grid underneath it put shelves and artifacts on one screen. */}
-      {!showCollections && (
-        <>
-          {isPending ? (
-            showSkeleton ? (
-              <LibrarySkeleton />
-            ) : null
-          ) : isError ? (
-            <StatusPanel
-              tone="danger"
-              title="Couldn’t load the library"
-              description="This is usually temporary."
-              action={
-                <Button
-                  variant="outline"
-                  size="sm"
-                  data-testid="library-retry"
-                  onClick={() => refetch()}
-                >
-                  Try again
-                </Button>
-              }
-            />
-          ) : items.length === 0 ? (
-            emptyHome ? (
-              <HowItWorks />
-            ) : (
-              <EmptyState {...emptyProps} />
-            )
-          ) : isSyncedCollection ? (
-            <SyncedCollection
-              items={recencyItems}
-              showFolders={showFolders}
-              onToggle={setShowFolders}
+      {!showCollections &&
+        (isPending ? (
+          showSkeleton ? (
+            <LibrarySkeleton />
+          ) : null
+        ) : isError ? (
+          <StatusPanel
+            tone="danger"
+            title="Couldn’t load the library"
+            description="This is usually temporary."
+            action={
+              <Button
+                variant="outline"
+                size="sm"
+                data-testid="library-retry"
+                onClick={() => refetch()}
+              >
+                Try again
+              </Button>
+            }
+          />
+        ) : items.length === 0 ? (
+          emptyHome ? (
+            <HowItWorks />
+          ) : (
+            <EmptyState {...emptyProps} />
+          )
+        ) : isSyncedCollection ? (
+          <SyncedCollection
+            items={recencyItems}
+            showFolders={showFolders}
+            onToggle={setShowFolders}
+            hasNextPage={!!hasNextPage}
+            isFetchingNextPage={isFetchingNextPage}
+            onLoadMore={() => fetchNextPage()}
+            onOpen={(a) =>
+              nav({ to: "/artifacts/$ref", params: { ref: refFor(a) }, search: openContext })
+            }
+            onToggleFavorite={toggleFavorite}
+            onPickAuthor={pickAuthor}
+            onAddToCollection={setPendingCollections}
+            onDelete={setPendingDelete}
+            onPrefetch={(a) => prefetch(a.short_id)}
+            selection={selection}
+          />
+        ) : isManualCollection && folders.length > 0 ? (
+          // An organized manual collection. Grouping is DECOUPLED from presentation: the
+          // Display menu's "Group by folder" flips grouping on/off, and BOTH states are the
+          // card grid — grouping never costs you the thumbnails. Default grouped.
+          foldersView ? (
+            <CollectionFolders
+              collectionId={filter.id}
+              items={items}
+              folders={folders}
+              assignments={folderAssignments}
+              canManage={!!canManageFolders}
               hasNextPage={!!hasNextPage}
               isFetchingNextPage={isFetchingNextPage}
-              onLoadMore={() => fetchNextPage()}
+              scrollToFolderId={folderAnchor}
               onOpen={(a) =>
                 nav({ to: "/artifacts/$ref", params: { ref: refFor(a) }, search: openContext })
               }
               onToggleFavorite={toggleFavorite}
-              onPickAuthor={pickAuthor}
               onAddToCollection={setPendingCollections}
               onDelete={setPendingDelete}
               onPrefetch={(a) => prefetch(a.short_id)}
               selection={selection}
             />
-          ) : isManualCollection && folders.length > 0 ? (
-            // An organized manual collection. Grouping is DECOUPLED from presentation: the
-            // Display menu's "Group by folder" flips grouping on/off, and BOTH states are the
-            // card grid — grouping never costs you the thumbnails. Default grouped.
-            foldersView ? (
-              <CollectionFolders
-                collectionId={filter.id}
-                items={items}
-                folders={folders}
-                assignments={folderAssignments}
-                canManage={!!canManageFolders}
-                hasNextPage={!!hasNextPage}
-                isFetchingNextPage={isFetchingNextPage}
-                scrollToFolderId={folderAnchor}
-                onOpen={(a) =>
-                  nav({ to: "/artifacts/$ref", params: { ref: refFor(a) }, search: openContext })
-                }
-                onToggleFavorite={toggleFavorite}
-                onAddToCollection={setPendingCollections}
-                onDelete={setPendingDelete}
-                onPrefetch={(a) => prefetch(a.short_id)}
-                selection={selection}
-              />
-            ) : (
-              <>
-                <ArtifactGrid
-                  layout={layout}
-                  sort={search.sort ?? DEFAULT_SORT}
-                  onSort={setSort}
-                  onPickAuthor={pickAuthor}
-                  items={items}
-                  scrollRef={scrollRef}
-                  hasNextPage={!!hasNextPage}
-                  isFetchingNextPage={isFetchingNextPage}
-                  onLoadMore={() => fetchNextPage()}
-                  onOpen={(a) =>
-                    nav({ to: "/artifacts/$ref", params: { ref: refFor(a) }, search: openContext })
-                  }
-                  onToggleFavorite={toggleFavorite}
-                  onAddToCollection={setPendingCollections}
-                  onDelete={setPendingDelete}
-                  onPrefetch={(a) => prefetch(a.short_id)}
-                  selection={selection}
-                />
-                {isFetchingNextPage && (
-                  <div className="flex justify-center py-2" data-testid="library-loading-more">
-                    <Spinner />
-                  </div>
-                )}
-              </>
-            )
           ) : (
             <>
               <ArtifactGrid
@@ -765,9 +736,35 @@ function LibraryBody({ view }: { view: LibraryView }) {
                 </div>
               )}
             </>
-          )}
-        </>
-      )}
+          )
+        ) : (
+          <>
+            <ArtifactGrid
+              layout={layout}
+              sort={search.sort ?? DEFAULT_SORT}
+              onSort={setSort}
+              onPickAuthor={pickAuthor}
+              items={items}
+              scrollRef={scrollRef}
+              hasNextPage={!!hasNextPage}
+              isFetchingNextPage={isFetchingNextPage}
+              onLoadMore={() => fetchNextPage()}
+              onOpen={(a) =>
+                nav({ to: "/artifacts/$ref", params: { ref: refFor(a) }, search: openContext })
+              }
+              onToggleFavorite={toggleFavorite}
+              onAddToCollection={setPendingCollections}
+              onDelete={setPendingDelete}
+              onPrefetch={(a) => prefetch(a.short_id)}
+              selection={selection}
+            />
+            {isFetchingNextPage && (
+              <div className="flex justify-center py-2" data-testid="library-loading-more">
+                <Spinner />
+              </div>
+            )}
+          </>
+        ))}
 
       {/* The bulk-action bar — the only surface multi-select adds. It rides at the end of
           the page content (sticky), so it pins above the fold while you scroll and never

--- a/packages/facts/src/index.test.ts
+++ b/packages/facts/src/index.test.ts
@@ -150,7 +150,7 @@ describe("parseFacts — HTML", () => {
 })
 
 describe("parseFacts — markdown", () => {
-  const md = (name: string, body: string) => "```derive-facts " + name + "\n" + body + "\n```"
+  const md = (name: string, body: string) => `\`\`\`derive-facts ${name}\n${body}\n\`\`\``
 
   it("extracts a fenced data block", () => {
     const src = `# Report\n\n${md("checks", `{"pass":41,"fail":2}`)}\n\nprose`
@@ -286,7 +286,7 @@ describe("parseFacts — content type gating", () => {
 
   it("is total and deterministic — same input, same result twice", () => {
     const src = html(
-      slot("a", "1") + slot("a", "2") + `<script type="application/derive-facts">bad</script>`,
+      `${slot("a", "1") + slot("a", "2")}<script type="application/derive-facts">bad</script>`,
     )
     expect(parseFacts(src, "text/html")).toEqual(parseFacts(src, "text/html"))
   })


### PR DESCRIPTION
## What

- **Removes the prev/next chevrons and the `n / m` counter** from the artifact header breadcrumb. The title caret still opens the sibling switcher, and `[` / `]` still page between siblings from the keyboard — the arrows duplicated both without earning the chrome.
- **Removes the Ask button from the library top bar** on every view it rode (a collection's page, home, the feeds, the Collections digest). ⌘↵ in the filter box still hands the typed text to the agent, and the search page keeps its Ask button.
- Picks up two biome auto-fixes `main` was warning on (a useless fragment in the library body, string concatenation in the facts tests).

## Why

The arrow cluster and the Ask button were low-value chrome on high-traffic surfaces — both duplicated affordances that already exist elsewhere.

## Testing

- `pnpm verify` green locally (ci → typecheck → test:coverage incl. the coverage ratchet).
- No tests referenced the removed test ids (`sibling-prev`, `sibling-next`, `library-ask`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/658"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788727884&installation_model_id=428097&pr_number=658&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F658&signature=87cd4352bc748ed2e24febb81ae7e96eb5e058bb6403a0799a71a7848ff72cc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->