### PR TITLE
Feat/mcp directory listings

### DIFF
--- a/apps/web/public/.well-known/mcp-registry-auth
+++ b/apps/web/public/.well-known/mcp-registry-auth
@@ -1,0 +1,1 @@
+v=MCPv1; k=ed25519; p=2nRr9DbdW0rMhQhFEJ6ejwh/4wuAk7SOO0hLnYr384w=

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -3,6 +3,7 @@
   "version": "0.5.1",
   "type": "module",
   "description": "Stdio MCP server for Derive — list, read, catch up on, comment on, and publish artifacts on a Derive instance.",
+  "mcpName": "to.derive/derive",
   "keywords": [
     "mcp",
     "model-context-protocol",

--- a/server.json
+++ b/server.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "to.derive/derive",
+  "title": "Derive",
+  "description": "Publish agent output to permanent versioned URLs, read review comments back, and revise.",
+  "version": "1.0.0",
+  "websiteUrl": "https://derive.to",
+  "repository": {
+    "url": "https://github.com/derive-to/derive",
+    "source": "github",
+    "id": "1266729582"
+  },
+  "icons": [
+    {
+      "src": "https://derive.to/brand/masters/icon-square-light.png",
+      "mimeType": "image/png",
+      "sizes": ["3840x3840"],
+      "theme": "light"
+    },
+    {
+      "src": "https://derive.to/brand/masters/icon-square-dark.png",
+      "mimeType": "image/png",
+      "sizes": ["3840x3840"],
+      "theme": "dark"
+    }
+  ],
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://derive.to/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
Three files, all additive, no code paths touched. Everything needed before
`mcp-publisher publish` can run.

## `server.json`

The registry lists a server from a manifest its publisher signs for a namespace
it can prove it owns. Ours declares the hosted remote at `https://derive.to/mcp`
over streamable HTTP.

No `headers` are declared, deliberately. The endpoint already answers an
unauthenticated call with `WWW-Authenticate: Bearer resource_metadata=...`, so a
client discovers OAuth on its own. Declaring an `Authorization` header is what
API-key servers do, and it would wrongly imply a token the user pastes. The other
DCR-based remotes already in the registry (Linear, Atlassian) declare none either.

Verified with `mcp-publisher validate` against the live registry, not just the
JSON schema. Worth knowing for anyone editing it later: `description` is capped at
100 characters.

## `apps/web/public/.well-known/mcp-registry-auth`

The name is `to.derive/derive`, the reverse-DNS form of our own domain, rather
than the `io.github.derive-to` fallback that would name GitHub as the owner.
Claiming it requires proving control of derive.to.

The registry accepts either a TXT record on the zone apex or this file. This is
the file, because it ships with an ordinary deploy instead of needing whoever
holds the DNS zone, and because it is reviewable here rather than in a dashboard.
The DNS route stays available with the same key if we would rather.

The value is an ed25519 **public** key. Publishing it is the point. The private
half never leaves the operator's keychain, and holding this string grants nothing.

One deploy-shape caveat, found while testhe SPA shell
for unknown paths, so a missing file here answers 200 with HTML rather than 404,
and registry verification would fail on a obvious
absence. `security.txt` already proves that real files under `public/.well-known`
take precedence, which is what makes thistops serving,
that is the failure mode to expect.

## `packages/mcp/package.json`

Gains the `mcpName` field the registry requires to prove we own `@derive-to/mcp`
on npm.

It is deliberately not joined by a `packa` yet.
Ownership is checked against the currently published tarball, so that entry can
only land once a release carries this fielocker for the
remote listing.

## After merge

Deploy, then `mcp-publisher login http --domain=derive.to` and
`mcp-publisher publish`. Nothing in this .

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788984481&installation_model_id=428097&pr_number=683&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F683&signature=b81a6e3402fb393bff910528991889f2c789322dc92a422f80ad15addd9f123c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->