### PR TITLE
fix(auth): advertise and stamp the same OAuth issuer

### DIFF
--- a/apps/api/src/auth-config.ts
+++ b/apps/api/src/auth-config.ts
@@ -111,6 +111,26 @@ export function mcpAudiences(baseUrl: string): string[] {
   return [...new Set([baseUrl, origin, `${origin}/`, `${origin}/mcp`, `${origin}/mcp/`])]
 }
 
+/**
+ * The OAuth issuer identifier: the bare ORIGIN of `baseUrl`. Sibling to mcpAudiences —
+ * another value the AS and RS sides must derive identically or tokens stop verifying.
+ *
+ * RFC 9207 makes it a byte-for-byte contract: the `iss` on an authorization response must
+ * equal the `issuer` in the metadata the client discovered. Three sites produce it —
+ * routes/oauth.ts advertises it, the jwt plugin stamps it, lib/oauth-agent.ts verifies it
+ * — so it lives in one function rather than three expressions. It drifted once already:
+ * the plugin defaulted to Better Auth's baseURL, which carries the /api/auth basePath,
+ * and clients that check the claim could not complete a callback.
+ *
+ * Not the basePath form, deliberately. RFC 8414 derives the metadata URL from the issuer,
+ * so `${origin}/api/auth` would belong at /.well-known/oauth-authorization-server/api/auth
+ * rather than where we serve it. Endpoints keep the basePath; the identifier does not.
+ *
+ * Assumes `baseUrl` is the origin clients actually reach — the same assumption
+ * mcpAudiences and the passkey rpID already make.
+ */
+export const oauthIssuerFor = (baseUrl: string): string => originOf(baseUrl)
+
 /** Whatever Better Auth accepts as its datastore: a better-sqlite3 / pg handle on
  *  Node, or a Kysely dialect config (`{ dialect, type }`) on the edge (D1). */
 export type AuthDb = BetterAuthOptions["database"]
@@ -450,7 +470,11 @@ export function makeAuth(db: AuthDb, baseUrl: string, secret: string, hooks: Aut
       // What still works, because none of it runs through this hook: GET /api/auth/jwks,
       // id-token + JWS-access-token signing at token-mint time (oauthProvider), and our own
       // verifier in lib/oauth-agent.ts, which fetches and caches JWKS per isolate.
-      jwt({ disableSettingJwtHeader: true }),
+      //
+      // `jwt.issuer` must be set. Left unset the plugin falls back to Better Auth's
+      // baseURL, which carries the /api/auth basePath and so contradicts the issuer the
+      // metadata advertises; see oauthIssuerFor for the contract and who else depends on it.
+      jwt({ disableSettingJwtHeader: true, jwt: { issuer: oauthIssuerFor(baseUrl) } }),
       // Derive as an OAuth 2.1 authorization server: agents (MCP clients) authenticate
       // via a browser consent instead of a pasted token, and get a scoped, expiring
       // access token. Endpoints land under /api/auth/oauth2/*; the consent screen is

--- a/apps/api/src/lib/oauth-agent.ts
+++ b/apps/api/src/lib/oauth-agent.ts
@@ -1,6 +1,6 @@
 import { type AgentRecord, capRole, type MetaStore, type Role } from "@derive/core"
 import { createLocalJWKSet, type JWTPayload, jwtVerify } from "jose"
-import type { Auth } from "../auth-config"
+import { type Auth, oauthIssuerFor } from "../auth-config"
 import { sha256 } from "./crypto"
 
 /** What a valid OAuth access token resolves to: the synthetic agent record (a workspace
@@ -88,11 +88,14 @@ export function makeOauthAgent({
     return { org, memberRole: "owner", bound }
   }
 
+  // The RS side of the issuer contract: what we require on every JWS access token, and
+  // the same derivation the AS stamps them with (see oauthIssuerFor).
+  const oauthIssuer = oauthIssuerFor(baseUrl)
+
   // Our own JWKS (served by the jwt plugin at /api/auth/jwks), read straight from
   // Better Auth's store on this instance — NOT an HTTP self-fetch, which a
   // Cloudflare Worker can't do against its own hostname. The local key set is
   // cached per isolate, rebuilt on a verify miss (a rotated signing key).
-  const oauthIssuer = new URL("/api/auth", baseUrl).toString()
   let jwksCache: ReturnType<typeof createLocalJWKSet> | null = null
   const loadJwks = async () => {
     const res = (await auth?.api.getJwks()) as Parameters<typeof createLocalJWKSet>[0] | undefined

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -3278,7 +3278,11 @@ describe("remote MCP endpoint (/mcp)", () => {
       new SignJWT({ scope: "openid derive:read derive:publish", azp: "cli", ...over })
         .setProtectedHeader({ alg: "EdDSA", kid })
         .setSubject("u_jwt")
-        .setIssuer("http://derive.test/api/auth")
+        // The ORIGIN, not origin + /api/auth: what the AS metadata advertises, what the
+        // jwt plugin is pinned to, and what oauth-agent verifies (RFC 9207). This line
+        // read `${origin}/api/auth` while the metadata said `${origin}`, and strict OAuth
+        // clients refused the callback over exactly that gap.
+        .setIssuer("http://derive.test")
         .setAudience("http://derive.test/mcp")
         .setExpirationTime("1h")
         .sign(privateKey)
@@ -3295,7 +3299,7 @@ describe("remote MCP endpoint (/mcp)", () => {
     const wrongIss = await new SignJWT({ scope: "openid derive:read", azp: "cli" })
       .setProtectedHeader({ alg: "EdDSA", kid })
       .setSubject("u_jwt")
-      .setIssuer("http://evil.test/api/auth")
+      .setIssuer("http://evil.test")
       .setAudience("http://derive.test/mcp")
       .setExpirationTime("1h")
       .sign(privateKey)

--- a/apps/api/test/oauth.test.ts
+++ b/apps/api/test/oauth.test.ts
@@ -6,6 +6,7 @@ import { FsBlobStore } from "@derive/storage/fs"
 import Database from "better-sqlite3"
 import { afterAll, describe, expect, it } from "vitest"
 import { createApp } from "../src/app"
+import { oauthIssuerFor } from "../src/auth-config"
 import { sha256 } from "../src/lib/crypto"
 
 // The OAuth consent flow (Better Auth's oauth-provider) issues an opaque access
@@ -67,6 +68,45 @@ const publish = (app: ReturnType<typeof createApp>, token: string) => {
     headers: { authorization: `Bearer ${token}` },
   })
 }
+
+describe("the OAuth issuer identifier (RFC 9207)", () => {
+  // A strict client compares the `iss` on an authorization response against the `issuer`
+  // in the metadata it discovered, byte for byte, and refuses the callback on a mismatch.
+  // Ours disagreed — the metadata advertised the origin, Better Auth stamped its own
+  // baseURL (origin + /api/auth) — and only clients that check were affected, so the
+  // surface looked healthy from every client we use ourselves.
+  //
+  // oauthIssuerFor is now the single derivation; auth-config stamps with it and
+  // oauth-agent verifies with it. What this file can reach is the third site: the
+  // metadata route. Note it derives from the REQUEST origin (deliberately — so a proxy
+  // or workers.dev host is correct without configuration), while the stamp derives from
+  // the configured baseUrl. They coincide when baseUrl is the origin clients reach,
+  // which is the assumption oauthIssuerFor documents.
+  it("is the bare origin, whatever shape baseUrl arrives in", () => {
+    expect(oauthIssuerFor("https://derive.to")).toBe("https://derive.to")
+    expect(oauthIssuerFor("https://derive.to/")).toBe("https://derive.to")
+    // Better Auth's baseURL shape — the value that caused the mismatch — normalises away.
+    expect(oauthIssuerFor("https://derive.to/api/auth")).toBe("https://derive.to")
+    expect(oauthIssuerFor("http://localhost:8787")).toBe("http://localhost:8787")
+  })
+
+  it("is what the discovery metadata advertises, never a path-bearing form", async () => {
+    const app = appWithGrant("issuer", {
+      token: "tok_iss",
+      scopes: "openid derive:read",
+      expiresAt: new Date(Date.now() + 3_600_000),
+    })
+    const discovery = await (await app.request("/.well-known/oauth-authorization-server")).json()
+
+    // RFC 8414 derives the metadata URL from the issuer, so `${origin}/api/auth` would
+    // belong at /.well-known/oauth-authorization-server/api/auth rather than here — a path
+    // in this field breaks discovery even if the stamp agreed with it.
+    expect(discovery.issuer).toBe(oauthIssuerFor(discovery.issuer))
+    // The endpoints DO keep the basePath. That asymmetry is what made this easy to get
+    // wrong, so pin it rather than leaving it to memory.
+    expect(discovery.authorization_endpoint).toBe(`${discovery.issuer}/api/auth/oauth2/authorize`)
+  })
+})
 
 describe("OAuth access token acts as a scoped agent", () => {
   const future = () => new Date(Date.now() + 3_600_000)


### PR DESCRIPTION
RFC 9207 requires the `iss` on an authorization response to equal, byte for
byte, the `issuer` in the metadata the client discovered. Ours disagreed.

`/.well-known/oauth-authorization-server` advertises the ORIGIN. Better Auth
stamps the claim, and with no `jwt.issuer` set it fell back to its own
`baseURL`, which carries the `/api/auth` basePath. So a client was told
`https://derive.to` and handed back `https://derive.to/api/auth`, and a client
that checks refused the callback with "unexpected iss (issuer) response
parameter value".

Lenient clients never compared the two, which is why this survived unnoticed:
the surface looked healthy from Claude Code and from our own tests, while any
strict OAuth client simply could not connect. Found by an external directory
scanner, not by us.

**Three places have to agree**, each in a different file:


The comments at each now point at the other two.

Note the asymmetry that made this easy to get wrong: **the issuer is the bare
origin, while the endpoints keep the `/api/auth` basePath.** That isn't
cosmetic. RFC 8414 derives the metadata URL from the issuer, so an issuer of
`${origin}/api/auth` belongs at
`/.well-known/oauth-authorization-server/api/auth` — moving our metadata to
match would break discovery instead of fixing it.

**The existing suite caught the coupling.** The "Needs Auth" regression guard
in `mcp.test.ts` mints a JWT and verifies it through the real path; it went red
the moment the verifier moved, which is the test doing exactly its job. Updated
to sign the origin, with the negative case still signing a foreign issuer.

`oauth.test.ts` gains a guard that the advertised issuer is a bare origin while
the endpoints stay under the basePath. Limitation worth knowing: the true
invariant is our metadata versus Better Auth's own discovery document, and that
route isn't mounted in the test harness, so this pins the shape rather than the
full cross-check.

### Deploy note

JWS access tokens minted before this carry the old `iss` and stop verifying.
They resolve to nothing, so an affected client degrades to anonymous rather
than erroring, and recovers as soon as it refreshes (the refresh path doesn't
check `iss`). Bounded by the 24h access-token lifetime. Deploy when a brief
reconnect is acceptable.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789010484&installation_model_id=428097&pr_number=686&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F686&signature=a5e9c879d2d9fdec706f5ec0ac1672e857c883fc7e41be66aa0a07dcc909d27a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->