### PR TITLE
feat(slack): gate unfurl broadcasts on access, not listing

### DIFF
--- a/apps/api/scripts/slack-live-probe.ts
+++ b/apps/api/scripts/slack-live-probe.ts
@@ -81,10 +81,12 @@ Also <!channel> please look, and <https://evil.example|Derive Support>.`
 const run = async () => {
   console.log(`posting probes to ${CHANNEL}\n`)
 
-  // 1 — the unfurl card for a feed-visible artifact, with proposal buttons.
+  // 1 — the unfurl card for a feed-visible artifact, with proposal buttons. No image: the
+  // probe's fake OG URL would render a broken block, and the image path is exercised live by
+  // pasting a real workspace doc.
   await post(
     "unfurl card (with Approve / Request changes)",
-    unfurlBlocks(info(), true, "a_1", "p_1"),
+    unfurlBlocks(info(), null, true, "a_1", "p_1"),
     "P1 unfurl card",
   )
 
@@ -100,6 +102,7 @@ const run = async () => {
     "unfurl card with a hostile title (must not ping)",
     unfurlBlocks(
       info({ title: "<!channel> <@U000> & <https://evil.example|Support>" }),
+      null,
       false,
       "a_2",
       null,

--- a/apps/api/src/lib/slack-unfurl.ts
+++ b/apps/api/src/lib/slack-unfurl.ts
@@ -3,8 +3,16 @@
 // The whole design turns on one property of Slack's API: an unfurl is attached to the MESSAGE,
 // not to a viewer. `chat.unfurl` takes no `user` parameter, so whatever we render is seen by
 // everyone in the channel. The question is therefore never "may this viewer read it" but "may
-// this be broadcast" — which the connected app already answers everywhere else with
-// `artifact.listed !== "none"`, and which we answer the same way here.
+// this be broadcast" — and the field that answers it is ACCESS, not discovery: an artifact with
+// `workspace_access === "member"` is readable by every member of the workspace this Slack team
+// is connected to, so a channel in that workspace's own Slack is substantially its audience.
+// That includes the default "team draft" (workspace_access=member, link_role=none, listed=none),
+// which is the shape people paste most. `listed` is discovery-only and carries no access
+// (schema.ts), so it gates nothing here beyond the one case access can't cover: a
+// publicly-LISTED artifact is world-discoverable, so it broadcasts too. What stays locked is
+// an artifact granting the workspace nothing — a link-only draft or a doc shared with named
+// people — because every grant it has is personal to its holder, and a personal grant must
+// never unlock a broadcast.
 //
 // The one per-person surface Slack does offer is the sign-in prompt, which goes to the person
 // who POSTED the link. We use it for someone who hasn't linked their Derive account: without a
@@ -17,22 +25,24 @@ import {
   type UnfurlInfo,
   unfurlDescription,
 } from "@derive/core"
+import { type ArtifactStatus, artifactStatus } from "./artifact-status"
 import { context, mrkdwnLabel, section } from "./slack-cards"
 import { encodeProposalAction, SLACK_PROPOSAL_ACTION } from "./slack-comments"
 import { unfurlInfoFor } from "./unfurl-info"
 
-/** The card for an artifact the channel may see: title, one-line description, and — for an open
- *  proposal — the buttons to decide it.
+/** The card for an artifact the channel may see: title, one-line description, the screenshot
+ *  when one is ready, and — for an open proposal — the buttons to decide it.
  *
- *  Deliberately NO image, even though `UnfurlInfo` carries one and Derive's OG screenshot is the
- *  best-looking thing it has. Slack fetches an unfurl's image ANONYMOUSLY, and `/v1/og/:ref`
- *  answers an anonymous fetch by the artifact's link role: a workspace-listed artifact with no
- *  world link — the common shape for internal docs — returns the title-less LOCKED card. So the
- *  image would be a padlock placeholder on precisely the cards people paste most, next to a
- *  title we are already showing. A broken-looking card is worse than none. Revisit if the OG
- *  endpoint ever accepts a signed, short-lived token an unfurl could carry. */
+ *  `imageUrl` is the caller's decision, not `info.imageUrl` verbatim: Slack fetches an unfurl's
+ *  image ANONYMOUSLY, and `/v1/og/:ref` answers an anonymous fetch by the artifact's link role —
+ *  for anything short of world-readable it returns the title-less LOCKED card, a padlock
+ *  placeholder next to a title we are already showing. The caller therefore passes either a URL
+ *  it KNOWS answers anonymously with the rendered PNG (a signed OG token for a workspace doc,
+ *  the bare URL for a public one — see routes/slack.ts previewUrlFor), or null, and null means
+ *  no image at all. A broken-looking card is worse than none. */
 export const unfurlBlocks = (
   info: UnfurlInfo,
+  imageUrl: string | null,
   hasOpenProposal: boolean,
   artifactId: string,
   proposalId: string | null,
@@ -42,6 +52,15 @@ export const unfurlBlocks = (
       `*<${info.pageUrl}|${mrkdwnLabel(info.title)}>*\n${mrkdwnLabel(unfurlDescription(info), 120)}`,
     ),
   ]
+  // alt_text is required on an image block, and it is plain text, not mrkdwn — no escaping.
+  // Same phrasing as the Work Object thumbnail. The title is safe to use: only broadcast-safe
+  // artifacts reach this builder at all.
+  if (imageUrl)
+    blocks.push({
+      type: "image",
+      image_url: imageUrl,
+      alt_text: `Preview of ${info.title}`.slice(0, 200),
+    })
   // An open proposal turns the preview into somewhere you can act, the way Linear's issue
   // unfurls do. The clicker is re-authorized as their own linked account by the interactivity
   // handler, so showing the buttons to a channel is safe — an unauthorized click gets an
@@ -107,7 +126,18 @@ export type UnfurlDecision =
    *  the URL. The caller logs this. */
   | { kind: "skip"; why: string }
   | { kind: "auth" }
-  | { kind: "card"; url: string; blocks: unknown[]; artifact: ArtifactRecord; info: UnfurlInfo }
+  | {
+      kind: "card"
+      url: string
+      blocks: unknown[]
+      artifact: ArtifactRecord
+      info: UnfurlInfo
+      /** Resolved once here, carried so the Work Object builder doesn't re-read the same rows. */
+      status: ArtifactStatus
+      /** The image URL both card shapes share (block `image` and Work Object preview), or null
+       *  when there is nothing safe to promise — see UnfurlDeps.previewUrl. */
+      previewUrl: string | null
+    }
   | { kind: "locked"; url: string; blocks: unknown[]; artifact: ArtifactRecord }
 
 export interface UnfurlDeps {
@@ -121,6 +151,15 @@ export interface UnfurlDeps {
    *  role is personal to whoever holds the URL; an unfurl is a broadcast, so it must not be
    *  what unlocks the preview. (context.ts authorizeUserStanding) */
   canRead: (userId: string, artifact: ArtifactRecord) => Promise<boolean>
+  /** The screenshot URL a card may promise for this artifact, or null for none. Must be a URL
+   *  that answers an ANONYMOUS fetch with the rendered PNG — Slack fetches preview images with
+   *  no credential — which for a workspace doc means a signed OG token (routes/slack.ts
+   *  previewUrlFor, lib/og-token.ts). Absent means cards carry no image. */
+  previewUrl?: (
+    artifact: ArtifactRecord,
+    info: UnfurlInfo,
+    status: ArtifactStatus,
+  ) => Promise<string | null>
 }
 
 /** Resolve one shared URL to a decision.
@@ -131,8 +170,8 @@ export interface UnfurlDeps {
  *    not ours / gone    → skip, so a stray URL on our domain doesn't render an empty card
  *    another workspace  → skip (see UnfurlDeps.orgId)
  *    can't read it      → skip; they shouldn't confirm the existence of something they can't open
- *    listed === "none"  → locked card
- *    otherwise          → the full card
+ *    grants the workspace nothing and is unlisted → locked card
+ *    otherwise          → the full card (workspace-readable or listed; see the module header)
  */
 export const decideUnfurl = async (
   deps: UnfurlDeps,
@@ -157,8 +196,10 @@ export const decideUnfurl = async (
     return { kind: "skip", why: "sharer has no read standing on it" }
 
   // Build the locked card BEFORE unfurlInfoFor: it needs none of that, and the whole point is
-  // to touch as little of the artifact as possible.
-  if (artifact.listed === "none")
+  // to touch as little of the artifact as possible. Locked means the workspace gets no access
+  // AND it is unlisted — the module header carries the reasoning; a link role alone never
+  // counts toward a broadcast.
+  if (artifact.workspace_access === "none" && artifact.listed === "none")
     return {
       kind: "locked",
       url,
@@ -167,13 +208,17 @@ export const decideUnfurl = async (
     }
 
   const info = await unfurlInfoFor(deps.meta, deps.baseUrl, artifact)
+  const status = await artifactStatus(deps.meta, artifact)
+  const previewUrl = (await deps.previewUrl?.(artifact, info, status)) ?? null
   const open = await deps.meta.listProposals(artifact.id, { state: "open" })
   return {
     kind: "card",
     url,
-    blocks: unfurlBlocks(info, open.length > 0, artifact.id, open[0]?.id ?? null),
+    blocks: unfurlBlocks(info, previewUrl, open.length > 0, artifact.id, open[0]?.id ?? null),
     artifact,
     info,
+    status,
+    previewUrl,
   }
 }
 

--- a/apps/api/src/routes/slack.ts
+++ b/apps/api/src/routes/slack.ts
@@ -240,6 +240,7 @@ export const slackRoutes = (ctx: AppContext) => {
           baseUrl: deps.baseUrl,
           orgId: install.org_id,
           canRead: (userId, artifact) => authorizeUserStanding(userId, "read", artifact),
+          previewUrl: previewUrlFor,
         },
         l.url,
         userLink.user_id,
@@ -313,15 +314,17 @@ export const slackRoutes = (ctx: AppContext) => {
    *
    * Slack fetches preview images anonymously, so the question is never "may this viewer see it"
    * but "may this be fetched with no credential at all" — and the answer, for anything short of
-   * world-readable, used to be no. A workspace-listed doc therefore rendered the title-less
-   * padlock, which is why the cards people paste most carried no picture.
+   * world-readable, used to be no. A workspace doc therefore rendered the title-less padlock,
+   * which is why the cards people paste most carried no picture.
    *
    * A signed token settles it without loosening `/v1/og` for anyone else: it buys that one
-   * version's rendered image, expires, and retires itself on the next publish. The reasoning for
-   * why a workspace-listed doc is the right place to draw this line is the product's own —
-   * `workspace` means the org may see it, a Slack channel in that org's own workspace is
-   * substantially that audience, and anything genuinely sensitive is marked `none`, which never
-   * reaches this function.
+   * version's rendered image, expires, and retires itself on the next publish. The line is
+   * drawn at ACCESS, matching decideUnfurl's broadcast gate: `workspace_access === "member"`
+   * means every member of this workspace may read it — the default team draft included — and a
+   * Slack channel in that workspace's own Slack is substantially that audience. (`listed ===
+   * "workspace"` implies member access, an invariant routes/artifacts.ts enforces; it is checked
+   * here anyway so a legacy row degrades to the tokened image, never to a leak.) Anything
+   * granting the workspace nothing stays a padlock.
    *
    * ONE RULE, both visibilities: offer a URL only when a rendered PNG is actually behind it.
    *
@@ -342,7 +345,11 @@ export const slackRoutes = (ctx: AppContext) => {
     info: UnfurlInfo,
     status: ArtifactStatus,
   ): Promise<string | null> => {
-    if (artifact.listed !== "public" && artifact.listed !== "workspace") return null
+    const broadcastVisible =
+      artifact.workspace_access === "member" ||
+      artifact.listed === "public" ||
+      artifact.listed === "workspace"
+    if (!broadcastVisible) return null
     if (!status.previewReady) return null
     // A world-readable doc needs no capability: /v1/og already serves its PNG to anyone.
     if (artifact.listed === "public") return info.imageUrl
@@ -383,19 +390,20 @@ export const slackRoutes = (ctx: AppContext) => {
           fields: {},
         },
       }
-    const status = await artifactStatus(meta, d.artifact)
     return artifactEntity({
       pastedUrl,
       artifact: d.artifact,
       info: d.info,
-      status,
-      // The screenshot. Slack fetches preview images ANONYMOUSLY, so a world-readable artifact
-      // links its OG image directly and a workspace-listed one carries a signed, version-pinned
-      // token that buys that image and nothing else (lib/og-token.ts). `listed: "none"` never
-      // reaches here — decideUnfurl answered it with the locked card above — which is the line
-      // this feature deliberately does not cross: a doc someone marked private stays a padlock.
-      previewUrl: await previewUrlFor(d.artifact, d.info, status),
-      withActions: status.review?.state === "pending",
+      status: d.status,
+      // The screenshot, resolved once by decideUnfurl (via previewUrlFor above) and shared with
+      // the block-card fallback so both shapes promise the same image. Slack fetches preview
+      // images ANONYMOUSLY, so a world-readable artifact links its OG image directly and a
+      // workspace-readable one carries a signed, version-pinned token that buys that image and
+      // nothing else (lib/og-token.ts). An artifact granting the workspace nothing never reaches
+      // here — decideUnfurl answered it with the locked card above — which is the line this
+      // feature deliberately does not cross: a doc someone kept private stays a padlock.
+      previewUrl: d.previewUrl,
+      withActions: d.status.review?.state === "pending",
       iconUrl,
     })
   }

--- a/apps/api/test/slack-routes.test.ts
+++ b/apps/api/test/slack-routes.test.ts
@@ -1343,14 +1343,19 @@ describe("slack link unfurls", () => {
   // Slack fetches preview images anonymously, so for anything short of world-readable the card
   // used to show /v1/og's title-less padlock — on precisely the docs people paste most. A
   // signed, version-pinned token (lib/og-token.ts) buys that one image without loosening the
-  // endpoint for anyone else. The line is drawn at `listed`: `workspace` means the org may see
-  // it and a channel in that org's own Slack is substantially that audience; `none` is what
-  // somebody chose when they meant private, and it must stay a padlock.
+  // endpoint for anyone else. The line is drawn at ACCESS: `workspace_access === "member"`
+  // means every member of the org may read it — the default team draft included — and a channel
+  // in that org's own Slack is substantially that audience. An artifact granting the workspace
+  // nothing is what somebody chose when they meant private, and it must stay a padlock.
   const unfurlEntity = async (
     name: string,
-    listed: "workspace" | "none" | "public",
+    access: {
+      listed: "workspace" | "none" | "public"
+      workspace_access?: "member" | "none"
+    },
     rendered = true,
   ) => {
+    const { listed, workspace_access = "member" } = access
     const { app, meta } = make(name)
     await meta.setSlackInstall({
       org_id: "default",
@@ -1376,12 +1381,22 @@ describe("slack link unfurls", () => {
       org_id: "default",
       slug: null,
       title: "Q4 roadmap",
-      workspace_access: "member",
+      workspace_access,
       link_role: listed === "public" ? "viewer" : "none",
       listed,
       kind: "file",
       spa: 0,
     })
+    // A doc granting the workspace nothing is readable only through an explicit share — give
+    // the sharer one, so the test exercises the broadcast gate rather than the read check
+    // (a sharer without standing skips long before any card is considered).
+    if (workspace_access === "none")
+      await meta.setArtifactMember({
+        id: newId("am"),
+        artifact_id: artifact.id,
+        user_id: owner.id,
+        role: "viewer",
+      })
     // `createArtifact` alone leaves current_version = 0 and no version row — a shape production
     // never has, because publishing makes v1. Give it one, then decide whether it has rendered:
     // renders are enqueued in the BACKGROUND after a publish, so the unrendered window is real
@@ -1423,23 +1438,46 @@ describe("slack link unfurls", () => {
     return { entity: ents?.[0] as Record<string, unknown> | undefined, artifact }
   }
 
-  it("carries a signed screenshot URL for a workspace-listed doc", async () => {
-    const { entity, artifact } = await unfurlEntity("slack-unfurl-preview-ws", "workspace")
-    const preview = (
+  const fullSizePreview = (entity: Record<string, unknown> | undefined) =>
+    (
       (entity?.entity_payload as { attributes?: Record<string, unknown> })?.attributes as {
         full_size_preview?: { preview_url?: string }
       }
     )?.full_size_preview
-    const url = new URL(preview?.preview_url ?? "")
+
+  it("carries a signed screenshot URL for a workspace-listed doc", async () => {
+    const { entity, artifact } = await unfurlEntity("slack-unfurl-preview-ws", {
+      listed: "workspace",
+    })
+    const url = new URL(fullSizePreview(entity)?.preview_url ?? "")
     expect(url.pathname).toContain(`/v1/og/${artifact.short_id}`)
     // The token is the whole mechanism — without it Slack's anonymous fetch gets the padlock.
     expect(url.searchParams.get("t")).toBeTruthy()
   })
 
-  it("carries NO screenshot for a doc somebody marked private", async () => {
-    // `listed: "none"` is answered by the locked card, which is title-less by construction —
-    // so there is nothing to mint a token for, and nothing that could be minted by mistake.
-    const { entity } = await unfurlEntity("slack-unfurl-preview-none", "none")
+  it("carries a signed screenshot URL for a team draft — access broadcasts, not listing", async () => {
+    // The default publish shape: workspace_access=member, listed=none. Every member of the
+    // workspace behind this Slack team may open it, so the card shows the real thing — title
+    // and tokened screenshot — exactly as a workspace-LISTED doc does. `listed` is discovery,
+    // not access, and must not decide a broadcast.
+    const { entity, artifact } = await unfurlEntity("slack-unfurl-preview-draft", {
+      listed: "none",
+      workspace_access: "member",
+    })
+    expect(JSON.stringify(entity)).toContain("Q4 roadmap")
+    const url = new URL(fullSizePreview(entity)?.preview_url ?? "")
+    expect(url.pathname).toContain(`/v1/og/${artifact.short_id}`)
+    expect(url.searchParams.get("t")).toBeTruthy()
+  })
+
+  it("carries NO screenshot for a doc somebody kept private", async () => {
+    // Grants the workspace nothing and is unlisted → the locked card, which is title-less by
+    // construction — so there is nothing to mint a token for, and nothing that could be minted
+    // by mistake.
+    const { entity } = await unfurlEntity("slack-unfurl-preview-none", {
+      listed: "none",
+      workspace_access: "none",
+    })
     expect(JSON.stringify(entity)).not.toContain("full_size_preview")
     expect(JSON.stringify(entity)).not.toContain("Q4 roadmap")
   })
@@ -1448,7 +1486,11 @@ describe("slack link unfurls", () => {
     // `chat.unfurl` accepts a preview_url without fetching it (verified against the API: ok:true,
     // no warning), so a card that promises image/png and serves the SVG fallback fails silently.
     // The same check therefore covers both visibilities rather than only the new one.
-    const { entity } = await unfurlEntity("slack-unfurl-preview-pub-pending", "public", false)
+    const { entity } = await unfurlEntity(
+      "slack-unfurl-preview-pub-pending",
+      { listed: "public" },
+      false,
+    )
     expect(JSON.stringify(entity)).not.toContain("full_size_preview")
   })
 
@@ -1457,18 +1499,18 @@ describe("slack link unfurls", () => {
     // anonymous fetch for an unrendered workspace doc with the TITLE-LESS padlock, so offering
     // the URL would put a padlock graphic on the card beside the title we are already showing —
     // the exact outcome the block card avoided by carrying no image at all.
-    const { entity } = await unfurlEntity("slack-unfurl-preview-pending", "workspace", false)
+    const { entity } = await unfurlEntity(
+      "slack-unfurl-preview-pending",
+      { listed: "workspace" },
+      false,
+    )
     expect(JSON.stringify(entity)).toContain("Q4 roadmap")
     expect(JSON.stringify(entity)).not.toContain("full_size_preview")
   })
 
   it("needs no token for a world-readable doc — /v1/og already serves it", async () => {
-    const { entity } = await unfurlEntity("slack-unfurl-preview-pub", "public")
-    const preview = (
-      (entity?.entity_payload as { attributes?: Record<string, unknown> })?.attributes as {
-        full_size_preview?: { preview_url?: string }
-      }
-    )?.full_size_preview
+    const { entity } = await unfurlEntity("slack-unfurl-preview-pub", { listed: "public" })
+    const preview = fullSizePreview(entity)
     expect(preview?.preview_url).toBeTruthy()
     expect(new URL(preview?.preview_url ?? "").searchParams.get("t")).toBeNull()
   })
@@ -2440,7 +2482,10 @@ describe("question Reply actions", () => {
 // broadcast card has always had to assume the most cautious reader in the channel. This surface
 // carries the clicking user, so the answer can finally depend on who is asking.
 describe("entity_details_requested (the flexpane)", () => {
-  const withInstall = async (name: string, opts: { link?: boolean; listed?: string } = {}) => {
+  const withInstall = async (
+    name: string,
+    opts: { link?: boolean; listed?: string; workspace_access?: "member" | "none" } = {},
+  ) => {
     const { app, meta } = make(name)
     await meta.setSlackInstall({
       org_id: "default",
@@ -2467,12 +2512,21 @@ describe("entity_details_requested (the flexpane)", () => {
       org_id: "default",
       slug: null,
       title: "Secret plan",
-      workspace_access: "member",
+      workspace_access: opts.workspace_access ?? "member",
       link_role: "viewer",
       listed: (opts.listed ?? "workspace") as "workspace",
       kind: "file",
       spa: 0,
     })
+    // A doc granting the workspace nothing is readable only through an explicit share; the
+    // viewer needs one so the private-doc tests exercise the minting gate, not the read check.
+    if (opts.workspace_access === "none")
+      await meta.setArtifactMember({
+        id: newId("am"),
+        artifact_id: artifact.id,
+        user_id: owner.id,
+        role: "viewer",
+      })
     await meta.setVersionPreview(artifact.id, await addV(meta, artifact.id), {
       preview_key: "blob-og",
       preview_status: "ready",
@@ -2523,20 +2577,33 @@ describe("entity_details_requested (the flexpane)", () => {
 
   // THE ONE PATH WHERE A PRIVATE DOC CAN REACH THE MINTER.
   //
-  // The unfurl never does — decideUnfurl answers `listed: "none"` with the locked card long
-  // before a preview is considered. The flexpane resolves an artifact itself, so a private doc
-  // arrives at the same function, and only its own `listed` check stops a token being minted.
+  // The unfurl never does — decideUnfurl answers a doc that grants the workspace nothing with
+  // the locked card long before a preview is considered. The flexpane resolves an artifact
+  // itself, so a private doc arrives at the same function, and only its own access check stops
+  // a token being minted.
   //
   // Which it must, even though this panel is per-viewer and this viewer just passed a read
   // check. The panel is private; the IMAGE URL is not — Slack fetches it anonymously and its
   // proxy caches the bytes. Being entitled to read something is not the same as consenting to
   // a copy of it living in another company's cache.
   it("mints no screenshot URL for a private doc, even for a viewer who may read it", async () => {
-    const { app, artifact } = await withInstall("flex-private-preview", { listed: "none" })
+    const { app, artifact } = await withInstall("flex-private-preview", {
+      listed: "none",
+      workspace_access: "none",
+    })
     const body = await clickAndCapture(app, artifact.short_id)
     // The viewer IS entitled — the panel opens and names the doc.
     expect(JSON.stringify(body)).toContain("Secret plan")
     expect(JSON.stringify(body)).not.toContain("full_size_preview")
+  })
+
+  // The default team draft, by contrast, mints one here exactly as the channel card does: the
+  // workspace may read it, and the flexpane viewer is a member of that workspace.
+  it("mints a screenshot URL for a team draft in the flexpane", async () => {
+    const { app, artifact } = await withInstall("flex-draft-preview", { listed: "none" })
+    const body = await clickAndCapture(app, artifact.short_id)
+    expect(JSON.stringify(body)).toContain("Secret plan")
+    expect(JSON.stringify(body)).toContain("full_size_preview")
   })
 
   it("does mint one for a workspace-listed doc, which is the whole point", async () => {

--- a/apps/api/test/slack-unfurl.test.ts
+++ b/apps/api/test/slack-unfurl.test.ts
@@ -30,7 +30,15 @@ describe("artifactRefFromUrl", () => {
 })
 
 describe("decideUnfurl — the broadcast gate", () => {
-  const setup = async (name: string, listed: "none" | "workspace") => {
+  // The broadcast gate is ACCESS, not discovery: locked means the artifact grants the
+  // workspace nothing AND is unlisted. The default team draft (workspace_access=member,
+  // listed=none) broadcasts; a link-only draft does not — a link role is personal to
+  // whoever holds the URL, so `link_role: "viewer"` rides along on the locked fixtures
+  // to pin that it never unlocks one.
+  const setup = async (
+    name: string,
+    access: { workspace_access: "none" | "member"; listed: "none" | "workspace" },
+  ) => {
     const { meta } = quotaApp(name, { defaultOrgId: "default" }, [], [])
     const artifact = (await meta.createArtifact({
       id: newId("a"),
@@ -38,9 +46,9 @@ describe("decideUnfurl — the broadcast gate", () => {
       org_id: "default",
       slug: null,
       title: "Q4 plan",
-      workspace_access: "member",
+      workspace_access: access.workspace_access,
       link_role: "viewer",
-      listed,
+      listed: access.listed,
       kind: "file",
       spa: 0,
     })) as ArtifactRecord
@@ -52,19 +60,58 @@ describe("decideUnfurl — the broadcast gate", () => {
     }
     return { meta, artifact, deps, url: `${BASE}/artifacts/${artifact.short_id}` }
   }
+  const TEAM = { workspace_access: "member", listed: "workspace" } as const
+  const DRAFT = { workspace_access: "member", listed: "none" } as const
+  const LINK_ONLY = { workspace_access: "none", listed: "none" } as const
 
   // Without an account link there is no principal to authorize, so Slack's own sign-in prompt
   // is the answer — it is also the only per-person surface chat.unfurl offers.
   it("asks an unlinked sharer to connect", async () => {
-    const { deps, url } = await setup("unfurl-unlinked", "workspace")
+    const { deps, url } = await setup("unfurl-unlinked", TEAM)
     expect((await decideUnfurl(deps, url, null)).kind).toBe("auth")
   })
 
   it("renders a card for a feed-visible artifact", async () => {
-    const { deps, url } = await setup("unfurl-listed", "workspace")
+    const { deps, url } = await setup("unfurl-listed", TEAM)
     const d = await decideUnfurl(deps, url, "u-1")
     expect(d.kind).toBe("card")
     if (d.kind === "card") expect(JSON.stringify(d.blocks)).toContain("Q4 plan")
+  })
+
+  // The default publish shape: workspace members may read it, it just isn't in the library
+  // feed. `listed` is discovery-only and carries no access, so it must not be what decides a
+  // broadcast into the workspace's own Slack — every member of the audience may already open it.
+  it("renders a card for a team draft — workspace access broadcasts, unlisted or not", async () => {
+    const { deps, url } = await setup("unfurl-draft", DRAFT)
+    const d = await decideUnfurl(deps, url, "u-1")
+    expect(d.kind).toBe("card")
+    if (d.kind === "card") expect(JSON.stringify(d.blocks)).toContain("Q4 plan")
+  })
+
+  // The screenshot rides both card shapes: the deps callback resolves the (possibly tokened)
+  // URL once, the blocks carry it as an image block, and the decision carries it for the Work
+  // Object. Null (or no callback at all) means no image block — never a broken one.
+  it("puts the resolved preview image on the block card, and none when unresolved", async () => {
+    const { deps, url } = await setup("unfurl-image", DRAFT)
+    const withImage = await decideUnfurl(
+      { ...deps, previewUrl: async () => "https://derive.test/v1/og/x?t=tok" },
+      url,
+      "u-1",
+    )
+    expect(withImage.kind).toBe("card")
+    if (withImage.kind === "card") {
+      expect(withImage.previewUrl).toBe("https://derive.test/v1/og/x?t=tok")
+      const image = (withImage.blocks as { type: string; image_url?: string }[]).find(
+        (b) => b.type === "image",
+      )
+      expect(image?.image_url).toBe("https://derive.test/v1/og/x?t=tok")
+    }
+    const without = await decideUnfurl(deps, url, "u-1")
+    expect(without.kind).toBe("card")
+    if (without.kind === "card") {
+      expect(without.previewUrl).toBe(null)
+      expect((without.blocks as { type: string }[]).some((b) => b.type === "image")).toBe(false)
+    }
   })
 
   // The unfurl is seen by the whole channel, so a private draft gets a card that confirms
@@ -74,7 +121,7 @@ describe("decideUnfurl — the broadcast gate", () => {
   // the card's href read `…/artifacts/q4-plan-vs8g8mh6` — the title was right there, lowercased
   // and hyphenated, recoverable by hovering the link.
   it("renders a locked card that leaks the title in no form, including the slug", async () => {
-    const { deps, url, artifact } = await setup("unfurl-private", "none")
+    const { deps, url, artifact } = await setup("unfurl-private", LINK_ONLY)
     const d = await decideUnfurl(deps, url, "u-1")
     // `locked` is its own kind now: the BROADCAST half must still say nothing, but the artifact
     // rides along so the caller can build a clickable entity whose flexpane answers per-viewer.
@@ -99,7 +146,7 @@ describe("decideUnfurl — the broadcast gate", () => {
   // on every rename, so building the href from the record would add a title the channel never
   // had — even though the pasted URL carried none.
   it("does not add a title the pasted URL never carried", async () => {
-    const { deps, artifact } = await setup("unfurl-private-bare", "none")
+    const { deps, artifact } = await setup("unfurl-private-bare", LINK_ONLY)
     const d = await decideUnfurl(deps, `${BASE}/artifacts/${artifact.short_id}`, "u-1")
     expect(d.kind).toBe("locked")
     // Same short-id excision as the card test above — its comment already recorded CI
@@ -110,7 +157,7 @@ describe("decideUnfurl — the broadcast gate", () => {
   })
 
   it("skips an artifact the sharer cannot read", async () => {
-    const { deps, url } = await setup("unfurl-unreadable", "workspace")
+    const { deps, url } = await setup("unfurl-unreadable", TEAM)
     const d = await decideUnfurl({ ...deps, canRead: async () => false }, url, "u-1")
     expect(d.kind).toBe("skip")
   })
@@ -118,7 +165,7 @@ describe("decideUnfurl — the broadcast gate", () => {
   // Belongs to another Derive workspace: even if the sharer personally has access, it must not
   // render into THIS team's channel.
   it("skips an artifact from a different workspace", async () => {
-    const { deps, url } = await setup("unfurl-other-org", "workspace")
+    const { deps, url } = await setup("unfurl-other-org", TEAM)
     const d = await decideUnfurl({ ...deps, orgId: "some-other-org" }, url, "u-1")
     expect(d.kind).toBe("skip")
   })
@@ -126,7 +173,7 @@ describe("decideUnfurl — the broadcast gate", () => {
   it("skips a URL with a malformed percent escape instead of throwing", async () => {
     // This used to raise URIError out of decodeURIComponent, which runAfterAck swallowed —
     // silently killing every OTHER preview in the same message.
-    const { deps } = await setup("unfurl-badescape", "workspace")
+    const { deps } = await setup("unfurl-badescape", TEAM)
     expect(artifactRefFromUrl(BASE, `${BASE}/artifacts/%zz`)).toBe(null)
     expect((await decideUnfurl(deps, `${BASE}/artifacts/100%-done-abc12345`, "u-1")).kind).toBe(
       "skip",
@@ -134,7 +181,7 @@ describe("decideUnfurl — the broadcast gate", () => {
   })
 
   it("skips a URL that isn't an artifact link", async () => {
-    const { deps } = await setup("unfurl-nonartifact", "workspace")
+    const { deps } = await setup("unfurl-nonartifact", TEAM)
     expect((await decideUnfurl(deps, `${BASE}/pricing`, "u-1")).kind).toBe("skip")
     expect((await decideUnfurl(deps, `${BASE}/artifacts/nope404`, "u-1")).kind).toBe("skip")
   })


### PR DESCRIPTION
## What

Pasting a Derive link into the workspace's own Slack now renders the full card — title, description, screenshot — for any doc the whole workspace can read, including the default team draft (`workspace_access=member, listed=none`). Previously those rendered the title-less padlock card, because the broadcast gate keyed on `listed` rather than access.

## Why the gate moved

An unfurl is attached to the message, not a viewer, so the question is "may this be broadcast to the channel". The field that answers it is `workspace_access` — whether every member of the workspace behind this Slack team may read the doc — not `listed`, which is discovery-only and carries no access (per the schema). The team draft is the default publish shape and the one people paste most, and it was exactly the shape that rendered as locked.

## Changes

- **`decideUnfurl`**: locked card only when the artifact grants the workspace nothing AND is unlisted. A link role alone still never broadcasts (personal to the URL holder), cross-workspace links still never render, and the sharer still needs read standing.
- **`previewUrlFor`**: mints the signed, version-pinned OG token (`lib/og-token.ts`) for `workspace_access=member` too, so team drafts carry their screenshot on the channel card and in the flexpane. Public docs still link the image directly; docs granting the workspace nothing still mint nothing.
- **Block Kit fallback card** now carries the same image the Work Object does. It predated the token mechanism and had a "revisit when a signed token exists" note; the token resolves once in `decideUnfurl` and rides both card shapes.

## What deliberately did not change

- Genuinely private docs (explicit shares only, or link-only drafts) keep the padlock: no title, no image, no token minted — including for a flexpane viewer who may personally read the doc, since the image URL is fetched anonymously and cached by Slack's proxy.
- Channel subscriptions (`lib/slack-subscriptions.ts`) still suppress `listed=none` docs. That's push rather than a deliberate paste, so it stays as-is.

Known trade, same one already accepted for workspace-listed docs: Slack channel membership isn't identical to Derive workspace membership (guests, Slack Connect), so a team draft's card is visible to whoever can see the channel.

Tests cover the new gate at both layers: the decision ladder unit tests (team draft → card, link-only → locked with no title in any form) and the route tests (tokened screenshot for team drafts, none for private docs, flexpane minting).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789051207&installation_model_id=428097&pr_number=694&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F694&signature=5beccd5e7b0fe137889966cd57e58d893cb8cf4a629e8f5468aeb79e7928a629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->