### PR TITLE
fix: verified-clean subset of the QA-round harvest (#671, #672)

### DIFF
--- a/apps/api/src/lib/model-anthropic.ts
+++ b/apps/api/src/lib/model-anthropic.ts
@@ -123,6 +123,13 @@ export const anthropicModel = (opts: AnthropicOptions): AgentLoopInput["callMode
     // reads ANTHROPIC_API_KEY from the environment when given none — which on a self-host box is
     // how one workspace's run quietly bills the operator's key. Always pass the connected value.
     apiKey: opts.credential.value,
+    // PIN the Messages API origin. createAnthropic otherwise reads ANTHROPIC_BASE_URL from the
+    // process environment (a local Claude proxy, a self-host gateway rewrite, a test harness) and
+    // that quietly redirects every hosted plan-token turn off api.anthropic.com. The credential
+    // path exists specifically to spend a WORKSPACE's Claude plan; the destination is not a
+    // deploy-time preference. Mirror openAiCompatModel, which takes baseUrl as a required option
+    // rather than an ambient env.
+    baseURL: "https://api.anthropic.com/v1",
     headers: authHeaders(opts.credential) as Record<string, string>,
     ...(opts.fetchImpl ? { fetch: opts.fetchImpl } : {}),
   })

--- a/apps/api/src/mcp-tools/automate.ts
+++ b/apps/api/src/mcp-tools/automate.ts
@@ -11,6 +11,7 @@ import { automationProvider, runMetaForAutomation } from "../lib/automation"
 import { connectionBindError } from "../lib/broker"
 import { ContextConflictError, createContextCore } from "../lib/create-context"
 import { mintToken, sha256 } from "../lib/crypto"
+import { parseManifestSkillPins } from "../lib/manifest-pins"
 import { badChoice, choiceDescription } from "../lib/open-choice"
 import { canPayForAgent, NO_PAYER_MESSAGE } from "../lib/payer"
 import { scopeGapMessage } from "../lib/scope-gap"
@@ -154,9 +155,20 @@ export function registerAutomateTool(tc: ToolContext): void {
         })
 
       if (input.action === "list") {
-        const rows = await meta.listAutomations(org)
+        // Deliberately NOT gated (reads stay open), but the gate state rides along: a bare
+        // `count: 0` in a gated workspace reads as "none yet", and the agent only learns the
+        // flag exists when its create is refused. Saying so here is what lets it plan.
+        const [rows, off] = await Promise.all([meta.listAutomations(org), automateOff()])
         return json({
           count: rows.length,
+          automations_enabled: !off,
+          ...(off
+            ? {
+                note:
+                  "automations are not enabled for this workspace (automateBeta) — create and " +
+                  "run_now will be refused until an owner turns them on in workspace settings.",
+              }
+            : {}),
           automations: rows.map((a) => ({
             id: a.id,
             instruction: a.instruction.slice(0, 140),
@@ -214,6 +226,20 @@ export function registerAutomateTool(tc: ToolContext): void {
           return json({ error: "no such manifest artifact in this workspace" })
         if (!roleAllows(reached.role, "share"))
           return json({ error: "creating a context needs share standing on the manifest" })
+        // The pin count the REST create already reports (routes/contexts.ts, skills_count):
+        // skills load ONLY from the frontmatter `skills:` list (parseManifestSkillPins), and
+        // a prose derive://skills/... mention does nothing — so a manifest whose body names
+        // skills but pins none gets told, in the result it is already reading, instead of
+        // discovering skills:[] on the finished context. Deliberately no skills param and no
+        // prose parsing: pins stay the one way to declare a skill.
+        const mv = await meta.getVersion(reached.a.id, reached.a.current_version)
+        const manifestMd = mv ? await ctx.sourceText(mv) : null
+        const pins = manifestMd ? parseManifestSkillPins(manifestMd) : []
+        const bodyMentionsSkills =
+          pins.length === 0 &&
+          /derive:\/\/skills\//.test(
+            (manifestMd ?? "").replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, ""),
+          )
         try {
           const made = await createContextCore(meta, {
             orgId: org,
@@ -228,6 +254,15 @@ export function registerAutomateTool(tc: ToolContext): void {
             name: made.context.name,
             agent_id: made.agentId,
             ask_policy: made.context.ask_policy,
+            skills_count: pins.length,
+            ...(bodyMentionsSkills
+              ? {
+                  skills_hint:
+                    "The manifest body mentions derive://skills/... but its frontmatter pins " +
+                    "none, so this context loads no skills. Skills must be pinned in " +
+                    "frontmatter: skills:\n  - id: <skill short_id>",
+                }
+              : {}),
             note:
               "No token is returned over MCP. You (an owner) run this context directly: " +
               "use({context}) pulls its queued work. A dedicated runner's token comes from " +

--- a/apps/api/src/routes/session.ts
+++ b/apps/api/src/routes/session.ts
@@ -13,6 +13,7 @@ import type { AppContext } from "../context"
 import { authorProfile, handlesFrom } from "../lib/author"
 import { bail, fail, IMMUTABLE_CACHE, readJson, toBody } from "../lib/http"
 import { MAX_AVATAR_BYTES, sniffImageType } from "../lib/image"
+import { log } from "../log"
 import { Artifact, PersonalBrandprintSchema } from "../schemas"
 
 /** Session identity + the workspace member/agent directory for the @mention picker.
@@ -35,6 +36,38 @@ export const sessionRoutes = (ctx: AppContext) => {
     analyticsOn,
   } = ctx
   const app = new OpenAPIHono<BlankEnv>()
+
+  // The /v1/me/* writes below go straight to the user row (meta.*), bypassing Better
+  // Auth — but the SPA's identity read is /api/auth/get-session, which the session
+  // COOKIE CACHE (auth-config.ts) answers from a signed `session_data` cookie for up
+  // to 60s without touching the database. Every one of these fields rides that cookie
+  // (additionalFields), so a save followed by a reload showed the OLD value — data
+  // loss to the user's eye. After the write, re-resolve the session with the cache
+  // bypassed: Better Auth re-reads the rows and re-signs a fresh `session_data`
+  // cookie, forwarded here onto the response so the very next read is already new.
+  // Skipped when the caller carries no cached cookie (bearer tokens, the test
+  // harness): with nothing cached there is nothing stale.
+  const refreshSessionCookie = async (c: Context): Promise<void> => {
+    if (!deps.auth) return
+    if (!(c.req.header("cookie") ?? "").includes("session_data")) return
+    try {
+      const { headers } = await deps.auth.api.getSession({
+        headers: c.req.raw.headers,
+        query: { disableCookieCache: true },
+        returnHeaders: true,
+      })
+      // getSetCookie is runtime-universal (Node 20+, workerd) but absent from the
+      // worker tsconfig's Headers lib, so reach it through a structural widening.
+      const withSetCookie = headers as Headers & { getSetCookie?: () => string[] }
+      for (const cookie of withSetCookie.getSetCookie?.() ?? [])
+        c.header("set-cookie", cookie, { append: true })
+    } catch (err) {
+      // Best-effort: the write itself succeeded and the cookie self-expires in 60s.
+      log.warn("session cookie cache refresh failed after a profile write", {
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
 
   // A public profile by @handle — email is intentionally omitted. The list surfaces
   // (search/people/followers/following) carry the top fields; the full /users/:handle
@@ -167,6 +200,7 @@ export const sessionRoutes = (ctx: AppContext) => {
       if (err) return bail(fail(c, 400, err))
       const res = await meta.setUsername(u.id, username)
       if (res === "taken") return bail(fail(c, 409, "That username is taken."))
+      await refreshSessionCookie(c)
       return c.json({ username })
     },
   )
@@ -230,6 +264,7 @@ export const sessionRoutes = (ctx: AppContext) => {
       if (body.brandprint !== undefined)
         patch.brandprint = body.brandprint ? JSON.stringify(body.brandprint) : null
       await meta.setUserProfile(u.id, patch)
+      await refreshSessionCookie(c)
       return c.json({
         profession: patch.profession ?? null,
         about: patch.about ?? null,
@@ -258,6 +293,7 @@ export const sessionRoutes = (ctx: AppContext) => {
       const body = await readJson(c, z.object({ discoverable: z.boolean() }))
       if (body instanceof Response) return bail(body)
       await meta.setUserDiscoverable(u.id, body.discoverable)
+      await refreshSessionCookie(c)
       return c.json({ discoverable: body.discoverable })
     },
   )
@@ -280,6 +316,7 @@ export const sessionRoutes = (ctx: AppContext) => {
       const u = await requireUser(c)
       if (u instanceof Response) return bail(u)
       await meta.setUserOnboarded(u.id, true)
+      await refreshSessionCookie(c)
       return c.json({ onboarded: true })
     },
   )
@@ -617,6 +654,7 @@ export const sessionRoutes = (ctx: AppContext) => {
       // from a separate origin (hosted split); the bytes never touch the app cookie.
       const image = `${deps.baseUrl.replace(/\/$/, "")}/v1/avatars/${key}`
       await meta.setUserImage(u.id, image)
+      await refreshSessionCookie(c)
       return c.json({ image })
     },
   )

--- a/apps/api/test/auth-session-cache.test.ts
+++ b/apps/api/test/auth-session-cache.test.ts
@@ -56,6 +56,14 @@ const cookiesOf = (res: Response): string =>
     .map((c) => c.split(";")[0])
     .join("; ")
 
+/** What a browser does with a response: fold its Set-Cookie into the jar, by name. */
+const mergeCookies = (jar: string, res: Response): string => {
+  const fresh = res.headers.getSetCookie().map((c) => c.split(";")[0] ?? "")
+  const names = new Set(fresh.map((c) => c.split("=")[0]))
+  const kept = jar.split("; ").filter((c) => !names.has(c.split("=")[0]))
+  return [...kept, ...fresh].join("; ")
+}
+
 afterAll(() => {
   db.close()
   rmSync(dir, { recursive: true, force: true })
@@ -97,6 +105,40 @@ describe("the session cookie cache", () => {
     const after = await get("/v1/me", cookie)
     expect(after.status).toBe(200)
     expect(await after.json()).toMatchObject({ user: { email } })
+  })
+
+  it("a profile write refreshes the cached cookie — the save is visible immediately", async () => {
+    // Re-establish a session (the row-deletion case above burned the old one).
+    const signin = await post("/api/auth/sign-in/email", { email, password: "initialPassw0rd" })
+    expect(signin.status).toBe(200)
+    let jar = cookiesOf(signin)
+    expect(jar).toContain("session_data")
+
+    // The cached cookie is what /v1/me answers from: it still carries no profession.
+    const before = await (await get("/v1/me", jar)).json()
+    expect(before.user.profession).toBeNull()
+
+    // Save a role. The write goes straight to the user row, BELOW the cookie cache —
+    // so the response must carry a re-signed session_data cookie, or every read for
+    // the next 60s serves the old value and the save looks lost.
+    const saved = await app.request(`${BASE}/v1/me/profile`, {
+      method: "POST",
+      headers: { "content-type": "application/json", origin: BASE, cookie: jar },
+      body: JSON.stringify({ profession: "Design" }),
+    })
+    expect(saved.status).toBe(200)
+    const refreshed = cookiesOf(saved)
+    expect(refreshed).toContain("session_data")
+
+    // The STALE jar still serves the old identity — proof the cache is the reader,
+    // and that without the refreshed cookie this would read as data loss.
+    const stale = await (await get("/v1/me", jar)).json()
+    expect(stale.user.profession).toBeNull()
+
+    // A browser folds the Set-Cookie in; do the same, then the very next read is new.
+    jar = mergeCookies(jar, saved)
+    const after = await (await get("/v1/me", jar)).json()
+    expect(after.user.profession).toBe("Design")
   })
 
   it("refuses once the cached cookie is gone — the window is bounded, not a bypass", async () => {

--- a/apps/api/test/automate-gate.test.ts
+++ b/apps/api/test/automate-gate.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest"
+import { sha256 } from "../src/lib/crypto"
 import { materializeAllDueRuns } from "../src/lib/schedule"
 import { as, jsonAs, makeAuthedApp, type TestUser } from "./helpers"
 
@@ -185,5 +186,89 @@ describe("the schedule tick obeys the gate", () => {
           : Reflect.get(t, prop, recv),
     })
     expect(await materializeAllDueRuns(blipping, new Date())).toBe(0)
+  })
+})
+
+// THE GATE STATE IS PART OF THE LIST, over MCP. `automate {action:"list"}` stays deliberately
+// UNGATED (the beta flag binds the lanes that create or run work, never reads) — but a bare
+// `count: 0` in a gated workspace reads exactly like "none created yet", so an agent only
+// discovered `automateBeta` when its create was refused. The list now says which it is.
+describe("automate list over MCP reports the gate state", () => {
+  const owner: TestUser = { id: "u_gate_mcp", email: "gatemcp@derive.test", name: "Owner" }
+
+  type App = ReturnType<typeof makeAuthedApp>["app"]
+
+  // A direct tools/call over the stateless /mcp endpoint (mcp-contexts' shape).
+  const callAutomate = async (app: App, token: string, args: Record<string, unknown>) => {
+    const res = await app.request("/mcp", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "automate", arguments: args },
+      }),
+    })
+    const ct = res.headers.get("content-type") ?? ""
+    const txt = await res.text()
+    const out = ct.includes("application/json")
+      ? JSON.parse(txt)
+      : JSON.parse(
+          (txt.split("\n").find((l) => l.startsWith("data:")) ?? "data:null").slice(5).trim(),
+        )
+    const t = (out?.result as { content?: { text: string }[] } | undefined)?.content?.[0]?.text
+    if (t == null) throw new Error(`no tool text: ${JSON.stringify(out)}`)
+    // biome-ignore lint/suspicious/noExplicitAny: test convenience over a JSON payload
+    return JSON.parse(t) as any
+  }
+
+  // The automate tool is owner-only, and /v1/agents caps registration at editor — so the
+  // owner-role MCP caller is seeded straight into the store, acting for the workspace owner.
+  const setup = async (name: string) => {
+    const { app, meta } = makeAuthedApp(name, [owner])
+    await app.request("/v1/me", { headers: as(owner.email) })
+    const raw = `dk_agt_${name}`
+    await meta.createAgent({
+      id: `ag_${name}`,
+      org_id: "default",
+      name: "GateBot",
+      token: sha256(raw),
+      role: "owner",
+      created_by: owner.id,
+    })
+    return { app, meta, raw }
+  }
+
+  it("a gated workspace reports enabled:false and names the flag — the read itself stays open", async () => {
+    const { app, meta, raw } = await setup("gate-mcp-list-off")
+    // One automation stood up while the beta is on (makeAuthedApp's seed), so the gated
+    // list below proves rows still come back — the flag closed the lanes, not the read.
+    const made = await callAutomate(app, raw, {
+      action: "create",
+      trigger: { kind: "manual" },
+      instruction: "Keep the roadmap current",
+    })
+    expect(made.id).toBeTruthy()
+    const current = await meta.getOrgSettings("default")
+    if (current) await meta.setOrgSettings("default", { ...current, automateBeta: false })
+
+    const r = await callAutomate(app, raw, { action: "list" })
+    expect(r.count).toBe(1)
+    expect(r.automations).toHaveLength(1)
+    expect(r.automations_enabled).toBe(false)
+    // The note names the flag, so the agent learns create/run_now will fail BEFORE trying.
+    expect(r.note).toContain("automateBeta")
+  })
+
+  it("an opted-in workspace reports enabled:true with no warning", async () => {
+    const { app, raw } = await setup("gate-mcp-list-on")
+    const r = await callAutomate(app, raw, { action: "list" })
+    expect(r.automations_enabled).toBe(true)
+    expect(r.note).toBeUndefined()
   })
 })

--- a/apps/api/test/mcp-contexts.test.ts
+++ b/apps/api/test/mcp-contexts.test.ts
@@ -450,3 +450,75 @@ describe("use({wait}) — the settle wake and the session loop", () => {
     expect(check.state).toBe("open")
   })
 })
+
+// create_context and the FRONTMATTER-ONLY skill rule: a context's skills load from the
+// manifest's `skills:` frontmatter pins (lib/manifest-pins.ts) — a prose derive://skills/...
+// mention in the body is deliberately not parsed. The REST create reports skills_count; the
+// MCP create_context said nothing, so a body-only mention came back as a working context with
+// skills:[] and no signal. It now reports the pin count and, when the body names skills that
+// nothing pinned, says how to pin them — without adding a skills param or parsing prose.
+describe("automate create_context — skills_count comes from frontmatter pins", () => {
+  // The automate tool is owner-only, and /v1/agents caps registration at editor — so the
+  // owner-role MCP caller is seeded straight into the store, acting for the workspace owner.
+  const setupOwnerBot = async (name: string) => {
+    const { app, meta } = makeAuthedApp(name, [owner])
+    await app.request("/v1/me", { headers: as(owner.email) })
+    const raw = `dk_agt_${name}`
+    await meta.createAgent({
+      id: `ag_${name}`,
+      org_id: "default",
+      name: "OwnerBot",
+      token: sha256(raw),
+      role: "owner",
+      created_by: owner.id,
+    })
+    const createContext = async (contextName: string, content: string) => {
+      const manifest = await (
+        await publishAs(app, content, { title: `${contextName} manifest` }, as(owner.email))
+      ).json()
+      return call(app, raw, "automate", {
+        action: "create_context",
+        name: contextName,
+        manifest_short_id: manifest.short_id,
+      })
+    }
+    return { createContext }
+  }
+
+  it("counts the frontmatter pins, with no hint when the declaration is right", async () => {
+    const { createContext } = await setupOwnerBot("mcx-cc-pins")
+    const md = [
+      "---",
+      "skills:",
+      "  - id: skl11111",
+      "    version: 2",
+      "  - id: skl22222",
+      "---",
+      "# QA manifest",
+      "Run the checks with derive://skills/loop in mind.",
+    ].join("\n")
+    const r = await createContext("QA", md)
+    expect(r.context_id).toBeTruthy()
+    expect(r.skills_count).toBe(2)
+    // Pinned properly: the body mention changes nothing and earns no lecture.
+    expect(r.skills_hint).toBeUndefined()
+  })
+
+  it("a body-only derive://skills mention pins nothing — and the response says so", async () => {
+    const { createContext } = await setupOwnerBot("mcx-cc-prose")
+    const r = await createContext("QA", "# QA manifest\nRead derive://skills/loop before acting.")
+    expect(r.context_id).toBeTruthy()
+    expect(r.skills_count).toBe(0)
+    // The hint teaches the fix: pins live in frontmatter, one `- id:` per skill.
+    expect(r.skills_hint).toContain("frontmatter")
+    expect(r.skills_hint).toContain("- id:")
+  })
+
+  it("no pins and no mention is just zero — silence, not a warning", async () => {
+    const { createContext } = await setupOwnerBot("mcx-cc-plain")
+    const r = await createContext("QA", "# QA manifest\nRun the checks.")
+    expect(r.context_id).toBeTruthy()
+    expect(r.skills_count).toBe(0)
+    expect(r.skills_hint).toBeUndefined()
+  })
+})

--- a/apps/api/test/model-anthropic.test.ts
+++ b/apps/api/test/model-anthropic.test.ts
@@ -76,6 +76,27 @@ describe("how a connected plan authenticates", () => {
     })
     expect((calls[0]?.body as { model: string }).model).toBe(DEFAULT_ANTHROPIC_MODEL)
   })
+
+  it("hits api.anthropic.com even when ANTHROPIC_BASE_URL is set in the process environment", async () => {
+    // createAnthropic reads ANTHROPIC_BASE_URL unless baseURL is pinned. A local Claude proxy,
+    // CI harness, or self-host rewrite would otherwise steer every plan-token turn off the
+    // Messages API the connected credential is for — and the intercept in substrate-loop's
+    // credential tests (which keys on api.anthropic.com) would go silent the same way.
+    const prev = process.env.ANTHROPIC_BASE_URL
+    process.env.ANTHROPIC_BASE_URL = "http://127.0.0.1:9"
+    try {
+      const { calls, impl } = captured()
+      await anthropicModel({ credential: { kind: "api_key", value: "k" }, fetchImpl: impl })({
+        system: "s",
+        messages: [{ role: "user", content: "hi" }],
+        tools: [],
+      })
+      expect(calls[0]?.url).toMatch(/^https:\/\/api\.anthropic\.com\//)
+    } finally {
+      if (prev === undefined) delete process.env.ANTHROPIC_BASE_URL
+      else process.env.ANTHROPIC_BASE_URL = prev
+    }
+  })
 })
 
 describe("what a plan turn reports", () => {

--- a/apps/api/test/profiles.test.ts
+++ b/apps/api/test/profiles.test.ts
@@ -1,5 +1,13 @@
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { newId } from "@derive/core"
-import { describe, expect, it } from "vitest"
+import { SqliteMetaStore } from "@derive/db/sqlite"
+import { FsBlobStore } from "@derive/storage/fs"
+import Database from "better-sqlite3"
+import { afterAll, describe, expect, it } from "vitest"
+import { createApp } from "../src/app"
+import { makeAuth, migrateAuth } from "../src/auth-config"
 import { as, jsonAs, makeAuthedApp, type TestUser } from "./helpers"
 
 const post = (
@@ -564,5 +572,96 @@ describe("people (/v1/people) — your workmates, not a directory", () => {
 
     // Signed-in only — anonymous is refused.
     expect((await app.request("/v1/people")).status).toBe(401)
+  })
+})
+
+// The fake-session harness above can't see the session COOKIE CACHE (auth-config.ts:
+// Better Auth answers /api/auth/get-session from a signed `session_data` cookie for up
+// to 60s). The /v1/me/* writes go straight to the user row, below that cache, so a save
+// used to read as a revert until the cookie expired. This suite runs a REAL Better Auth
+// instance and pins the fix: each write hands back a re-signed cookie, and the very
+// next identity read serves the NEW value.
+describe("profile writes stay fresh through the session cookie cache", () => {
+  const dir = mkdtempSync(join(tmpdir(), "derive-profile-cache-"))
+  const dbPath = join(dir, "auth.db")
+  const db = new Database(dbPath)
+  const BASE = "http://localhost:8080"
+  const auth = makeAuth(db, BASE, "test-secret-0123456789abcd")
+  const app = createApp({
+    meta: new SqliteMetaStore(dbPath),
+    blobs: new FsBlobStore(join(dir, "blobs")),
+    baseUrl: BASE,
+    auth,
+  })
+
+  afterAll(() => {
+    db.close()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  // A minimal browser: keep one jar, fold every response's Set-Cookie back in by name.
+  let jar = ""
+  const absorb = (res: Response): Response => {
+    const fresh = res.headers.getSetCookie().map((c) => c.split(";")[0] ?? "")
+    if (fresh.length) {
+      const names = new Set(fresh.map((c) => c.split("=")[0]))
+      const kept = jar ? jar.split("; ").filter((c) => !names.has(c.split("=")[0])) : []
+      jar = [...kept, ...fresh].join("; ")
+    }
+    return res
+  }
+  const post = async (path: string, body?: unknown) =>
+    absorb(
+      await app.request(`${BASE}${path}`, {
+        method: "POST",
+        headers: { "content-type": "application/json", origin: BASE, cookie: jar },
+        body: JSON.stringify(body ?? {}),
+      }),
+    )
+  const me = async () => {
+    const res = await app.request(`${BASE}/v1/me`, { headers: { origin: BASE, cookie: jar } })
+    return (await res.json()).user
+  }
+
+  it("signs up and holds a cached-session cookie", async () => {
+    await migrateAuth(auth)
+    const up = await post("/api/auth/sign-up/email", {
+      email: "fresh@derive.test",
+      password: "initialPassw0rd",
+      name: "Fresh",
+    })
+    expect(up.status).toBe(200)
+    const sin = await post("/api/auth/sign-in/email", {
+      email: "fresh@derive.test",
+      password: "initialPassw0rd",
+    })
+    expect(sin.status).toBe(200)
+    expect(jar).toContain("session_data")
+  })
+
+  it("serves a saved role + bio on the next read — no 60s revert", async () => {
+    expect((await me()).profession).toBeNull()
+    const saved = await post("/v1/me/profile", { profession: "Design", about: "maps + moods" })
+    expect(saved.status).toBe(200)
+    const u = await me()
+    expect(u.profession).toBe("Design")
+    expect(u.about).toBe("maps + moods")
+  })
+
+  it("serves a discoverable opt-out on the next read", async () => {
+    expect((await me()).discoverable).toBe(true)
+    expect((await post("/v1/me/discoverable", { discoverable: false })).status).toBe(200)
+    expect((await me()).discoverable).toBe(false)
+  })
+
+  it("serves the onboarded flag on the next read", async () => {
+    expect((await me()).onboarded).toBe(false)
+    expect((await post("/v1/me/onboarded")).status).toBe(200)
+    expect((await me()).onboarded).toBe(true)
+  })
+
+  it("serves a claimed handle on the next read", async () => {
+    expect((await post("/v1/me/username", { username: "freshly" })).status).toBe(200)
+    expect((await me()).username).toBe("freshly")
   })
 })


### PR DESCRIPTION
## Summary

The verified-clean subset of @weprintmoney's QA-round harvest (#671, #672). These three
fixes each landed in their own self-contained commit, were confirmed correct on review, and
are independent of the surrounding work in those PRs — so they're broken out here as small,
independently-reviewable changes. **The original commits are cherry-picked unchanged, so
authorship is preserved.**

The remaining items from #671/#672/#673 are held back — see those PRs for the per-item
rationale.

## What's included

- **`fix(api): pin Anthropic Messages base URL for plan-token runs`** (from #672)
  Pins `baseURL` to `https://api.anthropic.com/v1` so a process-level `ANTHROPIC_BASE_URL`
  (local proxy / test harness) can't silently divert a workspace's connected-plan token off
  `api.anthropic.com`. Mirrors how `openAiCompatModel` already takes the origin as an explicit
  option rather than an ambient env var.

- **`fix(mcp): automate tells agents what's gated and what the manifest pinned`** (from #671)
  `automate list` now reports whether automations are enabled for the workspace (and names the
  flag) instead of returning a bare `count: 0` that reads as "none yet"; and context creation
  surfaces a hint when a manifest body mentions `derive://skills/...` but pins no skills in
  frontmatter. Purely additive metadata on the responses.

- **`fix(session): a saved profile shouldn't revert behind the session cookie cache`** (from #671)
  The `/v1/me/*` profile writes go straight to the user row, but the SPA reads identity through
  Better Auth's 60s `session_data` cookie cache — so a save-then-reload showed the stale value.
  After each write we re-resolve the session with the cache bypassed and forward the re-signed
  cookie, so the next read is already fresh. No-op for bearer-token callers with no cached cookie.

## Note on the base-URL pin

This pin also removes the `ANTHROPIC_BASE_URL` escape hatch that a self-host behind a mandated
egress gateway might rely on. That's an acceptable trade for the hosted credential path (a
workspace plan's destination isn't a deploy-time preference), but if we want to keep an operator
override we should add it back as an explicit config option rather than an ambient env — tracked
separately, not a blocker here.

## Test plan

- [x] Each fix carries the contributor's original tests (`model-anthropic`, `automate-gate`,
      `mcp-contexts`, `auth-session-cache`, `profiles`).
- [ ] `pnpm verify` green on this branch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/681"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788978812&installation_model_id=428097&pr_number=681&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F681&signature=755cca9648515489b43b9c6bd3bc47b33e145036e4aced4c7bddd7a400affee7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->