### PR TITLE
fix(settings): polish the Agents, Webhooks, and GitHub pages

### DIFF
--- a/apps/web/src/pages/settings/agents-section.tsx
+++ b/apps/web/src/pages/settings/agents-section.tsx
@@ -40,14 +40,7 @@ export function AgentsSection({ meId }: { meId: string }) {
   return (
     <SettingsSection
       title="Agents"
-      description={
-        <>
-          Register an agent so people can <code className="font-mono">@mention</code> it in a
-          thread. It gets a scoped token and acts as a commenter — it can propose changes for
-          review, but a human still approves. The agent reads its mentions from{" "}
-          <code className="font-mono">GET /v1/agent/inbox</code> with its token.
-        </>
-      }
+      description="Register an agent so people can @mention it in a thread. It proposes changes; a human approves."
     >
       <NewAgent onCreated={reload} />
 
@@ -77,8 +70,8 @@ export function AgentsSection({ meId }: { meId: string }) {
           plan), then the agent OWNER's plan (only for agents lent above), then the shared
           workspace pool. The personal plan lives under You → Model plans and is linked
           here; only the workspace pool is managed in place. */}
-      <div className="flex flex-col gap-5">
-        <SettingsGroup title="Your plan" description="Managed under You → Model plans.">
+      <div className="flex flex-col gap-8">
+        <SettingsGroup>
           <SettingRow
             label="Your plan"
             description="Runs you start bill your own connected plan first."
@@ -92,8 +85,8 @@ export function AgentsSection({ meId }: { meId: string }) {
         </SettingsGroup>
 
         <SettingsGroup
-          title="Workspace model plan pool"
-          description="A shared plan billed when a run's initiator has no plan of their own and the agent isn't lent its owner's. Optional — leave it empty to require everyone to bring their own."
+          title="Workspace plan pool"
+          description="Optional. A shared plan for runs whose starter has no plan of their own."
         >
           <div>
             <ModelPlanManager scope="pool" />
@@ -136,7 +129,7 @@ function NewAgent({ onCreated }: { onCreated: () => void }) {
           className="min-w-45 flex-1"
         />
         <Select value={role} onValueChange={(v) => setRole(v as Role)}>
-          <SelectTrigger data-testid="agent-role" aria-label="Agent role" className="w-37.5">
+          <SelectTrigger data-testid="agent-role" aria-label="Agent role" className="w-46">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>

--- a/apps/web/src/pages/settings/github-advanced-pat.tsx
+++ b/apps/web/src/pages/settings/github-advanced-pat.tsx
@@ -55,10 +55,10 @@ export function AdvancedPat({ onCreated }: { onCreated: () => void }) {
       <Button
         variant="link"
         data-testid="github-advanced-toggle"
-        className="h-auto p-0"
+        className="h-auto p-0 font-normal text-muted-foreground underline decoration-border underline-offset-2 hover:text-foreground"
         onClick={() => setOpen((o) => !o)}
       >
-        {open ? "Hide advanced" : "Advanced: connect with a token or a public repo"}
+        {open ? "Hide advanced" : "Advanced: connect with a token or a public repo…"}
       </Button>
       {open && (
         <Card className="mt-2 gap-3 p-4">

--- a/apps/web/src/pages/settings/github-section.tsx
+++ b/apps/web/src/pages/settings/github-section.tsx
@@ -92,10 +92,16 @@ export function GithubSection() {
         <SetUpApp />
       )}
 
-      {/* Rendered only once status is known. */}
+      {/* Rendered only once status is known. Before the App exists, the setup
+          card above is the whole story — a "no repos yet" line under it would
+          point at a step that isn't available yet. */}
       {status !== null &&
         (status.sources.length === 0 ? (
-          <EmptyState>No repos connected yet. Add one above.</EmptyState>
+          appConfigured && (
+            <EmptyState>
+              No repos mirrored yet — install the app on a repo above, then pick it here.
+            </EmptyState>
+          )
         ) : (
           <SettingsGroup title="Mirrored repositories">
             {status.sources.map((s) => (

--- a/apps/web/src/pages/settings/model-plan-manager.tsx
+++ b/apps/web/src/pages/settings/model-plan-manager.tsx
@@ -2,7 +2,6 @@ import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useState } from "react"
 import { api, type ModelCredentialHint } from "@/api"
 import { ConfirmDialog } from "@/components/shared/confirm-dialog"
-import { EmptyState } from "@/components/shared/empty-state"
 import { ListRow } from "@/components/shared/list-row"
 import { LoadError } from "@/components/shared/load-error"
 import { SettingsGroup } from "@/components/shared/settings-group"
@@ -82,10 +81,6 @@ export function ModelPlanManager({ scope }: { scope: Scope }) {
   const connect = scope === "pool" ? api.connectPoolCredential : api.connectModelCredential
   const disconnect = scope === "pool" ? api.disconnectPoolCredential : api.disconnectModelCredential
   const prefix = scope === "pool" ? "pool-model-plan" : "model-plan"
-  const empty =
-    scope === "pool"
-      ? "No shared plan connected. Connect one above to give the workspace a fallback."
-      : "No plan connected yet. Connect one above to run on your own plan."
 
   return (
     <>
@@ -101,9 +96,9 @@ export function ModelPlanManager({ scope }: { scope: Scope }) {
           testId={`${prefix}-retry`}
           onRetry={() => refetch()}
         />
-      ) : !creds || creds.length === 0 ? (
-        <EmptyState>{empty}</EmptyState>
-      ) : (
+      ) : // No plans yet renders NOTHING: the connect form above is the empty
+      // state, and a "no plan yet" line under it would only repeat the form.
+      !creds || creds.length === 0 ? null : (
         <SettingsGroup>
           {creds.map((c) => (
             <CredentialRow

--- a/apps/web/src/pages/settings/webhooks-section.tsx
+++ b/apps/web/src/pages/settings/webhooks-section.tsx
@@ -37,8 +37,8 @@ export function WebhooksSection() {
       title="Webhooks"
       description={
         <>
-          Get a POST (or a Slack message) when a comment is added or resolved, or a new version is
-          published. Generic payloads are signed with{" "}
+          Get a POST — or a Slack message — when comments change or a new version is published.
+          Payloads are signed (
           <a
             href="https://www.standardwebhooks.com"
             target="_blank"
@@ -46,9 +46,8 @@ export function WebhooksSection() {
             className="text-primary underline underline-offset-2"
           >
             Standard Webhooks
-          </a>{" "}
-          headers (<code className="font-mono">webhook-signature</code>), and the legacy{" "}
-          <code className="font-mono">X-Derive-Signature</code>.
+          </a>
+          ).
         </>
       }
     >
@@ -86,6 +85,7 @@ function NewWebhook({
   const [kind, setKind] = useState<"generic" | "slack">("generic")
   // Everything ticked by default, and "everything ticked" is what sends no filter at all.
   const [events, setEvents] = useState<string[] | null>(null)
+  const [filtering, setFiltering] = useState(false)
   const selected = events ?? eventOptions
   const valid = /^https?:\/\//.test(url)
   const urlField = fieldError(
@@ -108,6 +108,7 @@ function NewWebhook({
     onSuccess: () => {
       setUrl("")
       setEvents(null)
+      setFiltering(false)
       onCreated()
     },
   })
@@ -124,21 +125,37 @@ function NewWebhook({
       after={
         <>
           {urlField.node}
-          <div className="flex flex-wrap gap-3.5">
-            {eventOptions.map((e) => (
-              <label
-                key={e}
-                className="flex items-center gap-1.5 font-mono text-2xs text-muted-foreground"
-              >
-                <Checkbox
-                  data-testid={`webhook-event-${e}`}
-                  checked={selected.includes(e)}
-                  onCheckedChange={() => toggle(e)}
-                />
-                {e}
-              </label>
-            ))}
-          </div>
+          {/* The default is every event, which stores no filter — so the checkbox
+              wall carries no information until someone wants to narrow it. Keep it
+              behind a quiet disclosure; surface it automatically once narrowed. */}
+          {!filtering && events === null ? (
+            <Button
+              type="button"
+              data-testid="webhook-filter-events"
+              variant="link"
+              size="sm"
+              className="self-start px-0 text-muted-foreground"
+              onClick={() => setFiltering(true)}
+            >
+              Sends every event — filter…
+            </Button>
+          ) : (
+            <div className="flex flex-wrap gap-3.5">
+              {eventOptions.map((e) => (
+                <label
+                  key={e}
+                  className="flex items-center gap-1.5 font-mono text-2xs text-muted-foreground"
+                >
+                  <Checkbox
+                    data-testid={`webhook-event-${e}`}
+                    checked={selected.includes(e)}
+                    onCheckedChange={() => toggle(e)}
+                  />
+                  {e}
+                </label>
+              ))}
+            </div>
+          )}
         </>
       }
     >


### PR DESCRIPTION
From a design review of the live pages (screenshots in the review notes; each fix verified by screenshotting the running app):

- **Agents** — the plan area rendered "Your plan" twice (a group title and a row label saying the same thing); one header now. The role select was too narrow for its own longest option ("Commenter (propose)" truncated). The intro is one human sentence instead of API documentation. The pool description is one line, and the redundant "no plan connected" line under the connect form is gone — the form is the empty state.
- **Webhooks** — the ten event checkboxes (all ticked by default, which stores no filter) hide behind a quiet "Sends every event — filter…" disclosure until someone narrows them. Intro trimmed; signature details stay one link away.
- **GitHub** — the advanced connect disclosure reads as a link instead of a bare heading; the empty state names the real next step (install the app on a repo, then pick it) and no longer renders before the App exists.

No behavior changes beyond the disclosure default; all testids preserved (one added: `webhook-filter-events`). `pnpm verify` green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/695"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789052842&installation_model_id=428097&pr_number=695&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F695&signature=27cb6ab47989e4b688d5b48b0dec66bc164aaff35a123df9a3897c821b8e4ffe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->