### PR TITLE
docs: add CI publishing recipe — PR preview and living artifact patterns

### DIFF
--- a/docs/ci-publishing.md
+++ b/docs/ci-publishing.md
@@ -1,0 +1,132 @@
+# Publishing from CI
+
+Use Derive's GitHub Actions composite action to turn any CI output into a living artifact — a
+versioned, commentable page that reviewers reach without downloading anything.
+
+## The two patterns
+
+### PR preview (build-and-review)
+
+Every pull request builds the artifact and drops a review link in the PR. Reviewers comment on
+the rendered page, not on the diff.
+
+```yaml
+# .github/workflows/preview.yml
+name: Preview
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write   # needed to post the review comment
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build (if needed)
+        run: npm ci && npm run build   # skip if publishing a raw file
+      - uses: derive-to/derive/.github/actions/derive-publish@main
+        with:
+          server: ${{ vars.DERIVE_SERVER }}
+          token: ${{ secrets.DERIVE_TOKEN }}
+          path: ./dist           # built directory or a single file
+          name: ${{ github.sha }}
+```
+
+The action posts one comment per artifact and updates it on every push, so the PR always shows
+the latest version.
+
+### Scheduled report (living artifact)
+
+A recurring job updates the same artifact in place. Every run creates a new version, and readers
+browse history or subscribe to the feed. There is nothing to poll — the artifact is always
+current.
+
+```yaml
+# .github/workflows/weekly-report.yml
+name: Weekly report
+on:
+  schedule:
+    - cron: "0 12 * * 5"   # Fridays at noon UTC
+  workflow_dispatch:        # run manually too
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate report
+        run: node scripts/build-report.js > report.md
+        env:
+          # any secrets your generator needs
+          API_KEY: ${{ secrets.API_KEY }}
+
+      - uses: derive-to/derive/.github/actions/derive-publish@main
+        with:
+          server: ${{ vars.DERIVE_SERVER }}
+          token: ${{ secrets.DERIVE_TOKEN }}
+          id: ${{ vars.REPORT_ARTIFACT_ID }}  # short_id of the artifact to update
+          path: ./report.md
+          name: ${{ github.run_id }}
+          comment-pr: "false"   # not a PR workflow
+```
+
+Store the artifact's `short_id` (from the initial publish) in a repo variable
+(`REPORT_ARTIFACT_ID`). Every run adds a version to that artifact without creating a new one.
+
+## Setup
+
+1. **Mint a token.** Open Settings → Agents → New agent. Give it publish-only scope and save the
+   token. For a report that only updates one artifact, scope it to that artifact's short_id.
+
+2. **Store the token** as a secret: `DERIVE_TOKEN` in the repository or organisation secrets.
+
+3. **Set the server URL** as a variable (`DERIVE_SERVER`, e.g. `https://derive.to`).
+
+4. **First publish.** Run the workflow once (or publish via the CLI) and note the `short_id` in
+   the output. For a living artifact, store it as `REPORT_ARTIFACT_ID`.
+
+## Using the CLI directly
+
+If you'd rather call the CLI than use the action, install `@derive-to/cli` and run:
+
+```bash
+npx @derive-to/cli publish ./report.md \
+  --id "$REPORT_ARTIFACT_ID" \
+  --name "$GITHUB_RUN_ID" \
+  --json
+```
+
+`DERIVE_SERVER` and `DERIVE_TOKEN` are picked up from the environment automatically.
+
+## Reading the published URL
+
+The action exposes three outputs:
+
+```yaml
+- uses: derive-to/derive/.github/actions/derive-publish@main
+  id: derive
+  with: { ... }
+- run: echo "Published ${{ steps.derive.outputs.url }}"
+```
+
+| Output     | Value                                  |
+| ---------- | -------------------------------------- |
+| `url`      | Canonical artifact URL.                |
+| `short_id` | Short id (stable across versions).     |
+| `embed`    | Ready-to-paste `<iframe>` snippet.     |
+
+## Notes
+
+- **Visibility.** A new artifact defaults to private. Pass `visibility: link` to make it
+  link-accessible without sign-in, or `visibility: public` to list it publicly.
+- **Version names.** Use `${{ github.sha }}` for PR previews, `${{ github.run_id }}` or a
+  human-readable date for scheduled reports. Names appear in the version history drawer.
+- **HTML output.** Derive renders HTML natively. If your generator produces HTML, publish the
+  file directly — the styled page renders as authored, no conversion.


### PR DESCRIPTION
## What this gives users

Teams that publish to Derive from CI currently have to piece together the workflow
from the CLI readme and the composite action source — there is no single place that
shows the end-to-end setup for the two common patterns.

This doc fills that gap. A developer who wants to add a PR-preview step can copy
the YAML, swap in their build command, and be done in minutes. A team that wants
a living report (weekly digest, coverage badge, changelog) has a worked example
with the idempotent `--id` flag and a note on where to store the artifact's
`short_id` so each run updates the same artifact rather than creating a new one.

## Value

- **Shorter time-to-first-publish for CI workflows** — the two patterns cover the
  vast majority of CI use cases.
- **Correct by default** — shows the right `permissions:` block, the right
  output variables (`url`, `short_id`, `embed`), and the visibility note so
  new artifacts don't accidentally go public.
- **Agent-friendly** — the CLI section means an agent can publish without the
  action wrapper, which matters for non-GitHub CI or local scripts.

## What changed

`docs/ci-publishing.md` — new file with:
- **PR preview pattern** (`build-and-review`): checkout → build → publish action → review link posted on the PR, updated on every push.
- **Scheduled report pattern** (`living artifact`): recurring job updates the same artifact in place via `--id`; each run adds a version without creating a new artifact.
- Setup walkthrough: mint agent token, store as secret, set server URL variable, note `short_id` for living artifacts.
- CLI equivalent for non-action use.
- Outputs table (`url`, `short_id`, `embed`) and notes on visibility and version naming.

## Test plan

- [ ] Verify both YAML examples are syntactically valid GitHub Actions workflow files.
- [ ] Confirm `derive-publish` action inputs (`server`, `token`, `path`, `name`, `id`, `comment-pr`, `visibility`) match the composite action definition.
- [ ] Check that the CLI command (`npx @derive-to/cli publish`) and env var names (`DERIVE_SERVER`, `DERIVE_TOKEN`) match the CLI source.
- [ ] Read the rendered doc end to end: correct headings, no broken code fences, outputs table renders properly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788922599&installation_model_id=428097&pr_number=674&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F674&signature=14f7d09fe383d970fd6a17ba662eaa2a3297d5bcd30d87ccf81afba1059014f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->