### PR TITLE
feat(site): surface the no-account publish path

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ No account, no install — one request publishes a live page:
 ```bash
 curl -F file=@page.html https://derive.to/v1/drafts   # or a .zip of a whole site
 # → a live URL in about a second, plus a claim link that turns the
-#   expiring draft into a permanent, versioned artifact in your workspace
+#   draft into a permanent, versioned artifact in your workspace
 ```
 
 Give your agent the whole loop — publish, read comments back, revise:
@@ -48,10 +48,15 @@ claude mcp add --transport http derive https://derive.to/mcp   # or connect over
 
 Or paste this into any agent and let it set itself up:
 
-> I'd like you to set up Derive: the home for the work my agents and I make — published pages with versions and review.
-> Install the skill if I have npm: `npx skills add derive-to/derive --skill derive`
-> Otherwise connect over MCP: the server is `https://derive.to/mcp` (Claude Code: `claude mcp add --transport http derive https://derive.to/mcp`)
-> After setup, review https://derive.to/skill.md and ask me what I'd like to publish first.
+```text
+I'd like you to set up Derive: the home for the work my agents and I make — published pages with versions and review.
+
+Install the skill if I have npm: npx skills add derive-to/derive --skill derive
+
+Otherwise connect over MCP: the server is https://derive.to/mcp (Claude Code: claude mcp add --transport http derive https://derive.to/mcp)
+
+After setup, review https://derive.to/skill.md and ask me what I'd like to publish first.
+```
 
 ## What is Derive
 
@@ -211,7 +216,9 @@ Or skip installation entirely: the skill is served at [derive.to/skill.md](https
 curl -F file=@page.html https://derive.to/v1/drafts   # or a .zip of a whole site
 # → a live URL in about a second, plus a claim link that turns the
 #   draft into a permanent, versioned artifact in your workspace
-``` `derive init` scaffolds one canonical `derive` skill into the native Codex and Claude locations (`.agents/skills/derive` and `.claude/skills/derive`) plus each client's project MCP config. For an existing repo, run `derive agent setup`; rerun with `--update` to refresh only the packaged Derive skill files while preserving MCP configs. The skill declares its MCP dependency for Codex and routes either client into the matching `derive://skills/*` workflow before it acts.
+```
+
+`derive init` scaffolds one canonical `derive` skill into the native Codex and Claude locations (`.agents/skills/derive` and `.claude/skills/derive`) plus each client's project MCP config. For an existing repo, run `derive agent setup`; rerun with `--update` to refresh only the packaged Derive skill files while preserving MCP configs. The skill declares its MCP dependency for Codex and routes either client into the matching `derive://skills/*` workflow before it acts.
 
 The core MCP tools: `find` (search + browse artifacts and contexts), `read` (content), `catch_up` (what changed, open feedback, version history, and — with no id — your work queue), `comment` (leave, reply, resolve), `publish` (save a revision), `stage` (upload out of band), `use` (ask a workspace context), and `checkpoint` (save resumable working state). For an image/font, `stage` mints a short-lived upload URL; the agent POSTs the local file's raw bytes, then uses the returned permanent URL or bundle ref in `publish`. Staging alone does not publish an artifact. `publish` goes live if your role can publish; otherwise, or with `for_review: true`, it files a proposal a human approves.
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,23 @@ Permanent versioned URLs and a review loop your team and its agents share, on in
   <img src="docs/assets/readme/hero.png" alt="The Derive library: published artifacts with live previews" width="900">
 </p>
 
+## Try it in ten seconds
+
+No account, no install — one request publishes a live page:
+
+```bash
+curl -F file=@page.html https://derive.to/v1/drafts   # or a .zip of a whole site
+# → a live URL in about a second, plus a claim link that turns the
+#   expiring draft into a permanent, versioned artifact in your workspace
+```
+
+Give your agent the whole loop — publish, read comments back, revise:
+
+```bash
+npx skills add derive-to/derive --skill derive        # any agent that reads skills
+claude mcp add --transport http derive https://derive.to/mcp   # or connect over MCP
+```
+
 ## What is Derive
 
 Derive gives any static artifact, an HTML page, a Markdown doc, or a whole built site, a permanent URL with version history. Publish it from the CLI, the HTTP API, or an agent over MCP. View it rendered inside a sandboxed iframe. Share it with your team, gather comments pinned to the exact text, and approve revisions in a review loop that people and agents run together.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ npx skills add derive-to/derive --skill derive        # any agent that reads ski
 claude mcp add --transport http derive https://derive.to/mcp   # or connect over MCP
 ```
 
+Or paste this into any agent and let it set itself up:
+
+> I'd like you to set up Derive: the home for the work my agents and I make — published pages with versions and review.
+> Install the skill if I have npm: `npx skills add derive-to/derive --skill derive`
+> Otherwise connect over MCP: the server is `https://derive.to/mcp` (Claude Code: `claude mcp add --transport http derive https://derive.to/mcp`)
+> After setup, review https://derive.to/skill.md and ask me what I'd like to publish first.
+
 ## What is Derive
 
 Derive gives any static artifact, an HTML page, a Markdown doc, or a whole built site, a permanent URL with version history. Publish it from the CLI, the HTTP API, or an agent over MCP. View it rendered inside a sandboxed iframe. Share it with your team, gather comments pinned to the exact text, and approve revisions in a review loop that people and agents run together.

--- a/apps/web/public/site/index.html
+++ b/apps/web/public/site/index.html
@@ -615,8 +615,10 @@ html.light .pcursor .flag{color:#fff}
   font-family:var(--mono);font-size:11.5px;letter-spacing:.03em;color:var(--faint);
 }
 .loop .cast span b{color:var(--muted);font-weight:500}
-/* ── connect yours: the three real commands, each one click to copy ── */
-.hookup{margin-top:34px;border:1px solid var(--border-soft);border-radius:10px;background:var(--card);overflow:hidden}
+/* ── connect yours: one paste for the agent, or the three commands by hand ── */
+.hk-lead{margin-top:34px;display:flex;align-items:center;gap:16px;flex-wrap:wrap}
+.hk-lead .hk-leadnote{font-size:13px;color:var(--muted);max-width:40ch}
+.hookup{margin-top:14px;border:1px solid var(--border-soft);border-radius:10px;background:var(--card);overflow:hidden}
 .hookup .hk-row{
   display:flex;align-items:center;gap:16px;width:100%;text-align:left;background:none;border:0;
   padding:13px 18px;cursor:pointer;transition:background .15s ease;
@@ -1166,6 +1168,17 @@ footer{margin-top:170px;position:relative;overflow:hidden;border-top:1px solid v
     <div class="tbody" id="termBody"><span class="cursor" id="termCursor"></span></div>
   </div>
   <p class="cast reveal"><span><b>publish</b> save a revision</span><span><b>catch_up</b> what changed + open feedback</span><span><b>comment</b> reply or resolve</span><span><b>read</b> any artifact, any version</span></p>
+  <script type="text/plain" id="agentPrompt">I'd like you to set up Derive: the home for the work my agents and I make — published pages with versions and review.
+
+Install the skill if I have npm: npx skills add derive-to/derive --skill derive
+
+Otherwise connect over MCP: the server is https://derive.to/mcp (Claude Code: claude mcp add --transport http derive https://derive.to/mcp)
+
+After setup, review https://derive.to/skill.md and ask me what I'd like to publish first.</script>
+  <div class="hk-lead reveal">
+    <button class="btn btn-primary" type="button" data-copy-from="agentPrompt" data-copied-label="Copied — paste it into your agent">Copy instructions for my agent</button>
+    <span class="hk-leadnote">one paste into any agent — it sets itself up, then asks what you'd like to publish</span>
+  </div>
   <div class="hookup reveal">
     <button class="hk-row" type="button" data-copy="npx skills add derive-to/derive --skill derive" title="Copy">
       <span class="hk-what">Give any agent the skill</span>
@@ -1257,16 +1270,26 @@ const reduced = matchMedia('(prefers-reduced-motion: reduce)').matches;
 const nav = $('nav');
 addEventListener('scroll', () => nav.classList.toggle('scrolled', scrollY > 8), {passive:true});
 
-/* click-to-copy commands (hero curl + the connect rows). Clipboard API needs a
-   secure context; if it's unavailable the click quietly does nothing — the text
-   is right there to select by hand. */
-document.querySelectorAll('[data-copy]').forEach(el => {
+/* click-to-copy (hero curl, the connect rows, the agent-instructions prompt).
+   data-copy holds the text inline; data-copy-from points at a text/plain block
+   for multi-line prompts. Clipboard API needs a secure context; if it's
+   unavailable the click quietly does nothing — the text is there to select. */
+document.querySelectorAll('[data-copy], [data-copy-from]').forEach(el => {
   el.addEventListener('click', async () => {
-    try { await navigator.clipboard.writeText(el.dataset.copy); } catch { return; }
+    const text = el.dataset.copy ?? $(el.dataset.copyFrom)?.textContent.trim();
+    if (!text) return;
+    try { await navigator.clipboard.writeText(text); } catch { return; }
     el.classList.add('copied');
     const tag = el.querySelector('.hc-copy, .hk-copy');
+    const label = el.dataset.copiedLabel;
+    const prev = label && !tag ? el.textContent : null;
     if (tag) tag.textContent = 'COPIED';
-    setTimeout(() => { el.classList.remove('copied'); if (tag) tag.textContent = 'COPY'; }, 1600);
+    else if (label) el.textContent = label;
+    setTimeout(() => {
+      el.classList.remove('copied');
+      if (tag) tag.textContent = 'COPY';
+      else if (prev !== null) el.textContent = prev;
+    }, 1800);
   });
 });
 

--- a/apps/web/public/site/index.html
+++ b/apps/web/public/site/index.html
@@ -249,6 +249,19 @@ html.light .wordmark .wm-light{display:block}
   margin-top:8px;font-family:var(--mono);font-size:10.5px;letter-spacing:.05em;color:var(--faint);
 }
 .wl-meta:empty{display:none}
+/* ── the other door: publish before you even have an account ── */
+.hero-curl{
+  margin-top:20px;display:inline-flex;align-items:center;gap:10px;max-width:100%;min-width:0;
+  font-family:var(--mono);font-size:11.5px;letter-spacing:.02em;color:var(--muted);
+  background:none;border:1px solid var(--border-soft);border-radius:7px;padding:7px 12px;
+  cursor:pointer;transition:border-color .15s ease,color .15s ease;
+}
+.hero-curl:hover,.hero-curl:focus-visible{border-color:var(--border);color:var(--fg)}
+.hero-curl .hc-cmd{color:var(--fg);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;min-width:0}
+.hero-curl .hc-note{color:var(--faint);white-space:nowrap}
+.hero-curl .hc-copy{flex:none;font-size:9.5px;letter-spacing:.08em;color:var(--faint);border:1px solid var(--border);border-radius:5px;padding:2px 7px}
+.hero-curl.copied .hc-copy{color:var(--success);border-color:color-mix(in srgb,var(--success) 45%,transparent)}
+@media(max-width:680px){.hero-curl .hc-note{display:none}}
 .hero-eyebrow{margin-bottom:0;color:var(--muted);font-size:14px;letter-spacing:.14em}
 /* the tagline in gradient ink: lit at the cap line, settling toward the baseline */
 .grad-ink{
@@ -602,6 +615,26 @@ html.light .pcursor .flag{color:#fff}
   font-family:var(--mono);font-size:11.5px;letter-spacing:.03em;color:var(--faint);
 }
 .loop .cast span b{color:var(--muted);font-weight:500}
+/* ── connect yours: the three real commands, each one click to copy ── */
+.hookup{margin-top:34px;border:1px solid var(--border-soft);border-radius:10px;background:var(--card);overflow:hidden}
+.hookup .hk-row{
+  display:flex;align-items:center;gap:16px;width:100%;text-align:left;background:none;border:0;
+  padding:13px 18px;cursor:pointer;transition:background .15s ease;
+}
+.hookup .hk-row + .hk-row{border-top:1px solid var(--border-soft)}
+.hookup .hk-row:hover,.hookup .hk-row:focus-visible{background:var(--secondary)}
+.hookup .hk-what{flex:none;width:21ch;font-size:12.5px;color:var(--muted)}
+.hookup .hk-row code{
+  flex:1;min-width:0;font-family:var(--mono);font-size:12px;color:var(--fg);
+  white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
+}
+.hookup .hk-copy{flex:none;font-family:var(--mono);font-size:9.5px;letter-spacing:.08em;color:var(--faint);border:1px solid var(--border);border-radius:5px;padding:2px 7px}
+.hookup .hk-row.copied .hk-copy{color:var(--success);border-color:color-mix(in srgb,var(--success) 45%,transparent)}
+@media(max-width:680px){
+  .hookup .hk-row{flex-wrap:wrap;gap:6px 12px}
+  .hookup .hk-what{width:100%}
+  .hookup .hk-row code{white-space:normal;overflow:visible;text-overflow:clip;overflow-wrap:anywhere}
+}
 
 /* ══════════ PRICING STATEMENT ══════════ */
 .price{padding-top:210px}
@@ -781,6 +814,11 @@ footer{margin-top:170px;position:relative;overflow:hidden;border-top:1px solid v
         </div>
         <div class="wl-meta" id="wlMeta"></div>
       </div>
+      <button class="hero-curl" type="button" data-copy="curl -F file=@page.html https://derive.to/v1/drafts" title="Copy. Publishes an expiring draft — claim it into a workspace whenever.">
+        <span class="hc-cmd">curl -F file=@page.html https://derive.to/v1/drafts</span>
+        <span class="hc-note">→ a live URL in a second, no account</span>
+        <span class="hc-copy" aria-hidden="true">COPY</span>
+      </button>
     </div>
   </div>
 
@@ -1128,6 +1166,23 @@ footer{margin-top:170px;position:relative;overflow:hidden;border-top:1px solid v
     <div class="tbody" id="termBody"><span class="cursor" id="termCursor"></span></div>
   </div>
   <p class="cast reveal"><span><b>publish</b> save a revision</span><span><b>catch_up</b> what changed + open feedback</span><span><b>comment</b> reply or resolve</span><span><b>read</b> any artifact, any version</span></p>
+  <div class="hookup reveal">
+    <button class="hk-row" type="button" data-copy="npx skills add derive-to/derive --skill derive" title="Copy">
+      <span class="hk-what">Give any agent the skill</span>
+      <code>npx skills add derive-to/derive --skill derive</code>
+      <span class="hk-copy" aria-hidden="true">COPY</span>
+    </button>
+    <button class="hk-row" type="button" data-copy="claude mcp add --transport http derive https://derive.to/mcp" title="Copy">
+      <span class="hk-what">Or connect over MCP</span>
+      <code>claude mcp add --transport http derive https://derive.to/mcp</code>
+      <span class="hk-copy" aria-hidden="true">COPY</span>
+    </button>
+    <button class="hk-row" type="button" data-copy="curl -F file=@page.html https://derive.to/v1/drafts" title="Copy. Publishes an expiring draft — claim it into a workspace whenever.">
+      <span class="hk-what">No agent, no account</span>
+      <code>curl -F file=@page.html https://derive.to/v1/drafts</code>
+      <span class="hk-copy" aria-hidden="true">COPY</span>
+    </button>
+  </div>
 </section>
 
 <!-- ══════════ PRICING ══════════ -->
@@ -1201,6 +1256,19 @@ const reduced = matchMedia('(prefers-reduced-motion: reduce)').matches;
 /* nav hairline */
 const nav = $('nav');
 addEventListener('scroll', () => nav.classList.toggle('scrolled', scrollY > 8), {passive:true});
+
+/* click-to-copy commands (hero curl + the connect rows). Clipboard API needs a
+   secure context; if it's unavailable the click quietly does nothing — the text
+   is right there to select by hand. */
+document.querySelectorAll('[data-copy]').forEach(el => {
+  el.addEventListener('click', async () => {
+    try { await navigator.clipboard.writeText(el.dataset.copy); } catch { return; }
+    el.classList.add('copied');
+    const tag = el.querySelector('.hc-copy, .hk-copy');
+    if (tag) tag.textContent = 'COPIED';
+    setTimeout(() => { el.classList.remove('copied'); if (tag) tag.textContent = 'COPY'; }, 1600);
+  });
+});
 
 /* beta signup: the API records the email and sends the access link */
 document.querySelectorAll('[data-waitlist]').forEach(form => {

--- a/apps/web/public/site/index.html
+++ b/apps/web/public/site/index.html
@@ -1262,6 +1262,9 @@ After setup, review https://derive.to/skill.md and ask me what I'd like to publi
   </div>
 </footer>
 
+<!-- announces copy-button success to assistive tech; visually hidden -->
+<div id="copyStatus" role="status" aria-live="polite" style="position:absolute;width:1px;height:1px;overflow:hidden;clip-path:inset(50%)"></div>
+
 <script>
 const $ = id => document.getElementById(id);
 const reduced = matchMedia('(prefers-reduced-motion: reduce)').matches;
@@ -1274,12 +1277,15 @@ addEventListener('scroll', () => nav.classList.toggle('scrolled', scrollY > 8), 
    data-copy holds the text inline; data-copy-from points at a text/plain block
    for multi-line prompts. Clipboard API needs a secure context; if it's
    unavailable the click quietly does nothing — the text is there to select. */
+const copyStatus = $('copyStatus');
 document.querySelectorAll('[data-copy], [data-copy-from]').forEach(el => {
   el.addEventListener('click', async () => {
+    if (el.classList.contains('copied')) return; // still showing the last copy
     const text = el.dataset.copy ?? $(el.dataset.copyFrom)?.textContent.trim();
     if (!text) return;
     try { await navigator.clipboard.writeText(text); } catch { return; }
     el.classList.add('copied');
+    copyStatus.textContent = 'Copied to clipboard';
     const tag = el.querySelector('.hc-copy, .hk-copy');
     const label = el.dataset.copiedLabel;
     const prev = label && !tag ? el.textContent : null;
@@ -1287,6 +1293,7 @@ document.querySelectorAll('[data-copy], [data-copy-from]').forEach(el => {
     else if (label) el.textContent = label;
     setTimeout(() => {
       el.classList.remove('copied');
+      copyStatus.textContent = '';
       if (tag) tag.textContent = 'COPY';
       else if (prev !== null) el.textContent = prev;
     }, 1800);


### PR DESCRIPTION
## What

The anonymous-draft flow (`POST /v1/drafts` → live URL in a second, claim link turns it into a permanent versioned artifact) has been live for weeks but is invisible everywhere a human looks. This PR surfaces it on the three human-facing front doors:

- **Hero**: a quiet click-to-copy curl one-liner under the beta form — the page's only try-it-without-signup path.
- **Agents section**: the section said "one command connects" without showing a command. Now a three-row connect card: skill install (`npx skills add`), MCP add, and the no-account curl — each one click to copy.
- **README**: a "Try it in ten seconds" block in the first screenful (the deep agents section further down keeps the detail).

## Notes

- Copy-to-clipboard is progressive enhancement: no clipboard API → the click does nothing and the text is selectable by hand.
- All styling uses the site's existing CSS vars, so both themes hold. Verified by screenshot at 1440px and 390px.
- No routing changes; `marketing.test.ts` untouched and green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788953893&installation_model_id=428097&pr_number=677&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F677&signature=ca3580e904602789956c5e1265a47a745517acfc8d4f3d607823919a9603dd6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->