### PR TITLE
fix(settings): one row grammar, quiet list empties, no shouted duplicates

### DIFF
--- a/apps/web/src/components/shared/setting-row.tsx
+++ b/apps/web/src/components/shared/setting-row.tsx
@@ -34,7 +34,21 @@ export function SettingRow({
         className,
       )}
     >
-      <div className="flex min-w-0 flex-col gap-0.5">
+      {/* flex-1, NOT auto-width: the text column has to shrink and wrap its own
+          sentences instead of pushing the control onto a second line. Without it,
+          a long description silently moved the control below the text — so a row's
+          switch sat left-aligned under its paragraph while every short-description
+          row beside it kept its switch on the right.
+          A described row also takes basis-64, so a narrow pane wraps it deliberately
+          rather than squeezing prose to a ribbon. A bare label keeps flex-1's own
+          0 basis: reserving 256px for two words is what pushes a wide control
+          (an arbitrary-length select) onto its own line — the same bug, moved. */}
+      <div
+        className={cn(
+          "flex min-w-0 flex-1 flex-col gap-0.5",
+          description !== undefined && "basis-64",
+        )}
+      >
         {htmlFor ? (
           <Label htmlFor={htmlFor} className="text-foreground">
             {label}

--- a/apps/web/src/components/shared/settings-empty.tsx
+++ b/apps/web/src/components/shared/settings-empty.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react"
+
+// "Nothing in this list yet", inside a settings section.
+//
+// NOT EmptyState: that one is a page-level moment — centered, p-10/py-14, a serif
+// headline — which is right for an empty library and wrong under an add-form,
+// where it strands a centered sentence in a lake of whitespace far below the
+// control that fills it. This is the quiet version: one muted line, left-aligned,
+// sitting directly under the form at row rhythm. Say what the list will hold, not
+// "add one above" — the form is already above, and pointing at it is noise.
+export function SettingsEmpty({ children }: { children: ReactNode }) {
+  return <p className="py-3.5 text-sm text-muted-foreground">{children}</p>
+}

--- a/apps/web/src/pages/brandprint/brandprint-section.tsx
+++ b/apps/web/src/pages/brandprint/brandprint-section.tsx
@@ -356,13 +356,25 @@ export function BrandprintSection({ scope }: { scope: "workspace" | "account" })
           )}
         </>
       ) : (
+        // Both scopes render this row, so its label can't be a generic "Get
+        // started" and its button can't be a second filled primary — stacked,
+        // they read as the same block pasted twice. The scope's own group header
+        // says which one this is; the row says what it would do.
         <SettingRow
-          label="Get started"
-          description="Upload files for how your work should look and read, write your conventions from scratch, or use an existing collection."
+          label="Nothing set up yet"
+          description="Upload files, write your conventions, or point at an existing collection."
         >
           <Dialog open={createOpen} onOpenChange={setCreateOpen}>
             <DialogTrigger asChild>
-              <Button size="sm" data-testid={`brandprint-create-${scope}`} disabled={disabled}>
+              {/* Outline in both scopes: whichever one is empty may be the only
+                  create row on the page, so keying the fill to scope would
+                  de-emphasize the page's single action half the time. */}
+              <Button
+                size="sm"
+                variant="outline"
+                data-testid={`brandprint-create-${scope}`}
+                disabled={disabled}
+              >
                 Create Brandprint
               </Button>
             </DialogTrigger>

--- a/apps/web/src/pages/settings/agents-section.tsx
+++ b/apps/web/src/pages/settings/agents-section.tsx
@@ -4,11 +4,11 @@ import { Bot } from "lucide-react"
 import { useState } from "react"
 import { type Agent, api, type Role } from "@/api"
 import { ConfirmDialog } from "@/components/shared/confirm-dialog"
-import { EmptyState } from "@/components/shared/empty-state"
 import { ListRow } from "@/components/shared/list-row"
 import { LoadError } from "@/components/shared/load-error"
 import { SecretReveal } from "@/components/shared/secret-reveal"
 import { SettingRow } from "@/components/shared/setting-row"
+import { SettingsEmpty } from "@/components/shared/settings-empty"
 import { SettingsGroup } from "@/components/shared/settings-group"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
@@ -49,7 +49,9 @@ export function AgentsSection({ meId }: { meId: string }) {
       ) : isError ? (
         <LoadError title="Couldn’t load agents" testId="agents-retry" onRetry={() => refetch()} />
       ) : !agents || agents.filter((a) => !a.managed).length === 0 ? (
-        <EmptyState>No agents yet. Add one above.</EmptyState>
+        <SettingsEmpty>
+          No agents yet. A registered agent can be @mentioned in any thread.
+        </SettingsEmpty>
       ) : (
         <SettingsGroup>
           {agents

--- a/apps/web/src/pages/settings/automations-section.tsx
+++ b/apps/web/src/pages/settings/automations-section.tsx
@@ -5,10 +5,10 @@ import { useState } from "react"
 import { type Automation, api, type Run } from "@/api"
 import { AdminNote } from "@/components/shared/admin-note"
 import { ConfirmDialog } from "@/components/shared/confirm-dialog"
-import { EmptyState } from "@/components/shared/empty-state"
 import { ListRow } from "@/components/shared/list-row"
 import { LoadError } from "@/components/shared/load-error"
 import { Eyebrow } from "@/components/shared/section-eyebrow"
+import { SettingsEmpty } from "@/components/shared/settings-empty"
 import { SettingsGroup } from "@/components/shared/settings-group"
 import { StatusBadge } from "@/components/shared/status-badge"
 import { Badge } from "@/components/ui/badge"
@@ -70,9 +70,11 @@ export function AutomationsSection() {
           onRetry={() => refetch()}
         />
       ) : !automations || automations.length === 0 ? (
-        <EmptyState>
-          {isAdmin ? "No automations yet. Create one above." : "No automations yet."}
-        </EmptyState>
+        <SettingsEmpty>
+          {isAdmin
+            ? "No automations yet — nothing runs on a schedule or trigger."
+            : "No automations yet."}
+        </SettingsEmpty>
       ) : (
         <SettingsGroup>
           {automations.map((a) => (

--- a/apps/web/src/pages/settings/custom-domains-section.tsx
+++ b/apps/web/src/pages/settings/custom-domains-section.tsx
@@ -5,6 +5,7 @@ import { ConfirmDialog } from "@/components/shared/confirm-dialog"
 import { EmptyState } from "@/components/shared/empty-state"
 import { ListRow } from "@/components/shared/list-row"
 import { LoadError } from "@/components/shared/load-error"
+import { SettingsEmpty } from "@/components/shared/settings-empty"
 import { SettingsGroup } from "@/components/shared/settings-group"
 import { StatusBadge, type StatusTone } from "@/components/shared/status-badge"
 import { Button } from "@/components/ui/button"
@@ -44,6 +45,8 @@ export function CustomDomainsSection() {
   if (!state?.enabled)
     return (
       <SettingsSection title="Domains" description={description}>
+        {/* Not a list empty — this IS the section when the server has no custom-domain
+            support, so it keeps the page-level treatment. */}
         <EmptyState>Custom domains aren't enabled on this server.</EmptyState>
       </SettingsSection>
     )
@@ -53,7 +56,9 @@ export function CustomDomainsSection() {
       <NewDomain cnameTarget={state.cname_target} onCreated={reload} />
 
       {state.domains.length === 0 ? (
-        <EmptyState>No custom domains yet. Add one above.</EmptyState>
+        <SettingsEmpty>
+          No custom domains yet — shared pages use the default derive.to address.
+        </SettingsEmpty>
       ) : (
         <SettingsGroup>
           {state.domains.map((d) => (

--- a/apps/web/src/pages/settings/general-section.tsx
+++ b/apps/web/src/pages/settings/general-section.tsx
@@ -208,8 +208,8 @@ export function GeneralSection() {
         <>
           <SettingsGroup title="Danger zone">
             <SettingRow
-              label={<span className="font-medium text-destructive">Delete this workspace</span>}
-              description="Permanently delete this workspace. It must be empty (no artifacts), and this can't be undone."
+              label="Delete this workspace"
+              description="Permanently deletes this workspace. It must be empty (no artifacts), and this can't be undone."
             >
               <Button
                 data-testid="workspace-delete"

--- a/apps/web/src/pages/settings/github-section.tsx
+++ b/apps/web/src/pages/settings/github-section.tsx
@@ -1,8 +1,8 @@
 import { useQueryClient } from "@tanstack/react-query"
 import { useEffect, useState } from "react"
 import { api, type GithubSyncStatus } from "@/api"
-import { EmptyState } from "@/components/shared/empty-state"
 import { LoadError } from "@/components/shared/load-error"
+import { SettingsEmpty } from "@/components/shared/settings-empty"
 import { SettingsGroup } from "@/components/shared/settings-group"
 import { toast } from "@/components/ui/sonner"
 import { useOneShotParams } from "@/lib/use-one-shot-params"
@@ -98,9 +98,9 @@ export function GithubSection() {
       {status !== null &&
         (status.sources.length === 0 ? (
           appConfigured && (
-            <EmptyState>
+            <SettingsEmpty>
               No repos mirrored yet — install the app on a repo above, then pick it here.
-            </EmptyState>
+            </SettingsEmpty>
           )
         ) : (
           <SettingsGroup title="Mirrored repositories">

--- a/apps/web/src/pages/settings/profile-section.tsx
+++ b/apps/web/src/pages/settings/profile-section.tsx
@@ -67,11 +67,9 @@ export function ProfileSection() {
         <FormField
           label="Username"
           className="min-w-60 flex-1"
-          hint={
-            <>
-              <span className="font-medium text-foreground">{me.email}</span> stays private.
-            </>
-          }
+          // The address is a fact, not the emphasis: bolding it made the hint
+          // louder than the field label above it.
+          hint={`${me.email} stays private.`}
         >
           <UsernameForm
             initial={me.username ?? ""}
@@ -93,7 +91,7 @@ export function ProfileSection() {
         <SettingRow
           htmlFor="account-discoverable"
           label="Public profile"
-          description={`On by default. Your profile at @${me.username ?? "handle"} — name, role, photo, and public work — is visible to anyone, and you appear in people search. Turn it off and only people who share a workspace with you can see it.`}
+          description={`Anyone can see your name, role, photo, and public work at @${me.username ?? "handle"}, and you turn up in people search. Off means only workspace-mates find you.`}
         >
           <Switch
             id="account-discoverable"

--- a/apps/web/src/pages/settings/security-section.tsx
+++ b/apps/web/src/pages/settings/security-section.tsx
@@ -4,12 +4,12 @@ import { QRCodeSVG } from "qrcode.react"
 import { useEffect, useState } from "react"
 import { type AuthCapabilities, api } from "@/api"
 import { ConfirmDialog } from "@/components/shared/confirm-dialog"
-import { EmptyState } from "@/components/shared/empty-state"
 import { FormField } from "@/components/shared/form-field"
 import { ListRow } from "@/components/shared/list-row"
 import { LoadError } from "@/components/shared/load-error"
 import { SecretReveal } from "@/components/shared/secret-reveal"
 import { SettingRow } from "@/components/shared/setting-row"
+import { SettingsEmpty } from "@/components/shared/settings-empty"
 import { SettingsGroup } from "@/components/shared/settings-group"
 import { StatusPanel } from "@/components/shared/status-panel"
 import { Badge } from "@/components/ui/badge"
@@ -201,9 +201,12 @@ function DeleteAccount() {
 
   return (
     <SettingsGroup title="Danger zone">
+      {/* The group header carries the danger; the label states the thing and the
+          button is the verb. Saying "Delete account" in red twice on one row —
+          once as a label, once as the button — is emphasis eating itself. */}
       <SettingRow
-        label={<span className="font-medium text-destructive">Delete account</span>}
-        description="Permanently delete your account and remove you from every workspace. This can't be undone."
+        label="Delete this account"
+        description="Permanently deletes your account and removes you from every workspace. This can't be undone."
       >
         <Dialog open={open} onOpenChange={setOpen}>
           <DialogTrigger asChild>
@@ -729,9 +732,9 @@ function Passkeys() {
         </div>
       ) : !passkeys || passkeys.length === 0 ? (
         <div>
-          <EmptyState>
+          <SettingsEmpty>
             No passkeys yet. Add one for a phishing-resistant, one-tap sign-in.
-          </EmptyState>
+          </SettingsEmpty>
         </div>
       ) : (
         passkeys.map((p) => (

--- a/apps/web/src/pages/settings/slack-subscriptions-section.tsx
+++ b/apps/web/src/pages/settings/slack-subscriptions-section.tsx
@@ -1,8 +1,8 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useState } from "react"
 import { api } from "@/api"
-import { EmptyState } from "@/components/shared/empty-state"
 import { LoadError } from "@/components/shared/load-error"
+import { SettingsEmpty } from "@/components/shared/settings-empty"
 import { SettingsGroup } from "@/components/shared/settings-group"
 import {
   Select,
@@ -43,7 +43,11 @@ export function SlackSubscriptionsSection() {
           onRetry={() => refetch()}
         />
       ) : !data || data.subscriptions.length === 0 ? (
-        <EmptyState>No channels subscribed yet. Add one above.</EmptyState>
+        // Padding-neutral wrapper: as the group's last child its own pb would be
+        // stripped, hugging the sentence against the group's bottom edge.
+        <div>
+          <SettingsEmpty>No channels subscribed yet — nothing is posted to Slack.</SettingsEmpty>
+        </div>
       ) : (
         data.subscriptions.map((s) => (
           <SlackSubscriptionRow

--- a/apps/web/src/pages/settings/sources-section.tsx
+++ b/apps/web/src/pages/settings/sources-section.tsx
@@ -2,9 +2,9 @@ import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useEffect, useState } from "react"
 import { api, type Connection } from "@/api"
 import { ConfirmDialog } from "@/components/shared/confirm-dialog"
-import { EmptyState } from "@/components/shared/empty-state"
 import { ListRow } from "@/components/shared/list-row"
 import { LoadError } from "@/components/shared/load-error"
+import { SettingsEmpty } from "@/components/shared/settings-empty"
 import { SettingsGroup } from "@/components/shared/settings-group"
 import { StatusBadge } from "@/components/shared/status-badge"
 import { StatusPanel } from "@/components/shared/status-panel"
@@ -54,14 +54,10 @@ export function SourcesSection() {
   return (
     <SettingsSection
       title="Sources"
-      description={
-        <>
-          Connect a Model Context Protocol server and your agents can read from it during a run. The
-          server's tools are recorded when you connect, and if that list later changes the
-          connection goes quiet until you reconnect — so a server cannot rewrite what your agent
-          reads after you have approved it.
-        </>
-      }
+      // The second sentence is not decoration: a server that changes its tool list
+      // goes quiet, and the row still reads "Connected" while runs read nothing
+      // from it. This page is the only place that fact is stated.
+      description="Connect an MCP server and your agents can read from it during a run. Its tools are recorded when you connect; if that list changes later, the source goes quiet until you reconnect."
     >
       {justConnected ? (
         <StatusPanel
@@ -83,10 +79,9 @@ export function SourcesSection() {
           onRetry={() => refetch()}
         />
       ) : sources.length === 0 ? (
-        <EmptyState
-          title="No sources connected"
-          description="Add an MCP server above to give your agents something to read."
-        />
+        <SettingsEmpty>
+          No sources connected — your agents have nothing extra to read.
+        </SettingsEmpty>
       ) : (
         <SettingsGroup>
           {sources.map((c) => (
@@ -203,9 +198,8 @@ function AddSource({ onAdded }: { onAdded: () => void }) {
           onChange={(e) => setSecret(e.target.value)}
         />
         <p className="text-muted-foreground text-xs">
-          Leave this empty unless the server has no sign-in. If it asks you to authorize, Connect
-          takes you there. A token you do paste is encrypted, spent on the server, and never shown
-          again — you will only ever see its last four characters.
+          Leave empty unless the server has no sign-in. A pasted token is encrypted and never shown
+          again.
         </p>
       </div>
       {error ? (

--- a/apps/web/src/pages/settings/webhooks-section.tsx
+++ b/apps/web/src/pages/settings/webhooks-section.tsx
@@ -2,10 +2,10 @@ import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useState } from "react"
 import { api, type Webhook } from "@/api"
 import { ConfirmDialog } from "@/components/shared/confirm-dialog"
-import { EmptyState } from "@/components/shared/empty-state"
 import { fieldError } from "@/components/shared/field-error"
 import { ListRow } from "@/components/shared/list-row"
 import { LoadError } from "@/components/shared/load-error"
+import { SettingsEmpty } from "@/components/shared/settings-empty"
 import { SettingsGroup } from "@/components/shared/settings-group"
 import { Spinner } from "@/components/shared/spinner"
 import { StatusBadge, type StatusTone } from "@/components/shared/status-badge"
@@ -62,7 +62,7 @@ export function WebhooksSection() {
           onRetry={() => refetch()}
         />
       ) : !hooks || hooks.length === 0 ? (
-        <EmptyState>No webhooks yet. Add one above.</EmptyState>
+        <SettingsEmpty>No webhooks yet — nothing is being sent anywhere.</SettingsEmpty>
       ) : (
         <SettingsGroup>
           {hooks.map((w) => (


### PR DESCRIPTION
A design pass over the settings pages, each fix verified by screenshotting the running app.

## The row primitive had a layout bug with real reach

A long description sized `SettingRow`'s text column to its content, pushing the row's control onto a second line. Integrations rendered one switch left-aligned under its paragraph while the three rows beside it kept theirs on the right; Profile's discoverability switch did the same. The text column now flexes and wraps its own sentences instead.

A *described* row keeps a basis so a narrow pane still wraps deliberately; a bare label doesn't — reserving 256px for two words pushes a wide select (Brandprint's collection picker, whose trigger renders an arbitrary title) onto its own line, which is the same bug relocated.

## List empties get their own quiet component

`EmptyState` is a page-level moment — centered, `py-14`, serif headline — which under an add-form stranded a sentence in a lake of whitespace. Worst on Security, where "No passkeys yet" floated in a void between two groups. New `SettingsEmpty`: one muted line at row rhythm, saying what the list will hold rather than pointing at the form directly above it. Applied to agents, webhooks, domains, slack subscriptions, automations, github, sources, passkeys. The Domains *capability* state ("not enabled on this server") stays page-level — it is the whole section, not a list empty.

## Duplication and emphasis

- Both danger rows said their verb twice, once as a red label and again as a red button. The group header carries the danger; the label states the thing, the button is the verb.
- Brandprint's two setup rows were the same block pasted twice, down to the sentence — relabeled, and neither button is filled (whichever scope is empty may be the page's only create action).
- Profile bolded the email inside a hint until it outweighed the field label above it.
- Sources and Profile shed sentences that weren't earning their line — but **Sources keeps** the one saying a changed tool list goes quiet: the row still reads "Connected" while runs read nothing from it, and this page is the only place that fact appears. Profile's discoverability copy keeps "you turn up in people search" for the same reason (the flag gates search enumeration, not just profile visibility).

## Verified

`pnpm verify` green. Screenshotted before/after on the affected pages. Independent adversarial review; all six surviving findings fixed in this branch (the two copy regressions above, the bare-label basis case, the misapplied Domains empty, a stripped bottom padding on the Slack list empty, and the scope-keyed button fill).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789055099&installation_model_id=428097&pr_number=696&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F696&signature=f74ffcd399ada5bbb0a8e1033f6296e6467470aba5de08f75eb154f7efb981dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->