### PR TITLE
docs(privacy): say how long we keep things

### DIFF
--- a/apps/web/public/site/privacy.html
+++ b/apps/web/public/site/privacy.html
@@ -161,7 +161,7 @@ footer{margin-top:130px;border-top:1px solid var(--border-soft)}
 <header class="head wrap">
   <div class="eyebrow">Privacy</div>
   <h1>Your data, in simple terms.</h1>
-  <p class="lede">Derive stores what it takes to run your workspace: an account, the content you publish, and the bare usage signals that keep the product honest with you. Nothing more, and nothing sold. <strong>Effective August 3, 2026.</strong></p>
+  <p class="lede">Derive stores what it takes to run your workspace: an account, the content you publish, and the bare usage signals that keep the product honest with you. Nothing more, and nothing sold. <strong>Effective August 10, 2026.</strong></p>
   <div class="beta">
     <span class="k">NOTE</span>
     <span>This page is a <strong>plain-language summary, not legal advice</strong>. It describes how Derive actually handles data. Full transparency, no surprises here.</span>
@@ -206,6 +206,10 @@ footer{margin-top:130px;border-top:1px solid var(--border-soft)}
     <details>
       <summary>What happens when I delete my account or a workspace?</summary>
       <p class="a">Deleting your account removes your sign-in data, your memberships, and your personal workspace container, and it permanently disconnects your name from everything you authored. It does not delete the artifacts themselves: that's a separate, explicit step. Delete an artifact and its versions and search entries go with it; do that first, then delete your account. A workspace works the same way: it has to be empty before it can be deleted, so remove or move its artifacts before you delete the workspace itself. One honest exception either way: a URL you already published and shared stays live at that link until you (or a remaining owner) take it down yourself, the same way a link you emailed someone doesn't un-send when you delete the file on your end. We won't pretend a link that's already out in the world quietly disappears.</p>
+    </details>
+    <details>
+      <summary>How long do you keep things?</summary>
+      <p class="a">Most of it has no clock on it, and that is deliberate: your artifacts, their version history, and the comments on them stay until you delete them. A permanent URL that quietly expired would not be permanent. The things that do have a clock, all of them enforced by a job rather than a promise: view analytics are a rolling <strong>365-day</strong> window, pruned daily, so old traffic ages out instead of piling up forever. A page published without an account is a draft, and it is deleted <strong>72 hours</strong> after you create it unless you claim it into a workspace. A password reset link lasts <strong>one hour</strong>. A signed-in session's access token lasts <strong>24 hours</strong> and renews quietly until you have been away for a year. An agent app that begins connecting but never finishes the consent screen is cleared after <strong>30 days</strong>. Self-hosting changes all of this: every window above is yours to set, and the analytics one can be switched off entirely.</p>
     </details>
     <details>
       <summary>Can I avoid all of this by self-hosting?</summary>


### PR DESCRIPTION
The policy covered what we collect, why, and who processes it, but never how long
any of it lives. That is the one element a reader (and an app directory review)
asks for and could not find here.

Every duration is read off the code rather than asserted: the analytics window
from `DERIVE_ANALYTICS_RETENTION_DAYS` (365 by default, pruned daily, and no
override exists in `wrangler.toml` or CI, so that is what production runs), the
draft sweep from `DRAFT_TTL_MS`, and the reset-link, access-token and stale-OAuth
client windows from `auth-config.ts`. **If any of those constants move, this
paragraph is wrong and should move with them.**

The lead is that most data has no clock, because it shouldn't: a permanent URL
that quietly expired would not be permanent. Retention by event is still
retention, and saying so plainly beats inventing a number.

Backups are deliberately not mentioned. Derive implements none; recovery windows
belong to Neon and R2 and are configured in their dashboards, so no claim here
could be verified from this repo.

Effective date moves to match the change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789003899&installation_model_id=428097&pr_number=684&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F684&signature=c21f497cbd00a8d8371bc60da9dfc333c1094a0b9a05d42fc46c117f15051003"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->