### PR TITLE
fix(web+api): QA round harvest — share confirm, private-link sign-in, render retry, boot timeout, stale-edit latch

### DIFF
--- a/apps/api/src/lib/model-anthropic.ts
+++ b/apps/api/src/lib/model-anthropic.ts
@@ -123,6 +123,13 @@ export const anthropicModel = (opts: AnthropicOptions): AgentLoopInput["callMode
     // reads ANTHROPIC_API_KEY from the environment when given none — which on a self-host box is
     // how one workspace's run quietly bills the operator's key. Always pass the connected value.
     apiKey: opts.credential.value,
+    // PIN the Messages API origin. createAnthropic otherwise reads ANTHROPIC_BASE_URL from the
+    // process environment (a local Claude proxy, a self-host gateway rewrite, a test harness) and
+    // that quietly redirects every hosted plan-token turn off api.anthropic.com. The credential
+    // path exists specifically to spend a WORKSPACE's Claude plan; the destination is not a
+    // deploy-time preference. Mirror openAiCompatModel, which takes baseUrl as a required option
+    // rather than an ambient env.
+    baseURL: "https://api.anthropic.com/v1",
     headers: authHeaders(opts.credential) as Record<string, string>,
     ...(opts.fetchImpl ? { fetch: opts.fetchImpl } : {}),
   })

--- a/apps/api/test/model-anthropic.test.ts
+++ b/apps/api/test/model-anthropic.test.ts
@@ -76,6 +76,27 @@ describe("how a connected plan authenticates", () => {
     })
     expect((calls[0]?.body as { model: string }).model).toBe(DEFAULT_ANTHROPIC_MODEL)
   })
+
+  it("hits api.anthropic.com even when ANTHROPIC_BASE_URL is set in the process environment", async () => {
+    // createAnthropic reads ANTHROPIC_BASE_URL unless baseURL is pinned. A local Claude proxy,
+    // CI harness, or self-host rewrite would otherwise steer every plan-token turn off the
+    // Messages API the connected credential is for — and the intercept in substrate-loop's
+    // credential tests (which keys on api.anthropic.com) would go silent the same way.
+    const prev = process.env.ANTHROPIC_BASE_URL
+    process.env.ANTHROPIC_BASE_URL = "http://127.0.0.1:9"
+    try {
+      const { calls, impl } = captured()
+      await anthropicModel({ credential: { kind: "api_key", value: "k" }, fetchImpl: impl })({
+        system: "s",
+        messages: [{ role: "user", content: "hi" }],
+        tools: [],
+      })
+      expect(calls[0]?.url).toMatch(/^https:\/\/api\.anthropic\.com\//)
+    } finally {
+      if (prev === undefined) delete process.env.ANTHROPIC_BASE_URL
+      else process.env.ANTHROPIC_BASE_URL = prev
+    }
+  })
 })
 
 describe("what a plan turn reports", () => {

--- a/apps/web/src/lib/race-timeout.test.ts
+++ b/apps/web/src/lib/race-timeout.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { raceTimeout } from "./race-timeout"
+import { reportVital } from "./vitals"
+
+vi.mock("./vitals", () => ({
+  reportVital: vi.fn(),
+  reportWebVitals: vi.fn(),
+}))
+
+afterEach(() => {
+  vi.clearAllMocks()
+  vi.useRealTimers()
+})
+
+describe("raceTimeout", () => {
+  it("passes the value through when the promise resolves before the timeout", async () => {
+    await expect(raceTimeout(Promise.resolve("warm"), 1000, "cold")).resolves.toBe("warm")
+    expect(reportVital).not.toHaveBeenCalled()
+  })
+
+  it("falls back when the promise never settles", async () => {
+    vi.useFakeTimers()
+    const hang = new Promise<string>(() => {})
+    const pending = raceTimeout(hang, 50, "cold", "cache-restore-timeout")
+    await vi.advanceTimersByTimeAsync(50)
+    await expect(pending).resolves.toBe("cold")
+  })
+
+  it("logs a vital on timeout when a name is provided", async () => {
+    vi.useFakeTimers()
+    const hang = new Promise<string>(() => {})
+    const pending = raceTimeout(hang, 30, "cold", "cache-restore-timeout")
+    await vi.advanceTimersByTimeAsync(30)
+    await pending
+    expect(reportVital).toHaveBeenCalledWith("cache-restore-timeout", 30, "poor")
+  })
+
+  it("does not log a vital when the promise wins the race", async () => {
+    await raceTimeout(Promise.resolve(1), 500, 0, "cache-restore-timeout")
+    expect(reportVital).not.toHaveBeenCalled()
+  })
+
+  it("propagates a rejection that arrives before the timeout", async () => {
+    await expect(raceTimeout(Promise.reject(new Error("boom")), 1000, "cold")).rejects.toThrow(
+      "boom",
+    )
+  })
+})

--- a/apps/web/src/lib/race-timeout.ts
+++ b/apps/web/src/lib/race-timeout.ts
@@ -1,0 +1,40 @@
+import { reportVital } from "./vitals"
+
+/**
+ * Resolve `promise`, or `fallback` once `ms` elapses — whichever first.
+ * Use for best-effort boot work (persisted-cache restore) that must not wedge the app
+ * if the underlying I/O never settles (wedged IndexedDB, etc.).
+ *
+ * When `vitalName` is set, a timeout beacons through the vitals sink so the hang is
+ * observable in field telemetry / dev consoles.
+ */
+export const raceTimeout = async <T>(
+  promise: Promise<T>,
+  ms: number,
+  fallback: T,
+  vitalName?: string,
+): Promise<T> => {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    const result = await Promise.race([
+      promise.then((value) => ({ timedOut: false as const, value })),
+      new Promise<{ timedOut: true }>((resolve) => {
+        timer = setTimeout(() => {
+          if (vitalName) reportVital(vitalName, ms, "poor")
+          resolve({ timedOut: true })
+        }, ms)
+      }),
+    ])
+    if (result.timedOut) {
+      // Absorb a late settle so a reject after timeout is not an unhandled rejection.
+      void promise.then(
+        () => {},
+        () => {},
+      )
+      return fallback
+    }
+    return result.value
+  } finally {
+    if (timer !== undefined) clearTimeout(timer)
+  }
+}

--- a/apps/web/src/lib/vitals.ts
+++ b/apps/web/src/lib/vitals.ts
@@ -8,6 +8,31 @@ import { API_BASE } from "@/api"
 const BEACON_URL =
   (import.meta.env.VITE_VITALS_URL as string | undefined) ?? `${API_BASE}/v1/vitals`
 
+type VitalRating = Metric["rating"]
+
+// One metric (Core Web Vital or a custom boot/field event) through the shared
+// sink. Dev logs; prod beacons. No-op off-window.
+export function reportVital(
+  name: string,
+  value: number,
+  rating: VitalRating = "poor",
+  id?: string,
+) {
+  if (typeof window === "undefined") return
+  if (import.meta.env.DEV) {
+    console.info(`[web-vitals] ${name} ${Math.round(value)} (${rating})`)
+    return
+  }
+  const body = JSON.stringify({
+    name,
+    value,
+    rating,
+    id: id ?? `${name}-${Math.round(performance.now())}`,
+    path: location.pathname,
+  })
+  navigator.sendBeacon?.(BEACON_URL, body)
+}
+
 // Report Core Web Vitals. In dev we log each metric to the console (with its
 // rating) for before/after tuning; in prod we also beacon it to the collector —
 // sendBeacon survives the page unload that finalizes CLS/INP/LCP, so the numbers
@@ -15,18 +40,7 @@ const BEACON_URL =
 export function reportWebVitals() {
   if (typeof window === "undefined") return
   const sink = (m: Metric) => {
-    if (import.meta.env.DEV) {
-      console.info(`[web-vitals] ${m.name} ${Math.round(m.value)} (${m.rating})`)
-    } else {
-      const body = JSON.stringify({
-        name: m.name,
-        value: m.value,
-        rating: m.rating,
-        id: m.id,
-        path: location.pathname,
-      })
-      navigator.sendBeacon?.(BEACON_URL, body)
-    }
+    reportVital(m.name, m.value, m.rating, m.id)
   }
   onLCP(sink)
   onINP(sink)

--- a/apps/web/src/pages/artifact/artifact-states.tsx
+++ b/apps/web/src/pages/artifact/artifact-states.tsx
@@ -1,23 +1,50 @@
+import { Link } from "@tanstack/react-router"
 import { Icon } from "@/components/icons"
 import { EmptyState } from "@/components/shared/empty-state"
 import { StatusPanel } from "@/components/shared/status-panel"
 import { Button } from "@/components/ui/button"
+import { artifactUnavailableView } from "./lib/login-return"
 
 /** Full-page states the artifact route renders instead of the doc. The loading
  *  frame is the shape-matched WorkbenchSkeleton (workbench-skeleton.tsx), not a
  *  bare spinner. */
 
-export function ArtifactNotFound({ onBack }: { onBack: () => void }) {
+/**
+ * Masked 404/403 (missing and private are indistinguishable by design). Signed-out
+ * visitors get "Sign in to view" with a return path; signed-in visitors stay on a
+ * not-available page — no CTA that would imply the doc exists under another seat.
+ */
+export function ArtifactNotFound({
+  authed,
+  location,
+  onBack,
+}: {
+  /** Auth has settled: true when a session is present. */
+  authed: boolean
+  /** Current URL pieces for the sign-in return path (used when signed out). */
+  location: Pick<Location, "pathname" | "search">
+  onBack: () => void
+}) {
+  const view = artifactUnavailableView(authed, location)
   return (
     <EmptyState
       className="h-full"
       icon={<Icon name="removed" strokeWidth={1.75} />}
-      title="Artifact not found"
-      description="It doesn’t exist, or you don’t have access to it."
+      title={view.title}
+      description={view.description}
       action={
-        <Button variant="outline" data-testid="artifact-notfound-back" onClick={onBack}>
-          Back to library
-        </Button>
+        <div className="flex gap-2">
+          {view.signIn && (
+            <Button asChild variant="default" data-testid="artifact-notfound-sign-in">
+              <Link to="/login" search={view.signIn.search}>
+                {view.signIn.label}
+              </Link>
+            </Button>
+          )}
+          <Button variant="outline" data-testid="artifact-notfound-back" onClick={onBack}>
+            Back to library
+          </Button>
+        </div>
       }
     />
   )

--- a/apps/web/src/pages/artifact/edit-bar.tsx
+++ b/apps/web/src/pages/artifact/edit-bar.tsx
@@ -33,6 +33,7 @@ export function EditBar({
   canRedo = false,
   canFormat = false,
   allowElementEdits = false,
+  staleNotice,
   onUndo,
   onRedo,
   onFormat,
@@ -51,6 +52,8 @@ export function EditBar({
   canFormat?: boolean
   /** HTML/deck sources can persist resize operations; rendered Markdown cannot. */
   allowElementEdits?: boolean
+  /** Concurrent publish while editing — sticky for the whole remaining session. */
+  staleNotice?: string | null
   onUndo: () => void
   onRedo: () => void
   /** A link needs a URL; the bar asks for it (below) before it sends one. */
@@ -76,162 +79,173 @@ export function EditBar({
   return (
     // role=status + aria-live: entering the mode unmounts the Edit button the user
     // just pressed, so focus falls to body and a screen reader would otherwise get
-    // no signal at all that the document became editable.
+    // no signal at all that the document became editable. The concurrent-publish
+    // chip rides under the tools so it stays visible for the whole remaining edit.
     <div
       data-testid="inline-edit-bar"
       role="status"
       aria-live="polite"
-      className="flex shrink-0 items-center gap-2 border-border border-b bg-accent/40 py-1.5 pr-2 pl-4"
+      className="flex shrink-0 flex-col border-border border-b bg-accent/40"
     >
-      <Icon name="pencil" size={14} className="shrink-0 text-muted-foreground" />
-      {/* The word is the mode's name; it drops on a phone, where the pencil and the
+      <div className="flex items-center gap-2 py-1.5 pr-2 pl-4">
+        <Icon name="pencil" size={14} className="shrink-0 text-muted-foreground" />
+        {/* The word is the mode's name; it drops on a phone, where the pencil and the
           live controls already say what this is and every px of width is spoken for. */}
-      <span className="hidden font-medium text-foreground text-xs sm:inline">Editing</span>
+        <span className="hidden font-medium text-foreground text-xs sm:inline">Editing</span>
 
-      {/* History, then formatting: two groups, held apart by a hairline rather than
+        {/* History, then formatting: two groups, held apart by a hairline rather than
           gaps alone, because they answer different questions. */}
-      <div className="flex shrink-0 items-center gap-0.5">
-        <ToolButton
-          testId="inline-edit-undo"
-          icon="undo"
-          label="Undo"
-          chord="⌘Z"
-          size={toolSize}
-          disabled={!canUndo || saving}
-          onClick={onUndo}
-        />
-        <ToolButton
-          testId="inline-edit-redo"
-          icon="redo"
-          label="Redo"
-          chord="⇧⌘Z"
-          size={toolSize}
-          disabled={!canRedo || saving}
-          onClick={onRedo}
-        />
-        <span aria-hidden className="mx-1 h-4 w-px bg-border" />
-        <ToolButton
-          testId="inline-edit-bold"
-          icon="bold"
-          label="Bold"
-          chord="⌘B"
-          size={toolSize}
-          disabled={!canFormat || saving}
-          onClick={() => onFormat("b")}
-        />
-        <ToolButton
-          testId="inline-edit-italic"
-          icon="italic"
-          label="Italic"
-          chord="⌘I"
-          size={toolSize}
-          disabled={!canFormat || saving}
-          onClick={() => onFormat("i")}
-        />
-        <ToolButton
-          testId="inline-edit-link"
-          icon="link"
-          label="Link"
-          chord="⌘K"
-          size={toolSize}
-          disabled={(!canFormat && href === null) || saving}
-          onClick={() => setHref("")}
-        />
-      </div>
+        <div className="flex shrink-0 items-center gap-0.5">
+          <ToolButton
+            testId="inline-edit-undo"
+            icon="undo"
+            label="Undo"
+            chord="⌘Z"
+            size={toolSize}
+            disabled={!canUndo || saving}
+            onClick={onUndo}
+          />
+          <ToolButton
+            testId="inline-edit-redo"
+            icon="redo"
+            label="Redo"
+            chord="⇧⌘Z"
+            size={toolSize}
+            disabled={!canRedo || saving}
+            onClick={onRedo}
+          />
+          <span aria-hidden className="mx-1 h-4 w-px bg-border" />
+          <ToolButton
+            testId="inline-edit-bold"
+            icon="bold"
+            label="Bold"
+            chord="⌘B"
+            size={toolSize}
+            disabled={!canFormat || saving}
+            onClick={() => onFormat("b")}
+          />
+          <ToolButton
+            testId="inline-edit-italic"
+            icon="italic"
+            label="Italic"
+            chord="⌘I"
+            size={toolSize}
+            disabled={!canFormat || saving}
+            onClick={() => onFormat("i")}
+          />
+          <ToolButton
+            testId="inline-edit-link"
+            icon="link"
+            label="Link"
+            chord="⌘K"
+            size={toolSize}
+            disabled={(!canFormat && href === null) || saving}
+            onClick={() => setHref("")}
+          />
+        </div>
 
-      {/* Asking for the URL takes the status line's place: one line, one question,
+        {/* Asking for the URL takes the status line's place: one line, one question,
           gone the moment it's answered. Enter applies it, Escape drops it. */}
-      {href !== null && (
-        <input
-          // biome-ignore lint/a11y/noAutofocus: the field IS the question the button just asked.
-          autoFocus
-          aria-label="Link to"
-          data-testid="inline-edit-link-input"
-          placeholder="Link to…"
-          className="min-w-0 flex-1 rounded-sm bg-transparent px-1 text-xs outline-none ring-1 ring-border focus:ring-ring"
-          value={href}
-          onChange={(e) => setHref(e.target.value)}
-          onBlur={commitLink}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") {
-              e.preventDefault()
-              commitLink()
-            } else if (e.key === "Escape") {
-              e.preventDefault()
-              setHref(null)
-            }
-            e.stopPropagation()
-          }}
-        />
-      )}
-
-      {/* The status line. It yields first under width pressure — the controls and the
-          way to save matter more than the sentence describing them. */}
-      <span
-        className={cn(
-          "hidden min-w-0 truncate text-2xs text-muted-foreground md:inline",
-          href !== null && "md:hidden",
+        {href !== null && (
+          <input
+            // biome-ignore lint/a11y/noAutofocus: the field IS the question the button just asked.
+            autoFocus
+            aria-label="Link to"
+            data-testid="inline-edit-link-input"
+            placeholder="Link to…"
+            className="min-w-0 flex-1 rounded-sm bg-transparent px-1 text-xs outline-none ring-1 ring-border focus:ring-ring"
+            value={href}
+            onChange={(e) => setHref(e.target.value)}
+            onBlur={commitLink}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault()
+                commitLink()
+              } else if (e.key === "Escape") {
+                e.preventDefault()
+                setHref(null)
+              }
+              e.stopPropagation()
+            }}
+          />
         )}
-      >
-        {dirty === 0
-          ? allowElementEdits
-            ? touch
-              ? "tap text to edit; tap an image to resize or replace it"
-              : "click text to edit; drag a media or box corner to resize"
-            : touch
-              ? "tap text to edit; select an image to replace it"
-              : "click text to edit; select an image to replace it"
-          : `${dirty} unsaved change${dirty === 1 ? "" : "s"}`}
-      </span>
-      {/* …and on a phone the count still has to be visible, so it appears alone. */}
-      {dirty > 0 && (
-        <span className="shrink-0 text-2xs text-muted-foreground tabular-nums md:hidden">
-          {dirty}
-        </span>
-      )}
 
-      <div className="ml-auto flex shrink-0 items-center gap-1">
-        {dirty > 0 ? (
-          <>
+        {/* The status line. It yields first under width pressure — the controls and the
+          way to save matter more than the sentence describing them. */}
+        <span
+          className={cn(
+            "hidden min-w-0 truncate text-2xs text-muted-foreground md:inline",
+            href !== null && "md:hidden",
+          )}
+        >
+          {dirty === 0
+            ? allowElementEdits
+              ? touch
+                ? "tap text to edit; tap an image to resize or replace it"
+                : "click text to edit; drag a media or box corner to resize"
+              : touch
+                ? "tap text to edit; select an image to replace it"
+                : "click text to edit; select an image to replace it"
+            : `${dirty} unsaved change${dirty === 1 ? "" : "s"}`}
+        </span>
+        {/* …and on a phone the count still has to be visible, so it appears alone. */}
+        {dirty > 0 && (
+          <span className="shrink-0 text-2xs text-muted-foreground tabular-nums md:hidden">
+            {dirty}
+          </span>
+        )}
+
+        <div className="ml-auto flex shrink-0 items-center gap-1">
+          {dirty > 0 ? (
+            <>
+              <Button
+                variant="ghost"
+                size="sm"
+                data-testid="inline-edit-discard"
+                onClick={onDiscard}
+                disabled={saving}
+                className={hit}
+              >
+                Discard
+              </Button>
+              <Button
+                variant="default"
+                size="sm"
+                data-testid="inline-edit-save"
+                onClick={onSave}
+                loading={saving}
+                className={hit}
+              >
+                {canPublish ? "Save" : "Suggest"}
+                <Kbd aria-hidden className="max-sm:hidden">
+                  ⌘S
+                </Kbd>
+              </Button>
+            </>
+          ) : (
             <Button
               variant="ghost"
               size="sm"
-              data-testid="inline-edit-discard"
-              onClick={onDiscard}
-              disabled={saving}
+              data-testid="inline-edit-done"
+              onClick={onDone}
               className={hit}
             >
-              Discard
-            </Button>
-            <Button
-              variant="default"
-              size="sm"
-              data-testid="inline-edit-save"
-              onClick={onSave}
-              loading={saving}
-              className={hit}
-            >
-              {canPublish ? "Save" : "Suggest"}
+              Done
               <Kbd aria-hidden className="max-sm:hidden">
-                ⌘S
+                Esc
               </Kbd>
             </Button>
-          </>
-        ) : (
-          <Button
-            variant="ghost"
-            size="sm"
-            data-testid="inline-edit-done"
-            onClick={onDone}
-            className={hit}
-          >
-            Done
-            <Kbd aria-hidden className="max-sm:hidden">
-              Esc
-            </Kbd>
-          </Button>
-        )}
+          )}
+        </div>
       </div>
+      {staleNotice && (
+        <div
+          data-testid="stale-edit-notice"
+          className="border-warning/25 border-t bg-warning/10 px-4 py-1 text-2xs text-warning"
+        >
+          {staleNotice}
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -40,7 +40,6 @@ import { EditBar } from "./edit-bar"
 import { FloatingControl } from "./floating-control"
 import { canCommentWithRole } from "./lib/comment-access"
 import { bucketThreads } from "./lib/layout"
-import { artifactLoginSearch } from "./lib/login-return"
 import { useArtifactChat } from "./lib/use-artifact-chat"
 import { takeUseIntent } from "./lib/use-intent"
 import { parseRef, refFor } from "./parse-ref"
@@ -503,8 +502,8 @@ export function Artifact() {
     post({ type: "focus-anchor", id: threadId, bias: isMobile ? 0.28 : undefined })
   }
 
-  // URL canonicalisation, the anon-bounce gate, and the ?comment deep link — the
-  // page's routing side-effects. `nav` stays here; the hook takes decoupled callbacks.
+  // URL canonicalisation and the ?comment / ?review deep links — the page's routing
+  // side-effects. `nav` stays here; the hook takes decoupled callbacks.
   useArtifactRoute({
     art,
     ref,
@@ -512,13 +511,8 @@ export function Artifact() {
     version,
     comments,
     authed: !!me,
-    loading,
-    failed,
-    locked,
-    error,
     onCanonical: (canonical) =>
       nav({ to: "/artifacts/$ref", params: { ref: canonical }, search: (s) => s, replace: true }),
-    onLoginBounce: () => nav({ to: "/login", search: artifactLoginSearch(window.location) }),
     onOpenReview: (proposalId: string) => setReviewing({ proposalId }),
     post,
     setPanel,
@@ -676,7 +670,17 @@ export function Artifact() {
     // dead-end. This is what made the outage look like a permanent failure.
     const status = error instanceof ApiError ? error.status : undefined
     return status === 404 || status === 403 ? (
-      <ArtifactNotFound onBack={() => nav({ to: "/" })} />
+      // Wait for auth to settle so signed-out visitors get the Sign-in CTA (not a flash
+      // of the signed-in empty state while `me` is still loading).
+      loading ? (
+        <WorkbenchSkeleton />
+      ) : (
+        <ArtifactNotFound
+          authed={!!me}
+          location={{ pathname: window.location.pathname, search: window.location.search }}
+          onBack={() => nav({ to: "/" })}
+        />
+      )
     ) : (
       <ArtifactLoadError onRetry={() => refetch()} onBack={() => nav({ to: "/" })} />
     )
@@ -703,7 +707,13 @@ export function Artifact() {
   // SETTLED anonymous: while it loads, `me` is null for signed-in users too,
   // and they must not flash a not-found for a version they can see.
   if (!loading && !me && shown !== art.current_version && !art.public_history)
-    return <ArtifactNotFound onBack={() => nav({ to: "/" })} />
+    return (
+      <ArtifactNotFound
+        authed={false}
+        location={{ pathname: window.location.pathname, search: window.location.search }}
+        onBack={() => nav({ to: "/" })}
+      />
+    )
   // The `t/:raw_token` segment is the sandboxed iframe's own proof of access: it has no
   // `allow-same-origin` (by design — the content must never touch our cookies/storage),
   // so it has no origin to send our session cookie back on, and Chrome refuses to attach

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -48,6 +48,7 @@ import { PublicViewer } from "./public-viewer"
 import { Presence } from "./rail-deck"
 import { ReviewCard } from "./review-card"
 import { SourceEditor } from "./source-editor"
+import { clearStaleEdit, noteStalePublish, type StaleEditState, staleEditCopy } from "./stale-edit"
 import { type ComposerState, parseAnchor } from "./types"
 import { useArtifactFrame } from "./use-artifact-frame"
 import { useArtifactLive } from "./use-artifact-live"
@@ -184,6 +185,8 @@ export function Artifact() {
   // password prompt rather than the not-found state or a bounce to login.
   const locked = failed && error instanceof ApiError && error.status === 401
   const [editing, setEditing] = useState(false)
+  // Concurrent publish while mid-edit — sticky chip until save/exit (toast alone is too easy to miss).
+  const [staleVersion, setStaleVersion] = useState<StaleEditState>(null)
   // Focus/hero mode — strip the workbench chrome to just the matted render (Esc exits).
   const [focus, setFocus] = useState(false)
   useEffect(() => {
@@ -295,11 +298,11 @@ export function Artifact() {
 
   // A version published while we're LOOKING refetches (the unpinned render swaps
   // in place) and gets a cue, so the repaint reads as an update, not a glitch:
-  // a quiet toast normally, a WARNING while editing (this edit started from the
-  // old version — publishing it replaces the newer one). Pinned views (@vN) get
-  // neither: their version bar already carries "you're on an old version", and the
-  // refetch keeps it truthful. Read through refs so the SSE stream doesn't
-  // resubscribe every time the user opens the editor.
+  // a quiet toast while reading; a sticky chip while either edit surface is open
+  // (the document under the edit moved — save re-checks / publish replaces).
+  // Pinned views (@vN) get neither: their version bar already carries "you're on
+  // an old version", and the refetch keeps it truthful. Read through refs so the
+  // SSE stream doesn't resubscribe every time the user opens the editor.
   const editingRef = useRef(editing)
   editingRef.current = editing
   // Same read-through-a-ref pattern for INLINE editing (set after the hook below):
@@ -329,22 +332,16 @@ export function Artifact() {
     (n?: number) => {
       load()
       if (pinnedRef.current !== undefined) return
-      const v = n !== undefined ? `v${n}` : "A new version"
-      if (inlineEditRef.current.active) {
-        toast.warning(`${v} was just published. Saving will re-check your edits against it.`, {
-          id: `stale-edit-${shortId}`,
-          duration: 8000,
-        })
-      } else if (editingRef.current) {
-        toast.warning(`${v} was just published — publishing this edit will replace it.`, {
-          id: `stale-edit-${shortId}`,
-          duration: 8000,
-        })
-      } else {
-        toast(`Updated to ${v === "A new version" ? "the newest version" : v}.`, {
-          id: `live-version-${shortId}`,
-        })
+      const editingNow = inlineEditRef.current.active || editingRef.current
+      if (editingNow) {
+        // Sticky chip for the whole remaining edit — the toast alone was easy to miss.
+        setStaleVersion((prev) => noteStalePublish(prev, true, n))
+        return
       }
+      const v = n !== undefined ? `v${n}` : "A new version"
+      toast(`Updated to ${v === "A new version" ? "the newest version" : v}.`, {
+        id: `live-version-${shortId}`,
+      })
     },
     [load, shortId],
   )
@@ -602,6 +599,12 @@ export function Artifact() {
     save: inlineEdit.save,
     start: inlineEdit.start,
   }
+
+  // Drop the concurrent-publish latch the moment neither edit surface is open —
+  // covers Save / Done / Discard / Cancel / Escape / nav-confirm / frame-gone.
+  useEffect(() => {
+    if (!editing && !inlineEdit.active) setStaleVersion(clearStaleEdit())
+  }, [editing, inlineEdit.active])
 
   // Inspect is an edit-mode companion, never a passive third destination. The existing
   // Edit entry point is the only way in; when it activates an editable HTML artifact,
@@ -1118,6 +1121,7 @@ export function Artifact() {
                 canRedo={inlineEdit.tools.canRedo}
                 canFormat={inlineEdit.tools.canFormat}
                 allowElementEdits={inlineEdit.allowElementEdits}
+                staleNotice={staleEditCopy(staleVersion, "inline")}
                 onUndo={inlineEdit.undo}
                 onRedo={inlineEdit.redo}
                 onFormat={inlineEdit.format}
@@ -1138,6 +1142,7 @@ export function Artifact() {
                 onProposeMsg={setProposeMsg}
                 onMessage={setMessage}
                 onSrc={setSrc}
+                staleNotice={staleEditCopy(staleVersion, "source")}
                 onCancel={() => setEditing(false)}
                 onPublish={publishEdit}
                 onPropose={proposeEdit}

--- a/apps/web/src/pages/artifact/lib/access-segment.test.ts
+++ b/apps/web/src/pages/artifact/lib/access-segment.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest"
+import {
+  accessSegmentNeedsConfirm,
+  accessSegmentOf,
+  accessSegmentToast,
+  decideAccessSegmentChange,
+  draftForAccessSegment,
+} from "./access-segment"
+
+// Share-dialog "WHO CAN OPEN THIS" decisions. The confirm gate only fires when
+// widening to Anyone — accidental public exposure is the bug (BUG-16). Toast copy
+// names the new reach so a silent apply can't happen again.
+
+describe("accessSegmentOf", () => {
+  it("projects the triple onto the widest reach", () => {
+    expect(accessSegmentOf("viewer", "none")).toBe("anyone")
+    expect(accessSegmentOf("none", "member")).toBe("workspace")
+    expect(accessSegmentOf("none", "none")).toBe("invite")
+    // world link outranks workspace seat
+    expect(accessSegmentOf("editor", "member")).toBe("anyone")
+  })
+})
+
+describe("accessSegmentNeedsConfirm", () => {
+  it("confirms only when widening TO anyone", () => {
+    expect(accessSegmentNeedsConfirm("invite", "anyone")).toBe(true)
+    expect(accessSegmentNeedsConfirm("workspace", "anyone")).toBe(true)
+  })
+  it("stays one-click for narrowing and non-anyone moves", () => {
+    expect(accessSegmentNeedsConfirm("anyone", "invite")).toBe(false)
+    expect(accessSegmentNeedsConfirm("anyone", "workspace")).toBe(false)
+    expect(accessSegmentNeedsConfirm("invite", "workspace")).toBe(false)
+    expect(accessSegmentNeedsConfirm("workspace", "invite")).toBe(false)
+    expect(accessSegmentNeedsConfirm("anyone", "anyone")).toBe(false)
+  })
+})
+
+describe("accessSegmentToast", () => {
+  it("names the new reach in plain language", () => {
+    expect(accessSegmentToast("anyone")).toBe("Anyone with the link can now open this")
+    expect(accessSegmentToast("workspace")).toBe("Everyone in the workspace can now open this")
+    expect(accessSegmentToast("invite")).toBe("Only people you've added can open this")
+  })
+})
+
+describe("decideAccessSegmentChange", () => {
+  it("pairs the confirm gate with the landing toast", () => {
+    expect(decideAccessSegmentChange("invite", "anyone")).toEqual({
+      needsConfirm: true,
+      toast: "Anyone with the link can now open this",
+    })
+    expect(decideAccessSegmentChange("anyone", "invite")).toEqual({
+      needsConfirm: false,
+      toast: "Only people you've added can open this",
+    })
+    expect(decideAccessSegmentChange("invite", "workspace")).toEqual({
+      needsConfirm: false,
+      toast: "Everyone in the workspace can now open this",
+    })
+  })
+})
+
+describe("draftForAccessSegment", () => {
+  it("invite clears every general-access field", () => {
+    expect(draftForAccessSegment("invite", "editor", "public")).toEqual({
+      workspaceAccess: "none",
+      linkRole: "none",
+      listed: "none",
+    })
+  })
+  it("workspace keeps an existing workspace listing, drops the world link", () => {
+    expect(draftForAccessSegment("workspace", "viewer", "workspace")).toEqual({
+      workspaceAccess: "member",
+      linkRole: "none",
+      listed: "workspace",
+    })
+    expect(draftForAccessSegment("workspace", "viewer", "public")).toEqual({
+      workspaceAccess: "member",
+      linkRole: "none",
+      listed: "none",
+    })
+  })
+  it("anyone defaults the world link to viewer and keeps a public listing", () => {
+    expect(draftForAccessSegment("anyone", "none", "none")).toEqual({
+      workspaceAccess: "member",
+      linkRole: "viewer",
+      listed: "none",
+    })
+    expect(draftForAccessSegment("anyone", "commenter", "public")).toEqual({
+      workspaceAccess: "member",
+      linkRole: "commenter",
+      listed: "public",
+    })
+  })
+})

--- a/apps/web/src/pages/artifact/lib/access-segment.ts
+++ b/apps/web/src/pages/artifact/lib/access-segment.ts
@@ -1,0 +1,55 @@
+import type { LinkRole, Listed, WorkspaceAccess } from "@/api"
+
+/** The "WHO CAN OPEN THIS" primary choice in the share dialog. */
+export type AccessSegment = "invite" | "workspace" | "anyone"
+
+/** Project the access triple onto the widest-reach segment. */
+export const accessSegmentOf = (
+  linkRole: LinkRole,
+  workspaceAccess: WorkspaceAccess,
+): AccessSegment =>
+  linkRole !== "none" ? "anyone" : workspaceAccess === "member" ? "workspace" : "invite"
+
+/**
+ * Widening to "Anyone" is the one irreversible-feeling step — a private doc becomes
+ * link-reachable. Confirm that jump only; narrowing (and invite ↔ workspace) stay one-click.
+ */
+export const accessSegmentNeedsConfirm = (from: AccessSegment, to: AccessSegment): boolean =>
+  to === "anyone" && from !== "anyone"
+
+/** Toast copy after a segment change lands — names the new reach, not the old. */
+export const accessSegmentToast = (segment: AccessSegment): string => {
+  if (segment === "anyone") return "Anyone with the link can now open this"
+  if (segment === "workspace") return "Everyone in the workspace can now open this"
+  return "Only people you've added can open this"
+}
+
+/** Segment pick → access triple at the safe defaults the share dialog already used. */
+export const draftForAccessSegment = (
+  seg: AccessSegment,
+  currentLinkRole: LinkRole,
+  currentListed: Listed,
+): { workspaceAccess: WorkspaceAccess; linkRole: LinkRole; listed: Listed } => {
+  if (seg === "invite") return { workspaceAccess: "none", linkRole: "none", listed: "none" }
+  if (seg === "workspace")
+    return {
+      workspaceAccess: "member",
+      linkRole: "none",
+      listed: currentListed === "workspace" ? "workspace" : "none",
+    }
+  // anyone: keep the current link role (or default to view), keep a public listing.
+  return {
+    workspaceAccess: "member",
+    linkRole: currentLinkRole === "none" ? "viewer" : currentLinkRole,
+    listed: currentListed === "public" ? "public" : "none",
+  }
+}
+
+/** One decision for a segment click: confirm gate + toast once the write lands. */
+export const decideAccessSegmentChange = (
+  from: AccessSegment,
+  to: AccessSegment,
+): { needsConfirm: boolean; toast: string } => ({
+  needsConfirm: accessSegmentNeedsConfirm(from, to),
+  toast: accessSegmentToast(to),
+})

--- a/apps/web/src/pages/artifact/lib/login-return.test.ts
+++ b/apps/web/src/pages/artifact/lib/login-return.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { artifactLoginSearch } from "./login-return"
+import { artifactLoginSearch, artifactUnavailableView } from "./login-return"
 
 describe("artifactLoginSearch", () => {
   it("returns to the gated workspace artifact after sign-in", () => {
@@ -20,5 +20,31 @@ describe("artifactLoginSearch", () => {
     ).toEqual({
       return_to: "/artifacts/quarterly-plan-abc12345@v3?comment=thread_1&review=proposal_2",
     })
+  })
+})
+
+describe("artifactUnavailableView", () => {
+  const loc = {
+    pathname: "/artifacts/quarterly-plan-abc12345",
+    search: "?comment=thread_1",
+  }
+
+  it("signed-out: sign-in CTA with the artifact return path", () => {
+    const view = artifactUnavailableView(false, loc)
+    expect(view.title).toBe("This page isn’t available")
+    expect(view.description).toMatch(/signing in may help/i)
+    expect(view.signIn).toEqual({
+      label: "Sign in to view",
+      search: {
+        return_to: "/artifacts/quarterly-plan-abc12345?comment=thread_1",
+      },
+    })
+  })
+
+  it("signed-in: not-available copy with no sign-in CTA", () => {
+    const view = artifactUnavailableView(true, loc)
+    expect(view.title).toBe("This page isn’t available")
+    expect(view.description).toMatch(/ask whoever shared/i)
+    expect(view.signIn).toBeNull()
   })
 })

--- a/apps/web/src/pages/artifact/lib/login-return.ts
+++ b/apps/web/src/pages/artifact/lib/login-return.ts
@@ -1,8 +1,43 @@
 /**
- * Preserve the exact artifact deep link when an anonymous request is gated and
- * bounced through sign-in. The login route validates this same-origin relative
- * value before using it, then hard-navigates back after any auth method completes.
+ * Preserve the exact artifact deep link when an anonymous request is gated and the
+ * visitor chooses Sign in. The login route validates this same-origin relative value
+ * before using it, then hard-navigates back after any auth method completes.
  */
 export const artifactLoginSearch = (location: Pick<Location, "pathname" | "search">) => ({
   return_to: `${location.pathname}${location.search}`,
 })
+
+/**
+ * What the artifact route shows for a masked 404/403 (missing and private are the same
+ * status by design — never leak which). Signed-out visitors get a path forward via
+ * sign-in-with-return; signed-in visitors stay on a not-available page with no CTA that
+ * would imply the doc exists under another account.
+ */
+export type ArtifactUnavailableView = {
+  title: string
+  description: string
+  /** Present only for signed-out visitors — login search carries the return path. */
+  signIn: { label: string; search: { return_to: string } } | null
+}
+
+export const artifactUnavailableView = (
+  authed: boolean,
+  location: Pick<Location, "pathname" | "search">,
+): ArtifactUnavailableView => {
+  if (authed) {
+    return {
+      title: "This page isn’t available",
+      description:
+        "It doesn’t exist, or you don’t have access. You may need to ask whoever shared it.",
+      signIn: null,
+    }
+  }
+  return {
+    title: "This page isn’t available",
+    description: "If someone shared it with you, signing in may help.",
+    signIn: {
+      label: "Sign in to view",
+      search: artifactLoginSearch(location),
+    },
+  }
+}

--- a/apps/web/src/pages/artifact/render-stage.test.ts
+++ b/apps/web/src/pages/artifact/render-stage.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest"
-import { type UpdateCueState, updateCue } from "./render-stage"
+import {
+  BOOT_MAX_TRIES,
+  bootStatusCopy,
+  bootTimeoutDecision,
+  type UpdateCueState,
+  updateCue,
+} from "./render-stage"
 
 // The soft "Updated · vN" cue's decision, pinned after it shipped a phantom: the render
 // stage stays mounted while the sibling switcher pages between artifacts, and a bare
@@ -50,5 +56,36 @@ describe("updateCue", () => {
     expect(s.state).toBeNull()
     s = step(s.state, "other", 9)
     expect(s.fire).toBeNull()
+  })
+})
+
+// Boot timeout after publish often races a still-warm render. Auto-retry a few times
+// with growing backoff; only the exhausted attempt is terminal (manual Retry).
+describe("bootTimeoutDecision", () => {
+  it("retries with growing backoff, then fails once tries are exhausted", () => {
+    expect(BOOT_MAX_TRIES).toBe(3)
+    const sequence = Array.from({ length: BOOT_MAX_TRIES }, (_, i) => bootTimeoutDecision(i))
+    expect(sequence).toEqual([
+      { action: "retry", delayMs: 1_000 },
+      { action: "retry", delayMs: 2_000 },
+      { action: "fail" },
+    ])
+  })
+
+  it("stays terminal past the last budgeted try", () => {
+    expect(bootTimeoutDecision(BOOT_MAX_TRIES)).toEqual({ action: "fail" })
+    expect(bootTimeoutDecision(BOOT_MAX_TRIES + 4)).toEqual({ action: "fail" })
+  })
+})
+
+describe("bootStatusCopy", () => {
+  it("keeps the calm first-paint label until a retry path engages", () => {
+    expect(bootStatusCopy(0, false)).toBe("Loading preview…")
+  })
+
+  it("names the extended wait after a timeout or on a later try", () => {
+    expect(bootStatusCopy(0, true)).toBe("Still rendering…")
+    expect(bootStatusCopy(1, false)).toBe("Still rendering…")
+    expect(bootStatusCopy(2, true)).toBe("Still rendering…")
   })
 })

--- a/apps/web/src/pages/artifact/render-stage.tsx
+++ b/apps/web/src/pages/artifact/render-stage.tsx
@@ -11,6 +11,26 @@ import { cn } from "@/lib/utils"
 // white frame (NN/g #1 — visibility of system status; the render's own failure
 // must be legible, not indistinguishable from "still loading").
 const BOOT_TIMEOUT_MS = 15_000
+/** Total boot tries before the stage goes terminal-failed (initial + auto-retries). */
+export const BOOT_MAX_TRIES = 3
+
+/**
+ * Pure decision after a boot timeout at `tryIndex` (0-based). Retries with growing
+ * backoff while tries remain; only the last exhaustion is terminal. Extracted so the
+ * sequence is pinned by tests — the viewer should keep waiting on a slow server-side
+ * render instead of forcing a manual Retry at 15s.
+ */
+export const bootTimeoutDecision = (
+  tryIndex: number,
+): { action: "retry"; delayMs: number } | { action: "fail" } => {
+  if (tryIndex + 1 >= BOOT_MAX_TRIES) return { action: "fail" }
+  // 1s, then 2s — short enough to feel alive, long enough for the render to land.
+  return { action: "retry", delayMs: 1_000 * 2 ** tryIndex }
+}
+
+/** Waiting-state copy: first try is calm; after a timeout/retry we name the wait. */
+export const bootStatusCopy = (tryIndex: number, awaitingRetry: boolean): string =>
+  tryIndex > 0 || awaitingRetry ? "Still rendering…" : "Loading preview…"
 
 /**
  * The render stage — the artifact is the hero. The sandboxed iframe fills the stage
@@ -94,24 +114,57 @@ export function RenderStage({
   // Boot/failure state is per-source: a new rawSrc (version swap, retry) resets it.
   const [phase, setPhase] = useState<"booting" | "ready" | "failed">("booting")
   const [attempt, setAttempt] = useState(0)
+  // 0-based try within the current boot cycle — independent of the iframe mount key so
+  // a manual Retry after terminal failure can re-arm the full auto-retry budget.
+  const [bootTry, setBootTry] = useState(0)
+  // True between a timed-out boot and the backoff-driven remount (copy flips here).
+  const [awaitingRetry, setAwaitingRetry] = useState(false)
+  // biome-ignore lint/correctness/useExhaustiveDependencies: rawSrc is an intentional reset trigger (version swap / new src); body only flips local boot state.
   useEffect(() => {
     setPhase("booting")
-  }, [])
+    setBootTry(0)
+    setAwaitingRetry(false)
+  }, [rawSrc])
 
   // Arm the stuck-boot timeout while booting; clear it the moment the frame loads.
   // No src yet means no load in flight — don't count seed-wait time against the render.
+  // On timeout: auto-retry with backoff a few times (slow server-side render is common
+  // right after publish); only exhaust into terminal failed after BOOT_MAX_TRIES.
   useEffect(() => {
     if (phase !== "booting" || rawSrc == null) return
-    const t = setTimeout(() => setPhase("failed"), BOOT_TIMEOUT_MS)
-    return () => clearTimeout(t)
-  }, [phase, rawSrc])
+    let cancelled = false
+    let backoffId: ReturnType<typeof setTimeout> | undefined
+    const bootId = setTimeout(() => {
+      const decision = bootTimeoutDecision(bootTry)
+      if (decision.action === "fail") {
+        setPhase("failed")
+        setAwaitingRetry(false)
+        return
+      }
+      setAwaitingRetry(true)
+      backoffId = setTimeout(() => {
+        if (cancelled) return
+        setAwaitingRetry(false)
+        setBootTry((n) => n + 1)
+        setAttempt((n) => n + 1)
+      }, decision.delayMs)
+    }, BOOT_TIMEOUT_MS)
+    return () => {
+      cancelled = true
+      clearTimeout(bootId)
+      if (backoffId !== undefined) clearTimeout(backoffId)
+    }
+  }, [phase, rawSrc, bootTry])
 
   const handleLoad = () => {
     setPhase("ready")
+    setAwaitingRetry(false)
     onFrameLoad?.()
   }
   const retry = () => {
     setPhase("booting")
+    setBootTry(0)
+    setAwaitingRetry(false)
     setAttempt((n) => n + 1)
   }
 
@@ -211,7 +264,9 @@ export function RenderStage({
               {/* Decorative: the wrapping div is the live region (aria-live) with the
                   visible label, so the spinner must not announce a second time. */}
               <Spinner size="lg" role="presentation" aria-label={undefined} />
-              <span className="font-mono text-2xs text-muted-foreground">Loading preview…</span>
+              <span className="font-mono text-2xs text-muted-foreground">
+                {bootStatusCopy(bootTry, awaitingRetry)}
+              </span>
             </div>
           </div>
         )}

--- a/apps/web/src/pages/artifact/share-dialog.tsx
+++ b/apps/web/src/pages/artifact/share-dialog.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/api"
 import { Icon, type IconName } from "@/components/icons"
 import { AccessSegmentToggle } from "@/components/shared/access-segment-toggle"
+import { ConfirmDialog } from "@/components/shared/confirm-dialog"
 import { PersonSearchInput } from "@/components/shared/person-search-input"
 import { ROLE_LABELS, RoleSelect } from "@/components/shared/role-select"
 import { Eyebrow, SectionEyebrow } from "@/components/shared/section-eyebrow"
@@ -44,6 +45,13 @@ import { getInitials } from "@/lib/initials"
 import { artifactQuery, workspaceQuery } from "@/lib/queries"
 import { STORAGE_KEYS } from "@/lib/storage-keys"
 import { useApiMutation } from "@/lib/use-api-mutation"
+import {
+  type AccessSegment,
+  accessSegmentOf,
+  accessSegmentToast,
+  decideAccessSegmentChange,
+  draftForAccessSegment,
+} from "@/pages/artifact/lib/access-segment"
 import { ShareCollectionDialog } from "@/pages/library/share-collection-dialog"
 
 // Access is ONE primary question — who can open this — projected from the v2
@@ -51,8 +59,7 @@ import { ShareCollectionDialog } from "@/pages/library/share-collection-dialog"
 // is the WIDEST reach currently granted: a world link is "anyone"; workspace-seat
 // access is "workspace"; neither is "invite". The world link's role and each
 // segment's listing (does it show in a feed) are secondary switches beneath it.
-type Segment = "invite" | "workspace" | "anyone"
-const SEGMENTS: { value: Segment; label: string; icon: IconName }[] = [
+const SEGMENTS: { value: AccessSegment; label: string; icon: IconName }[] = [
   { value: "invite", label: "Invited", icon: "lock" },
   { value: "workspace", label: "Workspace", icon: "workspace" },
   { value: "anyone", label: "Anyone", icon: "globe" },
@@ -215,8 +222,7 @@ export function ShareButton({
   // listed) draft ──────────────────────────────────────────────────────────────
   // The segment is the WIDEST reach: a live world link is "anyone"; workspace-seat
   // access is "workspace"; neither is "invite".
-  const segment: Segment =
-    lRole !== "none" ? "anyone" : wsAccess === "member" ? "workspace" : "invite"
+  const segment: AccessSegment = accessSegmentOf(lRole, wsAccess)
   // The listing switch per segment — public directory for "anyone", the workspace
   // library for "workspace". Invited lists nowhere.
   const isListed =
@@ -228,9 +234,15 @@ export function ShareButton({
   // checking the box reveals the input, and nothing applies until Set password.
   // Optimistic so the controls don't flash the old state; the primitive rolls back the
   // draft AND toasts on failure (converged with ShareCollectionDialog — no more inline err).
+  // Pending "open to anyone" confirm — only the widen-to-Anyone jump asks first.
+  const [pendingAnyone, setPendingAnyone] = useState<AccessDraft | null>(null)
+  // Snapshot the reach BEFORE optimistic state lands — success runs after a re-render
+  // and would otherwise see the post-optimistic segment and skip the toast.
+  const reachBeforeRef = useRef<AccessSegment | null>(null)
   const accessMut = useApiMutation({
     mutationFn: (next: AccessDraft) => api.setAccess(shortId, next),
     optimistic: (next) => {
+      reachBeforeRef.current = accessSegmentOf(lRole, wsAccess)
       const prev = { wsAccess, lRole, lst, hasLock, lockDraft, pubHist }
       setWsAccess(next.workspaceAccess)
       setLRole(next.linkRole)
@@ -249,6 +261,14 @@ export function ShareButton({
         setPubHist(prev.pubHist)
       }
     },
+    // Segment picks name the new reach; other access writes (role/list/password) stay quiet.
+    success: (_r, next) => {
+      const prevSeg = reachBeforeRef.current
+      reachBeforeRef.current = null
+      const nextSeg = accessSegmentOf(next.linkRole, next.workspaceAccess)
+      if (prevSeg == null || nextSeg === prevSeg) return
+      return accessSegmentToast(nextSeg)
+    },
     onSuccess: (r) => {
       setWsAccess(r.workspace_access)
       setLRole(r.link_role)
@@ -258,6 +278,7 @@ export function ShareButton({
       setLockDraft(false)
       setPw("")
       setPwOpen(false)
+      setPendingAnyone(null)
     },
     // Refresh the artifact (drives the toolbar glyph) and the library.
     invalidate: [artifactQuery(shortId).queryKey, ["artifacts"]],
@@ -265,21 +286,15 @@ export function ShareButton({
   const applyAccess = (next: AccessDraft) => accessMut.mutate(next)
   // Picking a segment sets its fields at the safe default: a fresh segment starts
   // UNLISTED (the switch is how you opt into a feed), the world link at view.
-  const pickSegment = (seg: Segment) => {
-    if (seg === "invite")
-      return void applyAccess({ workspaceAccess: "none", linkRole: "none", listed: "none" })
-    if (seg === "workspace")
-      return void applyAccess({
-        workspaceAccess: "member",
-        linkRole: "none",
-        listed: lst === "workspace" ? "workspace" : "none",
-      })
-    // anyone: keep the current link role (or default to view), keep a public listing.
-    return void applyAccess({
-      workspaceAccess: "member",
-      linkRole: lRole === "none" ? "viewer" : lRole,
-      listed: lst === "public" ? "public" : "none",
-    })
+  // Widening to Anyone confirms first (BUG-16); everything else still applies on click.
+  const pickSegment = (seg: AccessSegment) => {
+    const decision = decideAccessSegmentChange(segment, seg)
+    const next = draftForAccessSegment(seg, lRole, lst)
+    if (decision.needsConfirm) {
+      setPendingAnyone(next)
+      return
+    }
+    applyAccess(next)
   }
   // The world-link role select (Anyone only).
   const pickRole = (r: Exclude<LinkRole, "none">) =>
@@ -1048,6 +1063,22 @@ export function ShareButton({
           onClose={() => setManageCol(null)}
         />
       )}
+      {/* Widening to Anyone is the one reach jump that needs a beat — a private doc
+          becomes link-reachable. Confirm only that direction; toast names the change. */}
+      <ConfirmDialog
+        open={pendingAnyone !== null}
+        onOpenChange={(o) => {
+          if (!o) setPendingAnyone(null)
+        }}
+        title="Open this to anyone with the link?"
+        description="Anyone who has the link will be able to open this. You can tighten access again anytime."
+        confirmLabel="Open to anyone"
+        confirmTestId="share-anyone-confirm"
+        onConfirm={async () => {
+          if (!pendingAnyone) return
+          await accessMut.mutateAsync(pendingAnyone)
+        }}
+      />
     </Dialog>
   )
 }

--- a/apps/web/src/pages/artifact/source-editor.tsx
+++ b/apps/web/src/pages/artifact/source-editor.tsx
@@ -37,6 +37,7 @@ export function SourceEditor({
   onTitle,
   placeholder,
   publishing,
+  staleNotice,
 }: {
   canPublish: boolean
   title: string
@@ -58,6 +59,8 @@ export function SourceEditor({
   // True while the parent's publish/propose mutation is in flight — disables the toolbar
   // buttons and shows a spinner, so a double-click can't duplicate a version.
   publishing?: boolean
+  /** Concurrent publish while editing — sticky for the whole remaining session. */
+  staleNotice?: string | null
 }) {
   const [pane, setPane] = useState<"edit" | "preview">("edit")
   // Desktop preview-pane visibility (mobile uses the Edit/Preview tabs instead).
@@ -206,6 +209,14 @@ export function SourceEditor({
           )}
         </span>
       </div>
+      {staleNotice && (
+        <div
+          data-testid="stale-edit-notice"
+          className="border-b border-warning/25 bg-warning/10 px-4 py-1.5 text-2xs text-warning"
+        >
+          {staleNotice}
+        </div>
+      )}
 
       <div className="flex min-h-0 flex-1">
         <div className={cn("min-h-0 flex-1 flex-col md:flex", pane === "edit" ? "flex" : "hidden")}>

--- a/apps/web/src/pages/artifact/stale-edit.test.ts
+++ b/apps/web/src/pages/artifact/stale-edit.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest"
+import { clearStaleEdit, noteStalePublish, staleEditCopy } from "./stale-edit"
+
+// Concurrent-publish latch: set only while editing, bump on later publishes, clear
+// on save/exit. The chip reads this; the toast no longer is the sole signal.
+describe("noteStalePublish", () => {
+  it("latches a version only while an edit is active", () => {
+    expect(noteStalePublish(null, false, 12)).toBeNull()
+    expect(noteStalePublish(null, true, 12)).toBe(12)
+  })
+
+  it("ignores publishes when not editing even if a prior latch exists", () => {
+    // A publish after exit must not re-arm; clearing is the edit-end path's job.
+    expect(noteStalePublish(12, false, 13)).toBe(12)
+  })
+
+  it("bumps to the newest version when several land mid-edit", () => {
+    let s = noteStalePublish(null, true, 4)
+    s = noteStalePublish(s, true, 5)
+    expect(s).toBe(5)
+    s = noteStalePublish(s, true, 3) // out-of-order / replay stays at the high-water mark
+    expect(s).toBe(5)
+  })
+
+  it("treats an unnumbered publish as 'a new version' until a concrete one arrives", () => {
+    expect(noteStalePublish(null, true, undefined)).toBe(0)
+    expect(noteStalePublish(0, true, 9)).toBe(9)
+    // A later unnumbered event must not wipe a known version.
+    expect(noteStalePublish(9, true, undefined)).toBe(9)
+  })
+})
+
+describe("clearStaleEdit", () => {
+  it("drops the latch on save or exit", () => {
+    expect(clearStaleEdit()).toBeNull()
+    expect(noteStalePublish(clearStaleEdit(), true, 2)).toBe(2)
+  })
+})
+
+describe("staleEditCopy", () => {
+  it("is silent when nothing is stale", () => {
+    expect(staleEditCopy(null, "inline")).toBeNull()
+    expect(staleEditCopy(null, "source")).toBeNull()
+  })
+
+  it("names the version and the surface's save path", () => {
+    expect(staleEditCopy(12, "inline")).toBe(
+      "v12 was published while you've been editing — saving re-checks your edits against it.",
+    )
+    expect(staleEditCopy(12, "source")).toBe(
+      "v12 was published while you've been editing — publishing this edit will replace it.",
+    )
+  })
+
+  it("falls back when the SSE carried no version number", () => {
+    expect(staleEditCopy(0, "inline")).toMatch(/^A new version was published/)
+  })
+})

--- a/apps/web/src/pages/artifact/stale-edit.ts
+++ b/apps/web/src/pages/artifact/stale-edit.ts
@@ -1,0 +1,43 @@
+// Concurrent-publish awareness while a user is mid-edit.
+//
+// A live version.published event used to fire an 8s toast and then vanish — glance
+// away and the document has moved under you with no signal left. This state is the
+// durable latch: set while either edit surface is open, bump as further publishes
+// land, clear only when the edit ends. The toast is gone; the chip is the truth.
+
+/** The version that landed under an active edit, or null when the session is current.
+ *  `0` is the sentinel for "a new version" whose number the SSE didn't carry. */
+export type StaleEditState = number | null
+
+/**
+ * Latch a live publish against an edit session.
+ * - Not editing → ignored (prev unchanged).
+ * - Editing → take the newest concrete version; an unnumbered publish latches as 0
+ *   only when nothing concrete is already held.
+ */
+export const noteStalePublish = (
+  prev: StaleEditState,
+  editing: boolean,
+  version?: number,
+): StaleEditState => {
+  if (!editing) return prev
+  if (version === undefined) return prev ?? 0
+  if (prev === null || prev === 0) return version
+  return Math.max(prev, version)
+}
+
+/** Edit ended (save / discard / cancel) — drop the latch. */
+export const clearStaleEdit = (): StaleEditState => null
+
+/** Chip copy for the active surface, or null when nothing is stale. */
+export const staleEditCopy = (
+  stale: StaleEditState,
+  surface: "inline" | "source",
+): string | null => {
+  if (stale === null) return null
+  const v = stale > 0 ? `v${stale}` : "A new version"
+  if (surface === "source") {
+    return `${v} was published while you've been editing — publishing this edit will replace it.`
+  }
+  return `${v} was published while you've been editing — saving re-checks your edits against it.`
+}

--- a/apps/web/src/pages/artifact/use-artifact-route.ts
+++ b/apps/web/src/pages/artifact/use-artifact-route.ts
@@ -1,6 +1,6 @@
 import type { Dispatch, SetStateAction } from "react"
 import { useEffect, useRef } from "react"
-import { ApiError, type Artifact, type Comment } from "@/api"
+import type { Artifact, Comment } from "@/api"
 import { refFor } from "./parse-ref"
 import type { Panel } from "./types"
 
@@ -9,15 +9,17 @@ import type { Panel } from "./types"
  * keeps only view state:
  *  - canonicalise the URL to /artifacts/<name>-<shortId> once the artifact loads
  *    (preserving the @vN suffix + current search), so the browser holds the readable ref;
- *  - bounce a logged-out visitor to /login ONLY on a genuine 404/403 gate — never on a
- *    transient 5xx/network failure (which also nulls `me`), so an outage doesn't eject them;
  *  - honour a ?comment=<thread> deep link once comments arrive (open the panel, activate
  *    the thread, scroll to its highlight), exactly once;
  *  - honour a ?review=<proposal> deep link once the artifact loads (open the review
  *    overlay on that proposal), exactly once.
  *
- * `nav` stays in the page: the two navigations are passed in as `onCanonical`/
- * `onLoginBounce` so this hook is router-type-free (matching artifact-actions).
+ * A gated (404/403) read no longer auto-bounces to /login — the page renders
+ * ArtifactNotFound with an optional Sign-in CTA (return path) so missing and private
+ * stay indistinguishable and signed-out visitors still have a path forward.
+ *
+ * `nav` stays in the page: the navigations are passed in as `onCanonical` so this
+ * hook is router-type-free (matching artifact-actions).
  */
 export function useArtifactRoute(p: {
   art: Artifact | undefined
@@ -27,20 +29,15 @@ export function useArtifactRoute(p: {
   comments: Comment[]
   /** !!me — a signed-in viewer. */
   authed: boolean
-  loading: boolean
-  failed: boolean
-  locked: boolean
-  error: unknown
   onCanonical: (canonicalRef: string) => void
-  onLoginBounce: () => void
   /** Open the proposal-review overlay on a specific proposal (the ?review deep link). */
   onOpenReview: (proposalId: string) => void
   post: (msg: Record<string, unknown>) => void
   setPanel: Dispatch<SetStateAction<Panel>>
   setActiveThread: Dispatch<SetStateAction<string | null>>
 }) {
-  const { art, ref, shortId, version, comments, authed, loading, failed, locked, error } = p
-  const { onCanonical, onLoginBounce, onOpenReview, post, setPanel, setActiveThread } = p
+  const { art, ref, shortId, version, comments, authed } = p
+  const { onCanonical, onOpenReview, post, setPanel, setActiveThread } = p
 
   // Canonicalise the URL client-side: rewrite any non-canonical ref (bare id, stale
   // name, legacy order) to /artifacts/<name>-<shortId>. Idempotent — once the ref
@@ -52,15 +49,6 @@ export function useArtifactRoute(p: {
       : refFor({ short_id: shortId, title: art.title })
     if (ref !== canonical) onCanonical(canonical)
   }, [art, ref, version, shortId, onCanonical])
-
-  // Anonymous can view a public artifact (read-only, with a sign-up CTA). Bounce to
-  // login ONLY when the artifact is genuinely gated (404/403) for a logged-out visitor.
-  // A TRANSIENT failure (5xx/network) also nulls `me`, but must NOT eject the user
-  // mid-outage — the recoverable error state handles that.
-  useEffect(() => {
-    const gated = error instanceof ApiError && (error.status === 404 || error.status === 403)
-    if (!loading && !authed && failed && !locked && gated) onLoginBounce()
-  }, [loading, authed, failed, locked, error, onLoginBounce])
 
   // Deep link: ?review=<proposal> opens the review overlay on that proposal. Runs once,
   // after the artifact is in — the overlay owns loading and the role-appropriate view,

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -24,6 +24,7 @@ import { CHROMELESS_EXACT, CHROMELESS_PREFIX, isChromelessPath } from "../lib/ch
 import { cacheRestored } from "../lib/persist"
 import { LIBRARY_PAGE } from "../lib/queries"
 import { queryClient } from "../lib/query-client"
+import { raceTimeout } from "../lib/race-timeout"
 import { STORAGE_KEYS } from "../lib/storage-keys"
 import { reportWebVitals } from "../lib/vitals"
 import { DEFAULT_SORT } from "../pages/library/sort"
@@ -94,8 +95,12 @@ export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()(
   // Gate ALL route loading on the IndexedDB cache restore, so a loader's ensureQueryData reads
   // the persisted data instead of fetching cold before it lands — the ordering that lets a
   // reload paint from cache like a nav. Resolved-instant after the first boot; never rejects.
+  // Bound the wait: a wedged idb-keyval get() never settles (Chrome profile-level hang) and
+  // would otherwise block every route forever across reloads. Cold boot is correct; cache is
+  // an optimization. Late restore after timeout can't clobber fresher query state — the
+  // persister only hydrates once up front and then subscribes for future writes.
   beforeLoad: async () => {
-    await cacheRestored
+    await raceTimeout(cacheRestored, 3_000, undefined, "cache-restore-timeout")
   },
   head: () => ({
     meta: [


### PR DESCRIPTION
## Summary
- Web fixes from the Product QA round: confirm+toast before widening share to Anyone, sign-in interstitial for private links, render boot auto-retry, cold-boot cache-restore timeout with field vital, stale concurrent-publish warning that stays up for the whole edit.
- API: pin Anthropic Messages `baseURL` so a process-level `ANTHROPIC_BASE_URL` (local proxy / harness) cannot steer connected-plan turns off `api.anthropic.com`. Unblocks the credential-path substrate-loop tests and real plan-token runs in those environments.

Sibling of #671 (API harvest). Do not merge without review — owner merges.

## Test plan
- [ ] Share dialog: widen to Anyone prompts confirm, then success toast; other segment changes still apply without confirm
- [ ] Signed-out visit to a private artifact shows sign-in with return path, not a naked 404
- [ ] Slow screenshot/render recovers via retry instead of terminal 15s failure
- [ ] Wedged IndexedDB restore falls through after ~3s rather than hanging the root beforeLoad forever
- [ ] Concurrent publish while editing keeps the stale-edit chip/banner until the edit ends
- [ ] `pnpm --filter @derive/api exec vitest run test/substrate-loop.test.ts -t "resolving the model credential"` green with `ANTHROPIC_BASE_URL` set to a local proxy

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/672"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788916720&installation_model_id=428097&pr_number=672&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F672&signature=8a411c061c35363633065ad36890f650f1f20c074486f6b2ea1fb6d1edc6218c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->