### PR TITLE
refactor(settings): extract the shared pieces every section hand-rolled

### DIFF
--- a/apps/web/src/components/shared/admin-note.tsx
+++ b/apps/web/src/components/shared/admin-note.tsx
@@ -1,0 +1,24 @@
+import { cn } from "@/lib/utils"
+
+// The one register for "this control exists, but your role doesn't reach it".
+// When a role hides a control, absence gets EXPLAINED — a silently missing
+// invite form reads as a bug, not a permission. One sentence, one shape,
+// everywhere: "Only a workspace Admin can <verb phrase>."
+export function AdminNote({
+  can,
+  role = "workspace Admin",
+  className,
+  testId,
+}: {
+  /** The verb phrase: "create automations", "change billing", "invite people". */
+  can: string
+  role?: string
+  className?: string
+  testId?: string
+}) {
+  return (
+    <p data-testid={testId} className={cn("text-sm text-muted-foreground", className)}>
+      Only a {role} can {can}.
+    </p>
+  )
+}

--- a/apps/web/src/components/shared/list-row.tsx
+++ b/apps/web/src/components/shared/list-row.tsx
@@ -1,0 +1,67 @@
+import type { ComponentPropsWithoutRef, ReactNode } from "react"
+import { cn } from "@/lib/utils"
+
+// The one list row: an item and its actions — the sibling of SettingRow (a label
+// and its control). Members, agents, webhooks, domains, repos, passkeys, plans:
+// all the same anatomy, so it is drawn once. Leading slot for an avatar or badge,
+// a title over one quiet meta line, a trailing action cluster (ghost verbs,
+// destructive-ghost always LAST, never a filled button), and an optional `below`
+// lane for what expands out of the row — a delivery log, a lend toggle, a
+// one-time token. Rows stack inside a hairline-divided SettingsGroup at py-3.5,
+// the same height as SettingRow; the list skeleton renders THIS component, so
+// the placeholder can never drift from the real row again.
+export function ListRow({
+  leading,
+  title,
+  mono = false,
+  meta,
+  actions,
+  below,
+  className,
+  ...rest
+}: {
+  /** Avatar, badge, or glyph before the text block. Sized by the caller. */
+  leading?: ReactNode
+  title: ReactNode
+  /** Machine-made titles (a URL, a host, an id) render mono instead of medium. */
+  mono?: boolean
+  /** One quiet line under the title; mono spans inside for machine facts. */
+  meta?: ReactNode
+  /** The trailing cluster. Verbs are ghost; the destructive one is last. */
+  actions?: ReactNode
+  /** Full-width content under the row line (an expanded log, a token reveal). */
+  below?: ReactNode
+} & Omit<ComponentPropsWithoutRef<"div">, "title">) {
+  return (
+    <div {...rest} className={cn("flex flex-col gap-2 py-3.5", className)}>
+      <div className="flex items-center gap-3">
+        {leading}
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <div
+            className={cn(
+              "text-sm text-foreground",
+              mono ? "truncate font-mono" : "font-medium",
+              !mono && typeof title === "string" && "truncate",
+            )}
+          >
+            {title}
+          </div>
+          {meta != null && (
+            <div
+              className={cn(
+                "text-2xs text-muted-foreground",
+                typeof meta === "string" && "truncate",
+              )}
+            >
+              {meta}
+            </div>
+          )}
+        </div>
+        {actions && (
+          <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">{actions}</div>
+        )}
+      </div>
+      {below}
+    </div>
+  )
+}

--- a/apps/web/src/components/shared/secret-reveal.tsx
+++ b/apps/web/src/components/shared/secret-reveal.tsx
@@ -1,0 +1,109 @@
+import type { ReactNode } from "react"
+import { StatusPanel } from "@/components/shared/status-panel"
+import { Button } from "@/components/ui/button"
+import { copyText } from "@/lib/clipboard"
+
+// The one-time secret moment: an agent bearer, a runner token, a 2FA setup key,
+// a set of backup codes — shown exactly once, in the safety-orange warning
+// register (never the accent), with Copy and Done. One component so the moment
+// can't drift: the same panel, the same code register, the same action pair
+// everywhere a credential is revealed.
+export function SecretReveal({
+  title,
+  secret,
+  onDone,
+  copySuccess = "Token copied",
+  copyLabel = "Copy",
+  downloadName,
+  downloadTestId,
+  copyTestId,
+  doneTestId,
+  secretTestId,
+}: {
+  title: ReactNode
+  /** The credential. An array (backup codes) renders as a two-column grid. */
+  secret: string | string[]
+  /** Omit when a surrounding flow (a dialog step) owns the dismissal. */
+  onDone?: () => void
+  copySuccess?: string
+  copyLabel?: string
+  /** Offer a Download button saving the secret as this filename. */
+  downloadName?: string
+  downloadTestId?: string
+  copyTestId?: string
+  doneTestId?: string
+  secretTestId?: string
+}) {
+  const text = Array.isArray(secret) ? secret.join("\n") : secret
+  const download = () => {
+    const url = URL.createObjectURL(new Blob([`${text}\n`], { type: "text/plain" }))
+    const a = document.createElement("a")
+    a.href = url
+    a.download = downloadName ?? "secret.txt"
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+  return (
+    <StatusPanel
+      tone="warning"
+      layout="inline"
+      title={title}
+      description={
+        Array.isArray(secret) ? (
+          <div
+            data-testid={secretTestId}
+            className="grid grid-cols-2 gap-1 rounded-md bg-secondary px-2.5 py-2 font-mono text-2xs text-foreground"
+          >
+            {secret.map((s) => (
+              <span key={s}>{s}</span>
+            ))}
+          </div>
+        ) : (
+          <code
+            data-testid={secretTestId}
+            className="block break-all rounded-md bg-secondary px-2.5 py-1.5 font-mono text-2xs text-foreground"
+          >
+            {secret}
+          </code>
+        )
+      }
+      action={
+        <div className="flex items-center gap-2">
+          {/* type="button" throughout: a reveal often renders inside a form (the 2FA
+              enable dialog), and a bare Button would implicitly submit it. */}
+          <Button
+            type="button"
+            data-testid={copyTestId}
+            variant="secondary"
+            size="sm"
+            onClick={() => void copyText(text, { success: copySuccess })}
+          >
+            {copyLabel}
+          </Button>
+          {downloadName && (
+            <Button
+              type="button"
+              data-testid={downloadTestId}
+              variant="ghost"
+              size="sm"
+              onClick={download}
+            >
+              Download
+            </Button>
+          )}
+          {onDone && (
+            <Button
+              type="button"
+              data-testid={doneTestId}
+              variant="ghost"
+              size="sm"
+              onClick={onDone}
+            >
+              Done
+            </Button>
+          )}
+        </div>
+      }
+    />
+  )
+}

--- a/apps/web/src/components/shared/status-badge.tsx
+++ b/apps/web/src/components/shared/status-badge.tsx
@@ -1,0 +1,30 @@
+import type { ComponentPropsWithoutRef } from "react"
+import { Badge } from "@/components/ui/badge"
+
+// One vocabulary for state chips, keyed by MEANING so the same state can't wear
+// different clothes in different sections ("Pending" was outline in Members and
+// warning in Domains). Pick the tone by semantics, never by color:
+//   ok        — confirmed good; a quiet success (delivered, active)
+//   attention — waiting on YOU; act here (DNS pending, needs sign-in)
+//   error     — failed, or gave up retrying (dead, error)
+//   busy      — in flight right now (running, syncing)
+//   muted     — dormant, or waiting on someone else (paused, an invite pending)
+// Status hues are signals: never reuse them as decoration. Busy borrows the
+// brand tint deliberately — in-flight is a brand moment (StatusPanel's grammar),
+// not a judgment; the other four are judgments.
+export const STATUS_TONE_VARIANT = {
+  ok: "success",
+  attention: "warning",
+  error: "destructive",
+  busy: "brand",
+  muted: "outline",
+} as const
+
+export type StatusTone = keyof typeof STATUS_TONE_VARIANT
+
+export function StatusBadge({
+  tone,
+  ...rest
+}: { tone: StatusTone } & ComponentPropsWithoutRef<typeof Badge>) {
+  return <Badge variant={STATUS_TONE_VARIANT[tone]} {...rest} />
+}

--- a/apps/web/src/lib/one-shot-params.test.ts
+++ b/apps/web/src/lib/one-shot-params.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest"
+import { takeFromSearch } from "./one-shot-params"
+
+describe("takeFromSearch", () => {
+  it("takes only the named params and reports the rest", () => {
+    const { taken, rest } = takeFromSearch("?checkout=success&tab=plans", ["checkout"])
+    expect(taken).toEqual({ checkout: "success" })
+    expect(rest).toBe("tab=plans")
+  })
+
+  it("takes several params in one pass (the gh_install + gh_error shape)", () => {
+    const { taken, rest } = takeFromSearch("?gh_install=123&gh_error=denied", [
+      "gh_install",
+      "gh_error",
+    ])
+    expect(taken).toEqual({ gh_install: "123", gh_error: "denied" })
+    expect(rest).toBe("")
+  })
+
+  it("reports nothing taken when the param is absent", () => {
+    const { taken, rest } = takeFromSearch("?tab=plans", ["checkout"])
+    expect(taken).toEqual({})
+    expect(rest).toBe("tab=plans")
+  })
+
+  it("keeps an empty-but-present value (?new-workspace=) distinct from absent", () => {
+    const { taken } = takeFromSearch("?new-workspace=", ["new-workspace"])
+    expect(taken).toEqual({ "new-workspace": "" })
+  })
+
+  it("takes every occurrence of a repeated param, not just the first", () => {
+    const { taken, rest } = takeFromSearch("?connected=1&connected=2&x=y", ["connected"])
+    expect(taken).toEqual({ connected: "1" })
+    expect(rest).toBe("x=y")
+  })
+
+  it("handles a search string without the leading question mark", () => {
+    const { taken, rest } = takeFromSearch("connected=1", ["connected"])
+    expect(taken).toEqual({ connected: "1" })
+    expect(rest).toBe("")
+  })
+})

--- a/apps/web/src/lib/one-shot-params.ts
+++ b/apps/web/src/lib/one-shot-params.ts
@@ -1,0 +1,20 @@
+// Pure core of the one-shot URL-param handshake (?checkout=success,
+// ?slack_error=…, ?gh_install=…): take the named params out of a search string,
+// returning what was taken and the search that should remain. Pure so the
+// take-and-strip semantics are unit-testable; the browser wiring (history,
+// mount-once) lives in use-one-shot-params.tsx.
+export function takeFromSearch(
+  search: string,
+  names: readonly string[],
+): { taken: Record<string, string>; rest: string } {
+  const qs = new URLSearchParams(search)
+  const taken: Record<string, string> = {}
+  for (const name of names) {
+    const value = qs.get(name)
+    if (value !== null) {
+      taken[name] = value
+      qs.delete(name)
+    }
+  }
+  return { taken, rest: qs.toString() }
+}

--- a/apps/web/src/lib/use-one-shot-params.ts
+++ b/apps/web/src/lib/use-one-shot-params.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react"
+import { takeFromSearch } from "./one-shot-params"
+
+// The one-shot URL-param handshake: read the named params exactly once on
+// mount, then strip them from the address bar so a reload (or a copied link)
+// can't replay the moment. One hook for what billing (?checkout=success),
+// sources (?connected=1), general (?new-workspace=1), Slack (?slack_connected /
+// ?slack_error) and GitHub (?gh_install / ?gh_error) each hand-rolled — three
+// different replaceState signatures between them. history.state is preserved
+// so the router's own state survives the strip.
+export function useOneShotParams(...names: string[]): Record<string, string> {
+  const [taken] = useState(() =>
+    typeof window === "undefined" ? {} : takeFromSearch(window.location.search, names).taken,
+  )
+  // biome-ignore lint/correctness/useExhaustiveDependencies: strip exactly once, on mount — `names` is a per-call-site literal list and `taken` is frozen from the first render
+  useEffect(() => {
+    if (Object.keys(taken).length === 0) return
+    const { rest } = takeFromSearch(window.location.search, names)
+    window.history.replaceState(
+      window.history.state,
+      "",
+      `${window.location.pathname}${rest ? `?${rest}` : ""}${window.location.hash}`,
+    )
+  }, [])
+  return taken
+}

--- a/apps/web/src/pages/artifact/automate-dialog.tsx
+++ b/apps/web/src/pages/artifact/automate-dialog.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query"
+import { AdminNote } from "@/components/shared/admin-note"
 import {
   Dialog,
   DialogContent,
@@ -51,9 +52,7 @@ export function AutomateDialog({
             onDone={() => onOpenChange(false)}
           />
         ) : (
-          <p className="text-sm text-muted-foreground">
-            Only a workspace Admin can create automations. Ask an Admin to set this up.
-          </p>
+          <AdminNote can="create automations" />
         )}
       </DialogContent>
     </Dialog>

--- a/apps/web/src/pages/settings/add-form.tsx
+++ b/apps/web/src/pages/settings/add-form.tsx
@@ -1,0 +1,54 @@
+import type { ReactNode } from "react"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+// The one "add a row" form above a settings list: a flex-wrap line of controls
+// with a single secondary submit at the end, real <form> semantics (Enter in
+// any field submits — no per-input onKeyDown), and the button's spinner as the
+// only pending signal — no per-form "Adding…" label swaps. Extra content under
+// the line (an event-filter row, a CNAME hint, a field error) goes in `after`.
+export function AddForm({
+  onSubmit,
+  submitLabel,
+  submitTestId,
+  pending = false,
+  disabled = false,
+  children,
+  after,
+  className,
+}: {
+  onSubmit: () => void
+  /** A verb: "Add", "Subscribe", "Connect". */
+  submitLabel: string
+  submitTestId?: string
+  pending?: boolean
+  disabled?: boolean
+  children: ReactNode
+  after?: ReactNode
+  className?: string
+}) {
+  return (
+    <form
+      className={cn("flex flex-col gap-3", className)}
+      onSubmit={(e) => {
+        e.preventDefault()
+        if (!disabled && !pending) onSubmit()
+      }}
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        {children}
+        <Button
+          type="submit"
+          data-testid={submitTestId}
+          variant="secondary"
+          size="sm"
+          loading={pending}
+          disabled={disabled || pending}
+        >
+          {submitLabel}
+        </Button>
+      </div>
+      {after}
+    </form>
+  )
+}

--- a/apps/web/src/pages/settings/agents-section.tsx
+++ b/apps/web/src/pages/settings/agents-section.tsx
@@ -4,9 +4,10 @@ import { useState } from "react"
 import { type Agent, api, type Role } from "@/api"
 import { ConfirmDialog } from "@/components/shared/confirm-dialog"
 import { EmptyState } from "@/components/shared/empty-state"
+import { ListRow } from "@/components/shared/list-row"
 import { LoadError } from "@/components/shared/load-error"
+import { SecretReveal } from "@/components/shared/secret-reveal"
 import { SettingsGroup } from "@/components/shared/settings-group"
-import { StatusPanel } from "@/components/shared/status-panel"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -19,9 +20,9 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Switch } from "@/components/ui/switch"
-import { copyText } from "@/lib/clipboard"
 import { agentsQuery, modelCredentialsQuery } from "@/lib/queries"
 import { useApiMutation } from "@/lib/use-api-mutation"
+import { AddForm } from "./add-form"
 import { ModelPlanManager } from "./model-plan-manager"
 import { SettingsListSkeleton } from "./settings-list-skeleton"
 import { SettingsSection } from "./settings-section"
@@ -74,29 +75,28 @@ export function AgentsSection({ meId }: { meId: string }) {
           plan, below), then the agent OWNER's plan (only for agents lent above), then the
           shared workspace pool. Both plan surfaces live here so it's one place to reason
           about; your own plan also lives under Account → Model plans. */}
-      <div className="mt-6 flex flex-col gap-5 border-t pt-6">
-        <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-5">
+        <SettingsGroup
+          title="Your plan"
+          description="Runs you start bill your own connected plan first. Same plan as Account → Model plans; connect it here or there."
+        >
+          {/* One padding-neutral wrapper: SettingsGroup strips its first/last
+              child's vertical padding (a row contract) and divides siblings,
+              which would shave the connect well's p-4 and draw a stray hairline
+              through the manager's fragment. */}
           <div>
-            <div className="text-sm font-medium text-foreground">Your plan</div>
-            <p className="mt-0.5 text-2xs text-muted-foreground">
-              Runs you start bill your own connected plan first. Same plan as Account → Model plans;
-              connect it here or there.
-            </p>
+            <ModelPlanManager scope="personal" />
           </div>
-          <ModelPlanManager scope="personal" />
-        </div>
+        </SettingsGroup>
 
-        <div className="flex flex-col gap-3">
+        <SettingsGroup
+          title="Workspace model plan pool"
+          description="A shared plan billed when a run's initiator has no plan of their own and the agent isn't lent its owner's. Optional — leave it empty to require everyone to bring their own."
+        >
           <div>
-            <div className="text-sm font-medium text-foreground">Workspace model plan pool</div>
-            <p className="mt-0.5 text-2xs text-muted-foreground">
-              A shared plan billed when a run's initiator has no plan of their own and the agent
-              isn't lent its owner's. Optional — leave it empty to require everyone to bring their
-              own.
-            </p>
+            <ModelPlanManager scope="pool" />
           </div>
-          <ModelPlanManager scope="pool" />
-        </div>
+        </SettingsGroup>
       </div>
     </SettingsSection>
   )
@@ -116,20 +116,21 @@ function NewAgent({ onCreated }: { onCreated: () => void }) {
       onCreated()
     },
   })
-  const add = () => {
-    if (name.trim()) create.mutate()
-  }
-
   return (
     <div className="flex flex-col gap-3">
-      <div className="flex flex-wrap gap-2">
+      <AddForm
+        onSubmit={() => create.mutate()}
+        submitLabel="Add agent"
+        submitTestId="agent-add"
+        pending={create.isPending}
+        disabled={!name.trim()}
+      >
         <Input
           data-testid="agent-name"
           aria-label="Agent name"
           placeholder="Agent name (e.g. Claude)"
           value={name}
           onChange={(e) => setName(e.target.value)}
-          onKeyDown={(e) => e.key === "Enter" && add()}
           className="min-w-45 flex-1"
         />
         <Select value={role} onValueChange={(v) => setRole(v as Role)}>
@@ -141,50 +142,18 @@ function NewAgent({ onCreated }: { onCreated: () => void }) {
             <SelectItem value="editor">Editor (publish)</SelectItem>
           </SelectContent>
         </Select>
-        <Button
-          data-testid="agent-add"
-          variant="secondary"
-          size="sm"
-          onClick={add}
-          loading={create.isPending}
-          disabled={create.isPending || !name.trim()}
-        >
-          {create.isPending ? "Adding…" : "Add agent"}
-        </Button>
-      </div>
+      </AddForm>
       {/* The token is shown exactly once, right after creation — a safety-orange
-          warning moment, never the accent. */}
+          warning moment, never the accent. Below the form, not inside it: the
+          reveal outlives the submit that produced it. */}
       {created && (
         <div data-testid="agent-token">
-          <StatusPanel
-            tone="warning"
-            layout="inline"
+          <SecretReveal
             title={`Token for ${created.name} — copy it now, it won't be shown again.`}
-            description={
-              <code className="block break-all rounded-md bg-secondary px-2.5 py-1.5 font-mono text-2xs text-foreground">
-                {created.token}
-              </code>
-            }
-            action={
-              <div className="flex items-center gap-2">
-                <Button
-                  data-testid="agent-token-copy"
-                  variant="secondary"
-                  size="sm"
-                  onClick={() => void copyText(created.token, { success: "Token copied" })}
-                >
-                  Copy
-                </Button>
-                <Button
-                  data-testid="agent-token-done"
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setCreated(null)}
-                >
-                  Done
-                </Button>
-              </div>
-            }
+            secret={created.token}
+            onDone={() => setCreated(null)}
+            copyTestId="agent-token-copy"
+            doneTestId="agent-token-done"
           />
         </div>
       )}
@@ -226,100 +195,84 @@ function AgentRow({
     onSuccess: () => onDone(),
   })
   return (
-    <div data-testid={`agent-row-${agent.id}`} className="flex flex-col py-3">
-      <div className="flex items-center gap-3">
+    <ListRow
+      data-testid={`agent-row-${agent.id}`}
+      leading={
         <Avatar className="size-7 shrink-0">
           <AvatarFallback>
             <Bot className="size-4" aria-hidden />
           </AvatarFallback>
         </Avatar>
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-1.5 text-sm font-medium text-foreground">
-            @{agent.name}
-            <Badge variant="secondary">{agent.role}</Badge>
-          </div>
-          <div className="text-sm text-muted-foreground">
-            Mention it in any thread to send it work.
-          </div>
-        </div>
-        <Button
-          data-testid={`agent-rotate-${agent.id}`}
-          variant="ghost"
-          size="sm"
-          onClick={() => rotate.mutate()}
-          loading={rotate.isPending}
-          disabled={rotate.isPending}
-        >
-          Rotate token
-        </Button>
-        <Button
-          data-testid={`agent-remove-${agent.id}`}
-          variant="destructive-ghost"
-          size="sm"
-          onClick={() => setConfirming(true)}
-        >
-          Remove
-        </Button>
-        <ConfirmDialog
-          open={confirming}
-          onOpenChange={setConfirming}
-          title={`Remove @${agent.name}?`}
-          description="Its token stops working immediately."
-          confirmLabel="Remove"
-          onConfirm={() => remove.mutate()}
-        />
-      </div>
-      {isOwner && (
-        <label
-          htmlFor={`agent-lend-${agent.id}`}
-          className="mt-2 flex items-center gap-2 pl-10 text-2xs text-muted-foreground"
-        >
-          <Switch
-            id={`agent-lend-${agent.id}`}
-            data-testid={`agent-lend-${agent.id}`}
-            checked={agent.owner_lend}
-            onCheckedChange={(v) => lend.mutate(v)}
-            disabled={lend.isPending || !hasPersonalPlan}
+      }
+      title={
+        <span className="flex items-center gap-1.5">
+          @{agent.name}
+          <Badge variant="secondary">{agent.role}</Badge>
+        </span>
+      }
+      meta="Mention it in any thread to send it work."
+      actions={
+        <>
+          <Button
+            data-testid={`agent-rotate-${agent.id}`}
+            variant="ghost"
+            size="sm"
+            onClick={() => rotate.mutate()}
+            loading={rotate.isPending}
+            disabled={rotate.isPending}
+          >
+            Rotate token
+          </Button>
+          <Button
+            data-testid={`agent-remove-${agent.id}`}
+            variant="destructive-ghost"
+            size="sm"
+            onClick={() => setConfirming(true)}
+          >
+            Remove
+          </Button>
+          <ConfirmDialog
+            open={confirming}
+            onOpenChange={setConfirming}
+            title={`Remove @${agent.name}?`}
+            description="Its token stops working immediately."
+            confirmLabel="Remove"
+            onConfirm={() => remove.mutate()}
           />
-          {hasPersonalPlan
-            ? "Fall back to my plan when a run has none of its own"
-            : "Connect your plan under Account → Model plans to lend it here"}
-        </label>
-      )}
-      {rotated && (
-        <div data-testid={`agent-rotated-${agent.id}`} className="mt-2">
-          <StatusPanel
-            tone="warning"
-            layout="inline"
-            title={`New token for ${agent.name} — copy it now, it won't be shown again. The old one is dead.`}
-            description={
-              <code className="block break-all rounded-md bg-secondary px-2.5 py-1.5 font-mono text-2xs text-foreground">
-                {rotated}
-              </code>
-            }
-            action={
-              <div className="flex items-center gap-2">
-                <Button
-                  data-testid={`agent-rotated-copy-${agent.id}`}
-                  variant="secondary"
-                  size="sm"
-                  onClick={() => void copyText(rotated, { success: "Token copied" })}
-                >
-                  Copy
-                </Button>
-                <Button
-                  data-testid={`agent-rotated-done-${agent.id}`}
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setRotated(null)}
-                >
-                  Done
-                </Button>
-              </div>
-            }
-          />
-        </div>
-      )}
-    </div>
+        </>
+      }
+      below={
+        <>
+          {isOwner && (
+            <label
+              htmlFor={`agent-lend-${agent.id}`}
+              className="flex items-center gap-2 pl-10 text-2xs text-muted-foreground"
+            >
+              <Switch
+                id={`agent-lend-${agent.id}`}
+                data-testid={`agent-lend-${agent.id}`}
+                checked={agent.owner_lend}
+                onCheckedChange={(v) => lend.mutate(v)}
+                disabled={lend.isPending || !hasPersonalPlan}
+              />
+              {hasPersonalPlan
+                ? "Fall back to my plan when a run has none of its own"
+                : "Connect your plan under Account → Model plans to lend it here"}
+            </label>
+          )}
+          {rotated && (
+            <div data-testid={`agent-rotated-${agent.id}`}>
+              <SecretReveal
+                title={`New token for ${agent.name} — copy it now, it won't be shown again. The old one is dead.`}
+                secret={rotated}
+                onDone={() => setRotated(null)}
+                copyTestId={`agent-rotated-copy-${agent.id}`}
+                doneTestId={`agent-rotated-done-${agent.id}`}
+              />
+            </div>
+          )}
+        </>
+      }
+    />
   )
 }

--- a/apps/web/src/pages/settings/automation-form.tsx
+++ b/apps/web/src/pages/settings/automation-form.tsx
@@ -3,8 +3,8 @@ import { Link } from "@tanstack/react-router"
 import { FileText, FolderOpen, Hash, Plug, Plus, X } from "lucide-react"
 import { type ReactNode, useMemo, useState } from "react"
 import { type Automation, type AutomationRef, type AutomationTrigger, api } from "@/api"
+import { SecretReveal } from "@/components/shared/secret-reveal"
 import { Eyebrow } from "@/components/shared/section-eyebrow"
-import { StatusPanel } from "@/components/shared/status-panel"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -25,7 +25,6 @@ import {
 } from "@/components/ui/select"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Textarea } from "@/components/ui/textarea"
-import { copyText } from "@/lib/clipboard"
 import {
   agentsQuery,
   artifactQuery,
@@ -613,38 +612,15 @@ export function AutomationForm({
 
       {mintedToken && (
         <div data-testid="automation-agent-token">
-          <StatusPanel
-            tone="warning"
-            layout="inline"
+          <SecretReveal
             title="Runner token for this automation — copy it now, it won't be shown again."
-            description={
-              <code className="block break-all rounded-md bg-secondary px-2.5 py-1.5 font-mono text-2xs text-foreground">
-                {mintedToken}
-              </code>
-            }
-            action={
-              <div className="flex items-center gap-2">
-                <Button
-                  data-testid="automation-agent-token-copy"
-                  variant="secondary"
-                  size="sm"
-                  onClick={() => void copyText(mintedToken, { success: "Token copied" })}
-                >
-                  Copy
-                </Button>
-                <Button
-                  data-testid="automation-agent-token-done"
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => {
-                    setMintedToken(null)
-                    onDone()
-                  }}
-                >
-                  Done
-                </Button>
-              </div>
-            }
+            secret={mintedToken}
+            onDone={() => {
+              setMintedToken(null)
+              onDone()
+            }}
+            copyTestId="automation-agent-token-copy"
+            doneTestId="automation-agent-token-done"
           />
         </div>
       )}

--- a/apps/web/src/pages/settings/automations-section.tsx
+++ b/apps/web/src/pages/settings/automations-section.tsx
@@ -3,11 +3,14 @@ import { Link } from "@tanstack/react-router"
 import { Zap } from "lucide-react"
 import { useState } from "react"
 import { type Automation, api, type Run } from "@/api"
+import { AdminNote } from "@/components/shared/admin-note"
 import { ConfirmDialog } from "@/components/shared/confirm-dialog"
 import { EmptyState } from "@/components/shared/empty-state"
+import { ListRow } from "@/components/shared/list-row"
 import { LoadError } from "@/components/shared/load-error"
 import { Eyebrow } from "@/components/shared/section-eyebrow"
 import { SettingsGroup } from "@/components/shared/settings-group"
+import { StatusBadge } from "@/components/shared/status-badge"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
@@ -55,9 +58,7 @@ export function AutomationsSection() {
           <AutomationForm onDone={reload} />
         </div>
       ) : (
-        <p className="text-sm text-muted-foreground">
-          Only a workspace Admin can create automations. Ask an Admin to set one up.
-        </p>
+        <AdminNote can="create automations" />
       )}
 
       {isPending ? (
@@ -121,13 +122,19 @@ function AutomationRow({
     onSuccess: () => onDone(),
   })
   const summary = targetSummary(automation.refs)
+  const mode = automation.refs.some((r) => r.mode === "publish")
+    ? "Publishes live"
+    : "Proposes for review"
   return (
-    <div data-testid={`automation-row-${automation.id}`} className="flex items-center gap-3 py-3">
-      <div className="flex size-7 shrink-0 items-center justify-center rounded-full bg-accent">
-        <Zap className="size-4 text-muted-foreground" aria-hidden />
-      </div>
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-1.5 text-sm font-medium text-foreground">
+    <ListRow
+      data-testid={`automation-row-${automation.id}`}
+      leading={
+        <div className="flex size-7 shrink-0 items-center justify-center rounded-full bg-accent">
+          <Zap className="size-4 text-muted-foreground" aria-hidden />
+        </div>
+      }
+      title={
+        <span className="flex items-center gap-1.5">
           <span className="truncate">{automation.instruction}</span>
           <Badge variant="outline">
             {automation.provider === "codex" ? "Codex" : "Claude Code"}
@@ -136,89 +143,86 @@ function AutomationRow({
           <Badge variant="secondary">{triggerLabel(automation.trigger)}</Badge>
           {!automation.enabled && <Badge variant="outline">Paused</Badge>}
           <ExecutorBadge seenAt={automation.executor_seen_at ?? null} />
-        </div>
-        <div className="truncate text-sm text-muted-foreground">
-          {automation.refs.some((r) => r.mode === "publish")
-            ? "Publishes live"
-            : "Proposes for review"}
-          {summary && ` · ${summary}`}
-        </div>
-      </div>
-      <div className="flex shrink-0 items-center gap-1">
-        {canRun && automation.enabled && (
-          <Button
-            data-testid={`automation-run-${automation.id}`}
-            variant="secondary"
-            size="sm"
-            onClick={() => run.mutate()}
-            loading={run.isPending}
-            disabled={run.isPending}
-          >
-            Run now
-          </Button>
-        )}
-        {canRemove && (
-          <Button
-            data-testid={`automation-edit-${automation.id}`}
-            variant="ghost"
-            size="sm"
-            onClick={() => setEditing(true)}
-          >
-            Edit
-          </Button>
-        )}
-        {canRemove && (
-          <Button
-            data-testid={`automation-pause-${automation.id}`}
-            variant="ghost"
-            size="sm"
-            onClick={() => pause.mutate()}
-            loading={pause.isPending}
-            disabled={pause.isPending}
-          >
-            {automation.enabled ? "Pause" : "Resume"}
-          </Button>
-        )}
-        {canRemove && (
-          <Button
-            data-testid={`automation-remove-${automation.id}`}
-            variant="destructive-ghost"
-            size="sm"
-            onClick={() => setConfirming(true)}
-          >
-            Remove
-          </Button>
-        )}
-      </div>
-      <Dialog open={editing} onOpenChange={setEditing}>
-        <DialogContent
-          data-testid="automation-edit-dialog"
-          className="max-h-[calc(100dvh-2rem)] overflow-y-auto"
-        >
-          <DialogHeader>
-            <DialogTitle>Edit automation</DialogTitle>
-          </DialogHeader>
-          {/* Remount per open so stale state never leaks between edit sessions. */}
-          {editing && (
-            <AutomationForm
-              automation={automation}
-              onDone={() => {
-                setEditing(false)
-                onDone()
-              }}
-            />
+        </span>
+      }
+      meta={summary ? `${mode} · ${summary}` : mode}
+      actions={
+        <>
+          {canRun && automation.enabled && (
+            <Button
+              data-testid={`automation-run-${automation.id}`}
+              variant="secondary"
+              size="sm"
+              onClick={() => run.mutate()}
+              loading={run.isPending}
+              disabled={run.isPending}
+            >
+              Run now
+            </Button>
           )}
-        </DialogContent>
-      </Dialog>
-      <ConfirmDialog
-        open={confirming}
-        onOpenChange={setConfirming}
-        title="Remove this automation?"
-        description="Its queued runs are cancelled. Past runs stay in the activity."
-        confirmLabel="Remove"
-        onConfirm={() => remove.mutate()}
-      />
-    </div>
+          {canRemove && (
+            <Button
+              data-testid={`automation-edit-${automation.id}`}
+              variant="ghost"
+              size="sm"
+              onClick={() => setEditing(true)}
+            >
+              Edit
+            </Button>
+          )}
+          {canRemove && (
+            <Button
+              data-testid={`automation-pause-${automation.id}`}
+              variant="ghost"
+              size="sm"
+              onClick={() => pause.mutate()}
+              loading={pause.isPending}
+              disabled={pause.isPending}
+            >
+              {automation.enabled ? "Pause" : "Resume"}
+            </Button>
+          )}
+          {canRemove && (
+            <Button
+              data-testid={`automation-remove-${automation.id}`}
+              variant="destructive-ghost"
+              size="sm"
+              onClick={() => setConfirming(true)}
+            >
+              Remove
+            </Button>
+          )}
+          <Dialog open={editing} onOpenChange={setEditing}>
+            <DialogContent
+              data-testid="automation-edit-dialog"
+              className="max-h-[calc(100dvh-2rem)] overflow-y-auto"
+            >
+              <DialogHeader>
+                <DialogTitle>Edit automation</DialogTitle>
+              </DialogHeader>
+              {/* Remount per open so stale state never leaks between edit sessions. */}
+              {editing && (
+                <AutomationForm
+                  automation={automation}
+                  onDone={() => {
+                    setEditing(false)
+                    onDone()
+                  }}
+                />
+              )}
+            </DialogContent>
+          </Dialog>
+          <ConfirmDialog
+            open={confirming}
+            onOpenChange={setConfirming}
+            title="Remove this automation?"
+            description="Its queued runs are cancelled. Past runs stay in the activity."
+            confirmLabel="Remove"
+            onConfirm={() => remove.mutate()}
+          />
+        </>
+      }
+    />
   )
 }
 
@@ -238,7 +242,7 @@ function Activity() {
           <li
             key={r.id}
             data-testid={`run-row-${r.id}`}
-            className="flex flex-col gap-1 border-b py-2.5 text-sm last:border-0"
+            className="flex flex-col gap-1 border-b py-3 text-sm last:border-0"
           >
             <div className="flex items-center gap-3">
               <RunStatus status={r.status} />
@@ -313,18 +317,18 @@ function RunWrites({ meta }: { meta: string | null }) {
 }
 
 function RunStatus({ status }: { status: Run["status"] }) {
-  const variant =
+  const tone =
     status === "succeeded"
-      ? "success"
+      ? "ok"
       : status === "failed"
-        ? "destructive"
+        ? "error"
         : status === "running"
-          ? "brand"
-          : "secondary"
+          ? "busy"
+          : "muted"
   return (
-    <Badge variant={variant} shape="pill">
+    <StatusBadge tone={tone} shape="pill">
       {runStatusLabel(status)}
-    </Badge>
+    </StatusBadge>
   )
 }
 
@@ -336,8 +340,8 @@ function ExecutorBadge({ seenAt }: { seenAt: string | null }) {
   const age = seenAt ? Date.now() - new Date(seenAt).getTime() : Number.POSITIVE_INFINITY
   if (seenAt && age < 600_000) return null
   return (
-    <Badge variant="outline" className="border-warning/40 text-warning">
+    <StatusBadge tone="attention">
       {seenAt ? `Executor offline · seen ${ago(seenAt)}` : "No executor"}
-    </Badge>
+    </StatusBadge>
   )
 }

--- a/apps/web/src/pages/settings/billing-section.tsx
+++ b/apps/web/src/pages/settings/billing-section.tsx
@@ -4,12 +4,14 @@ import { api, type BillingInfo } from "@/api"
 import { BillingCycleToggle } from "@/components/billing/billing-cycle-toggle"
 import { PlanCard } from "@/components/billing/plan-card"
 import { useCheckout } from "@/components/billing/use-checkout"
+import { AdminNote } from "@/components/shared/admin-note"
 import { LoadError } from "@/components/shared/load-error"
 import { StatusPanel } from "@/components/shared/status-panel"
 import { Button } from "@/components/ui/button"
 import { gb } from "@/lib/bytes"
 import { billingQuery, workspaceQuery } from "@/lib/queries"
 import { useApiMutation } from "@/lib/use-api-mutation"
+import { useOneShotParams } from "@/lib/use-one-shot-params"
 import { FREE_SEAT_LIMIT, type PaidTier, PLANS, unitPrice } from "./billing-plans"
 import { SettingsListSkeleton } from "./settings-list-skeleton"
 import { SettingsSection } from "./settings-section"
@@ -73,19 +75,16 @@ export function BillingSection() {
   const pollDeadline = useRef<number | null>(null)
 
   // ?checkout=success lands here fresh back from Stripe: the cached billing
-  // query may predate the webhook, so consume + strip the param (same one-shot
-  // idiom as general-section's ?new-workspace=1), force a refetch, and poll
-  // briefly until the webhook flips `subscribed` true.
+  // query may predate the webhook, so consume the one-shot param, force a
+  // refetch, and poll briefly until the webhook flips `subscribed` true.
+  const { checkout: checkoutParam } = useOneShotParams("checkout")
   useEffect(() => {
-    const url = new URL(window.location.href)
-    if (url.searchParams.get("checkout") === "success") {
-      url.searchParams.delete("checkout")
-      window.history.replaceState(null, "", url)
+    if (checkoutParam === "success") {
       setShowSuccessBanner(true)
       pollDeadline.current = Date.now() + CHECKOUT_POLL_TIMEOUT_MS
       void qc.invalidateQueries({ queryKey: billingQuery().queryKey })
     }
-  }, [qc])
+  }, [checkoutParam, qc])
 
   const {
     data: billing,
@@ -140,13 +139,7 @@ export function BillingSection() {
             pendingTier={(t) => checkout.isPendingFor(t)}
             checkoutPending={checkout.isPending}
           />
-          {isAdmin ? (
-            billing.subscribed && <ManageBilling />
-          ) : (
-            <p className="text-sm text-muted-foreground">
-              Only a workspace Admin can change billing.
-            </p>
-          )}
+          {isAdmin ? billing.subscribed && <ManageBilling /> : <AdminNote can="change billing" />}
           <p className="text-sm text-muted-foreground">
             Need isolation, residency, or procurement?{" "}
             <a
@@ -205,18 +198,12 @@ function StorageMeter({
       </p>
       <div className="h-1.5 w-full max-w-xs overflow-hidden rounded-full bg-secondary">
         <div
-          className={
-            high
-              ? "h-full rounded-full bg-amber-500" /* tokens-ignore */
-              : "h-full rounded-full bg-primary"
-          }
+          className={high ? "h-full rounded-full bg-warning" : "h-full rounded-full bg-primary"}
           style={{ width: `${pct}%` }}
         />
       </div>
       {high && tier === "free" && (
-        <p className="text-amber-600 dark:text-amber-500" /* tokens-ignore */>
-          Running low? Team includes 50 GB pooled storage.
-        </p>
+        <p className="text-warning">Running low? Team includes 50 GB pooled storage.</p>
       )}
     </div>
   )

--- a/apps/web/src/pages/settings/custom-domains-section.tsx
+++ b/apps/web/src/pages/settings/custom-domains-section.tsx
@@ -3,13 +3,15 @@ import { useState } from "react"
 import { api, type WorkspaceDomain } from "@/api"
 import { ConfirmDialog } from "@/components/shared/confirm-dialog"
 import { EmptyState } from "@/components/shared/empty-state"
+import { ListRow } from "@/components/shared/list-row"
 import { LoadError } from "@/components/shared/load-error"
 import { SettingsGroup } from "@/components/shared/settings-group"
-import { Badge } from "@/components/ui/badge"
+import { StatusBadge, type StatusTone } from "@/components/shared/status-badge"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { customDomainsQuery } from "@/lib/queries"
 import { useApiMutation } from "@/lib/use-api-mutation"
+import { AddForm } from "./add-form"
 import { SettingsListSkeleton } from "./settings-list-skeleton"
 import { SettingsSection } from "./settings-section"
 
@@ -84,50 +86,43 @@ function NewDomain({
     if (h) addDomain.mutate(h)
   }
   return (
-    <div className="flex flex-col gap-2">
-      <div className="flex flex-wrap items-center gap-2">
-        <Input
-          data-testid="domain-host"
-          aria-label="Custom domain"
-          value={host}
-          onChange={(e) => setHost(e.target.value)}
-          onKeyDown={(e) => e.key === "Enter" && add()}
-          placeholder="docs.acme.com"
-          className="min-w-60 flex-1 font-mono"
-        />
-        <Button
-          data-testid="domain-add"
-          variant="secondary"
-          size="sm"
-          onClick={add}
-          loading={addDomain.isPending}
-          disabled={addDomain.isPending || !host.trim()}
-        >
-          {addDomain.isPending ? "Adding…" : "Add"}
-        </Button>
-      </div>
-      {cnameTarget && (
-        <p className="font-mono text-2xs text-muted-foreground">
-          CNAME your domain to <span className="text-foreground">{cnameTarget}</span>.
-        </p>
-      )}
-    </div>
+    <AddForm
+      onSubmit={add}
+      submitLabel="Add"
+      submitTestId="domain-add"
+      pending={addDomain.isPending}
+      disabled={!host.trim()}
+      after={
+        cnameTarget && (
+          <p className="font-mono text-2xs text-muted-foreground">
+            CNAME your domain to <span className="text-foreground">{cnameTarget}</span>.
+          </p>
+        )
+      }
+    >
+      <Input
+        data-testid="domain-host"
+        aria-label="Custom domain"
+        value={host}
+        onChange={(e) => setHost(e.target.value)}
+        placeholder="docs.acme.com"
+        className="min-w-60 flex-1 font-mono"
+      />
+    </AddForm>
   )
 }
 
-// Verification state → badge tone: a live cert is a success, a failed issuance is
-// destructive, and pending means DNS work is still on the user (warning, not the accent).
-const statusBadge = (
-  s: string,
-): { variant: "success" | "destructive" | "warning"; label: string } =>
+// Verification state → tone: a live cert is confirmed good, a failed issuance
+// errored, and pending means DNS work is still on the user (attention, not the accent).
+const statusTone = (s: string): { tone: StatusTone; label: string } =>
   s === "active"
-    ? { variant: "success", label: "Active" }
+    ? { tone: "ok", label: "Active" }
     : s === "error"
-      ? { variant: "destructive", label: "Error" }
-      : { variant: "warning", label: "Pending" }
+      ? { tone: "error", label: "Error" }
+      : { tone: "attention", label: "Pending" }
 
 function DomainRow({ domain, onChanged }: { domain: WorkspaceDomain; onChanged: () => void }) {
-  const b = statusBadge(domain.status)
+  const b = statusTone(domain.status)
   const [confirming, setConfirming] = useState(false)
   const refreshMut = useApiMutation({
     mutationFn: () => api.refreshWorkspaceDomain(domain.host),
@@ -141,51 +136,57 @@ function DomainRow({ domain, onChanged }: { domain: WorkspaceDomain; onChanged: 
   })
   const remove = () => removeMut.mutate()
   return (
-    <div data-testid={`domain-row-${domain.host}`} className="flex flex-col gap-2 py-3">
-      <div className="flex items-center gap-2.5">
-        <div className="min-w-0 flex-1 truncate font-mono text-sm text-foreground">
-          {domain.host}
-        </div>
-        <Badge data-testid="domain-status" variant={b.variant}>
-          {b.label}
-        </Badge>
-        {domain.status !== "active" && (
-          <Button data-testid="domain-refresh" variant="ghost" size="sm" onClick={refresh}>
-            Refresh
+    <ListRow
+      data-testid={`domain-row-${domain.host}`}
+      mono
+      title={domain.host}
+      actions={
+        <>
+          <StatusBadge data-testid="domain-status" tone={b.tone}>
+            {b.label}
+          </StatusBadge>
+          {domain.status !== "active" && (
+            <Button data-testid="domain-refresh" variant="ghost" size="sm" onClick={refresh}>
+              Refresh
+            </Button>
+          )}
+          <Button
+            data-testid="domain-remove"
+            variant="destructive-ghost"
+            size="sm"
+            onClick={() => setConfirming(true)}
+          >
+            Remove
           </Button>
-        )}
-        <Button
-          data-testid="domain-remove"
-          variant="destructive-ghost"
-          size="sm"
-          onClick={() => setConfirming(true)}
-        >
-          Remove
-        </Button>
-      </div>
-      <ConfirmDialog
-        open={confirming}
-        onOpenChange={setConfirming}
-        title={`Remove ${domain.host}?`}
-        description="Artifacts stop serving on this domain immediately; the TLS cert is released."
-        confirmLabel="Remove"
-        onConfirm={remove}
-      />
-      {domain.status !== "active" && domain.records && domain.records.length > 0 && (
-        <div className="rounded-lg bg-secondary px-3 py-2">
-          <p className="mb-1 font-mono text-2xs text-muted-foreground">
-            Add these DNS records at your registrar:
-          </p>
-          {domain.records.map((r) => (
-            <div
-              key={`${r.type}-${r.name}`}
-              className="truncate font-mono text-2xs text-foreground"
-            >
-              <span className="text-muted-foreground">{r.type}</span> {r.name} → {r.value}
+        </>
+      }
+      below={
+        <>
+          <ConfirmDialog
+            open={confirming}
+            onOpenChange={setConfirming}
+            title={`Remove ${domain.host}?`}
+            description="Artifacts stop serving on this domain immediately; the TLS cert is released."
+            confirmLabel="Remove"
+            onConfirm={remove}
+          />
+          {domain.status !== "active" && domain.records && domain.records.length > 0 && (
+            <div className="rounded-lg bg-secondary px-3 py-2">
+              <p className="mb-1 font-mono text-2xs text-muted-foreground">
+                Add these DNS records at your registrar:
+              </p>
+              {domain.records.map((r) => (
+                <div
+                  key={`${r.type}-${r.name}`}
+                  className="truncate font-mono text-2xs text-foreground"
+                >
+                  <span className="text-muted-foreground">{r.type}</span> {r.name} → {r.value}
+                </div>
+              ))}
             </div>
-          ))}
-        </div>
-      )}
-    </div>
+          )}
+        </>
+      }
+    />
   )
 }

--- a/apps/web/src/pages/settings/general-section.tsx
+++ b/apps/web/src/pages/settings/general-section.tsx
@@ -2,6 +2,8 @@ import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useEffect, useState } from "react"
 import { api, type OrgSettings } from "@/api"
 import { useShell } from "@/components/chrome/shell-context"
+import { AdminNote } from "@/components/shared/admin-note"
+import { ConfirmDialog } from "@/components/shared/confirm-dialog"
 import { FormField } from "@/components/shared/form-field"
 import { LoadError } from "@/components/shared/load-error"
 import { SettingRow } from "@/components/shared/setting-row"
@@ -27,6 +29,7 @@ import { Switch } from "@/components/ui/switch"
 import { reloadAfterWorkspaceChange } from "@/lib/persist"
 import { workspaceQuery, workspaceSettingsQuery, workspacesQuery } from "@/lib/queries"
 import { snapshot, useApiMutation } from "@/lib/use-api-mutation"
+import { useOneShotParams } from "@/lib/use-one-shot-params"
 import { SettingsSection } from "./settings-section"
 
 // Workspace identity + lifecycle: rename it, spin up a new one, or (admins only)
@@ -41,7 +44,7 @@ export function GeneralSection() {
   const [createOpen, setCreateOpen] = useState(false)
   const [newName, setNewName] = useState("")
   const [newInvites, setNewInvites] = useState("")
-  const [delName, setDelName] = useState("")
+  const [deleteOpen, setDeleteOpen] = useState(false)
 
   // Seed the editable name once the workspace loads (and re-seed on a rename that
   // updates the cache). Focus refetches are off globally, so this won't clobber typing.
@@ -50,16 +53,11 @@ export function GeneralSection() {
   }, [ws])
 
   // ?new-workspace=1 auto-opens the create dialog — the deep link the user pod and
-  // the share dialog's first-need hint navigate to. One-shot: consumed + stripped
-  // (same pattern as the GitHub section's gh_install handshake params).
+  // the share dialog's first-need hint navigate to. One-shot: consumed + stripped.
+  const { "new-workspace": newWorkspaceParam } = useOneShotParams("new-workspace")
   useEffect(() => {
-    const url = new URL(window.location.href)
-    if (url.searchParams.get("new-workspace")) {
-      setCreateOpen(true)
-      url.searchParams.delete("new-workspace")
-      window.history.replaceState(null, "", url)
-    }
-  }, [])
+    if (newWorkspaceParam) setCreateOpen(true)
+  }, [newWorkspaceParam])
 
   const isAdmin = ws?.role === "owner"
 
@@ -106,9 +104,6 @@ export function GeneralSection() {
     mutationFn: (id: string) => api.deleteWorkspace(id),
     onSuccess: () => reloadAfterWorkspaceChange(),
   })
-  const onDelete = () => {
-    if (ws) del.mutate(ws.id)
-  }
 
   return (
     <SettingsSection
@@ -208,51 +203,39 @@ export function GeneralSection() {
         </FormField>
       )}
 
-      {isAdmin && <SharingDefaults />}
+      {isAdmin ? <SharingDefaults /> : <AdminNote can="change workspace settings" />}
 
       {isAdmin && ws && (
-        <StatusPanel
-          tone="danger"
-          layout="inline"
-          title="Delete this workspace"
-          description="Permanently delete this workspace. It must be empty (no artifacts), and this can't be undone."
-          action={
-            <Dialog onOpenChange={(o) => !o && setDelName("")}>
-              <DialogTrigger asChild>
-                <Button data-testid="workspace-delete" variant="destructive" size="sm">
-                  Delete workspace
-                </Button>
-              </DialogTrigger>
-              <DialogContent>
-                <DialogHeader>
-                  <DialogTitle>Delete "{ws.name}"?</DialogTitle>
-                  <DialogDescription>
-                    This permanently deletes the workspace and removes everyone from it. To confirm,
-                    type <strong className="font-medium text-foreground">{ws.name}</strong> below.
-                  </DialogDescription>
-                </DialogHeader>
-                <Input
-                  data-testid="workspace-delete-confirm"
-                  aria-label="Type the workspace name to confirm"
-                  value={delName}
-                  onChange={(e) => setDelName(e.target.value)}
-                  placeholder={ws.name}
-                  autoComplete="off"
-                />
-                <Button
-                  data-testid="workspace-delete-go"
-                  variant="destructive"
-                  onClick={onDelete}
-                  loading={del.isPending}
-                  disabled={del.isPending || delName.trim() !== ws.name}
-                  className="mt-2 w-full"
-                >
-                  {del.isPending ? "Deleting…" : "Delete this workspace"}
-                </Button>
-              </DialogContent>
-            </Dialog>
-          }
-        />
+        <>
+          <StatusPanel
+            tone="danger"
+            layout="inline"
+            title="Delete this workspace"
+            description="Permanently delete this workspace. It must be empty (no artifacts), and this can't be undone."
+            action={
+              <Button
+                data-testid="workspace-delete"
+                variant="destructive"
+                size="sm"
+                onClick={() => setDeleteOpen(true)}
+              >
+                Delete workspace
+              </Button>
+            }
+          />
+          <ConfirmDialog
+            open={deleteOpen}
+            onOpenChange={setDeleteOpen}
+            title={`Delete "${ws.name}"?`}
+            description="This permanently deletes the workspace and removes everyone from it."
+            confirmLabel="Delete workspace"
+            confirmTestId="workspace-delete-go"
+            confirmPhrase={ws.name}
+            onConfirm={async () => {
+              await del.mutateAsync(ws.id)
+            }}
+          />
+        </>
       )}
     </SettingsSection>
   )

--- a/apps/web/src/pages/settings/github-install-flow.tsx
+++ b/apps/web/src/pages/settings/github-install-flow.tsx
@@ -31,21 +31,6 @@ const LEVEL_LABELS: Record<string, string> = {
   admin: "Admin",
 }
 
-// Read (and clear) the one-shot query params the App install flow lands back on.
-export const takeInstallParams = (): { install?: string; error?: string } => {
-  if (typeof window === "undefined") return {}
-  const qs = new URLSearchParams(window.location.search)
-  const install = qs.get("gh_install") ?? undefined
-  const error = qs.get("gh_error") ?? undefined
-  if (install || error) {
-    qs.delete("gh_install")
-    qs.delete("gh_error")
-    const rest = qs.toString()
-    window.history.replaceState({}, "", `${window.location.pathname}${rest ? `?${rest}` : ""}`)
-  }
-  return { install, error }
-}
-
 // No App yet: one button that kicks off the manifest flow (a top-level nav, since
 // it posts a form to GitHub).
 export function SetUpApp() {

--- a/apps/web/src/pages/settings/github-pr-preview.tsx
+++ b/apps/web/src/pages/settings/github-pr-preview.tsx
@@ -2,7 +2,8 @@ import { Link } from "@tanstack/react-router"
 import { ExternalLink } from "lucide-react"
 import { type PrPreview, parseProgress } from "@/api"
 import { Icon } from "@/components/icons"
-import { Spinner } from "@/components/shared/spinner"
+import { ListRow } from "@/components/shared/list-row"
+import { StatusBadge } from "@/components/shared/status-badge"
 import { Button } from "@/components/ui/button"
 import { ago } from "@/lib/time"
 
@@ -16,11 +17,12 @@ export function PrPreviewRow({ pr }: { pr: PrPreview }) {
   // The API titles a preview "PR #<n>: <title>"; show just the <title> here.
   const label = pr.title.replace(/^PR #\d+:\s*/, "") || pr.title
   return (
-    <div data-testid={`github-pr-${pr.pr_number}`} className="flex items-center gap-3 py-3">
-      <Icon name="review" className="text-muted-foreground" />
-      <div className="min-w-0 flex-1">
-        <div className="truncate text-sm font-medium text-foreground">{label}</div>
-        <div className="mt-0.5 flex items-center gap-1.5 truncate font-mono text-2xs text-muted-foreground">
+    <ListRow
+      data-testid={`github-pr-${pr.pr_number}`}
+      leading={<Icon name="review" className="text-muted-foreground" />}
+      title={label}
+      meta={
+        <span className="flex items-center gap-1.5 truncate font-mono">
           <a
             data-testid={`github-pr-link-${pr.pr_number}`}
             href={`https://github.com/${pr.repo}/pull/${pr.pr_number}`}
@@ -35,24 +37,22 @@ export function PrPreviewRow({ pr }: { pr: PrPreview }) {
           <span className="truncate">{pr.repo}</span>
           <span aria-hidden>·</span>
           {active ? (
-            <span className="inline-flex items-center gap-1 text-primary">
-              {/* Decorative — the "syncing…" text right here announces the state. */}
-              <Spinner role="presentation" aria-label={undefined} className="size-3 shrink-0" />
-              syncing…
-            </span>
+            <StatusBadge tone="busy">syncing…</StatusBadge>
           ) : (
             <span>
               {pr.file_count} doc{pr.file_count === 1 ? "" : "s"}
               {pr.last_synced_at ? ` · synced ${ago(pr.last_synced_at)}` : ""}
             </span>
           )}
-        </div>
-      </div>
-      <Button data-testid={`github-pr-view-${pr.pr_number}`} variant="outline" size="sm" asChild>
-        <Link to="/" search={{ collection: pr.collection_id }}>
-          View
-        </Link>
-      </Button>
-    </div>
+        </span>
+      }
+      actions={
+        <Button data-testid={`github-pr-view-${pr.pr_number}`} variant="outline" size="sm" asChild>
+          <Link to="/" search={{ collection: pr.collection_id }}>
+            View
+          </Link>
+        </Button>
+      }
+    />
   )
 }

--- a/apps/web/src/pages/settings/github-repo-row.tsx
+++ b/apps/web/src/pages/settings/github-repo-row.tsx
@@ -1,6 +1,7 @@
 import { AlertTriangle, CheckCircle2 } from "lucide-react"
 import { useEffect, useRef, useState } from "react"
 import { api, parseProgress, type RepoSource, type SyncProgress, type SyncStatus } from "@/api"
+import { ListRow } from "@/components/shared/list-row"
 import { Spinner } from "@/components/shared/spinner"
 import { StatusPanel } from "@/components/shared/status-panel"
 import { Button } from "@/components/ui/button"
@@ -127,145 +128,154 @@ export function RepoSourceRow({ source, onDone }: { source: RepoSource; onDone: 
   const indeterminate = active && (!prog || prog.total === 0)
 
   return (
-    <div data-testid={`github-row-${source.id}`} className="flex flex-col gap-3 py-3">
-      <div className="flex items-center gap-2.5">
-        <div className="min-w-0 flex-1">
-          <div className="truncate font-mono text-sm text-foreground">
-            {source.repo}
-            <span className="text-muted-foreground"> · {source.ref}</span>
-            {source.installation_id && <span className="text-muted-foreground"> · app</span>}
-          </div>
-          {!active && !errored && (
-            <div className="mt-px flex items-center gap-1 truncate font-mono text-2xs text-muted-foreground">
-              {(status.last_status?.startsWith("ok") || status.last_synced_at) && (
-                <CheckCircle2 className="size-3 shrink-0 text-success" aria-hidden />
-              )}
-              {status.file_count} doc{status.file_count === 1 ? "" : "s"}
-              {status.last_synced_at
-                ? ` · synced ${ago(status.last_synced_at)}`
-                : " · never synced"}
+    <ListRow
+      data-testid={`github-row-${source.id}`}
+      mono
+      title={
+        <>
+          {source.repo}
+          <span className="text-muted-foreground"> · {source.ref}</span>
+          {source.installation_id && <span className="text-muted-foreground"> · app</span>}
+        </>
+      }
+      meta={
+        !active && !errored ? (
+          <span className="flex items-center gap-1 truncate font-mono">
+            {(status.last_status?.startsWith("ok") || status.last_synced_at) && (
+              <CheckCircle2 className="size-3 shrink-0 text-success" aria-hidden />
+            )}
+            {status.file_count} doc{status.file_count === 1 ? "" : "s"}
+            {status.last_synced_at ? ` · synced ${ago(status.last_synced_at)}` : " · never synced"}
+          </span>
+        ) : undefined
+      }
+      actions={
+        <>
+          <Button
+            data-testid={`github-sync-${source.id}`}
+            variant="ghost"
+            size="sm"
+            onClick={() => sync.mutate()}
+            disabled={active}
+          >
+            {active ? "Syncing…" : "Sync now"}
+          </Button>
+          <Button
+            data-testid={`github-remove-${source.id}`}
+            variant="destructive-ghost"
+            size="sm"
+            onClick={() => setDisconnectDialog(true)}
+          >
+            Disconnect
+          </Button>
+        </>
+      }
+      below={
+        <>
+          {/* Hand-rolled on purpose: a two-outcome CHOICE (keep vs delete the synced docs), not a
+              yes/no confirm — ConfirmDialog has no second verb. */}
+          {disconnectDialog && (
+            <Dialog open onOpenChange={(o) => !o && setDisconnectDialog(false)}>
+              <DialogContent>
+                <DialogHeader>
+                  <DialogTitle>Disconnect {source.repo}?</DialogTitle>
+                  <DialogDescription>
+                    Choose what happens to the {status.file_count} synced doc
+                    {status.file_count === 1 ? "" : "s"}.
+                  </DialogDescription>
+                </DialogHeader>
+                <div className="mt-2 flex flex-col gap-2">
+                  <Button
+                    variant="outline"
+                    disabled={remove.isPending}
+                    data-testid={`github-disconnect-keep-${source.id}`}
+                    onClick={() => remove.mutate(false)}
+                  >
+                    Keep docs — stop syncing, docs stay readable
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    disabled={remove.isPending}
+                    data-testid={`github-disconnect-wipe-${source.id}`}
+                    onClick={() => remove.mutate(true)}
+                  >
+                    {remove.isPending ? "Deleting…" : "Delete docs — remove all synced content"}
+                  </Button>
+                </div>
+              </DialogContent>
+            </Dialog>
+          )}
+
+          {/* ACTIVE — the giant, explicit progress block. Every phase named, live counts,
+              a clear %, and a standing reassurance that it runs on the server. */}
+          {active && prog && (
+            <div
+              className="flex flex-col gap-2 rounded-lg border border-primary/30 bg-primary/5 p-3"
+              data-testid={`github-progress-${source.id}`}
+            >
+              <div className="flex items-center justify-between gap-2">
+                <div className="flex min-w-0 items-center gap-2 text-sm font-medium text-foreground">
+                  {/* Decorative — the phase headline beside it announces the state. */}
+                  <Spinner role="presentation" aria-label={undefined} className="size-4 shrink-0" />
+                  <span className="truncate">{phaseHeadline(prog, source.repo)}</span>
+                </div>
+                {!indeterminate && (
+                  <span className="shrink-0 font-mono text-sm font-medium tabular-nums text-primary">
+                    {pct}%
+                  </span>
+                )}
+              </div>
+
+              <div className="h-2.5 w-full overflow-hidden rounded-full bg-secondary">
+                <div
+                  className={`h-full rounded-full bg-primary transition-[width] duration-500 ${indeterminate ? "w-1/3 animate-pulse" : ""}`}
+                  style={indeterminate ? undefined : { width: `${pct}%` }}
+                />
+              </div>
+
+              <div
+                className="font-mono text-2xs text-muted-foreground"
+                data-testid={`github-progress-detail-${source.id}`}
+              >
+                {phaseDetail(prog)}
+              </div>
+
+              <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
+                <CheckCircle2 className="size-3 shrink-0 text-muted-foreground" aria-hidden />
+                Running on our servers — you can close this tab, it’ll keep going.
+              </div>
             </div>
           )}
-        </div>
-        <Button
-          data-testid={`github-sync-${source.id}`}
-          variant="outline"
-          size="sm"
-          onClick={() => sync.mutate()}
-          disabled={active}
-        >
-          {active ? "Syncing…" : "Sync now"}
-        </Button>
-        <Button
-          data-testid={`github-remove-${source.id}`}
-          variant="destructive-ghost"
-          size="sm"
-          onClick={() => setDisconnectDialog(true)}
-        >
-          Disconnect
-        </Button>
-      </div>
 
-      {disconnectDialog && (
-        <Dialog open onOpenChange={(o) => !o && setDisconnectDialog(false)}>
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>Disconnect {source.repo}?</DialogTitle>
-              <DialogDescription>
-                Choose what happens to the {status.file_count} synced doc
-                {status.file_count === 1 ? "" : "s"}.
-              </DialogDescription>
-            </DialogHeader>
-            <div className="mt-2 flex flex-col gap-2">
-              <Button
-                variant="outline"
-                disabled={remove.isPending}
-                data-testid={`github-disconnect-keep-${source.id}`}
-                onClick={() => remove.mutate(false)}
-              >
-                Keep docs — stop syncing, docs stay readable
-              </Button>
-              <Button
-                variant="destructive"
-                disabled={remove.isPending}
-                data-testid={`github-disconnect-wipe-${source.id}`}
-                onClick={() => remove.mutate(true)}
-              >
-                {remove.isPending ? "Deleting…" : "Delete docs — remove all synced content"}
-              </Button>
+          {/* ERROR — danger callout with the message and a one-click retry. */}
+          {errored && !active && (
+            <div data-testid={`github-error-${source.id}`}>
+              <StatusPanel
+                tone="danger"
+                layout="inline"
+                icon={<AlertTriangle aria-hidden />}
+                className="p-3"
+                title="Sync failed"
+                description={
+                  <span className="break-words font-mono text-2xs">
+                    {prog?.message ?? status.last_status ?? "Unknown error"}
+                  </span>
+                }
+                action={
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => sync.mutate()}
+                    data-testid={`github-retry-${source.id}`}
+                  >
+                    Try again
+                  </Button>
+                }
+              />
             </div>
-          </DialogContent>
-        </Dialog>
-      )}
-
-      {/* ACTIVE — the giant, explicit progress block. Every phase named, live counts,
-          a clear %, and a standing reassurance that it runs on the server. */}
-      {active && prog && (
-        <div
-          className="flex flex-col gap-2 rounded-lg border border-primary/30 bg-primary/5 p-3"
-          data-testid={`github-progress-${source.id}`}
-        >
-          <div className="flex items-center justify-between gap-2">
-            <div className="flex min-w-0 items-center gap-2 text-sm font-medium text-foreground">
-              {/* Decorative — the phase headline beside it announces the state. */}
-              <Spinner role="presentation" aria-label={undefined} className="size-4 shrink-0" />
-              <span className="truncate">{phaseHeadline(prog, source.repo)}</span>
-            </div>
-            {!indeterminate && (
-              <span className="shrink-0 font-mono text-sm font-medium tabular-nums text-primary">
-                {pct}%
-              </span>
-            )}
-          </div>
-
-          <div className="h-2.5 w-full overflow-hidden rounded-full bg-secondary">
-            <div
-              className={`h-full rounded-full bg-primary transition-[width] duration-500 ${indeterminate ? "w-1/3 animate-pulse" : ""}`}
-              style={indeterminate ? undefined : { width: `${pct}%` }}
-            />
-          </div>
-
-          <div
-            className="font-mono text-2xs text-muted-foreground"
-            data-testid={`github-progress-detail-${source.id}`}
-          >
-            {phaseDetail(prog)}
-          </div>
-
-          <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
-            <CheckCircle2 className="size-3 shrink-0 text-muted-foreground" aria-hidden />
-            Running on our servers — you can close this tab, it’ll keep going.
-          </div>
-        </div>
-      )}
-
-      {/* ERROR — danger callout with the message and a one-click retry. */}
-      {errored && !active && (
-        <div data-testid={`github-error-${source.id}`}>
-          <StatusPanel
-            tone="danger"
-            layout="inline"
-            icon={<AlertTriangle aria-hidden />}
-            className="p-3"
-            title="Sync failed"
-            description={
-              <span className="break-words font-mono text-2xs">
-                {prog?.message ?? status.last_status ?? "Unknown error"}
-              </span>
-            }
-            action={
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => sync.mutate()}
-                data-testid={`github-retry-${source.id}`}
-              >
-                Try again
-              </Button>
-            }
-          />
-        </div>
-      )}
-    </div>
+          )}
+        </>
+      }
+    />
   )
 }

--- a/apps/web/src/pages/settings/github-section.tsx
+++ b/apps/web/src/pages/settings/github-section.tsx
@@ -5,8 +5,9 @@ import { EmptyState } from "@/components/shared/empty-state"
 import { LoadError } from "@/components/shared/load-error"
 import { SettingsGroup } from "@/components/shared/settings-group"
 import { toast } from "@/components/ui/sonner"
+import { useOneShotParams } from "@/lib/use-one-shot-params"
 import { AdvancedPat } from "./github-advanced-pat"
-import { ConnectViaApp, SetUpApp, takeInstallParams } from "./github-install-flow"
+import { ConnectViaApp, SetUpApp } from "./github-install-flow"
 import { PrPreviewRow } from "./github-pr-preview"
 import { RepoPicker } from "./github-repo-picker"
 import { RepoSourceRow } from "./github-repo-row"
@@ -48,11 +49,12 @@ export function GithubSection() {
   }, [])
 
   // After the GitHub redirect (?gh_install / ?gh_error), open the picker or toast.
+  const { gh_install: ghInstall, gh_error: ghError } = useOneShotParams("gh_install", "gh_error")
   useEffect(() => {
-    const { install, error } = takeInstallParams()
-    if (error) toast.error(error === "install_expired" ? "Install link expired" : "Install failed") // mutation-ignore: OAuth ?gh_error redirect param, not a mutation
-    if (install) setPickerInstall(install)
-  }, [])
+    if (ghError)
+      toast.error(ghError === "install_expired" ? "Install link expired" : "Install failed") // mutation-ignore: OAuth ?gh_error redirect param, not a mutation
+    if (ghInstall) setPickerInstall(ghInstall)
+  }, [ghInstall, ghError])
 
   // Onboarding shortcut: an App is configured and installed but no repo is connected
   // yet → open the picker for the first installation so the user goes straight to

--- a/apps/web/src/pages/settings/integrations-section.tsx
+++ b/apps/web/src/pages/settings/integrations-section.tsx
@@ -12,6 +12,7 @@ import { toast } from "@/components/ui/sonner"
 import { Switch } from "@/components/ui/switch"
 import { slackQuery, workspaceSettingsQuery } from "@/lib/queries"
 import { snapshot, useApiMutation } from "@/lib/use-api-mutation"
+import { useOneShotParams } from "@/lib/use-one-shot-params"
 import { SettingsListSkeleton } from "./settings-list-skeleton"
 import { SettingsSection } from "./settings-section"
 import { SlackSubscriptionsSection } from "./slack-subscriptions-section"
@@ -44,17 +45,6 @@ const SLACK_INSTALL_ERRORS: Record<string, { title: string; description: string 
   oauth: DEFAULT_SLACK_INSTALL_ERROR,
 }
 
-// Read the one-shot callback result without mutating browser state during render.
-// The effect below clears it after mount and invalidates any restored Slack cache.
-const readSlackInstallResult = (): SlackInstallResult => {
-  if (typeof window === "undefined") return null
-  const qs = new URLSearchParams(window.location.search)
-  const connected = qs.get("slack_connected") === "1"
-  const error = qs.get("slack_error")
-  if (!connected && !error) return null
-  return connected ? { connected: true } : { connected: false, error: error ?? "oauth" }
-}
-
 // The workspace activity toggles (email + GitHub mirroring) plus the Slack connection.
 // Where Slack posts is per-channel now — see slack-subscriptions-section.tsx. Toggles apply optimistically
 // with no save (the toggle contract); the Slack channel id is an explicit save.
@@ -62,7 +52,18 @@ export function IntegrationsSection() {
   const qc = useQueryClient()
   const { data: settings, isPending, isError, refetch } = useQuery(workspaceSettingsQuery())
   const { data: slack, isFetching: slackIsFetching } = useQuery(slackQuery())
-  const [installResult] = useState(readSlackInstallResult)
+  // The one-shot callback result the Slack OAuth flow lands back on.
+  const { slack_connected: slackConnected, slack_error: slackError } = useOneShotParams(
+    "slack_connected",
+    "slack_error",
+  )
+  const [installResult] = useState<SlackInstallResult>(() =>
+    slackConnected === "1"
+      ? { connected: true }
+      : slackError
+        ? { connected: false, error: slackError }
+        : null,
+  )
   const installError =
     installResult && !installResult.connected
       ? (SLACK_INSTALL_ERRORS[installResult.error] ?? DEFAULT_SLACK_INSTALL_ERROR)
@@ -71,20 +72,8 @@ export function IntegrationsSection() {
 
   useEffect(() => {
     if (!installResult) return
-    const cleanupUrl = window.setTimeout(() => {
-      const qs = new URLSearchParams(window.location.search)
-      qs.delete("slack_connected")
-      qs.delete("slack_error")
-      const rest = qs.toString()
-      window.history.replaceState(
-        window.history.state,
-        "",
-        `${window.location.pathname}${rest ? `?${rest}` : ""}`,
-      )
-    }, 0)
     void qc.invalidateQueries({ queryKey: slackQuery().queryKey })
     if (installResult.connected) toast.success("Slack connected")
-    return () => window.clearTimeout(cleanupUrl)
   }, [installResult, qc])
 
   // Toggle a single settings key, optimistically flipping the shared cache entry so the
@@ -198,7 +187,19 @@ export function IntegrationsSection() {
         </SettingsGroup>
       ) : null}
 
-      <SettingsGroup title="Slack">
+      <SettingsGroup
+        title="Slack"
+        description={
+          slack?.connected ? (
+            <>
+              Connected to{" "}
+              <span className="font-medium">{slack.team_name ?? "your Slack workspace"}</span>.
+              Choose which channels hear about what under <strong>Slack channels</strong> below, or
+              run <code>/derive subscribe</code> in the channel itself.
+            </>
+          ) : undefined
+        }
+      >
         {installError && installResult && !installResult.connected && (
           <StatusPanel
             tone={installResult.error === "canceled" ? "warning" : "danger"}
@@ -246,23 +247,20 @@ export function IntegrationsSection() {
             }
           />
         ) : slack?.connected ? (
-          <div className="flex flex-col gap-4 py-1">
-            <p className="text-sm">
-              Connected to{" "}
-              <span className="font-medium">{slack.team_name ?? "your Slack workspace"}</span>.
-            </p>
+          <>
             {slack.needs_reauth && (
-              <div
-                data-testid="slack-reauth-banner"
-                className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm"
-              >
-                Derive can't use the saved Slack connection (the app may have been removed or its
-                token revoked, or it needs a permission that was added since. Reconnect to fix it.
-                <div className="mt-2">
-                  <Button data-testid="slack-reconnect" variant="default" size="sm" asChild>
-                    <a href="/v1/slack/install">Reconnect Slack</a>
-                  </Button>
-                </div>
+              <div data-testid="slack-reauth-banner">
+                <StatusPanel
+                  tone="danger"
+                  layout="inline"
+                  title="Derive can't use the saved Slack connection"
+                  description="The app may have been removed or its token revoked, or it needs a permission that was added since. Reconnect to fix it."
+                  action={
+                    <Button data-testid="slack-reconnect" variant="default" size="sm" asChild>
+                      <a href="/v1/slack/install">Reconnect Slack</a>
+                    </Button>
+                  }
+                />
               </div>
             )}
             <SettingRow
@@ -312,24 +310,18 @@ export function IntegrationsSection() {
                 </Button>
               )}
             </SettingRow>
-            <p className="text-sm text-muted-foreground">
-              Choose which channels hear about what under <strong>Slack channels</strong> below, or
-              run <code>/derive subscribe</code> in the channel itself.
-            </p>
-            <div>
-              <div className="flex flex-wrap items-center gap-2">
-                <Button data-testid="slack-change-workspace" variant="outline" size="sm" asChild>
-                  <a href="/v1/slack/install">Change Slack workspace</a>
-                </Button>
-                <Button
-                  data-testid="slack-disconnect"
-                  variant="destructive-ghost"
-                  size="sm"
-                  onClick={() => setDisconnecting(true)}
-                >
-                  Disconnect Slack
-                </Button>
-              </div>
+            <div className="flex flex-wrap items-center gap-2 py-3.5">
+              <Button data-testid="slack-change-workspace" variant="outline" size="sm" asChild>
+                <a href="/v1/slack/install">Change Slack workspace</a>
+              </Button>
+              <Button
+                data-testid="slack-disconnect"
+                variant="destructive-ghost"
+                size="sm"
+                onClick={() => setDisconnecting(true)}
+              >
+                Disconnect Slack
+              </Button>
             </div>
             <ConfirmDialog
               open={disconnecting}
@@ -340,7 +332,7 @@ export function IntegrationsSection() {
               onConfirm={disconnectSlack}
               confirmTestId="slack-disconnect-confirm"
             />
-          </div>
+          </>
         ) : (
           <div className="flex flex-col items-start gap-3 py-1">
             <p className="text-sm text-muted-foreground">

--- a/apps/web/src/pages/settings/members-section.tsx
+++ b/apps/web/src/pages/settings/members-section.tsx
@@ -2,7 +2,9 @@ import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
 import { useRef, useState } from "react"
 import { type ArtifactMember, api, type BillingInfo, type Role } from "@/api"
+import { AdminNote } from "@/components/shared/admin-note"
 import { ConfirmDialog } from "@/components/shared/confirm-dialog"
+import { ListRow } from "@/components/shared/list-row"
 import { LoadError } from "@/components/shared/load-error"
 import { PersonSearchInput } from "@/components/shared/person-search-input"
 import { SettingsGroup } from "@/components/shared/settings-group"
@@ -21,6 +23,7 @@ import { copyText } from "@/lib/clipboard"
 import { getInitials } from "@/lib/initials"
 import { billingQuery, workspaceInvitesQuery, workspaceQuery } from "@/lib/queries"
 import { useApiMutation } from "@/lib/use-api-mutation"
+import { AddForm } from "./add-form"
 import { FREE_SEAT_LIMIT, needsSeatConfirm, PLANS, unitPrice } from "./billing-plans"
 import { roleLabel, roleValue, WS_ROLES } from "./roles"
 import { SettingsListSkeleton } from "./settings-list-skeleton"
@@ -97,8 +100,7 @@ export function MembersSection({ meId }: { meId: string }) {
       },
     )
   }
-  const addMember = (e: React.FormEvent) => {
-    e.preventDefault()
+  const addMember = () => {
     if (addingRef.current || invite.isPending) return
     const em = email.trim()
     if (!em) return
@@ -165,8 +167,14 @@ export function MembersSection({ meId }: { meId: string }) {
       title="Members"
       description="Who's in this workspace and what they can do. Admins add people, Creators publish artifacts, Viewers read and comment."
     >
-      {isAdmin && (
-        <form onSubmit={addMember} className="flex flex-wrap gap-2">
+      {isAdmin ? (
+        <AddForm
+          onSubmit={addMember}
+          submitLabel="Add"
+          submitTestId="member-add"
+          pending={invite.isPending}
+          disabled={!email.trim()}
+        >
           <PersonSearchInput
             value={email}
             onChange={setEmail}
@@ -191,17 +199,9 @@ export function MembersSection({ meId }: { meId: string }) {
               ))}
             </SelectContent>
           </Select>
-          <Button
-            data-testid="member-add"
-            type="submit"
-            variant="secondary"
-            size="sm"
-            loading={invite.isPending}
-            disabled={invite.isPending || !email.trim()}
-          >
-            {invite.isPending ? "Adding…" : "Add"}
-          </Button>
-        </form>
+        </AddForm>
+      ) : (
+        <AdminNote can="invite people" />
       )}
 
       {billing &&
@@ -230,62 +230,70 @@ export function MembersSection({ meId }: { meId: string }) {
       ) : ws ? (
         <SettingsGroup>
           {ws.members.map((m) => (
-            <div
+            <ListRow
               key={m.user_id}
               data-testid={`member-row-${m.user_id}`}
-              className="flex items-center gap-3 py-3"
-            >
-              <Avatar className="size-7 shrink-0">
-                <AvatarFallback>{getInitials(m.name ?? m.handle ?? m.user_id)}</AvatarFallback>
-              </Avatar>
-              <div className="min-w-0 flex-1">
-                <div className="truncate text-sm font-medium text-foreground">
+              leading={
+                <Avatar className="size-7 shrink-0">
+                  <AvatarFallback>{getInitials(m.name ?? m.handle ?? m.user_id)}</AvatarFallback>
+                </Avatar>
+              }
+              title={
+                // block+truncate: a node title opts out of ListRow's string-only
+                // truncation, and the user_id fallback is one unbroken token.
+                <span className="block truncate">
                   {m.name ?? (m.handle ? `@${m.handle}` : m.user_id)}
                   {m.user_id === meId && (
                     <span className="font-normal text-muted-foreground"> (you)</span>
                   )}
-                </div>
-                {m.handle && m.name && (
-                  <div className="truncate font-mono text-2xs text-muted-foreground">
+                </span>
+              }
+              meta={
+                m.handle && m.name ? (
+                  <span className="block truncate font-mono">
                     @{m.handle}
                     {m.profession ? ` · ${m.profession}` : ""}
-                  </div>
-                )}
-              </div>
-              {isAdmin ? (
-                <Select
-                  value={roleValue(m.role)}
-                  onValueChange={(v) => requestRoleChange(m, v as Role)}
-                >
-                  <SelectTrigger
-                    data-testid={`member-role-${m.user_id}`}
-                    aria-label={`Role for ${m.name ?? (m.handle ? `@${m.handle}` : "member")}`}
-                    className="w-32.5 shrink-0"
-                  >
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {WS_ROLES.map((r) => (
-                      <SelectItem key={r.value} value={r.value}>
-                        {r.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              ) : (
-                <Badge variant="secondary">{roleLabel(m.role)}</Badge>
-              )}
-              {isAdmin && (
-                <Button
-                  data-testid={`member-remove-${m.user_id}`}
-                  variant="destructive-ghost"
-                  size="sm"
-                  onClick={() => setRemoving(m)}
-                >
-                  Remove
-                </Button>
-              )}
-            </div>
+                  </span>
+                ) : undefined
+              }
+              actions={
+                <>
+                  {isAdmin ? (
+                    <Select
+                      value={roleValue(m.role)}
+                      onValueChange={(v) => requestRoleChange(m, v as Role)}
+                    >
+                      <SelectTrigger
+                        data-testid={`member-role-${m.user_id}`}
+                        aria-label={`Role for ${m.name ?? (m.handle ? `@${m.handle}` : "member")}`}
+                        className="w-32.5 shrink-0"
+                      >
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {WS_ROLES.map((r) => (
+                          <SelectItem key={r.value} value={r.value}>
+                            {r.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  ) : (
+                    <Badge variant="secondary">{roleLabel(m.role)}</Badge>
+                  )}
+                  {isAdmin && (
+                    <Button
+                      data-testid={`member-remove-${m.user_id}`}
+                      variant="destructive-ghost"
+                      size="sm"
+                      onClick={() => setRemoving(m)}
+                    >
+                      Remove
+                    </Button>
+                  )}
+                </>
+              }
+            />
           ))}
         </SettingsGroup>
       ) : null}
@@ -354,31 +362,28 @@ function PendingInvites() {
   if (!invites || invites.length === 0) return null
 
   return (
-    <div className="flex flex-col gap-2">
-      <div className="text-sm font-medium text-muted-foreground">Pending invitations</div>
-      <SettingsGroup>
-        {invites.map((inv) => (
-          <div
-            key={inv.id}
-            data-testid={`invite-row-${inv.id}`}
-            className="flex items-center gap-3 py-3"
-          >
-            <div className="min-w-0 flex-1">
-              <div className="truncate text-sm font-medium text-foreground">{inv.email}</div>
-              <div className="text-2xs text-muted-foreground">Invited as {roleLabel(inv.role)}</div>
-            </div>
-            <Badge variant="outline">Pending</Badge>
-            <Button
-              data-testid={`invite-revoke-${inv.id}`}
-              variant="destructive-ghost"
-              size="sm"
-              onClick={() => revoke(inv.id)}
-            >
-              Revoke
-            </Button>
-          </div>
-        ))}
-      </SettingsGroup>
-    </div>
+    <SettingsGroup title="Pending invitations">
+      {invites.map((inv) => (
+        <ListRow
+          key={inv.id}
+          data-testid={`invite-row-${inv.id}`}
+          title={inv.email}
+          meta={`Invited as ${roleLabel(inv.role)}`}
+          actions={
+            <>
+              <Badge variant="outline">Pending</Badge>
+              <Button
+                data-testid={`invite-revoke-${inv.id}`}
+                variant="destructive-ghost"
+                size="sm"
+                onClick={() => revoke(inv.id)}
+              >
+                Revoke
+              </Button>
+            </>
+          }
+        />
+      ))}
+    </SettingsGroup>
   )
 }

--- a/apps/web/src/pages/settings/model-plan-manager.tsx
+++ b/apps/web/src/pages/settings/model-plan-manager.tsx
@@ -3,6 +3,7 @@ import { useState } from "react"
 import { api, type ModelCredentialHint } from "@/api"
 import { ConfirmDialog } from "@/components/shared/confirm-dialog"
 import { EmptyState } from "@/components/shared/empty-state"
+import { ListRow } from "@/components/shared/list-row"
 import { LoadError } from "@/components/shared/load-error"
 import { SettingsGroup } from "@/components/shared/settings-group"
 import { Badge } from "@/components/ui/badge"
@@ -88,7 +89,7 @@ export function ModelPlanManager({ scope }: { scope: Scope }) {
 
   return (
     <>
-      <div className="rounded-lg border bg-card p-4">
+      <div className="rounded-lg bg-secondary p-4">
         <ConnectForm connect={connect} prefix={prefix} onConnected={reload} />
       </div>
 
@@ -221,7 +222,7 @@ function ConnectForm({
           loading={connect.isPending}
           disabled={connect.isPending || !ready}
         >
-          {connect.isPending ? "Connecting…" : "Connect"}
+          Connect
         </Button>
       </div>
     </div>
@@ -246,33 +247,35 @@ function CredentialRow({
     onSuccess: () => onDone(),
   })
   return (
-    <div
+    <ListRow
       data-testid={`${prefix}-row-${cred.provider}`}
-      className="flex items-center gap-3 py-3 text-sm"
-    >
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-1.5 font-medium text-foreground">
+      title={
+        <span className="flex items-center gap-1.5">
           {providerLabel(cred.provider)}
           <Badge variant="outline">{kindLabel(cred.provider, cred.kind)}</Badge>
-        </div>
-        <div className="font-mono text-2xs text-muted-foreground">connected · ••••{cred.hint}</div>
-      </div>
-      <Button
-        data-testid={`${prefix}-disconnect-${cred.provider}`}
-        variant="destructive-ghost"
-        size="sm"
-        onClick={() => setConfirming(true)}
-      >
-        Disconnect
-      </Button>
-      <ConfirmDialog
-        open={confirming}
-        onOpenChange={setConfirming}
-        title="Disconnect this plan?"
-        description="Runs that relied on it will stop until it is reconnected."
-        confirmLabel="Disconnect"
-        onConfirm={() => remove.mutate()}
-      />
-    </div>
+        </span>
+      }
+      meta={<span className="font-mono">connected · ••••{cred.hint}</span>}
+      actions={
+        <>
+          <Button
+            data-testid={`${prefix}-disconnect-${cred.provider}`}
+            variant="destructive-ghost"
+            size="sm"
+            onClick={() => setConfirming(true)}
+          >
+            Disconnect
+          </Button>
+          <ConfirmDialog
+            open={confirming}
+            onOpenChange={setConfirming}
+            title="Disconnect this plan?"
+            description="Runs that relied on it will stop until it is reconnected."
+            confirmLabel="Disconnect"
+            onConfirm={() => remove.mutate()}
+          />
+        </>
+      }
+    />
   )
 }

--- a/apps/web/src/pages/settings/models-section.tsx
+++ b/apps/web/src/pages/settings/models-section.tsx
@@ -9,6 +9,7 @@ import { Input } from "@/components/ui/input"
 import { modelLibraryQuery } from "@/lib/queries"
 import { useApiMutation } from "@/lib/use-api-mutation"
 import { cn } from "@/lib/utils"
+import { AddForm } from "./add-form"
 import { SettingsSection } from "./settings-section"
 
 // THE MODEL LIBRARY — which models this deployment can answer with, which one serves which lane,
@@ -210,13 +211,18 @@ export function ModelsSection() {
               />
             ))}
             {data?.can_add && (
-              <form
-                className="flex flex-wrap items-center gap-2 py-3"
-                onSubmit={(e) => {
-                  e.preventDefault()
+              <AddForm
+                className="py-3.5"
+                onSubmit={() => {
                   const id = newId.trim()
                   if (id) add.mutate(id)
                 }}
+                // It is probed before it is saved, so the wait is a real call to the provider
+                // and saying "Add" alone would under-describe what is happening.
+                submitLabel="Add and probe"
+                submitTestId="add-model"
+                pending={add.isPending}
+                disabled={!newId.trim()}
               >
                 <Input
                   value={newId}
@@ -227,17 +233,7 @@ export function ModelsSection() {
                   className="min-w-56 flex-1 font-mono text-xs"
                   data-testid="add-model-id"
                 />
-                <Button
-                  type="submit"
-                  size="sm"
-                  disabled={!newId.trim() || add.isPending}
-                  data-testid="add-model"
-                >
-                  {/* It is probed before it is saved, so the wait is a real call to the provider
-                      and saying "Add" alone would under-describe what is happening. */}
-                  {add.isPending ? "Probing…" : "Add and probe"}
-                </Button>
-              </form>
+              </AddForm>
             )}
           </SettingsGroup>
         </>
@@ -320,7 +316,7 @@ function Row({
   const [editing, setEditing] = useState(false)
   const [label, setLabel] = useState(model.label)
   return (
-    <div className="flex flex-wrap items-start gap-3 py-3">
+    <div className="flex flex-wrap items-start gap-3 py-3.5">
       <div className="min-w-0 flex-1">
         <div className="text-sm font-medium text-foreground">
           {editing ? (
@@ -403,7 +399,7 @@ function Row({
         {model.removable && (
           <Button
             size="sm"
-            variant="ghost"
+            variant="destructive-ghost"
             disabled={busy}
             onClick={onRemove}
             data-testid={`remove-model-${model.id}`}

--- a/apps/web/src/pages/settings/reports-section.tsx
+++ b/apps/web/src/pages/settings/reports-section.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react"
 import { api, type Report } from "@/api"
 import { ConfirmDialog } from "@/components/shared/confirm-dialog"
+import { ListRow } from "@/components/shared/list-row"
 import { SettingsGroup } from "@/components/shared/settings-group"
 import { Button } from "@/components/ui/button"
 import { useApiMutation } from "@/lib/use-api-mutation"
@@ -32,46 +33,55 @@ function ReportRow({ report, onDone }: { report: Report; onDone: () => void }) {
     onSuccess: () => onDone(),
   })
   return (
-    <div data-testid={`report-row-${report.id}`} className="flex flex-wrap items-start gap-3 py-3">
-      <div className="min-w-0 flex-1">
-        <div className="text-sm font-medium text-foreground">
-          {report.reason}{" "}
-          <a
-            href={`/artifacts/${report.artifact_short_id}`}
-            className="font-mono text-2xs font-medium text-primary"
-          >
-            {report.artifact_short_id}
-          </a>
-        </div>
-        {report.detail && (
-          <div className="mt-0.5 text-sm text-pretty text-muted-foreground">{report.detail}</div>
-        )}
-        <div className="mt-1 font-mono text-2xs text-muted-foreground">
-          {report.reporter ? `reported from ${report.reporter}` : "reported anonymously"}
-        </div>
-      </div>
-      <div className="flex shrink-0 items-center gap-2">
-        <Button
-          data-testid={`report-dismiss-${report.id}`}
-          variant="outline"
-          size="sm"
-          disabled={act.isPending}
-          onClick={() =>
-            act.mutate({ fn: () => api.dismissReport(report.id), msg: "Report dismissed" })
-          }
-        >
-          Dismiss
-        </Button>
-        <Button
-          data-testid={`report-takedown-${report.id}`}
-          variant="destructive-ghost"
-          size="sm"
-          disabled={act.isPending}
-          onClick={() => setConfirming(true)}
-        >
-          Take down
-        </Button>
-      </div>
+    <>
+      <ListRow
+        data-testid={`report-row-${report.id}`}
+        title={
+          <>
+            {report.reason}{" "}
+            <a
+              href={`/artifacts/${report.artifact_short_id}`}
+              className="font-mono text-2xs font-medium text-primary"
+            >
+              {report.artifact_short_id}
+            </a>
+          </>
+        }
+        meta={
+          <>
+            {report.detail && (
+              <div className="text-sm text-pretty text-muted-foreground">{report.detail}</div>
+            )}
+            <div className="font-mono">
+              {report.reporter ? `reported from ${report.reporter}` : "reported anonymously"}
+            </div>
+          </>
+        }
+        actions={
+          <>
+            <Button
+              data-testid={`report-dismiss-${report.id}`}
+              variant="ghost"
+              size="sm"
+              disabled={act.isPending}
+              onClick={() =>
+                act.mutate({ fn: () => api.dismissReport(report.id), msg: "Report dismissed" })
+              }
+            >
+              Dismiss
+            </Button>
+            <Button
+              data-testid={`report-takedown-${report.id}`}
+              variant="destructive-ghost"
+              size="sm"
+              disabled={act.isPending}
+              onClick={() => setConfirming(true)}
+            >
+              Take down
+            </Button>
+          </>
+        }
+      />
       <ConfirmDialog
         open={confirming}
         onOpenChange={setConfirming}
@@ -83,6 +93,6 @@ function ReportRow({ report, onDone }: { report: Report; onDone: () => void }) {
           act.mutate({ fn: () => api.takedown(report.artifact_id), msg: "Artifact taken down" })
         }
       />
-    </div>
+    </>
   )
 }

--- a/apps/web/src/pages/settings/security-section.tsx
+++ b/apps/web/src/pages/settings/security-section.tsx
@@ -6,7 +6,9 @@ import { type AuthCapabilities, api } from "@/api"
 import { ConfirmDialog } from "@/components/shared/confirm-dialog"
 import { EmptyState } from "@/components/shared/empty-state"
 import { FormField } from "@/components/shared/form-field"
+import { ListRow } from "@/components/shared/list-row"
 import { LoadError } from "@/components/shared/load-error"
+import { SecretReveal } from "@/components/shared/secret-reveal"
 import { SettingRow } from "@/components/shared/setting-row"
 import { SettingsGroup } from "@/components/shared/settings-group"
 import { StatusPanel } from "@/components/shared/status-panel"
@@ -31,7 +33,6 @@ import {
 import { toast } from "@/components/ui/sonner"
 import { useAuth } from "@/ctx"
 import { authClient } from "@/lib/auth-client"
-import { copyText } from "@/lib/clipboard"
 import { connectedAgentsQuery } from "@/lib/queries"
 import { useApiMutation } from "@/lib/use-api-mutation"
 import { SettingsListSkeleton } from "./settings-list-skeleton"
@@ -39,8 +40,8 @@ import { SettingsSection } from "./settings-section"
 
 // Account security — the home for the credentials that protect your account (and, since a
 // human's factor is the root of trust the agent-delegation chain hangs from, a first-class
-// surface). This phase: password + email/verification. Passkeys, active sessions, connected
-// accounts, 2FA, and delete-account land here in later phases.
+// surface): password + email/verification, passkeys, 2FA, connected agents, active
+// sessions, and delete-account.
 export function SecuritySection() {
   const { me } = useAuth()
   // What flows this instance actually supports (change-password/email only make sense where
@@ -108,48 +109,47 @@ function ConnectedAgents() {
   if (!isPending && !isError && (!agents || agents.length === 0)) return null
 
   return (
-    <div className="flex flex-col gap-3">
-      <div>
-        <div className="text-sm font-medium text-foreground">Connected agents</div>
-        <p className="text-sm text-muted-foreground">
-          Agents you've authorized to act on your behalf. Revoke any at any time.
-        </p>
-      </div>
+    <SettingsGroup
+      title="Connected agents"
+      description="Agents you've authorized to act on your behalf. Revoke any at any time."
+    >
       {isPending ? (
         <SettingsListSkeleton />
       ) : isError ? (
-        <LoadError
-          title="Couldn’t load connected agents"
-          testId="security-agents-retry"
-          onRetry={() => refetch()}
-        />
+        // Padding-neutral wrapper: SettingsGroup strips its first/last child's
+        // vertical padding (a row contract), which would squash this state.
+        <div>
+          <LoadError
+            title="Couldn’t load connected agents"
+            testId="security-agents-retry"
+            onRetry={() => refetch()}
+          />
+        </div>
       ) : (
-        <SettingsGroup>
-          {agents?.map((a) => {
-            const perms = a.scopes.map((s) => SCOPE_LABEL[s]).filter(Boolean)
-            return (
-              <div
-                key={a.clientId}
-                data-testid={`agent-conn-${a.clientId}`}
-                className="flex items-center gap-3 py-3"
-              >
-                <div className="min-w-0 flex-1">
-                  <div className="truncate text-sm font-medium text-foreground">{a.clientName}</div>
-                  <div className="mt-0.5 flex flex-wrap items-center gap-1">
-                    {perms.length > 0 ? (
-                      perms.map((p) => (
-                        <Badge key={p} variant="secondary">
-                          {p}
-                        </Badge>
-                      ))
-                    ) : (
-                      <span className="text-2xs text-muted-foreground">Read-only</span>
-                    )}
-                    <span className="text-2xs text-muted-foreground">
-                      · since {new Date(a.grantedAt).toLocaleDateString()}
-                    </span>
-                  </div>
+        agents?.map((a) => {
+          const perms = a.scopes.map((s) => SCOPE_LABEL[s]).filter(Boolean)
+          return (
+            <ListRow
+              key={a.clientId}
+              data-testid={`agent-conn-${a.clientId}`}
+              title={a.clientName}
+              meta={
+                <div className="flex flex-wrap items-center gap-1">
+                  {perms.length > 0 ? (
+                    perms.map((p) => (
+                      <Badge key={p} variant="secondary">
+                        {p}
+                      </Badge>
+                    ))
+                  ) : (
+                    <span className="text-2xs text-muted-foreground">Read-only</span>
+                  )}
+                  <span className="text-2xs text-muted-foreground">
+                    · since {new Date(a.grantedAt).toLocaleDateString()}
+                  </span>
                 </div>
+              }
+              actions={
                 <Button
                   data-testid={`agent-conn-revoke-${a.clientId}`}
                   variant="destructive-ghost"
@@ -158,10 +158,10 @@ function ConnectedAgents() {
                 >
                   Revoke
                 </Button>
-              </div>
-            )
-          })}
-        </SettingsGroup>
+              }
+            />
+          )
+        })
       )}
       {confirming && (
         <ConfirmDialog
@@ -173,7 +173,7 @@ function ConnectedAgents() {
           onConfirm={() => revoke(confirming)}
         />
       )}
-    </div>
+    </SettingsGroup>
   )
 }
 
@@ -457,49 +457,18 @@ function EnableTwoFactor({ onDone }: { onDone: () => Promise<void> }) {
               )}
             </div>
             {backup.length > 0 && (
-              <div className="flex flex-col gap-1.5">
-                <div className="text-sm font-medium text-foreground">
-                  Backup codes — save these somewhere safe
-                </div>
-                <div
-                  data-testid="2fa-backup-codes"
-                  className="grid grid-cols-2 gap-1 rounded-md bg-secondary px-2.5 py-2 font-mono text-2xs text-foreground"
-                >
-                  {backup.map((c) => (
-                    <span key={c}>{c}</span>
-                  ))}
-                </div>
-                <div className="flex items-center gap-1">
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    data-testid="2fa-copy-backup"
-                    onClick={() =>
-                      void copyText(backup.join("\n"), { success: "Backup codes copied" })
-                    }
-                  >
-                    Copy codes
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    data-testid="2fa-download-backup"
-                    onClick={() => {
-                      const blob = new Blob([`${backup.join("\n")}\n`], { type: "text/plain" })
-                      const url = URL.createObjectURL(blob)
-                      const a = document.createElement("a")
-                      a.href = url
-                      a.download = "derive-backup-codes.txt"
-                      a.click()
-                      URL.revokeObjectURL(url)
-                    }}
-                  >
-                    Download
-                  </Button>
-                </div>
-              </div>
+              // No onDone: the dialog flow owns dismissal. (SecretReveal's buttons
+              // are type="button", so the reveal is safe inside this confirm form.)
+              <SecretReveal
+                title="Backup codes — save these somewhere safe"
+                secret={backup}
+                copySuccess="Backup codes copied"
+                copyLabel="Copy codes"
+                downloadName="derive-backup-codes.txt"
+                copyTestId="2fa-copy-backup"
+                downloadTestId="2fa-download-backup"
+                secretTestId="2fa-backup-codes"
+              />
             )}
             <FormField label="Confirm a code from your app" htmlFor="tfa-code">
               <InputOTP
@@ -646,7 +615,7 @@ function Sessions() {
           isPending
             ? "Loading your signed-in devices…"
             : isError
-              ? "Couldn't load your sessions."
+              ? "Couldn’t load your sessions."
               : count <= 1
                 ? "You're signed in on this device only."
                 : `You're signed in on ${count} devices.`
@@ -731,9 +700,9 @@ function Passkeys() {
   const remove = (id: string) => removeMut.mutate(id)
 
   return (
-    <div className="flex flex-col gap-3">
-      <div className="flex items-center justify-between">
-        <div className="text-sm font-medium text-foreground">Passkeys</div>
+    <SettingsGroup
+      title="Passkeys"
+      action={
         <Button
           variant="secondary"
           size="sm"
@@ -743,34 +712,35 @@ function Passkeys() {
         >
           {adding ? "Waiting…" : "Add passkey"}
         </Button>
-      </div>
+      }
+    >
       {isPending ? (
         <SettingsListSkeleton />
       ) : isError ? (
-        <LoadError
-          layout="inline"
-          title="Couldn’t load your passkeys"
-          testId="passkeys-retry"
-          onRetry={() => refetch()}
-        />
+        // Padding-neutral wrappers: SettingsGroup strips its first/last child's
+        // vertical padding (a row contract), which would squash these states.
+        <div>
+          <LoadError
+            layout="inline"
+            title="Couldn’t load your passkeys"
+            testId="passkeys-retry"
+            onRetry={() => refetch()}
+          />
+        </div>
       ) : !passkeys || passkeys.length === 0 ? (
-        <EmptyState>No passkeys yet. Add one for a phishing-resistant, one-tap sign-in.</EmptyState>
+        <div>
+          <EmptyState>
+            No passkeys yet. Add one for a phishing-resistant, one-tap sign-in.
+          </EmptyState>
+        </div>
       ) : (
-        <SettingsGroup>
-          {passkeys.map((p) => (
-            <div
-              key={p.id}
-              data-testid={`passkey-row-${p.id}`}
-              className="flex items-center gap-3 py-3"
-            >
-              <div className="min-w-0 flex-1">
-                <div className="truncate text-sm font-medium text-foreground">
-                  {p.name || "Passkey"}
-                </div>
-                <div className="text-2xs text-muted-foreground">
-                  Added {new Date(p.createdAt).toLocaleDateString()}
-                </div>
-              </div>
+        passkeys.map((p) => (
+          <ListRow
+            key={p.id}
+            data-testid={`passkey-row-${p.id}`}
+            title={p.name || "Passkey"}
+            meta={`Added ${new Date(p.createdAt).toLocaleDateString()}`}
+            actions={
               <Button
                 data-testid={`passkey-remove-${p.id}`}
                 variant="destructive-ghost"
@@ -779,11 +749,11 @@ function Passkeys() {
               >
                 Remove
               </Button>
-            </div>
-          ))}
-        </SettingsGroup>
+            }
+          />
+        ))
       )}
-    </div>
+    </SettingsGroup>
   )
 }
 

--- a/apps/web/src/pages/settings/settings-list-skeleton.tsx
+++ b/apps/web/src/pages/settings/settings-list-skeleton.tsx
@@ -1,13 +1,13 @@
+import { ListRow } from "@/components/shared/list-row"
 import { Skeleton } from "@/components/ui/skeleton"
 
 const ROW_KEYS = ["a", "b", "c", "d", "e", "f"]
 
 // Shape-matched placeholder for a settings section's list body (members, webhooks,
-// repos, agents, deliveries, …), replacing the old fixed h-20 centered spinner. The
-// section shell + header render immediately (static chrome); only the list swaps to
-// this while its data loads. Mirrors a settings row's box model — a leading token,
-// a two-line label, and an optional trailing control — with no border/background
-// (the divider hairlines belong to the real rows), so nothing shifts on arrival.
+// repos, agents, deliveries, …). Renders the REAL ListRow with skeleton content —
+// the placeholder shares the row's box model by construction, so it can never
+// drift from what arrives (it once sat at py-3 while the rows were py-3.5). No
+// border/background: the divider hairlines belong to the real rows.
 export function SettingsListSkeleton({
   rows = 4,
   trailing = true,
@@ -19,14 +19,13 @@ export function SettingsListSkeleton({
     <div role="status" className="flex flex-col">
       <span className="sr-only">Loading…</span>
       {ROW_KEYS.slice(0, rows).map((k) => (
-        <div key={k} className="flex items-center gap-3 py-3">
-          <Skeleton className="size-7 shrink-0 rounded-full" />
-          <div className="flex flex-col gap-1.5">
-            <Skeleton className="h-3.5 w-40" />
-            <Skeleton className="h-2.5 w-24" />
-          </div>
-          {trailing && <Skeleton className="ml-auto h-8 w-28 rounded-lg" />}
-        </div>
+        <ListRow
+          key={k}
+          leading={<Skeleton className="size-7 shrink-0 rounded-full" />}
+          title={<Skeleton className="h-3.5 w-40" />}
+          meta={<Skeleton className="h-2.5 w-24" />}
+          actions={trailing ? <Skeleton className="h-8 w-28 rounded-lg" /> : undefined}
+        />
       ))}
     </div>
   )

--- a/apps/web/src/pages/settings/slack-subscription-row.tsx
+++ b/apps/web/src/pages/settings/slack-subscription-row.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react"
 import { api, type SlackSubscription } from "@/api"
 import { ConfirmDialog } from "@/components/shared/confirm-dialog"
+import { ListRow } from "@/components/shared/list-row"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
@@ -17,9 +18,10 @@ import { useApiMutation } from "@/lib/use-api-mutation"
 
 /** One subscribed channel: what it hears, from whom, and whether it's live.
  *
- *  The Switch flips optimistically (the toggle contract); the event checkboxes and the author
- *  select save explicitly with a toast, because they change what a whole channel receives and a
- *  silent optimistic flip would be too quiet for that. */
+ *  The Switch saves quietly — no toast, no optimistic flip: it re-renders from the refetched
+ *  subscription once the invalidation lands. The event checkboxes and the author select save
+ *  explicitly with a toast, because they change what a whole channel receives and a silent save
+ *  would be too quiet for that. */
 export function SlackSubscriptionRow({
   sub,
   eventOptions,
@@ -54,75 +56,82 @@ export function SlackSubscriptionRow({
     })
 
   return (
-    <div className="flex flex-col gap-2 py-3">
-      <div className="flex flex-wrap items-center gap-2">
-        <span className="font-medium text-sm">
+    <ListRow
+      title={
+        <span className="flex items-center gap-2">
           {sub.channel_name ? `#${sub.channel_name}` : sub.channel_id}
+          {/* Name the collection. A channel can carry several scoped subscriptions, and a row that
+              just says "collection" gives an admin no way to tell which one Remove would delete. */}
+          <Badge>
+            {sub.scope_kind === "collection"
+              ? (sub.scope_title ?? "deleted collection")
+              : "workspace"}
+          </Badge>
         </span>
-        {/* Name the collection. A channel can carry several scoped subscriptions, and a row that
-            just says "collection" gives an admin no way to tell which one Remove would delete. */}
-        <Badge>
-          {sub.scope_kind === "collection"
-            ? (sub.scope_title ?? "deleted collection")
-            : "workspace"}
-        </Badge>
-        <div className="flex-1" />
-        <Select
-          value={sub.authors}
-          onValueChange={(v) => save.mutate({ authors: v as "all" | "human" | "agent" })}
-        >
-          <SelectTrigger
-            data-testid={`slack-sub-authors-${sub.id}`}
-            aria-label="Whose activity"
-            className="w-36"
+      }
+      actions={
+        <>
+          <Select
+            value={sub.authors}
+            onValueChange={(v) => save.mutate({ authors: v as "all" | "human" | "agent" })}
           >
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">People &amp; agents</SelectItem>
-            <SelectItem value="human">People only</SelectItem>
-            <SelectItem value="agent">Agents only</SelectItem>
-          </SelectContent>
-        </Select>
-        <Switch
-          data-testid={`slack-sub-active-${sub.id}`}
-          aria-label="Deliver to this channel"
-          checked={sub.active === 1}
-          onCheckedChange={(next) => pause.mutate(next)}
-        />
-        <Button
-          data-testid={`slack-sub-remove-${sub.id}`}
-          variant="destructive-ghost"
-          size="sm"
-          onClick={() => setConfirming(true)}
-        >
-          Remove
-        </Button>
-      </div>
-      <div className="flex flex-wrap gap-3.5">
-        {eventOptions.map((e) => (
-          <label
-            key={e}
-            className="flex items-center gap-1.5 font-mono text-2xs text-muted-foreground"
+            <SelectTrigger
+              data-testid={`slack-sub-authors-${sub.id}`}
+              aria-label="Whose activity"
+              className="w-36"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">People &amp; agents</SelectItem>
+              <SelectItem value="human">People only</SelectItem>
+              <SelectItem value="agent">Agents only</SelectItem>
+            </SelectContent>
+          </Select>
+          <Switch
+            data-testid={`slack-sub-active-${sub.id}`}
+            aria-label="Deliver to this channel"
+            checked={sub.active === 1}
+            onCheckedChange={(next) => pause.mutate(next)}
+          />
+          <Button
+            data-testid={`slack-sub-remove-${sub.id}`}
+            variant="destructive-ghost"
+            size="sm"
+            onClick={() => setConfirming(true)}
           >
-            <Checkbox
-              data-testid={`slack-sub-event-${sub.id}-${e}`}
-              checked={selected.includes(e)}
-              onCheckedChange={() => toggleEvent(e)}
-            />
-            {e}
-          </label>
-        ))}
-      </div>
-      <ConfirmDialog
-        open={confirming}
-        onOpenChange={setConfirming}
-        title="Unsubscribe this channel?"
-        description={`Derive stops posting to ${sub.channel_name ? `#${sub.channel_name}` : sub.channel_id}. Existing threads stay where they are.`}
-        confirmLabel="Remove"
-        confirmTestId={`slack-sub-remove-confirm-${sub.id}`}
-        onConfirm={() => remove.mutate()}
-      />
-    </div>
+            Remove
+          </Button>
+        </>
+      }
+      below={
+        <>
+          <div className="flex flex-wrap gap-3.5">
+            {eventOptions.map((e) => (
+              <label
+                key={e}
+                className="flex items-center gap-1.5 font-mono text-2xs text-muted-foreground"
+              >
+                <Checkbox
+                  data-testid={`slack-sub-event-${sub.id}-${e}`}
+                  checked={selected.includes(e)}
+                  onCheckedChange={() => toggleEvent(e)}
+                />
+                {e}
+              </label>
+            ))}
+          </div>
+          <ConfirmDialog
+            open={confirming}
+            onOpenChange={setConfirming}
+            title="Unsubscribe this channel?"
+            description={`Derive stops posting to ${sub.channel_name ? `#${sub.channel_name}` : sub.channel_id}. Existing threads stay where they are.`}
+            confirmLabel="Remove"
+            confirmTestId={`slack-sub-remove-confirm-${sub.id}`}
+            onConfirm={() => remove.mutate()}
+          />
+        </>
+      }
+    />
   )
 }

--- a/apps/web/src/pages/settings/slack-subscriptions-section.tsx
+++ b/apps/web/src/pages/settings/slack-subscriptions-section.tsx
@@ -4,7 +4,6 @@ import { api } from "@/api"
 import { EmptyState } from "@/components/shared/empty-state"
 import { LoadError } from "@/components/shared/load-error"
 import { SettingsGroup } from "@/components/shared/settings-group"
-import { Button } from "@/components/ui/button"
 import {
   Select,
   SelectContent,
@@ -14,6 +13,7 @@ import {
 } from "@/components/ui/select"
 import { collectionsQuery, slackChannelsQuery, slackSubscriptionsQuery } from "@/lib/queries"
 import { useApiMutation } from "@/lib/use-api-mutation"
+import { AddForm } from "./add-form"
 import { SettingsListSkeleton } from "./settings-list-skeleton"
 import { SlackSubscriptionRow } from "./slack-subscription-row"
 
@@ -84,7 +84,20 @@ function NewSubscription({ onCreated }: { onCreated: () => void }) {
   })
 
   return (
-    <div className="flex flex-wrap items-center gap-2 py-3">
+    <AddForm
+      className="py-3"
+      onSubmit={() => create.mutate()}
+      submitLabel="Subscribe"
+      submitTestId="slack-sub-add"
+      pending={create.isPending}
+      disabled={!channel || channel.startsWith("__")}
+      after={
+        <p className="w-full text-sm text-muted-foreground">
+          Invite the Derive app to a private channel before subscribing it — it can join public
+          channels itself.
+        </p>
+      }
+    >
       <Select value={channel} onValueChange={setChannel} onOpenChange={setOpen}>
         <SelectTrigger
           data-testid="slack-sub-channel"
@@ -136,20 +149,6 @@ function NewSubscription({ onCreated }: { onCreated: () => void }) {
           </SelectContent>
         </Select>
       ) : null}
-      <Button
-        data-testid="slack-sub-add"
-        variant="secondary"
-        size="sm"
-        onClick={() => create.mutate()}
-        loading={create.isPending}
-        disabled={create.isPending || !channel || channel.startsWith("__")}
-      >
-        {create.isPending ? "Adding…" : "Subscribe"}
-      </Button>
-      <p className="w-full text-sm text-muted-foreground">
-        Invite the Derive app to a private channel before subscribing it — it can join public
-        channels itself.
-      </p>
-    </div>
+    </AddForm>
   )
 }

--- a/apps/web/src/pages/settings/sources-section.tsx
+++ b/apps/web/src/pages/settings/sources-section.tsx
@@ -3,14 +3,18 @@ import { useEffect, useState } from "react"
 import { api, type Connection } from "@/api"
 import { ConfirmDialog } from "@/components/shared/confirm-dialog"
 import { EmptyState } from "@/components/shared/empty-state"
+import { ListRow } from "@/components/shared/list-row"
 import { LoadError } from "@/components/shared/load-error"
 import { SettingsGroup } from "@/components/shared/settings-group"
+import { StatusBadge } from "@/components/shared/status-badge"
 import { StatusPanel } from "@/components/shared/status-panel"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
 import { connectionsQuery, workspaceSettingsQuery } from "@/lib/queries"
 import { useApiMutation } from "@/lib/use-api-mutation"
+import { useOneShotParams } from "@/lib/use-one-shot-params"
 import { SettingsListSkeleton } from "./settings-list-skeleton"
 import { SettingsSection } from "./settings-section"
 
@@ -33,20 +37,15 @@ export function SourcesSection() {
   const qc = useQueryClient()
   const { data: connections, isPending, isError, refetch } = useQuery(connectionsQuery())
   const reload = () => qc.invalidateQueries({ queryKey: connectionsQuery().queryKey })
-  const [justConnected, setJustConnected] = useState(false)
 
   // ?connected=1 lands here fresh back from a provider's consent screen. The cached connections
   // query predates the callback that flipped the row active, so consume + strip the param (the
-  // same one-shot idiom as billing's ?checkout=success) and refetch.
+  // shared one-shot idiom) and refetch.
+  const { connected } = useOneShotParams("connected")
+  const justConnected = connected === "1"
   useEffect(() => {
-    const url = new URL(window.location.href)
-    if (url.searchParams.get("connected") === "1") {
-      url.searchParams.delete("connected")
-      window.history.replaceState(null, "", url)
-      setJustConnected(true)
-      void qc.invalidateQueries({ queryKey: connectionsQuery().queryKey })
-    }
-  }, [qc])
+    if (justConnected) void qc.invalidateQueries({ queryKey: connectionsQuery().queryKey })
+  }, [justConnected, qc])
   // MCP only, to match what this screen can actually add and explain. A GitHub App or Slack row
   // listed here has its own setup flow elsewhere, no server URL to show, and a `scopes_label`
   // that is an account name — which the row below would caption as "· token acme-corp".
@@ -147,8 +146,17 @@ function AddSource({ onAdded }: { onAdded: () => void }) {
   // reader sees (`source-error`, in the server's own words).
   const ready = name.trim().length > 0 && url.trim().length > 0
 
+  // A real <form> (Enter in any field submits), but NOT AddForm: this composer is a stacked
+  // grid of labelled fields, not AddForm's one-line flex-wrap of controls.
   return (
-    <div className="mb-6 space-y-3" data-testid="sources-add">
+    <form
+      className="mb-6 space-y-3"
+      data-testid="sources-add"
+      onSubmit={(e) => {
+        e.preventDefault()
+        if (ready && !connect.isPending) connect.mutate()
+      }}
+    >
       <div className="grid gap-3 sm:grid-cols-2">
         <div className="space-y-1.5">
           <label htmlFor="source-name" className="text-sm font-medium">
@@ -206,13 +214,16 @@ function AddSource({ onAdded }: { onAdded: () => void }) {
         </p>
       ) : null}
       <Button
+        type="submit"
         data-testid="source-connect"
+        variant="secondary"
+        size="sm"
+        loading={connect.isPending}
         disabled={!ready || connect.isPending}
-        onClick={() => connect.mutate()}
       >
-        {connect.isPending ? "Connecting…" : "Connect"}
+        Connect
       </Button>
-    </div>
+    </form>
   )
 }
 
@@ -249,86 +260,97 @@ function SourceRow({ conn, onRevoked }: { conn: Connection; onRevoked: () => voi
   const needsSignIn = conn.status === "pending"
 
   return (
-    <div className="flex items-center justify-between gap-4 py-3" data-testid="source-row">
-      <div className="min-w-0">
-        <div className="flex items-center gap-2">
-          <span className="font-medium">{conn.toolkit}</span>
+    <ListRow
+      data-testid="source-row"
+      title={
+        <span className="flex items-center gap-2">
+          {conn.toolkit}
           {conn.kind === "mcp" ? <Badge variant="secondary">MCP</Badge> : null}
           {conn.status === "active" ? (
             <Badge variant="outline">Connected</Badge>
           ) : needsSignIn ? (
-            <Badge variant="outline">Needs sign-in</Badge>
+            <StatusBadge tone="attention">Needs sign-in</StatusBadge>
           ) : (
-            <Badge variant="outline">{conn.status}</Badge>
+            <StatusBadge tone="muted">{conn.status}</StatusBadge>
           )}
-        </div>
-        <p className="text-muted-foreground truncate text-xs">
-          {needsSignIn
-            ? "Sign in with this server to finish connecting. Nothing can read from it until you do."
-            : (conn.base_url ?? "—")}
-          {/* A signed-in connection has no token to caption, and "token signed in" is what the
-              generic form produced. The label says which of the two ways this one authenticates. */}
-          {!needsSignIn && conn.scopes_label
-            ? conn.scopes_label === SIGNED_IN_LABEL
-              ? " · signed in"
-              : ` · token ${conn.scopes_label}`
-            : ""}
-        </p>
-        {error ? (
-          <p className="text-destructive text-xs" data-testid={`source-signin-error-${conn.id}`}>
-            {error}
-          </p>
-        ) : null}
-      </div>
-      {/* OFF by default, and per source: a workspace connecting a server has not thereby handed
-          every conversation a live tool. A PERSONAL source stays yours even when on — chat
-          reaches it for you and for nobody else, which is what its scope already means. */}
-      {!needsSignIn ? (
-        <label className="flex shrink-0 items-center gap-2 text-xs">
-          <input
-            type="checkbox"
-            checked={inChat}
-            disabled={setChat.isPending}
-            onChange={(e) => setChat.mutate(e.target.checked)}
-            data-testid={`source-chat-${conn.id}`}
-          />
-          <span className="text-muted-foreground">
-            {conn.scope === "workspace" ? "Chat (everyone)" : "Chat (just me)"}
+        </span>
+      }
+      meta={
+        <>
+          <span className="block truncate">
+            {needsSignIn
+              ? "Sign in with this server to finish connecting. Nothing can read from it until you do."
+              : (conn.base_url ?? "—")}
+            {/* A signed-in connection has no token to caption, and "token signed in" is what the
+                generic form produced. The label says which of the two ways this one authenticates. */}
+            {!needsSignIn && conn.scopes_label
+              ? conn.scopes_label === SIGNED_IN_LABEL
+                ? " · signed in"
+                : ` · token ${conn.scopes_label}`
+              : ""}
           </span>
-        </label>
-      ) : null}
-      {needsSignIn ? (
-        <Button
-          size="sm"
-          data-testid={`source-signin-${conn.id}`}
-          disabled={signIn.isPending}
-          onClick={() => {
-            setError(null)
-            signIn.mutate()
+          {error ? (
+            <span className="block text-destructive" data-testid={`source-signin-error-${conn.id}`}>
+              {error}
+            </span>
+          ) : null}
+        </>
+      }
+      actions={
+        <>
+          {/* OFF by default, and per source: a workspace connecting a server has not thereby handed
+              every conversation a live tool. A PERSONAL source stays yours even when on — chat
+              reaches it for you and for nobody else, which is what its scope already means. */}
+          {!needsSignIn ? (
+            <label className="flex shrink-0 items-center gap-2 text-xs">
+              <Checkbox
+                checked={inChat}
+                disabled={setChat.isPending}
+                onCheckedChange={(v) => setChat.mutate(v === true)}
+                data-testid={`source-chat-${conn.id}`}
+              />
+              <span className="text-muted-foreground">
+                {conn.scope === "workspace" ? "Chat (everyone)" : "Chat (just me)"}
+              </span>
+            </label>
+          ) : null}
+          {needsSignIn ? (
+            <Button
+              variant="secondary"
+              size="sm"
+              data-testid={`source-signin-${conn.id}`}
+              disabled={signIn.isPending}
+              onClick={() => {
+                setError(null)
+                signIn.mutate()
+              }}
+            >
+              {signIn.isPending ? "Opening…" : "Sign in"}
+            </Button>
+          ) : null}
+          <Button
+            variant="destructive-ghost"
+            size="sm"
+            data-testid={`source-revoke-${conn.id}`}
+            onClick={() => setConfirming(true)}
+          >
+            Disconnect
+          </Button>
+        </>
+      }
+      below={
+        <ConfirmDialog
+          open={confirming}
+          onOpenChange={setConfirming}
+          title={`Disconnect ${conn.toolkit}?`}
+          description="Runs bound to this source stop being able to read from it. Nothing already written changes."
+          confirmLabel="Disconnect"
+          onConfirm={() => {
+            revoke.mutate()
+            setConfirming(false)
           }}
-        >
-          {signIn.isPending ? "Opening…" : "Sign in"}
-        </Button>
-      ) : null}
-      <Button
-        variant="ghost"
-        size="sm"
-        data-testid={`source-revoke-${conn.id}`}
-        onClick={() => setConfirming(true)}
-      >
-        Disconnect
-      </Button>
-      <ConfirmDialog
-        open={confirming}
-        onOpenChange={setConfirming}
-        title={`Disconnect ${conn.toolkit}?`}
-        description="Runs bound to this source stop being able to read from it. Nothing already written changes."
-        confirmLabel="Disconnect"
-        onConfirm={() => {
-          revoke.mutate()
-          setConfirming(false)
-        }}
-      />
-    </div>
+        />
+      }
+    />
   )
 }

--- a/apps/web/src/pages/settings/webhooks-section.tsx
+++ b/apps/web/src/pages/settings/webhooks-section.tsx
@@ -4,9 +4,11 @@ import { api, type Webhook } from "@/api"
 import { ConfirmDialog } from "@/components/shared/confirm-dialog"
 import { EmptyState } from "@/components/shared/empty-state"
 import { fieldError } from "@/components/shared/field-error"
+import { ListRow } from "@/components/shared/list-row"
 import { LoadError } from "@/components/shared/load-error"
 import { SettingsGroup } from "@/components/shared/settings-group"
 import { Spinner } from "@/components/shared/spinner"
+import { StatusBadge, type StatusTone } from "@/components/shared/status-badge"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
@@ -20,6 +22,7 @@ import {
 } from "@/components/ui/select"
 import { webhookDeliveriesQuery, webhooksQuery } from "@/lib/queries"
 import { useApiMutation } from "@/lib/use-api-mutation"
+import { AddForm } from "./add-form"
 import { SettingsListSkeleton } from "./settings-list-skeleton"
 import { SettingsSection } from "./settings-section"
 
@@ -112,66 +115,61 @@ function NewWebhook({
     if (valid) create.mutate()
   }
   return (
-    <div className="flex flex-col gap-3">
-      <div className="flex flex-wrap items-center gap-2">
-        <Select value={kind} onValueChange={(v) => setKind(v as "generic" | "slack")}>
-          <SelectTrigger data-testid="webhook-kind" aria-label="Webhook type" className="w-27.5">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="generic">Webhook</SelectItem>
-            <SelectItem value="slack">Slack</SelectItem>
-          </SelectContent>
-        </Select>
-        <Input
-          data-testid="webhook-url"
-          aria-label="Endpoint URL"
-          {...urlField.aria}
-          value={url}
-          onChange={(e) => setUrl(e.target.value)}
-          onKeyDown={(e) => e.key === "Enter" && add()}
-          placeholder={
-            kind === "slack"
-              ? "Slack incoming-webhook URL"
-              : "https://your-endpoint.example.com/hook"
-          }
-          className="min-w-60 flex-1"
-        />
-        <Button
-          data-testid="webhook-add"
-          variant="secondary"
-          size="sm"
-          onClick={add}
-          loading={create.isPending}
-          disabled={create.isPending || !valid}
-        >
-          {create.isPending ? "Adding…" : "Add"}
-        </Button>
-      </div>
-      {urlField.node}
-      <div className="flex flex-wrap gap-3.5">
-        {eventOptions.map((e) => (
-          <label
-            key={e}
-            className="flex items-center gap-1.5 font-mono text-2xs text-muted-foreground"
-          >
-            <Checkbox
-              data-testid={`webhook-event-${e}`}
-              checked={selected.includes(e)}
-              onCheckedChange={() => toggle(e)}
-            />
-            {e}
-          </label>
-        ))}
-      </div>
-    </div>
+    <AddForm
+      onSubmit={add}
+      submitLabel="Add"
+      submitTestId="webhook-add"
+      pending={create.isPending}
+      disabled={!valid}
+      after={
+        <>
+          {urlField.node}
+          <div className="flex flex-wrap gap-3.5">
+            {eventOptions.map((e) => (
+              <label
+                key={e}
+                className="flex items-center gap-1.5 font-mono text-2xs text-muted-foreground"
+              >
+                <Checkbox
+                  data-testid={`webhook-event-${e}`}
+                  checked={selected.includes(e)}
+                  onCheckedChange={() => toggle(e)}
+                />
+                {e}
+              </label>
+            ))}
+          </div>
+        </>
+      }
+    >
+      <Select value={kind} onValueChange={(v) => setKind(v as "generic" | "slack")}>
+        <SelectTrigger data-testid="webhook-kind" aria-label="Webhook type" className="w-27.5">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="generic">Webhook</SelectItem>
+          <SelectItem value="slack">Slack</SelectItem>
+        </SelectContent>
+      </Select>
+      <Input
+        data-testid="webhook-url"
+        aria-label="Endpoint URL"
+        {...urlField.aria}
+        value={url}
+        onChange={(e) => setUrl(e.target.value)}
+        placeholder={
+          kind === "slack" ? "Slack incoming-webhook URL" : "https://your-endpoint.example.com/hook"
+        }
+        className="min-w-60 flex-1"
+      />
+    </AddForm>
   )
 }
 
-// Delivery outcome → badge tone: delivered is a quiet success, dead (gave up
-// retrying) is destructive, anything in flight (pending/retrying) stays neutral.
-const deliveryBadge = (status: string): "success" | "destructive" | "default" =>
-  status === "delivered" ? "success" : status === "dead" ? "destructive" : "default"
+// Delivery outcome → tone: delivered is a quiet success, dead means the server
+// gave up retrying, anything in flight (pending/retrying) stays muted.
+const deliveryTone = (status: string): StatusTone =>
+  status === "delivered" ? "ok" : status === "dead" ? "error" : "muted"
 
 function WebhookRow({ hook, onDone }: { hook: Webhook; onDone: () => void }) {
   const qc = useQueryClient()
@@ -201,70 +199,83 @@ function WebhookRow({ hook, onDone }: { hook: Webhook; onDone: () => void }) {
     onSuccess: () => onDone(),
   })
   return (
-    <div data-testid={`webhook-row-${hook.id}`} className="flex flex-col gap-2 py-3">
-      <div className="flex items-center gap-2.5">
-        <Badge>{hook.kind === "slack" ? "Slack" : "Webhook"}</Badge>
-        <div className="min-w-0 flex-1">
-          <div className="truncate font-mono text-sm text-foreground">{hook.url}</div>
-          <div className="mt-px font-mono text-2xs text-muted-foreground">
-            {hook.events === "*" ? "all events" : hook.events.split(",").join(" · ")}
-          </div>
-        </div>
-        <Button data-testid={`webhook-log-${hook.id}`} variant="ghost" size="sm" onClick={showLog}>
-          {open ? "Hide" : "Log"}
-        </Button>
-        <Button
-          data-testid={`webhook-test-${hook.id}`}
-          variant="ghost"
-          size="sm"
-          onClick={() => test.mutate()}
-          loading={test.isPending}
-        >
-          Test
-        </Button>
-        <Button
-          data-testid={`webhook-remove-${hook.id}`}
-          variant="destructive-ghost"
-          size="sm"
-          onClick={() => setConfirming(true)}
-        >
-          Remove
-        </Button>
-      </div>
-      <ConfirmDialog
-        open={confirming}
-        onOpenChange={setConfirming}
-        title="Remove this webhook?"
-        description={`Deliveries to ${hook.url} stop immediately.`}
-        confirmLabel="Remove"
-        onConfirm={() => remove.mutate()}
-      />
-      {open && (
-        <div className="rounded-lg bg-secondary px-3 py-2">
-          {isPending ? (
-            <div className="flex justify-center py-2">
-              <Spinner />
+    <ListRow
+      data-testid={`webhook-row-${hook.id}`}
+      leading={<Badge>{hook.kind === "slack" ? "Slack" : "Webhook"}</Badge>}
+      mono
+      title={hook.url}
+      meta={
+        <span className="block truncate font-mono">
+          {hook.events === "*" ? "all events" : hook.events.split(",").join(" · ")}
+        </span>
+      }
+      actions={
+        <>
+          <Button
+            data-testid={`webhook-log-${hook.id}`}
+            variant="ghost"
+            size="sm"
+            onClick={showLog}
+          >
+            {open ? "Hide" : "Log"}
+          </Button>
+          <Button
+            data-testid={`webhook-test-${hook.id}`}
+            variant="ghost"
+            size="sm"
+            onClick={() => test.mutate()}
+            loading={test.isPending}
+          >
+            Test
+          </Button>
+          <Button
+            data-testid={`webhook-remove-${hook.id}`}
+            variant="destructive-ghost"
+            size="sm"
+            onClick={() => setConfirming(true)}
+          >
+            Remove
+          </Button>
+        </>
+      }
+      below={
+        <>
+          <ConfirmDialog
+            open={confirming}
+            onOpenChange={setConfirming}
+            title="Remove this webhook?"
+            description={`Deliveries to ${hook.url} stop immediately.`}
+            confirmLabel="Remove"
+            onConfirm={() => remove.mutate()}
+          />
+          {open && (
+            <div className="rounded-lg bg-secondary px-3 py-2">
+              {isPending ? (
+                <div className="flex justify-center py-2">
+                  <Spinner />
+                </div>
+              ) : !deliveries || deliveries.length === 0 ? (
+                <div className="text-sm text-muted-foreground">No deliveries yet. Hit Test.</div>
+              ) : (
+                deliveries.map((d) => (
+                  <div key={d.id} className="flex items-center gap-2 py-0.5 text-2xs">
+                    <StatusBadge tone={deliveryTone(d.status)}>{d.status}</StatusBadge>
+                    <span className="font-mono text-muted-foreground">{d.event_type}</span>
+                    {d.attempts > 1 && (
+                      <span className="font-mono text-muted-foreground tabular-nums">
+                        · {d.attempts} tries
+                      </span>
+                    )}
+                    {d.last_error && (
+                      <span className="truncate font-mono text-destructive">· {d.last_error}</span>
+                    )}
+                  </div>
+                ))
+              )}
             </div>
-          ) : !deliveries || deliveries.length === 0 ? (
-            <div className="text-sm text-muted-foreground">No deliveries yet. Hit Test.</div>
-          ) : (
-            deliveries.map((d) => (
-              <div key={d.id} className="flex items-center gap-2 py-0.5 text-2xs">
-                <Badge variant={deliveryBadge(d.status)}>{d.status}</Badge>
-                <span className="font-mono text-muted-foreground">{d.event_type}</span>
-                {d.attempts > 1 && (
-                  <span className="font-mono text-muted-foreground tabular-nums">
-                    · {d.attempts} tries
-                  </span>
-                )}
-                {d.last_error && (
-                  <span className="truncate font-mono text-destructive">· {d.last_error}</span>
-                )}
-              </div>
-            ))
           )}
-        </div>
-      )}
-    </div>
+        </>
+      }
+    />
   )
 }


### PR DESCRIPTION
## What

Settings adopts its own kit. Six extractions replace per-section copies:

- **ListRow** — the "item + actions" row (members, agents, webhooks, domains, sources, repos, passkeys, plans, reports, subscriptions) drawn once: py-3.5 like SettingRow, one title register, one meta register, trailing action cluster with the destructive verb last. Eighteen hand-rolled rows deleted; the list skeleton now renders ListRow with placeholders, so the placeholder can no longer drift from the real row.
- **SecretReveal** — the one-time credential moment (agent token, rotated token, automation runner token, 2FA backup codes) was pasted verbatim across files; now one component whose actions are `type="button"`, so it is safe inside forms by construction.
- **useOneShotParams** — the `?checkout` / `?connected` / `?new-workspace` / `?slack_*` / `?gh_*` strip effect existed five times with three different replaceState signatures; now one hook that also preserves `history.state` and `location.hash`. The pure take-and-strip core is unit-tested.
- **StatusBadge** — one semantic tone vocabulary (ok / attention / error / busy / muted) replaces three local status→variant mappers, so the same state can't wear different clothes in different sections.
- **AdminNote** — one register for "your role doesn't reach this"; the invite form and sharing defaults no longer vanish silently for non-admins.
- **AddForm** — the add-a-row forms become real `<form>`s (Enter submits, per-input key handlers deleted), one layout, constant submit labels with the spinner as the only pending signal.

## Deliberate changes (the sanctioned perimeter)

Behavior-preserving except: row height py-3 → py-3.5 and meta registers unified · add-form submits unified to secondary/sm (sources **Connect** and models **Add and probe** lose their filled variant — one filled primary per view) · destructive row verbs unified to destructive-ghost (models **Remove**, sources **Disconnect**) · delete-workspace's typed confirm now rides ConfirmDialog's one contract (trimmed, case-insensitive; the old `workspace-delete-confirm` testid is superseded by `confirm-dialog-phrase` — nothing referenced it) · billing's amber meter uses the warning token (three `tokens-ignore` escapes deleted) · the model-plan connect card becomes a well per the surfaces rule · the Slack connected block sits properly in its group's divided stack · Enter can no longer double-submit a webhook/domain add mid-flight (the old onKeyDown path skipped the pending check).

## Verified

- `pnpm verify` green (biome + the custom lint battery, typecheck, coverage).
- New unit suite for the strip semantics, watched failing against a broken implementation first.
- Settings e2e smoke green locally against the refactored pages.
- Two independent adversarial review passes over the diff; every surviving finding fixed — SettingsGroup's first/last padding-strip squashing non-row children (model-plan well, empty/error states), lost truncation on member rows, lost mono register on webhook meta, action clusters not wrapping at narrow widths, and the hash-drop in the strip.

Net −81 lines, 30 files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789041703&installation_model_id=428097&pr_number=692&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F692&signature=2d358613b734feb67add97652b685f51b8efa2683cc3fa64a60aef6197223686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->