### PR TITLE
fix: clarify hosted automation publishing

### DIFF
--- a/apps/api/src/routes/model-credentials.ts
+++ b/apps/api/src/routes/model-credentials.ts
@@ -20,6 +20,12 @@ import { fallbackPayerTiers, POOL_USER } from "../lib/payer"
 const PROVIDERS = ["claude-code", "codex"] as const
 const isoNow = () => new Date().toISOString()
 
+/** A connection hint is product copy, never credential material. Codex subscription
+ * logins are an auth.json document, so their last characters are JSON punctuation (and
+ * can include part of a token). Name that credential shape instead of slicing it. */
+const credentialHint = (kind: "oauth" | "api_key" | "login", token: string): string =>
+  kind === "login" ? "subscription" : token.slice(-4)
+
 // The workspace-pool credential is a model_credential row keyed on a reserved sentinel user
 // id, so the org's shared plan reuses the whole encrypted-secret store with no new table. It
 // can never collide with a real user id (those are newId-prefixed). Defined in lib/payer.ts,
@@ -67,7 +73,7 @@ export const modelCredentialRoutes = (ctx: AppContext) => {
     const token = b.token.trim()
     if (token === "") return fail(c, 400, "token is empty")
     const now = isoNow()
-    const hint = token.slice(-4)
+    const hint = credentialHint(b.kind, token)
     await meta.setModelCredential({
       id: newId("mcr"),
       org_id: org,
@@ -126,7 +132,7 @@ export const modelCredentialRoutes = (ctx: AppContext) => {
     const token = b.token.trim()
     if (token === "") return fail(c, 400, "token is empty")
     const now = isoNow()
-    const hint = token.slice(-4)
+    const hint = credentialHint(b.kind, token)
     await meta.setModelCredential({
       id: newId("mcr"),
       org_id: org,

--- a/apps/api/test/model-credentials.test.ts
+++ b/apps/api/test/model-credentials.test.ts
@@ -50,6 +50,24 @@ describe("model credentials", () => {
     expect(JSON.stringify(list)).not.toContain(token)
   })
 
+  it("labels a pasted Codex subscription login without echoing auth.json punctuation", async () => {
+    const login = JSON.stringify({
+      tokens: { access_token: "access-secret", refresh_token: "refresh-secret" },
+    })
+    const res = await connect(owner.email, { provider: "codex", kind: "login", token: login })
+    expect(res.status).toBe(201)
+    expect((await res.json()).hint).toBe("subscription")
+
+    const list = await (
+      await app.request("/v1/me/model-credentials", { headers: as(owner.email) })
+    ).json()
+    expect(list.credentials).toContainEqual(
+      expect.objectContaining({ provider: "codex", kind: "login", hint: "subscription" }),
+    )
+    expect(JSON.stringify(list)).not.toContain("access-secret")
+    expect(JSON.stringify(list)).not.toContain("refresh-secret")
+  })
+
   it("owner-lend is OFF by default: a no-initiator fetch is null even though the owner has a plan", async () => {
     await connect(owner.email, { provider: "codex", kind: "api_key", token: "owner-plan-fixture" })
     const agent = await mintAgent(owner.email, "Owner Runner")

--- a/apps/web/src/pages/settings/automation-form.tsx
+++ b/apps/web/src/pages/settings/automation-form.tsx
@@ -36,9 +36,16 @@ import {
   modelCredentialsQuery,
   runsQuery,
   targetPickerQuery,
+  workspaceSettingsQuery,
 } from "@/lib/queries"
 import { useApiMutation } from "@/lib/use-api-mutation"
-import { EVENT_KINDS, SCHEDULE_PRESETS, stampMode } from "./automation-format"
+import {
+  EVENT_KINDS,
+  livePublishHoldReason,
+  SCHEDULE_PRESETS,
+  stampMode,
+} from "./automation-format"
+import { credentialHintLabel } from "./model-credential-format"
 
 // The automation form, shared by the Settings manager (create + edit) and the per-artifact
 // Automate dialog. Targets are first-class: one "Add target" search over documents and
@@ -131,7 +138,14 @@ export function AutomationForm({
   const connections = useQuery(connectionsQuery())
   const contexts = useQuery(contextsQuery())
   const modelCredentials = useQuery(modelCredentialsQuery())
+  const workspaceSettings = useQuery(workspaceSettingsQuery())
   const personalPlan = modelCredentials.data?.find((c) => c.provider === provider)
+  const livePublishHold =
+    mode === "publish"
+      ? workspaceSettings.isError
+        ? "We couldn't confirm the workspace publishing policy. This run may be proposed for review."
+        : livePublishHoldReason(workspaceSettings.data)
+      : null
   const sources = useMemo(
     () => (connections.data ?? []).filter((c) => c.kind === "mcp" && c.status === "active"),
     [connections.data],
@@ -331,7 +345,8 @@ export function AutomationForm({
             <span>Checking your connected model plans…</span>
           ) : personalPlan ? (
             <span>
-              {provider === "codex" ? "Codex" : "Claude"} plan connected · {personalPlan.hint}
+              {provider === "codex" ? "Codex" : "Claude"} plan connected ·{" "}
+              {credentialHintLabel(personalPlan)}
             </span>
           ) : (
             <span>
@@ -554,6 +569,16 @@ export function AutomationForm({
               <SelectItem value="publish">Publish live</SelectItem>
             </SelectContent>
           </Select>
+          {livePublishHold && (
+            <div data-testid="automation-live-publish-held">
+              <StatusPanel
+                tone="warning"
+                layout="inline"
+                title="Live publishing is currently held for review."
+                description={livePublishHold}
+              />
+            </div>
+          )}
         </Field>
       )}
 

--- a/apps/web/src/pages/settings/automation-format.test.ts
+++ b/apps/web/src/pages/settings/automation-format.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest"
 import type { AutomationRef } from "@/api"
 import {
+  automationWriteLabel,
+  livePublishHoldReason,
   runExecutionReceipt,
   runOutcome,
   runStatusLabel,
@@ -81,6 +83,31 @@ describe("stampMode", () => {
   })
   it("empty targets → empty", () => {
     expect(stampMode([], "publish")).toEqual([])
+  })
+})
+
+describe("live publishing labels", () => {
+  const publishTarget: AutomationRef[] = [{ kind: "artifact", id: "a1", mode: "publish" }]
+
+  it("explains when workspace policy demotes a requested live write to review", () => {
+    expect(livePublishHoldReason({ agentAutoEnabled: false, agentKillswitch: false })).toBe(
+      "Live publishing is disabled for this workspace. This run will propose changes for review.",
+    )
+    expect(
+      automationWriteLabel(publishTarget, { agentAutoEnabled: false, agentKillswitch: false }),
+    ).toBe("Requests live publishing · review gate is on")
+  })
+
+  it("keeps live publishing honest for a ready workspace and the safety stop", () => {
+    expect(
+      automationWriteLabel(publishTarget, { agentAutoEnabled: true, agentKillswitch: false }),
+    ).toBe("Publishes live")
+    expect(livePublishHoldReason({ agentAutoEnabled: true, agentKillswitch: true })).toBe(
+      "The workspace safety stop is on. This run will propose changes for review.",
+    )
+    expect(automationWriteLabel([{ kind: "artifact", id: "a1" }], undefined)).toBe(
+      "Proposes for review",
+    )
   })
 })
 

--- a/apps/web/src/pages/settings/automation-format.ts
+++ b/apps/web/src/pages/settings/automation-format.ts
@@ -1,4 +1,4 @@
-import type { AutomationRef, AutomationTrigger, Run } from "@/api"
+import type { AutomationRef, AutomationTrigger, OrgSettings, Run } from "@/api"
 
 // Pure formatting for the Automations UI — kept out of the component so it's unit-tested.
 
@@ -8,6 +8,29 @@ import type { AutomationRef, AutomationTrigger, Run } from "@/api"
  *  targets uniformly; per-target modes are a future refinement. */
 export function stampMode(refs: AutomationRef[], mode: "publish" | "propose"): AutomationRef[] {
   return refs.map((r) => (mode === "publish" ? { ...r, mode: "publish" } : r))
+}
+
+type AutonomySettings = Pick<OrgSettings, "agentAutoEnabled" | "agentKillswitch">
+
+/** Why a stored publish-mode target will still be routed through review. The executor reads
+ * these switches again at claim time; this is the current UI explanation, not a promise. */
+export function livePublishHoldReason(settings: AutonomySettings | undefined): string | null {
+  if (!settings) return null
+  if (settings.agentKillswitch)
+    return "The workspace safety stop is on. This run will propose changes for review."
+  if (!settings.agentAutoEnabled)
+    return "Live publishing is disabled for this workspace. This run will propose changes for review."
+  return null
+}
+
+/** The automation row must not say "Publishes live" when the workspace gate will demote it. */
+export function automationWriteLabel(
+  refs: AutomationRef[],
+  settings: AutonomySettings | undefined,
+): string {
+  if (!refs.some((ref) => ref.mode === "publish")) return "Proposes for review"
+  const hold = livePublishHoldReason(settings)
+  return hold ? "Requests live publishing · review gate is on" : "Publishes live"
 }
 
 /** A compact human summary of an automation's targets for the row subtitle, e.g.

--- a/apps/web/src/pages/settings/automations-section.tsx
+++ b/apps/web/src/pages/settings/automations-section.tsx
@@ -2,7 +2,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
 import { Zap } from "lucide-react"
 import { useState } from "react"
-import { type Automation, api, type Run } from "@/api"
+import { type Automation, api, type OrgSettings, type Run } from "@/api"
 import { ConfirmDialog } from "@/components/shared/confirm-dialog"
 import { EmptyState } from "@/components/shared/empty-state"
 import { LoadError } from "@/components/shared/load-error"
@@ -11,11 +11,12 @@ import { SettingsGroup } from "@/components/shared/settings-group"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
-import { automationsQuery, runsQuery, workspaceQuery } from "@/lib/queries"
+import { automationsQuery, runsQuery, workspaceQuery, workspaceSettingsQuery } from "@/lib/queries"
 import { ago } from "@/lib/time"
 import { useApiMutation } from "@/lib/use-api-mutation"
 import { AutomationForm } from "./automation-form"
 import {
+  automationWriteLabel,
   runExecutionReceipt,
   runOutcome,
   runStatusLabel,
@@ -29,6 +30,7 @@ import { SettingsSection } from "./settings-section"
 export function AutomationsSection() {
   const qc = useQueryClient()
   const { data: automations, isPending, isError, refetch } = useQuery(automationsQuery())
+  const { data: settings } = useQuery(workspaceSettingsQuery())
   // Creating / removing / activity are Admin-gated server-side; Run now needs a write seat.
   // Read the caller's role once and render only what they can actually do — never a form
   // whose submit is guaranteed a 403.
@@ -78,6 +80,7 @@ export function AutomationsSection() {
             <AutomationRow
               key={a.id}
               automation={a}
+              settings={settings}
               canRun={canRun}
               canRemove={isAdmin}
               onDone={reload}
@@ -94,11 +97,13 @@ export function AutomationsSection() {
 
 function AutomationRow({
   automation,
+  settings,
   canRun,
   canRemove,
   onDone,
 }: {
   automation: Automation
+  settings: Pick<OrgSettings, "agentAutoEnabled" | "agentKillswitch"> | undefined
   canRun: boolean
   canRemove: boolean
   onDone: () => void
@@ -121,6 +126,7 @@ function AutomationRow({
     onSuccess: () => onDone(),
   })
   const summary = targetSummary(automation.refs)
+  const writeLabel = automationWriteLabel(automation.refs, settings)
   return (
     <div data-testid={`automation-row-${automation.id}`} className="flex items-center gap-3 py-3">
       <div className="flex size-7 shrink-0 items-center justify-center rounded-full bg-accent">
@@ -138,9 +144,7 @@ function AutomationRow({
           <ExecutorBadge seenAt={automation.executor_seen_at ?? null} />
         </div>
         <div className="truncate text-sm text-muted-foreground">
-          {automation.refs.some((r) => r.mode === "publish")
-            ? "Publishes live"
-            : "Proposes for review"}
+          {writeLabel}
           {summary && ` · ${summary}`}
         </div>
       </div>

--- a/apps/web/src/pages/settings/model-credential-format.test.ts
+++ b/apps/web/src/pages/settings/model-credential-format.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest"
+import { credentialHintLabel } from "./model-credential-format"
+
+describe("credentialHintLabel", () => {
+  it("uses a semantic label for subscription login documents", () => {
+    expect(
+      credentialHintLabel({
+        provider: "codex",
+        kind: "login",
+        hint: 'Z" }',
+        updated_at: "2026-08-09T00:00:00.000Z",
+      }),
+    ).toBe("subscription")
+  })
+
+  it("keeps the masked suffix for ordinary opaque tokens", () => {
+    expect(
+      credentialHintLabel({
+        provider: "codex",
+        kind: "api_key",
+        hint: "7890",
+        updated_at: "2026-08-09T00:00:00.000Z",
+      }),
+    ).toBe("••••7890")
+  })
+})

--- a/apps/web/src/pages/settings/model-credential-format.ts
+++ b/apps/web/src/pages/settings/model-credential-format.ts
@@ -1,0 +1,9 @@
+import type { ModelCredentialHint } from "@/api"
+
+/**
+ * Login credentials are subscription auth documents, not opaque strings. Older rows may
+ * still carry the document's trailing punctuation as their hint, so never render it.
+ */
+export function credentialHintLabel(credential: ModelCredentialHint): string {
+  return credential.kind === "login" ? "subscription" : `••••${credential.hint}`
+}

--- a/apps/web/src/pages/settings/model-plan-manager.tsx
+++ b/apps/web/src/pages/settings/model-plan-manager.tsx
@@ -18,6 +18,7 @@ import {
 import { Textarea } from "@/components/ui/textarea"
 import { modelCredentialsQuery, poolCredentialsQuery } from "@/lib/queries"
 import { useApiMutation } from "@/lib/use-api-mutation"
+import { credentialHintLabel } from "./model-credential-format"
 import { SettingsListSkeleton } from "./settings-list-skeleton"
 
 type Provider = "claude-code" | "codex"
@@ -255,7 +256,9 @@ function CredentialRow({
           {providerLabel(cred.provider)}
           <Badge variant="outline">{kindLabel(cred.provider, cred.kind)}</Badge>
         </div>
-        <div className="font-mono text-2xs text-muted-foreground">connected · ••••{cred.hint}</div>
+        <div className="font-mono text-2xs text-muted-foreground">
+          connected · {credentialHintLabel(cred)}
+        </div>
       </div>
       <Button
         data-testid={`${prefix}-disconnect-${cred.provider}`}


### PR DESCRIPTION
## Summary
- explain when workspace policy holds a requested live automation write for review
- make the automation list say “Requests live publishing” while the review gate is on
- replace Codex auth.json tail hints with a semantic subscription label

## Root cause
The UI stored a live-publish intent but did not render the workspace-level autonomy gate that the executor applies at claim time. Codex subscription login treats an auth.json document as an opaque token and used its trailing JSON punctuation as the display hint.

## Validation
- focused API and web tests
- API and web typechecks
- web production build
- full repository verification under Node 24: CI checks, typechecks, and coverage suite

The verification hook completed successfully.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/669"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788880975&installation_model_id=428097&pr_number=669&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F669&signature=61cfcc2cf71925e36256ff4cbf82060ca2ca89e2e4c8732b63a52057c42d8ad1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->