### PR TITLE
Repair preview renders after transient raw misses

### DIFF
--- a/apps/api/src/mcp-tools/read.ts
+++ b/apps/api/src/mcp-tools/read.ts
@@ -49,7 +49,6 @@ import {
   sleep,
   toBase64,
 } from "../mcp-util"
-import { enqueueRender } from "../previews"
 import { CORE_SKILLS } from "../skills-reference.gen"
 
 /** Does this version's KIND carry facts at all? Extraction and derivation both run on
@@ -440,7 +439,10 @@ export function registerReadTool(tc: ToolContext): void {
         // trades an honest error message for "not ready yet, try again shortly" forever.
         // An old version keeps its failure, which is the truthful answer.
         if (variant.status === "failed" && n === a.current_version) {
-          await enqueueRender(ctx.meta, a.id, n)
+          // Use the shared notifier rather than enqueueing directly: on Workers it also
+          // pokes the PreviewRenderer DO, so this read's wait loop can observe the repair
+          // instead of depending on a later cron tick.
+          await ctx.notifyRender(a, n)
           if (render === "top")
             await ctx.meta.setVersionPreview(a.id, n, { preview_status: "pending" })
           else await ctx.meta.setVersionPreviewVariant(a.id, n, render, { status: "pending" })

--- a/apps/api/src/preview-cf.ts
+++ b/apps/api/src/preview-cf.ts
@@ -1,5 +1,10 @@
 import puppeteer, { type BrowserWorker } from "@cloudflare/puppeteer"
-import { assertNavigationOk, type Renderer, type ScreenshotOpts } from "./previews"
+import {
+  assertNavigationOk,
+  assertRenderedDocumentOk,
+  type Renderer,
+  type ScreenshotOpts,
+} from "./previews"
 
 /**
  * A Renderer backed by Cloudflare Browser Rendering. One warm browser per DO
@@ -20,6 +25,20 @@ export const cfBrowserRenderer = (binding: BrowserWorker): Renderer => ({
       })
       assertNavigationOk(
         await page.goto(url, { waitUntil: "networkidle0", timeout: opts.timeoutMs }),
+        url,
+      )
+      assertRenderedDocumentOk(
+        await page.evaluate(() => {
+          // The Worker build intentionally excludes DOM types, but this callback is
+          // serialized by Puppeteer and executes inside the browser page.
+          const pageGlobal = globalThis as unknown as {
+            document: { contentType: string; body?: { innerText: string } | null }
+          }
+          return {
+            contentType: pageGlobal.document.contentType,
+            bodyText: pageGlobal.document.body?.innerText ?? "",
+          }
+        }),
         url,
       )
       const buf = (await page.screenshot({ type: "png", fullPage: !!opts.fullPage })) as Uint8Array

--- a/apps/api/src/preview-node.ts
+++ b/apps/api/src/preview-node.ts
@@ -1,5 +1,10 @@
 import { chromium } from "playwright"
-import { assertNavigationOk, type Renderer, type ScreenshotOpts } from "./previews"
+import {
+  assertNavigationOk,
+  assertRenderedDocumentOk,
+  type Renderer,
+  type ScreenshotOpts,
+} from "./previews"
 
 /** A Renderer backed by a locally-installed Playwright Chromium. Node self-host only —
  *  never imported by the edge build. Each screenshot runs in a fresh isolated context. */
@@ -15,6 +20,13 @@ export const playwrightRenderer = (): Renderer => ({
       const page = await context.newPage()
       assertNavigationOk(
         await page.goto(url, { waitUntil: "networkidle", timeout: opts.timeoutMs }),
+        url,
+      )
+      assertRenderedDocumentOk(
+        await page.evaluate(() => ({
+          contentType: document.contentType,
+          bodyText: document.body?.innerText ?? "",
+        })),
         url,
       )
       const buf = await page.screenshot({ type: "png", fullPage: !!opts.fullPage })

--- a/apps/api/src/previews.ts
+++ b/apps/api/src/previews.ts
@@ -89,7 +89,10 @@ export interface Renderer {
  * missing), and a screenshot of the result cannot tell them apart. The status code in the
  * error is the first evidence anyone will have about which.
  *
- * `null` is not an error: a same-document navigation legitimately yields no response.
+ * `null` carries no status, so the renderer also probes the loaded document before it
+ * screenshots. Cloudflare Browser Rendering can occasionally return null for an HTTP
+ * navigation; treating that alone as success is how a bare raw-route error page escaped
+ * this status guard.
  *
  * The URL carries a short-lived `pv` capability token, and this message reaches both the
  * log and a stored DB column, so the token is redacted rather than persisted.
@@ -99,6 +102,23 @@ export const assertNavigationOk = (res: { status(): number } | null, url: string
   if (status === undefined || status < 400) return
   throw new Error(
     `navigation returned HTTP ${status}; refusing to screenshot an error page (${url.replace(/\/pv\/[^/]+\//, "/pv/<redacted>/")})`,
+  )
+}
+
+/**
+ * Refuse the raw route's tiny service-error documents even when browser navigation did
+ * not expose an HTTP response. Legitimate HTML/markdown artifacts are served as
+ * `text/html`; this targets only the exact `text/plain` bodies emitted by raw.ts.
+ */
+export const assertRenderedDocumentOk = (
+  doc: { contentType: string; bodyText: string },
+  url: string,
+): void => {
+  const contentType = doc.contentType.split(";", 1)[0]?.trim().toLowerCase()
+  const body = doc.bodyText.trim().toLowerCase()
+  if (contentType !== "text/plain" || !["not found", "blob missing"].includes(body)) return
+  throw new Error(
+    `navigation rendered a ${body} service response; refusing to screenshot an error page (${url.replace(/\/pv\/[^/]+\//, "/pv/<redacted>/")})`,
   )
 }
 

--- a/apps/api/test/agent-dx.test.ts
+++ b/apps/api/test/agent-dx.test.ts
@@ -1,5 +1,6 @@
 import type { MetaStore } from "@derive/core"
 import { describe, expect, it } from "vitest"
+import type { AppDeps } from "../src/context"
 import { parseManifestSkillPins, stalePins } from "../src/lib/manifest-pins"
 import { as, jsonAs, makeAuthedApp, type TestUser } from "./helpers"
 
@@ -49,8 +50,8 @@ const callRaw = async (
 const call = async (app: App, token: string, name: string, args = {}): Promise<any> =>
   JSON.parse((await callRaw(app, token, name, args)).text)
 
-const setup = async (name: string) => {
-  const { app, meta } = makeAuthedApp(name, [owner], "editor")
+const setup = async (name: string, deps: Partial<AppDeps> = {}) => {
+  const { app, meta } = makeAuthedApp(name, [owner], "editor", { deps })
   await app.request("/v1/me", { headers: as(owner.email) })
   const bot = await (
     await app.request("/v1/agents", jsonAs(as(owner.email), { name: "DxBot", role: "editor" }))
@@ -111,7 +112,13 @@ describe("publish advisories reach the MCP response", () => {
 
 describe("read render self-heal", () => {
   it("a dead-lettered render re-queues on read instead of demanding a republish", async () => {
-    const { app, meta, token } = await setup("dx-render-heal")
+    let pokes = 0
+    const { app, meta, token } = await setup("dx-render-heal", {
+      renderPreviews: true,
+      pokePreviews: () => {
+        pokes += 1
+      },
+    })
     const pub = await call(app, token, "publish", {
       title: "Healed",
       filename: "index.html",
@@ -126,6 +133,7 @@ describe("read render self-heal", () => {
       preview_status: "failed",
       preview_error: "boom (transient)",
     })
+    const pokesAfterPublish = pokes
     const healed = await callRaw(app, token, "read", { short_id: pub.short_id, render: "top" })
     expect(healed.isError).toBe(true)
     expect(healed.text).toContain("re-queued")
@@ -133,6 +141,9 @@ describe("read render self-heal", () => {
     // The variant was reset to pending (a second read must not say failed again)...
     const v = await meta.getVersion(a.id, pub.version)
     expect(v?.preview_status).toBe("pending")
+    // The repair also wakes the renderer now; otherwise the read's own wait loop can only
+    // succeed if a later cron tick happens to arrive before its deadline.
+    expect(pokes).toBe(pokesAfterPublish + 1)
     // ...and exactly one fresh job is waiting for the worker.
     const jobs = await meta.claimDueRenderJobs(new Date().toISOString(), 50, lease)
     expect(jobs.filter((j) => j.artifact_id === a.id && j.version_n === pub.version)).toHaveLength(

--- a/apps/api/test/previews.test.ts
+++ b/apps/api/test/previews.test.ts
@@ -13,6 +13,7 @@ import { sha256Hex } from "@derive/core"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import {
   assertNavigationOk,
+  assertRenderedDocumentOk,
   enqueueRender,
   MAX_ATTEMPTS,
   runRenderTick,
@@ -347,6 +348,45 @@ describe("previews: refusing to screenshot an error page", () => {
     // Still names WHICH artifact and version, which is the part that makes it diagnosable.
     expect(msg).toContain("ab12cd34")
     expect(msg).toContain("/v/7/")
+  })
+
+  it("rejects the raw route's service-error document when navigation has no status", () => {
+    const url = "https://x.test/raw/ab12cd34/v/7/pv/eyJhbGciOi.SECRETSIG/index.html"
+    expect(() =>
+      assertRenderedDocumentOk(
+        { contentType: "text/plain; charset=UTF-8", bodyText: "not found" },
+        url,
+      ),
+    ).toThrow(/navigation rendered a not found service response/)
+    expect(() =>
+      assertRenderedDocumentOk({ contentType: "text/plain", bodyText: "  BLOB MISSING\n" }, url),
+    ).toThrow(/navigation rendered a blob missing service response/)
+  })
+
+  it("does not confuse legitimate artifact content with a raw-route service error", () => {
+    const url = "https://x.test/raw/ab12cd34/v/7/pv/SIGNED.TOKEN/index.html"
+    expect(() =>
+      assertRenderedDocumentOk({ contentType: "text/html", bodyText: "not found" }, url),
+    ).not.toThrow()
+    expect(() =>
+      assertRenderedDocumentOk(
+        { contentType: "text/plain", bodyText: "The customer says not found" },
+        url,
+      ),
+    ).not.toThrow()
+  })
+
+  it("redacts the preview capability token from document-probe failures", () => {
+    const url = "https://x.test/raw/ab12cd34/v/7/pv/eyJhbGciOi.SECRETSIG/index.html"
+    let msg = ""
+    try {
+      assertRenderedDocumentOk({ contentType: "text/plain", bodyText: "not found" }, url)
+    } catch (e) {
+      msg = e instanceof Error ? e.message : String(e)
+    }
+    expect(msg).toContain("/pv/<redacted>/")
+    expect(msg).not.toContain("SECRETSIG")
+    expect(msg).not.toContain("eyJhbGciOi")
   })
 })
 


### PR DESCRIPTION
## What changed

- Reject exact plain-text `not found` and `blob missing` raw-route documents before either browser renderer stores a screenshot.
- Route read-time render repair through the shared notifier so it both enqueues work and wakes the PreviewRenderer Durable Object.
- Add regression coverage for response-less navigation, false-positive avoidance, token redaction, and renderer wake-up.

## Root cause

Cloudflare Browser Rendering can occasionally return no navigation response for an HTTP navigation. The existing status guard accepted that shape, allowing the raw service error page to be captured and marked ready. Once marked ready, normal retry and self-heal paths never ran. Separately, a failed render requeued by `read(render: ...)` did not poke the renderer, so the same read could wait until a later cron tick.

## Impact

Transient raw-route misses now enter the existing retry/backoff flow instead of becoming permanent error screenshots. A failed current-version render can repair immediately without an identical-byte republish.

## Validation

- `pnpm run ci`
- `pnpm typecheck`
- `pnpm test` (3,790 tests passed)
- pre-push `pnpm verify`, including coverage (3,790 tests passed)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/659"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788735515&installation_model_id=428097&pr_number=659&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F659&signature=e09eef1d2397d7686fce04d02f29c2e9df2d57189c87fe063f12a1e024ee7bab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->