### PR TITLE
Revert "chore(site): say fair source where we said open source (#690)"

### DIFF
--- a/apps/web/public/security.html
+++ b/apps/web/public/security.html
@@ -131,7 +131,7 @@ footer a:hover{color:var(--fg)}
     <a class="addr" href="mailto:security@derive.to">security@derive.to</a>
     <p>For vulnerabilities in Derive itself — the app, the API, or the hosting of user content. Please give
     us a reasonable window to remediate before public disclosure. The server is
-    <a href="https://github.com/derive-to/derive">public on GitHub</a>; issues in the code are also welcome there.</p>
+    <a href="https://github.com/derive-to/derive">open source</a>; issues in the code are also welcome there.</p>
   </section>
 </main>
 <footer>

--- a/apps/web/public/site/index.html
+++ b/apps/web/public/site/index.html
@@ -14,10 +14,10 @@
   c.toggle('light', light); c.toggle('dark', !light);
 })();
 </script>
-<title>Derive — The fair-source home for AI artifacts.</title>
-<meta name="description" content="You've never made more, and never kept less. Derive is where your team and its agents publish, review, and revise work. Fair source and self-hostable.">
+<title>Derive — The open source home for AI artifacts.</title>
+<meta name="description" content="You've never made more, and never kept less. Derive is where your team and its agents publish, review, and revise work. Open source and self-hostable.">
 <meta property="og:type" content="website">
-<meta property="og:title" content="Derive — The fair-source home for AI artifacts.">
+<meta property="og:title" content="Derive — The open source home for AI artifacts.">
 <meta property="og:description" content="You've never made more, and never kept less. Derive is where your team and its agents publish, review, and revise work.">
 <meta property="og:url" content="https://derive.to/">
 <meta property="og:image" content="https://derive.to/site/og.png">
@@ -57,7 +57,7 @@
       "applicationCategory": "BusinessApplication",
       "operatingSystem": "Web",
       "url": "https://derive.to/",
-      "description": "Derive is where your team and its agents publish, review, and revise work. Fair source and self-hostable.",
+      "description": "Derive is where your team and its agents publish, review, and revise work. Open source and self-hostable.",
       "isAccessibleForFree": true,
       "publisher": { "@id": "https://derive.to/#organization" }
     }
@@ -751,7 +751,7 @@ footer{margin-top:170px;position:relative;overflow:hidden;border-top:1px solid v
 <header class="hero" id="hero">
   <div class="stage">
     <div class="eyebrow hero-eyebrow">Make things worth keeping</div>
-    <h1 class="derivation grad-ink">The fair-source home for&nbsp;AI&nbsp;artifacts.</h1>
+    <h1 class="derivation grad-ink">The open source home for&nbsp;AI&nbsp;artifacts.</h1>
     <p class="sub"><strong>You've never made more, and never kept less.</strong> Derive is your team's library for the work you and your agents make: publish it, share it anywhere with a link, and revise it together until it's right. One URL, every version, yours.</p>
     <div class="cta-row">
       <button class="btn btn-primary hero-cta" type="button" data-copy-from="agentPrompt" data-copied-label="Copied — now paste it into your agent">
@@ -1076,7 +1076,7 @@ footer{margin-top:170px;position:relative;overflow:hidden;border-top:1px solid v
     <div>
       <p class="ch-lede reveal">Yours, not the model's, not ours.</p>
       <p class="ch-text reveal">Claude's artifacts live in Claude. ChatGPT's canvases live in ChatGPT. If half your team runs one and half runs the other, the work ends up split across two walled gardens. <strong>Derive doesn't care which model made what</strong>: context lives with the artifact, so a page Claude drafts on Monday gets revised by Codex on Tuesday, and your team reads both in one library.</p>
-      <p class="ch-text reveal">The same openness goes all the way down. The product is <strong>fair source — FSL now, Apache-2.0 two years after each release — and runs as a single container on your own infrastructure</strong> if you want it to, and everything exports in open formats: artifacts, versions, and comments. If you ever leave, the record leaves with you.</p>
+      <p class="ch-text reveal">The same openness goes all the way down. The product is <strong>open source and runs as a single container on your own infrastructure</strong> if you want it to, and everything exports in open formats: artifacts, versions, and comments. If you ever leave, the record leaves with you.</p>
     </div>
     <div class="ch-spec reveal">
       <div class="spec-card">

--- a/apps/web/public/site/pricing.html
+++ b/apps/web/public/site/pricing.html
@@ -295,7 +295,7 @@ footer{margin-top:130px;border-top:1px solid var(--border-soft)}
     </div>
     <div class="principle">
       <h3>Self-hosting is free, forever.</h3>
-      <p>The whole product is fair source and runs as one container. The hosted tier pays for the service, not the software.</p>
+      <p>The whole product is open source and runs as one container. The hosted tier pays for the service, not the software.</p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Reverts #690 on request. The public copy keeps "open source": the code is public, free to use, modify, and self-host for every purpose except selling Derive itself as a service, and every release becomes Apache-2.0 two years after it ships — we describe the license by those terms rather than by a coined label. A follow-up will align the README/pricing-FAQ/LICENSING.md wording (which currently says "fair source") with the same plain-terms framing.

Clean revert of 4218f391, copy-only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/691"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789040795&installation_model_id=428097&pr_number=691&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F691&signature=5730d1a08ebf7ee7227c3681c6b47ac61de7057052bdcc4f6426b413ff0dd2ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->