### PR TITLE
fix(slack): refresh install status after OAuth

### DIFF
--- a/apps/api/src/lib/slack.ts
+++ b/apps/api/src/lib/slack.ts
@@ -33,6 +33,15 @@ export interface SlackOAuthResult {
   botUserId: string | null
 }
 
+/** Slack's machine-readable OAuth failure. Keep the code so the callback can turn
+ *  configuration errors into useful UI instead of silently landing back on the
+ *  disconnected card. */
+export class SlackOAuthError extends Error {
+  constructor(public code: string) {
+    super(`slack oauth failed: ${code}`)
+  }
+}
+
 /** Exchange an OAuth `code` for a bot token via oauth.v2.access. */
 export const exchangeSlackOAuth = async (
   clientId: string,
@@ -57,8 +66,7 @@ export const exchangeSlackOAuth = async (
     bot_user_id?: string
     team?: { id?: string; name?: string }
   }
-  if (!data.ok || !data.access_token)
-    throw new Error(`slack oauth failed: ${data.error ?? "unknown"}`)
+  if (!data.ok || !data.access_token) throw new SlackOAuthError(data.error ?? "unknown")
   return {
     botToken: data.access_token,
     teamId: data.team?.id ?? "",

--- a/apps/api/src/routes/slack.ts
+++ b/apps/api/src/routes/slack.ts
@@ -24,6 +24,7 @@ import {
   openSlackView,
   postSlackResponseUrl,
   presentSlackEntityDetails,
+  SlackOAuthError,
   slackAuthorizeUrl,
   slackChannelReach,
   slackOidcAuthorizeUrl,
@@ -446,6 +447,13 @@ export const slackRoutes = (ctx: AppContext) => {
     iat: number
   }
 
+  const slackSettingsRedirect = (
+    result: "connected" | "canceled" | "expired" | "config" | "oauth" | "save",
+  ) =>
+    result === "connected"
+      ? "/settings/integrations?slack_connected=1"
+      : `/settings/integrations?slack_error=${result}`
+
   const SlackStatus = z
     .object({
       available: z.boolean().describe("True if this instance has Slack configured at all"),
@@ -502,12 +510,33 @@ export const slackRoutes = (ctx: AppContext) => {
   // OAuth callback: exchange the code for a bot token and store the install (encrypted).
   app.get("/v1/slack/oauth/callback", async (c) => {
     if (!slack || !deps.encryptionKey) return fail(c, 404, "Slack is not configured")
+    const oauthError = c.req.query("error")
+    if (oauthError)
+      return c.redirect(
+        slackSettingsRedirect(oauthError === "access_denied" ? "canceled" : "oauth"),
+      )
     const code = c.req.query("code")
     const stateRaw = c.req.query("state")
     const state = stateRaw ? verifyState<ConnectState>(stateRaw, deps.encryptionKey) : null
-    if (!code || !state) return fail(c, 400, "invalid Slack callback")
+    if (!code || !state) return c.redirect(slackSettingsRedirect("expired"))
+
+    let r: Awaited<ReturnType<typeof exchangeSlackOAuth>>
     try {
-      const r = await exchangeSlackOAuth(slack.clientId, slack.clientSecret, code, redirectUri)
+      r = await exchangeSlackOAuth(slack.clientId, slack.clientSecret, code, redirectUri)
+    } catch (err) {
+      log.warn("slack oauth failed", { error: err instanceof Error ? err.message : String(err) })
+      const configurationErrors = new Set([
+        "bad_client_secret",
+        "bad_redirect_uri",
+        "invalid_client_id",
+        "invalid_team_for_non_distributed_app",
+      ])
+      const result =
+        err instanceof SlackOAuthError && configurationErrors.has(err.code) ? "config" : "oauth"
+      return c.redirect(slackSettingsRedirect(result))
+    }
+
+    try {
       // A reconnect keeps the workspace's channel subscriptions (they live in their own table)
       // and its created_at; only the credentials are replaced.
       const existing = await meta.getSlackInstall(state.org)
@@ -521,10 +550,12 @@ export const slackRoutes = (ctx: AppContext) => {
         created_at: existing?.created_at ?? new Date().toISOString(),
       } satisfies SlackInstallRecord)
       // Slack lives under the Integrations section (there is no standalone Slack page).
-      return c.redirect("/settings/integrations")
+      return c.redirect(slackSettingsRedirect("connected"))
     } catch (err) {
-      log.warn("slack oauth failed", { error: err instanceof Error ? err.message : String(err) })
-      return c.redirect("/settings/integrations?error=oauth")
+      log.warn("slack install save failed", {
+        error: err instanceof Error ? err.message : String(err),
+      })
+      return c.redirect(slackSettingsRedirect("save"))
     }
   })
 

--- a/apps/api/test/slack-routes.test.ts
+++ b/apps/api/test/slack-routes.test.ts
@@ -148,6 +148,62 @@ const addV = async (m: MetaStore, artifactId: string): Promise<number> => {
 }
 
 describe("slack status + admin routes", () => {
+  it("persists an OAuth install and returns an explicit success handoff", async () => {
+    const { app, meta } = make("slack-oauth-success")
+    const start = await app.request("/v1/slack/install", { headers: as(owner.email) })
+    const authorizeUrl = new URL(start.headers.get("location") ?? "")
+    const state = authorizeUrl.searchParams.get("state")
+    expect(state).toBeTruthy()
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          ok: true,
+          access_token: "xoxb-oauth",
+          bot_user_id: "UBOT",
+          team: { id: "T-OAUTH", name: "Acme Slack" },
+        }),
+      ),
+    )
+    const callback = await app.request(
+      `/v1/slack/oauth/callback?code=oauth-code&state=${encodeURIComponent(state ?? "")}`,
+    )
+
+    expect(callback.status).toBe(302)
+    expect(callback.headers.get("location")).toBe("/settings/integrations?slack_connected=1")
+    expect(await meta.getSlackInstall("default")).toMatchObject({
+      team_id: "T-OAUTH",
+      team_name: "Acme Slack",
+      bot_user_id: "UBOT",
+    })
+  })
+
+  it("returns OAuth failures to settings with a useful recovery state", async () => {
+    const { app } = make("slack-oauth-error")
+    const canceled = await app.request("/v1/slack/oauth/callback?error=access_denied")
+    expect(canceled.status).toBe(302)
+    expect(canceled.headers.get("location")).toBe("/settings/integrations?slack_error=canceled")
+
+    const expired = await app.request("/v1/slack/oauth/callback?code=orphaned")
+    expect(expired.status).toBe(302)
+    expect(expired.headers.get("location")).toBe("/settings/integrations?slack_error=expired")
+
+    const start = await app.request("/v1/slack/install", { headers: as(owner.email) })
+    const state = new URL(start.headers.get("location") ?? "").searchParams.get("state")
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({ ok: false, error: "invalid_team_for_non_distributed_app" }),
+      ),
+    )
+    const misconfigured = await app.request(
+      `/v1/slack/oauth/callback?code=oauth-code&state=${encodeURIComponent(state ?? "")}`,
+    )
+    expect(misconfigured.status).toBe(302)
+    expect(misconfigured.headers.get("location")).toBe("/settings/integrations?slack_error=config")
+  })
+
   it("reports available + not connected before an install, connected after", async () => {
     const { app, meta } = make("slack-status")
     const before = await (await app.request("/v1/slack", { headers: as(owner.email) })).json()

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -462,14 +462,14 @@ export const blockedQuery = () =>
     queryFn: () => api.getBilling().then((b) => b.blocked),
   })
 
-// Slack connection status for the Integrations section (availability, connected
-// team, default channel). Invalidated on disconnect; staleTime Infinity so a
-// background refetch can't re-seed the editable channel field mid-edit.
+// Slack connection status for the Integrations section. Keep it eligible for focus
+// refetches so an OAuth flow completed in another tab updates the original settings
+// page as soon as the user returns.
 export const slackQuery = () =>
   queryOptions({
     queryKey: ["slack"] as const,
     queryFn: () => api.getSlack(),
-    staleTime: Number.POSITIVE_INFINITY,
+    refetchOnWindowFocus: "always",
   })
 
 // The workspace's Slack channel subscriptions, plus the event types one can carry (the server

--- a/apps/web/src/pages/settings/integrations-section.tsx
+++ b/apps/web/src/pages/settings/integrations-section.tsx
@@ -1,11 +1,14 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query"
-import { useState } from "react"
+import { AlertTriangle } from "lucide-react"
+import { useEffect, useState } from "react"
 import { api, type OrgSettings } from "@/api"
 import { ConfirmDialog } from "@/components/shared/confirm-dialog"
 import { LoadError } from "@/components/shared/load-error"
 import { SettingRow } from "@/components/shared/setting-row"
 import { SettingsGroup } from "@/components/shared/settings-group"
+import { StatusPanel } from "@/components/shared/status-panel"
 import { Button } from "@/components/ui/button"
+import { toast } from "@/components/ui/sonner"
 import { Switch } from "@/components/ui/switch"
 import { slackQuery, workspaceSettingsQuery } from "@/lib/queries"
 import { snapshot, useApiMutation } from "@/lib/use-api-mutation"
@@ -13,14 +16,76 @@ import { SettingsListSkeleton } from "./settings-list-skeleton"
 import { SettingsSection } from "./settings-section"
 import { SlackSubscriptionsSection } from "./slack-subscriptions-section"
 
+type SlackInstallResult = { connected: true } | { connected: false; error: string } | null
+
+const DEFAULT_SLACK_INSTALL_ERROR = {
+  title: "Slack couldn't be connected",
+  description: "Slack didn't complete the authorization. Try again or check the app configuration.",
+}
+
+const SLACK_INSTALL_ERRORS: Record<string, { title: string; description: string }> = {
+  canceled: {
+    title: "Slack connection canceled",
+    description: "Nothing changed. When you're ready, start the connection again below.",
+  },
+  expired: {
+    title: "Slack connection expired",
+    description: "The authorization session was missing or expired. Start again below.",
+  },
+  config: {
+    title: "Slack app configuration needs attention",
+    description:
+      "Slack rejected this app's credentials, redirect URL, or workspace eligibility. Check the Slack app configuration, then try again.",
+  },
+  save: {
+    title: "Derive couldn't save the Slack connection",
+    description: "Slack approved the app, but Derive couldn't persist the installation. Try again.",
+  },
+  oauth: DEFAULT_SLACK_INSTALL_ERROR,
+}
+
+// Read the one-shot callback result without mutating browser state during render.
+// The effect below clears it after mount and invalidates any restored Slack cache.
+const readSlackInstallResult = (): SlackInstallResult => {
+  if (typeof window === "undefined") return null
+  const qs = new URLSearchParams(window.location.search)
+  const connected = qs.get("slack_connected") === "1"
+  const error = qs.get("slack_error")
+  if (!connected && !error) return null
+  return connected ? { connected: true } : { connected: false, error: error ?? "oauth" }
+}
+
 // The workspace activity toggles (email + GitHub mirroring) plus the Slack connection.
 // Where Slack posts is per-channel now — see slack-subscriptions-section.tsx. Toggles apply optimistically
 // with no save (the toggle contract); the Slack channel id is an explicit save.
 export function IntegrationsSection() {
   const qc = useQueryClient()
   const { data: settings, isPending, isError, refetch } = useQuery(workspaceSettingsQuery())
-  const { data: slack } = useQuery(slackQuery())
+  const { data: slack, isFetching: slackIsFetching } = useQuery(slackQuery())
+  const [installResult] = useState(readSlackInstallResult)
+  const installError =
+    installResult && !installResult.connected
+      ? (SLACK_INSTALL_ERRORS[installResult.error] ?? DEFAULT_SLACK_INSTALL_ERROR)
+      : null
   const [disconnecting, setDisconnecting] = useState(false)
+
+  useEffect(() => {
+    if (!installResult) return
+    const cleanupUrl = window.setTimeout(() => {
+      const qs = new URLSearchParams(window.location.search)
+      qs.delete("slack_connected")
+      qs.delete("slack_error")
+      const rest = qs.toString()
+      window.history.replaceState(
+        window.history.state,
+        "",
+        `${window.location.pathname}${rest ? `?${rest}` : ""}`,
+      )
+    }, 0)
+    void qc.invalidateQueries({ queryKey: slackQuery().queryKey })
+    if (installResult.connected) toast.success("Slack connected")
+    return () => window.clearTimeout(cleanupUrl)
+  }, [installResult, qc])
 
   // Toggle a single settings key, optimistically flipping the shared cache entry so the
   // switch stays live; the primitive rolls back + toasts on failure, and the server's
@@ -134,6 +199,20 @@ export function IntegrationsSection() {
       ) : null}
 
       <SettingsGroup title="Slack">
+        {installError && installResult && !installResult.connected && (
+          <StatusPanel
+            tone={installResult.error === "canceled" ? "warning" : "danger"}
+            layout="inline"
+            icon={<AlertTriangle aria-hidden />}
+            title={installError.title}
+            description={installError.description}
+            action={
+              <Button data-testid="slack-install-retry" variant="outline" size="sm" asChild>
+                <a href="/v1/slack/install">Try again</a>
+              </Button>
+            }
+          />
+        )}
         {slack && !slack.available ? (
           <div className="flex flex-col items-start gap-3 py-1">
             <p className="text-sm text-muted-foreground">
@@ -144,6 +223,28 @@ export function IntegrationsSection() {
               <a href="/settings/slack/app/new">Set up Slack app</a>
             </Button>
           </div>
+        ) : installResult?.connected && !slack?.connected ? (
+          <StatusPanel
+            tone={slackIsFetching ? "neutral" : "danger"}
+            layout="inline"
+            title={
+              slackIsFetching
+                ? "Finishing the Slack connection…"
+                : "Slack approved the app, but the connection is missing"
+            }
+            description={
+              slackIsFetching
+                ? "Slack approved the app. Derive is confirming the saved workspace now."
+                : "Derive couldn't confirm the saved installation. Try connecting once more."
+            }
+            action={
+              !slackIsFetching && (
+                <Button data-testid="slack-confirm-retry" variant="outline" size="sm" asChild>
+                  <a href="/v1/slack/install">Try again</a>
+                </Button>
+              )
+            }
+          />
         ) : slack?.connected ? (
           <div className="flex flex-col gap-4 py-1">
             <p className="text-sm">
@@ -216,14 +317,19 @@ export function IntegrationsSection() {
               run <code>/derive subscribe</code> in the channel itself.
             </p>
             <div>
-              <Button
-                data-testid="slack-disconnect"
-                variant="destructive-ghost"
-                size="sm"
-                onClick={() => setDisconnecting(true)}
-              >
-                Disconnect Slack
-              </Button>
+              <div className="flex flex-wrap items-center gap-2">
+                <Button data-testid="slack-change-workspace" variant="outline" size="sm" asChild>
+                  <a href="/v1/slack/install">Change Slack workspace</a>
+                </Button>
+                <Button
+                  data-testid="slack-disconnect"
+                  variant="destructive-ghost"
+                  size="sm"
+                  onClick={() => setDisconnecting(true)}
+                >
+                  Disconnect Slack
+                </Button>
+              </div>
             </div>
             <ConfirmDialog
               open={disconnecting}
@@ -238,22 +344,12 @@ export function IntegrationsSection() {
         ) : (
           <div className="flex flex-col items-start gap-3 py-1">
             <p className="text-sm text-muted-foreground">
-              Connect a Slack workspace to get comments in a channel and reply back from Slack.
+              Authorize a Slack workspace for this Derive workspace. If you already installed the
+              app in Slack, complete this step once so Derive can save the connection.
             </p>
             <Button data-testid="slack-connect" variant="default" asChild>
-              <a href="/v1/slack/install">Add to Slack</a>
+              <a href="/v1/slack/install">Connect Slack</a>
             </Button>
-            <p className="text-xs text-muted-foreground">
-              Haven't created the Slack app yet?{" "}
-              <a
-                className="underline"
-                href="/settings/slack/app/new"
-                data-testid="slack-setup-link"
-              >
-                Set it up from a manifest
-              </a>
-              .
-            </p>
           </div>
         )}
       </SettingsGroup>


### PR DESCRIPTION
## Summary

- refresh Slack connection status after the OAuth flow returns or the original settings tab regains focus
- return explicit success and actionable failure states from the OAuth callback
- clarify the connected, disconnected, retry, and change-workspace experiences
- cover the OAuth persistence and handoff paths with route tests

## Root cause

The Slack install was saved immediately, but the web client cached the Slack status forever and the callback returned without an explicit success signal. The settings page could therefore keep rendering the pre-install disconnected state even though the installation was already present.

## Impact

After authorization, the settings experience confirms the saved workspace instead of continuing to show Connect Slack. Cancellation, expired state, Slack app configuration errors, OAuth failures, and persistence failures now have distinct recovery guidance.

## Verification

- pnpm verify
- Slack route suite: 83 tests passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/670"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788893389&installation_model_id=428097&pr_number=670&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F670&signature=314ffb41774670b0142ac18d0d952ef864d177f9baa314fbaa0021cd170c289f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->