### PR TITLE
feat(drafts): discovery chip on served draft pages

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -7,6 +7,7 @@ import type { BlankEnv } from "hono/types"
 import { OAUTH_ANON_CLIENT_TTL_MS } from "./auth-config"
 import { type AppDeps, buildContext } from "./context"
 import { captureSignupSource } from "./lib/attribution"
+import { draftChip, expiredDraftPage } from "./lib/draft-chip"
 import { cacheControlFor, corsFor, fail, TOMBSTONE } from "./lib/http"
 import { observability, redactPath } from "./lib/observability"
 import { inMemoryRateLimiters, ipRateLimit } from "./lib/rate-limit"
@@ -209,7 +210,7 @@ export function createApp(deps: AppDeps): Hono {
       // otherwise earn a year-long immutable cache — an expired-then-swept draft
       // could outlive itself at the edge.
       if (a.expires_at && a.expires_at <= new Date().toISOString())
-        return c.text("this draft expired — it was never claimed", 410)
+        return c.html(expiredDraftPage(deps.baseUrl), 410, { "Cache-Control": "no-store" })
       const version = await ctx.meta.getVersion(a.id, n)
       if (!version) return c.text("not found", 404)
       return serveContent(
@@ -227,6 +228,9 @@ export function createApp(deps: AppDeps): Hono {
         // app viewer, so its hover/selection comment UI would render but reach no
         // host — a "Comment" chip that can't comment.
         false,
+        // An unclaimed draft (the only artifact carrying an expiry) serves the
+        // discovery chip: attribution + the expiry nudge, gone once claimed.
+        a.expires_at ? draftChip(a.expires_at, deps.baseUrl) : "",
       )
     }
     app.use("*", async (c, next) => {

--- a/apps/api/src/lib/draft-chip.ts
+++ b/apps/api/src/lib/draft-chip.ts
@@ -1,41 +1,39 @@
+import { DRAFT_TTL_MS } from "./drafts"
+
 /**
- * Serve-time chrome for anonymous drafts (see lib/drafts.ts): a small fixed
- * chip on every served draft page carrying attribution plus the expiry nudge,
- * and the branded tombstone an expired draft's URL serves. Injected at serve
- * time only — never part of the stored bytes — and gone the moment the draft
- * is claimed (claiming clears `expires_at`, the one signal that gates it).
+ * Serve-time chrome for anonymous drafts (lib/drafts.ts): the attribution chip
+ * appended to every served draft page, and the tombstone an expired draft's
+ * URL serves. Gated on `expires_at` — only unclaimed drafts carry one — so it
+ * all disappears the moment a draft is claimed. Injected at serve time like
+ * the anchor client, never part of the stored bytes.
  *
- * Discovery, not capability. The chip links the viewer to the app origin;
- * the claim capability stays the single-use token from the mint response.
- * Nothing on the public page can claim, so showing the chip to every viewer
- * widens who can *find* Derive, never who can take the draft.
- *
- * The link is same-tab on purpose: draft bytes carry the sandbox CSP
- * (`allow-popups` without `allow-popups-to-escape-sandbox`), so a
- * target=_blank popup would inherit the sandbox — no cookies, no storage —
- * and open a broken app. A same-tab navigation loads the destination fresh,
- * outside the sandbox.
+ * Two constraints shape the markup:
+ * - Discovery only. The chip links the viewer to the app origin; claiming
+ *   stays the single-use token from the mint response.
+ * - Same-tab link. Draft bytes carry the sandbox CSP with `allow-popups` but
+ *   not `allow-popups-to-escape-sandbox`, so a target=_blank popup would
+ *   inherit the sandbox (no cookies, no storage) and open a broken app.
  */
 
-// Attribute-escape a server-config string (baseUrl) — order matters: & first.
-const attr = (s: string): string => s.replaceAll("&", "&amp;").replaceAll('"', "&quot;")
+// baseUrl is operator config, not user input; escaped on principle.
+const esc = (s: string): string =>
+  s.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll('"', "&quot;")
 
-/** The `?src=` campaign token the signup-attribution middleware records
- *  (lib/attribution.ts) when a chip click turns into a signup. */
+/** The `?src=` token lib/attribution.ts records when a chip visit becomes a signup. */
 const SRC = "draft_chip"
 
+const TTL_HOURS = DRAFT_TTL_MS / 3600_000
+
 /**
- * The chip appended to every HTML page of a live draft. Inline-styled and
- * self-contained: the sandbox CSP allows no external requests on our behalf,
- * and page CSS can't reach into inline styles. Dark regardless of the page's
- * own theme — the "Made with X" badge idiom (see web's PublicFrame): quiet
- * attribution + a soft nudge, never a wall.
+ * Inline-styled and self-contained — the sandbox CSP blocks external requests,
+ * and page CSS can't reach into inline styles. Dark whatever the page's own
+ * theme: the "Made with X" badge idiom (web's PublicFrame), attribution + a
+ * soft nudge, never a wall.
  */
 export const draftChip = (expiresAt: string, baseUrl: string): string => {
   const hours = Math.max(1, Math.ceil((Date.parse(expiresAt) - Date.now()) / 3600_000))
-  const href = attr(`${baseUrl}/?src=${SRC}`)
   return (
-    `<a data-derive-draft-chip href="${href}" ` +
+    `<a data-derive-draft-chip href="${esc(`${baseUrl}/?src=${SRC}`)}" ` +
     `title="An unclaimed draft on Derive. Claim it with the link your publish returned — claimed artifacts keep a permanent, versioned URL." ` +
     `style="position:fixed;right:14px;bottom:14px;z-index:2147483647;display:inline-flex;align-items:center;gap:8px;` +
     `padding:7px 12px;border-radius:999px;background:#101216;color:#f3f4f6;border:1px solid #2c2f36;` +
@@ -45,13 +43,8 @@ export const draftChip = (expiresAt: string, baseUrl: string): string => {
   )
 }
 
-/**
- * The page an expired draft's URL serves with its 410 — a shared link that
- * outlived its draft should say what this was and where to go, not dead-end
- * in a text line. Same visual register as the chip; no external requests.
- */
+/** The 410 an expired draft's URL serves: what this was, and the one-line republish. */
 export const expiredDraftPage = (baseUrl: string): string => {
-  const href = attr(`${baseUrl}/?src=${SRC}`)
   return `<!doctype html>
 <html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>This draft expired</title></head>
@@ -59,8 +52,8 @@ export const expiredDraftPage = (baseUrl: string): string => {
 <main style="max-width:34em;padding:48px 24px;text-align:center">
 <p style="margin:0;font:600 11px/1 ui-monospace,Menlo,Consolas,monospace;letter-spacing:.14em;color:#969aa2">DERIVE · ANONYMOUS DRAFT</p>
 <h1 style="margin:18px 0 0;font-size:28px;letter-spacing:-.01em">This draft expired — it was never claimed.</h1>
-<p style="margin:14px 0 0;color:#969aa2">Anonymous drafts live for 72 hours unless they're claimed into a workspace, where they keep a permanent URL and every version.</p>
-<p style="margin:26px 0 0"><a href="${href}" style="color:#f3f4f6">Publish another in one command →</a></p>
-<pre style="margin:14px 0 0;padding:12px 16px;display:inline-block;text-align:left;background:#101216;border:1px solid #2c2f36;border-radius:8px;font:12.5px/1.5 ui-monospace,Menlo,Consolas,monospace;color:#f3f4f6;overflow-x:auto;max-width:100%">curl -F file=@page.html ${attr(baseUrl)}/v1/drafts</pre>
+<p style="margin:14px 0 0;color:#969aa2">Anonymous drafts live for ${TTL_HOURS} hours unless they're claimed into a workspace, where they keep a permanent URL and every version.</p>
+<p style="margin:26px 0 0"><a href="${esc(`${baseUrl}/?src=${SRC}`)}" style="color:#f3f4f6">Publish another in one command →</a></p>
+<pre style="margin:14px 0 0;padding:12px 16px;display:inline-block;text-align:left;background:#101216;border:1px solid #2c2f36;border-radius:8px;font:12.5px/1.5 ui-monospace,Menlo,Consolas,monospace;color:#f3f4f6;overflow-x:auto;max-width:100%">curl -F file=@page.html ${esc(baseUrl)}/v1/drafts</pre>
 </main></body></html>`
 }

--- a/apps/api/src/lib/draft-chip.ts
+++ b/apps/api/src/lib/draft-chip.ts
@@ -1,0 +1,66 @@
+/**
+ * Serve-time chrome for anonymous drafts (see lib/drafts.ts): a small fixed
+ * chip on every served draft page carrying attribution plus the expiry nudge,
+ * and the branded tombstone an expired draft's URL serves. Injected at serve
+ * time only — never part of the stored bytes — and gone the moment the draft
+ * is claimed (claiming clears `expires_at`, the one signal that gates it).
+ *
+ * Discovery, not capability. The chip links the viewer to the app origin;
+ * the claim capability stays the single-use token from the mint response.
+ * Nothing on the public page can claim, so showing the chip to every viewer
+ * widens who can *find* Derive, never who can take the draft.
+ *
+ * The link is same-tab on purpose: draft bytes carry the sandbox CSP
+ * (`allow-popups` without `allow-popups-to-escape-sandbox`), so a
+ * target=_blank popup would inherit the sandbox — no cookies, no storage —
+ * and open a broken app. A same-tab navigation loads the destination fresh,
+ * outside the sandbox.
+ */
+
+// Attribute-escape a server-config string (baseUrl) — order matters: & first.
+const attr = (s: string): string => s.replaceAll("&", "&amp;").replaceAll('"', "&quot;")
+
+/** The `?src=` campaign token the signup-attribution middleware records
+ *  (lib/attribution.ts) when a chip click turns into a signup. */
+const SRC = "draft_chip"
+
+/**
+ * The chip appended to every HTML page of a live draft. Inline-styled and
+ * self-contained: the sandbox CSP allows no external requests on our behalf,
+ * and page CSS can't reach into inline styles. Dark regardless of the page's
+ * own theme — the "Made with X" badge idiom (see web's PublicFrame): quiet
+ * attribution + a soft nudge, never a wall.
+ */
+export const draftChip = (expiresAt: string, baseUrl: string): string => {
+  const hours = Math.max(1, Math.ceil((Date.parse(expiresAt) - Date.now()) / 3600_000))
+  const href = attr(`${baseUrl}/?src=${SRC}`)
+  return (
+    `<a data-derive-draft-chip href="${href}" ` +
+    `title="An unclaimed draft on Derive. Claim it with the link your publish returned — claimed artifacts keep a permanent, versioned URL." ` +
+    `style="position:fixed;right:14px;bottom:14px;z-index:2147483647;display:inline-flex;align-items:center;gap:8px;` +
+    `padding:7px 12px;border-radius:999px;background:#101216;color:#f3f4f6;border:1px solid #2c2f36;` +
+    `font:500 11px/1 ui-monospace,Menlo,Consolas,monospace;letter-spacing:.02em;text-decoration:none;` +
+    `box-shadow:0 2px 12px rgba(0,0,0,.3)">` +
+    `Made with Derive<span style="color:#969aa2">· expires in ~${hours}h</span></a>`
+  )
+}
+
+/**
+ * The page an expired draft's URL serves with its 410 — a shared link that
+ * outlived its draft should say what this was and where to go, not dead-end
+ * in a text line. Same visual register as the chip; no external requests.
+ */
+export const expiredDraftPage = (baseUrl: string): string => {
+  const href = attr(`${baseUrl}/?src=${SRC}`)
+  return `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>This draft expired</title></head>
+<body style="margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;background:#0a0b0d;color:#f3f4f6;font:16px/1.6 ui-sans-serif,system-ui,sans-serif">
+<main style="max-width:34em;padding:48px 24px;text-align:center">
+<p style="margin:0;font:600 11px/1 ui-monospace,Menlo,Consolas,monospace;letter-spacing:.14em;color:#969aa2">DERIVE · ANONYMOUS DRAFT</p>
+<h1 style="margin:18px 0 0;font-size:28px;letter-spacing:-.01em">This draft expired — it was never claimed.</h1>
+<p style="margin:14px 0 0;color:#969aa2">Anonymous drafts live for 72 hours unless they're claimed into a workspace, where they keep a permanent URL and every version.</p>
+<p style="margin:26px 0 0"><a href="${href}" style="color:#f3f4f6">Publish another in one command →</a></p>
+<pre style="margin:14px 0 0;padding:12px 16px;display:inline-block;text-align:left;background:#101216;border:1px solid #2c2f36;border-radius:8px;font:12.5px/1.5 ui-monospace,Menlo,Consolas,monospace;color:#f3f4f6;overflow-x:auto;max-width:100%">curl -F file=@page.html ${attr(baseUrl)}/v1/drafts</pre>
+</main></body></html>`
+}

--- a/apps/api/src/lib/serve-content.ts
+++ b/apps/api/src/lib/serve-content.ts
@@ -54,6 +54,11 @@ export const serveContent = async (
    *  hover UI renders but can deliver nothing. Default on for the raw routes,
    *  whose pages the viewer embeds. */
   anchors = true,
+  /** Serve-time HTML appended to every rendered page, after the anchor client —
+   *  the draft discovery chip today (lib/draft-chip.ts). Rides the same
+   *  injection seam as the anchor client: never part of the stored bytes,
+   *  never on non-HTML responses. Empty ⇒ nothing appended. */
+  append = "",
 ) => {
   const headers = { ...RAW_HEADERS, "Cache-Control": cacheControl }
   const tx = (doc: string) => (transformHtml ? transformHtml(doc) : Promise.resolve(doc))
@@ -69,7 +74,8 @@ export const serveContent = async (
   const anchorClient = anchors ? SELECTION_SCRIPT : ""
   // Produce the final HTML body for a document: cross-doc rewrite + auto-reflow, then append
   // the anchor client (for comment anchoring + live cursors) and, when asked, the marks overlay.
-  const htmlBody = async (doc: string): Promise<string> => rf(await tx(doc)) + anchorClient + marks
+  const htmlBody = async (doc: string): Promise<string> =>
+    rf(await tx(doc)) + anchorClient + marks + append
   let path = rawPath
   if (isBundleContentType(content.content_type)) {
     const manifestBytes = await blobs.get(content.blob_key)
@@ -91,7 +97,7 @@ export const serveContent = async (
       const rewritten = rewriteAbsoluteUrls(new TextDecoder().decode(data), prefix.slice(0, -1))
       // Bundle pages get the anchor client too — comments stick everywhere.
       const out = entry.type.startsWith("text/html")
-        ? rf(rewritten) + anchorClient + marks
+        ? rf(rewritten) + anchorClient + marks + append
         : rewritten
       return c.body(out, 200, { ...headers, "Content-Type": entry.type })
     }
@@ -108,7 +114,7 @@ export const serveContent = async (
       // would otherwise render it as a stray `<hr>` + heading. The parsed fields surface
       // as skill chrome around this iframe, not in the document body.
       const body = parseFrontmatter(new TextDecoder().decode(data)).body
-      const html = await tx(await renderMarkdown(body, title))
+      const html = (await tx(await renderMarkdown(body, title))) + append
       return c.body(html, 200, { ...headers, "Content-Type": "text/html; charset=utf-8" })
     }
     return c.body(toBody(data), 200, { ...headers, "Content-Type": entry.type })
@@ -137,7 +143,7 @@ export const serveContent = async (
         "Content-Type": "text/html; charset=utf-8",
       })
     }
-    const html = await tx(await renderMarkdown(text, title))
+    const html = (await tx(await renderMarkdown(text, title))) + append
     return c.body(html, 200, { ...headers, "Content-Type": "text/html; charset=utf-8" })
   }
 

--- a/apps/api/src/lib/serve-content.ts
+++ b/apps/api/src/lib/serve-content.ts
@@ -54,10 +54,9 @@ export const serveContent = async (
    *  hover UI renders but can deliver nothing. Default on for the raw routes,
    *  whose pages the viewer embeds. */
   anchors = true,
-  /** Serve-time HTML appended to every rendered page, after the anchor client —
-   *  the draft discovery chip today (lib/draft-chip.ts). Rides the same
-   *  injection seam as the anchor client: never part of the stored bytes,
-   *  never on non-HTML responses. Empty ⇒ nothing appended. */
+  /** Extra serve-time HTML appended to every rendered page (today: the draft
+   *  discovery chip, lib/draft-chip.ts). Same contract as the anchor client:
+   *  never part of the stored bytes, never on non-HTML responses. */
   append = "",
 ) => {
   const headers = { ...RAW_HEADERS, "Cache-Control": cacheControl }

--- a/apps/api/test/domains.test.ts
+++ b/apps/api/test/domains.test.ts
@@ -44,7 +44,11 @@ describe("vanity subdomains", () => {
     const served = await anon.request(`http://launch.${BASE}/`)
     expect(served.status).toBe(200)
     expect(served.headers.get("content-type")).toContain("text/html")
-    expect(await served.text()).toContain("Launch")
+    const html = await served.text()
+    expect(html).toContain("Launch")
+    // The draft discovery chip is drafts-only: a claimed artifact on its vanity
+    // host serves clean bytes with no injected attribution.
+    expect(html).not.toContain("data-derive-draft-chip")
   })
 
   it("409s a label already taken by another artifact", async () => {

--- a/apps/api/test/drafts.test.ts
+++ b/apps/api/test/drafts.test.ts
@@ -45,10 +45,19 @@ describe("POST /v1/drafts (anonymous mint)", () => {
     // Standalone hosts get no anchor client: its comment UI only works embedded in
     // the app viewer, and a vanity/draft page is never iframed by the app.
     expect(html).not.toContain("/raw/derive-client.js")
-    // The same artifact through the raw route (which the viewer embeds) keeps it.
+    // A draft page names its host: the discovery chip carries attribution + the
+    // expiry nudge. It is serve-time chrome, never part of the stored bytes.
+    expect(html).toContain("data-derive-draft-chip")
+    expect(html).toContain("Made with Derive")
+    expect(html).toMatch(/expires in ~\d+h/)
+    expect(html).toContain("http://derive.test/?src=draft_chip")
+    // The same artifact through the raw route (which the viewer embeds) keeps the
+    // anchor client and gets NO chip — the viewer is already Derive chrome.
     const raw = await drafts.request(`/raw/${body.short_id}/v/1/index.html`)
     expect(raw.status).toBe(200)
-    expect(await raw.text()).toContain("/raw/derive-client.js")
+    const rawHtml = await raw.text()
+    expect(rawHtml).toContain("/raw/derive-client.js")
+    expect(rawHtml).not.toContain("data-derive-draft-chip")
   })
 
   it("forces the draft access shape — client access fields are ignored", async () => {
@@ -79,6 +88,13 @@ describe("POST /v1/drafts (anonymous mint)", () => {
     await meta.setArtifactExpiry(a.id, new Date(Date.now() - 1000).toISOString())
     const served = await drafts.request(`http://${short_id}.${BASE}/`)
     expect(served.status).toBe(410)
+    // The tombstone is a small branded page, not a dead-end text line: a shared
+    // link that outlived its draft still explains what this was and where to go.
+    expect(served.headers.get("content-type")).toContain("text/html")
+    const gone = await served.text()
+    expect(gone).toContain("draft expired")
+    expect(gone).toContain("http://derive.test")
+    expect(served.headers.get("cache-control")).toBe("no-store")
   })
 })
 

--- a/apps/api/test/drafts.test.ts
+++ b/apps/api/test/drafts.test.ts
@@ -1,3 +1,4 @@
+import { zipSync } from "fflate"
 import { describe, expect, it } from "vitest"
 import { sweepExpiredDrafts } from "../src/lib/drafts"
 import { as, makeAuthedApp } from "./helpers"
@@ -58,6 +59,29 @@ describe("POST /v1/drafts (anonymous mint)", () => {
     const rawHtml = await raw.text()
     expect(rawHtml).toContain("/raw/derive-client.js")
     expect(rawHtml).not.toContain("data-derive-draft-chip")
+  })
+
+  it("chips every rendered page of a bundle draft, and only those", async () => {
+    const zip = zipSync({
+      "index.html": new TextEncoder().encode("<h1>Site</h1><script src=app.js></script>"),
+      "notes.md": new TextEncoder().encode("# Notes"),
+      "app.js": new TextEncoder().encode("console.log(1)"),
+    })
+    const form = new FormData()
+    form.append("file", new Blob([zip]), "site.zip")
+    const res = await drafts.request("/v1/drafts", { method: "POST", body: form })
+    expect(res.status).toBe(201)
+    const { short_id } = await res.json()
+    const page = async (path: string) => {
+      const r = await drafts.request(`http://${short_id}.${BASE}/${path}`)
+      expect(r.status).toBe(200)
+      return r.text()
+    }
+    // HTML pages and rendered markdown carry the chip; code assets must not —
+    // a chip inside a script the page loads would break the page.
+    expect(await page("")).toContain("data-derive-draft-chip")
+    expect(await page("notes.md")).toContain("data-derive-draft-chip")
+    expect(await page("app.js")).not.toContain("data-derive-draft-chip")
   })
 
   it("forces the draft access shape — client access fields are ignored", async () => {


### PR DESCRIPTION
## What

A served anonymous draft carries no Derive presence at all: the recipient of a draft link never learns what hosts it, and a publisher whose agent didn't clearly relay the claim link has no recovery path. The expired URL was a bare text line.

- Every HTML page of an **unclaimed draft** (`expires_at` is the gate — claiming clears it) gets a small fixed **"Made with Derive · expires in ~Nh"** chip, injected at serve time on the same seam as the anchor client. Never part of the stored bytes; never on claimed artifacts, vanity domains, or the /raw routes the viewer embeds.
- **Discovery, not capability**: the chip links to the app origin with a `?src=draft_chip` attribution tag. Claiming stays the single-use token from the mint response — nothing on the public page can claim.
- The link is **same-tab on purpose**: draft bytes carry the sandbox CSP with `allow-popups` but not `allow-popups-to-escape-sandbox`, so a `target=_blank` popup would inherit the sandbox (no cookies/storage) and open a broken app.
- The expired-draft **410 becomes a small branded page** with the one-line republish command, still `no-store`.

## Tests

Pinned in `drafts.test.ts` (chip present on the served draft, absent through the raw route, branded 410) and `domains.test.ts` (no chip on a claimed artifact's vanity host). Both new assertions were watched failing before the implementation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788954214&installation_model_id=428097&pr_number=678&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F678&signature=79bac10d038b327247012ab8457ab372e3e9462f12ec202bb9f6641b6afeda3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->