### PR TITLE
Harden self-hosted deployment and recovery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,9 +87,13 @@ DATA_DIR=./data
 # production (also encrypts stored third-party credentials at rest).
 # DERIVE_AUTH_SECRET=change-me-to-a-long-random-string
 
-# Instance operators (super-admins): comma-separated emails that get global powers
-# (cross-workspace takedown, the reports/audit queue) on top of the DERIVE_TOKEN bearer.
+# Deprecated migration only: matching verified legacy accounts are bound once to
+# immutable user-id operator records. This list never admits account creation.
 # DERIVE_SUPERADMIN_EMAILS=you@example.com,ops@example.com
+
+# Account admission: open (anyone), invite (requires a live invitation capability),
+# or closed (offline bootstrap only). Existing users can always sign in.
+# DERIVE_SIGNUP_MODE=invite
 
 # When the web app is served from a different origin than the API (the hosted split, or
 # a reverse proxy), list the web origin(s) here, comma-separated. localhost dev ports

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,12 +173,28 @@ jobs:
               - 'packages/**'
               - 'pnpm-lock.yaml'
               - 'package.json'
-            docker:
+            runner:
               - 'packages/cli/**'
               - 'pnpm-lock.yaml'
               - 'deploy/runner.Dockerfile'
               - 'deploy/runner.Dockerfile.dockerignore'
               - 'deploy/runner-entrypoint.sh'
+            app_image:
+              - '.dockerignore'
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/release-images.yml'
+              - 'apps/api/**'
+              - 'apps/web/**'
+              - 'packages/broker/**'
+              - 'packages/core/**'
+              - 'packages/db/**'
+              - 'packages/storage/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'deploy/Dockerfile*'
+              - 'deploy/compose*.yml'
+              - 'deploy/selfhost.env.example'
       - uses: ./.github/actions/setup
 
       # More workers than cores, deliberately. This lane is the critical path —
@@ -230,13 +246,39 @@ jobs:
       # CLI's only dependency is fflate, pure JS. So an arch change would not break
       # this step; it just would not be building the thing that ships.)
       - name: Build runner image + start check
-        if: steps.filter.outputs.docker == 'true'
+        if: steps.filter.outputs.runner == 'true'
         # No token/context on purpose: a healthy image exits 1 with the house
         # one-liner, not a stack trace — proves node, the CLI, and its deps wired.
         run: |
           docker build -f deploy/runner.Dockerfile -t derive-runner:ci .
           out=$(docker run --rm derive-runner:ci serve 2>&1) && exit 1 || true
           echo "$out" | grep -q "error: a context id and an agent token are required"
+
+      # The self-host image is a release artifact in its own right. Build and boot
+      # it on every affecting PR so a bad production dependency graph, non-root
+      # permission, SPA path, or healthcheck cannot wait until a version tag.
+      - name: Build self-host image + readiness check
+        if: steps.filter.outputs.app_image == 'true'
+        run: |
+          mkdir -p deploy/backups
+          printf '%s\n' 'build-context-secret-canary' > deploy/.env
+          printf '%s\n' 'build-context-backup-canary' > deploy/backups/build-context-canary
+          docker build -f deploy/Dockerfile --build-arg REVISION="$GITHUB_SHA" -t derive:ci .
+          id=$(docker run -d -p 127.0.0.1:18080:8080 derive:ci)
+          trap 'docker rm -f "$id" >/dev/null 2>&1 || true' EXIT
+          for _ in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:18080/readyz >/dev/null; then
+              curl -fsS http://127.0.0.1:18080/healthz >/dev/null
+              curl -fsS http://127.0.0.1:18080/ >/dev/null
+              test "$(docker inspect -f '{{.Config.User}}' derive:ci)" = node
+              docker exec "$id" node --import tsx src/server-cli.ts backup /tmp/smoke-backup
+              docker exec "$id" node --import tsx src/server-cli.ts verify-backup /tmp/smoke-backup
+              exit 0
+            fi
+            sleep 2
+          done
+          docker logs "$id"
+          exit 1
 
   # CD: ship main to the hosted tier (Workers + Hyperdrive/Neon, derive.to) once
   # both lanes pass. Schemas (D1 + Postgres) land BEFORE the worker flips, so a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,7 +279,8 @@ jobs:
           cp deploy/selfhost.env.example "$staged/selfhost.env.example"
           sed -i 's|^DERIVE_IMAGE=.*|DERIVE_IMAGE=derive:ci|' "$staged/selfhost.env.example"
           printf 'derive:ci\n' > "$staged/image-digest.txt"
-          cp "$staged/compose.yml" "$staged/selfhost.env.example" "$staged/image-digest.txt" "$published/"
+          (cd "$staged" && sha256sum compose.yml selfhost.env.example image-digest.txt > SHA256SUMS)
+          cp "$staged/compose.yml" "$staged/selfhost.env.example" "$staged/image-digest.txt" "$staged/SHA256SUMS" "$published/"
           DERIVE_RELEASE_DOWNLOAD_BASE="file://$bundle_root/published" \
             scripts/test-published-selfhost-bundle.sh \
               v0.0.0-ci derive:ci 18080 "$staged"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,7 @@ jobs:
               - 'deploy/compose*.yml'
               - 'deploy/selfhost.env.example'
               - 'scripts/selfhost-smoke-client.mjs'
+              - 'scripts/test-published-selfhost-bundle.sh'
               - 'scripts/test-selfhost-quickstart.sh'
       - uses: ./.github/actions/setup
 
@@ -267,7 +268,21 @@ jobs:
           printf '%s\n' 'build-context-secret-canary' > deploy/.env
           printf '%s\n' 'build-context-backup-canary' > deploy/backups/build-context-canary
           docker build -f deploy/Dockerfile --build-arg REVISION="$GITHUB_SHA" -t derive:ci .
-          scripts/test-selfhost-quickstart.sh derive:ci 18080
+
+          # Exercise the same download-and-handoff script used after a real GitHub release. This
+          # local URL is the PR-safe seam; the tag workflow supplies GitHub's anonymous URL.
+          bundle_root=$(mktemp -d "$RUNNER_TEMP/derive-release-test.XXXXXX")
+          staged="$bundle_root/staged"
+          published="$bundle_root/published/v0.0.0-ci"
+          mkdir -p "$staged" "$published"
+          cp deploy/compose.yml "$staged/compose.yml"
+          cp deploy/selfhost.env.example "$staged/selfhost.env.example"
+          sed -i 's|^DERIVE_IMAGE=.*|DERIVE_IMAGE=derive:ci|' "$staged/selfhost.env.example"
+          printf 'derive:ci\n' > "$staged/image-digest.txt"
+          cp "$staged/compose.yml" "$staged/selfhost.env.example" "$staged/image-digest.txt" "$published/"
+          DERIVE_RELEASE_DOWNLOAD_BASE="file://$bundle_root/published" \
+            scripts/test-published-selfhost-bundle.sh \
+              v0.0.0-ci derive:ci 18080 "$staged"
 
   # CD: ship main to the hosted tier (Workers + Hyperdrive/Neon, derive.to) once
   # both lanes pass. Schemas (D1 + Postgres) land BEFORE the worker flips, so a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,7 @@ jobs:
               - '.dockerignore'
               - '.github/workflows/ci.yml'
               - '.github/workflows/release-images.yml'
+              - 'QUICKSTART.md'
               - 'apps/api/**'
               - 'apps/web/**'
               - 'packages/broker/**'
@@ -195,6 +196,8 @@ jobs:
               - 'deploy/Dockerfile*'
               - 'deploy/compose*.yml'
               - 'deploy/selfhost.env.example'
+              - 'scripts/selfhost-smoke-client.mjs'
+              - 'scripts/test-selfhost-quickstart.sh'
       - uses: ./.github/actions/setup
 
       # More workers than cores, deliberately. This lane is the critical path —
@@ -264,21 +267,7 @@ jobs:
           printf '%s\n' 'build-context-secret-canary' > deploy/.env
           printf '%s\n' 'build-context-backup-canary' > deploy/backups/build-context-canary
           docker build -f deploy/Dockerfile --build-arg REVISION="$GITHUB_SHA" -t derive:ci .
-          id=$(docker run -d -p 127.0.0.1:18080:8080 derive:ci)
-          trap 'docker rm -f "$id" >/dev/null 2>&1 || true' EXIT
-          for _ in $(seq 1 30); do
-            if curl -fsS http://127.0.0.1:18080/readyz >/dev/null; then
-              curl -fsS http://127.0.0.1:18080/healthz >/dev/null
-              curl -fsS http://127.0.0.1:18080/ >/dev/null
-              test "$(docker inspect -f '{{.Config.User}}' derive:ci)" = node
-              docker exec "$id" node --import tsx src/server-cli.ts backup /tmp/smoke-backup
-              docker exec "$id" node --import tsx src/server-cli.ts verify-backup /tmp/smoke-backup
-              exit 0
-            fi
-            sleep 2
-          done
-          docker logs "$id"
-          exit 1
+          scripts/test-selfhost-quickstart.sh derive:ci 18080
 
   # CD: ship main to the hosted tier (Workers + Hyperdrive/Neon, derive.to) once
   # both lanes pass. Schemas (D1 + Postgres) land BEFORE the worker flips, so a

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -63,7 +63,6 @@ jobs:
           tags: |
             type=raw,value=${{ steps.version.outputs.value }}
             type=raw,value=${{ steps.version.outputs.value }},suffix=-${{ github.sha }}
-            type=raw,value=latest,enable=${{ github.ref_type == 'tag' && steps.version.outputs.stable == 'true' }}
 
       - name: Build and publish amd64 + arm64 with SBOM and provenance
         id: build
@@ -109,12 +108,54 @@ jobs:
           grep -q "image: ghcr.io/derive-to/derive@$DIGEST" release/rendered-compose.yml
           printf 'ghcr.io/derive-to/derive@%s\n' "$DIGEST" > release/image-digest.txt
 
-      - name: Attach install files to the GitHub release
+      # Keep the previous stable release at /releases/latest until an anonymous client has
+      # downloaded and exercised this release's exact public assets. Prereleases never move it.
+      - name: Publish a non-latest GitHub release with install files
         if: github.ref_type == 'tag'
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           generate_release_notes: true
+          prerelease: ${{ steps.version.outputs.stable != 'true' }}
+          make_latest: false
+          fail_on_unmatched_files: true
           files: |
             release/compose.yml
             release/selfhost.env.example
             release/image-digest.txt
+
+      - name: Download and exercise the public release bundle anonymously
+        if: github.ref_type == 'tag'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          ref="ghcr.io/derive-to/derive@$DIGEST"
+          scripts/test-published-selfhost-bundle.sh "$GITHUB_REF_NAME" "$ref" 18080 release
+
+      # The digest-pinned install path is now proven. Move both human-facing convenience aliases
+      # only for a stable tag, and move the image first so a failure cannot advertise a release
+      # whose convenience image still points at an older build.
+      - name: Log in to GHCR for stable promotion
+        if: github.ref_type == 'tag' && steps.version.outputs.stable == 'true'
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Promote the verified stable image and release to latest
+        if: github.ref_type == 'tag' && steps.version.outputs.stable == 'true'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ref="ghcr.io/derive-to/derive@$DIGEST"
+          docker buildx imagetools create --tag ghcr.io/derive-to/derive:latest "$ref"
+          gh release edit "$GITHUB_REF_NAME" --latest
+
+      - name: Verify the documented latest download path
+        if: github.ref_type == 'tag' && steps.version.outputs.stable == 'true'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          ref="ghcr.io/derive-to/derive@$DIGEST"
+          scripts/test-published-selfhost-bundle.sh latest "$ref" 18080 release assets-only

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -1,0 +1,134 @@
+name: Release self-host images
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version without v (for a recovery/manual publish)"
+        required: true
+
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.repository == 'derive-to/derive'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/setup
+      - name: Verify source gate before publishing
+        run: pnpm verify
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve version
+        id: version
+        env:
+          MANUAL_VERSION: ${{ inputs.version }}
+        run: |
+          if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+            version=${GITHUB_REF_NAME#v}
+          else
+            version=$MANUAL_VERSION
+          fi
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+            echo "version must be semver (for example 1.2.3)" >&2
+            exit 1
+          fi
+          echo "value=$version" >> "$GITHUB_OUTPUT"
+          if [[ "$version" == *-* ]]; then
+            echo "stable=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "stable=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        id: meta
+        with:
+          images: ghcr.io/derive-to/derive
+          tags: |
+            type=raw,value=${{ steps.version.outputs.value }}
+            type=raw,value=${{ steps.version.outputs.value }},suffix=-${{ github.sha }}
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' && steps.version.outputs.stable == 'true' }}
+
+      - name: Build and publish amd64 + arm64 with SBOM and provenance
+        id: build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: deploy/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.version.outputs.value }}
+            REVISION=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: mode=max
+          sbom: true
+
+      - name: Verify the release is anonymously pullable
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          docker logout ghcr.io
+          ref="ghcr.io/derive-to/derive@$DIGEST"
+          if ! docker buildx imagetools inspect "$ref"; then
+            echo "::error::The GHCR package is private. After the first publish, an organization owner must open the derive package settings, change visibility to Public, and rerun this workflow."
+            exit 1
+          fi
+          docker pull "$ref"
+          id=$(docker run -d -p 127.0.0.1:18080:8080 "$ref")
+          trap 'docker rm -f "$id" >/dev/null 2>&1 || true' EXIT
+          for _ in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:18080/readyz >/dev/null; then
+              curl -fsS http://127.0.0.1:18080/healthz >/dev/null
+              curl -fsS http://127.0.0.1:18080/ >/dev/null
+              test "$(docker inspect -f '{{.Config.User}}' "$ref")" = node
+              docker exec "$id" node --import tsx src/server-cli.ts backup /tmp/release-backup
+              docker exec "$id" node --import tsx src/server-cli.ts verify-backup /tmp/release-backup
+              exit 0
+            fi
+            sleep 2
+          done
+          docker logs "$id"
+          exit 1
+
+      - name: Prepare release install files
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir release
+          cp deploy/compose.yml release/compose.yml
+          cp deploy/selfhost.env.example release/selfhost.env.example
+          sed -i "s|^DERIVE_IMAGE=.*|DERIVE_IMAGE=ghcr.io/derive-to/derive@$DIGEST|" release/selfhost.env.example
+          grep -qx "DERIVE_IMAGE=ghcr.io/derive-to/derive@$DIGEST" release/selfhost.env.example
+          docker compose --env-file release/selfhost.env.example -f release/compose.yml config > release/rendered-compose.yml
+          grep -q "image: ghcr.io/derive-to/derive@$DIGEST" release/rendered-compose.yml
+          printf 'ghcr.io/derive-to/derive@%s\n' "$DIGEST" > release/image-digest.txt
+
+      - name: Attach install files to the GitHub release
+        if: github.ref_type == 'tag'
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        with:
+          generate_release_notes: true
+          files: |
+            release/compose.yml
+            release/selfhost.env.example
+            release/image-digest.txt

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -3,15 +3,11 @@ name: Release self-host images
 on:
   push:
     tags: ["v*"]
-  workflow_dispatch:
-    inputs:
-      version:
-        description: "Release version without v (for a recovery/manual publish)"
-        required: true
 
 permissions:
   contents: write
   packages: write
+  attestations: write
   id-token: write
 
 concurrency:
@@ -37,14 +33,8 @@ jobs:
 
       - name: Resolve version
         id: version
-        env:
-          MANUAL_VERSION: ${{ inputs.version }}
         run: |
-          if [ "$GITHUB_REF_TYPE" = "tag" ]; then
-            version=${GITHUB_REF_NAME#v}
-          else
-            version=$MANUAL_VERSION
-          fi
+          version=${GITHUB_REF_NAME#v}
           if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
             echo "version must be semver (for example 1.2.3)" >&2
             exit 1
@@ -82,6 +72,13 @@ jobs:
           provenance: mode=max
           sbom: true
 
+      - name: Publish GitHub build attestation
+        uses: actions/attest@v4
+        with:
+          subject-name: ghcr.io/derive-to/derive
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
       - name: Verify the release is anonymously pullable
         env:
           DIGEST: ${{ steps.build.outputs.digest }}
@@ -107,21 +104,30 @@ jobs:
           docker compose --env-file release/selfhost.env.example -f release/compose.yml config > release/rendered-compose.yml
           grep -q "image: ghcr.io/derive-to/derive@$DIGEST" release/rendered-compose.yml
           printf 'ghcr.io/derive-to/derive@%s\n' "$DIGEST" > release/image-digest.txt
+          (cd release && sha256sum compose.yml selfhost.env.example image-digest.txt > SHA256SUMS)
 
       # Keep the previous stable release at /releases/latest until an anonymous client has
       # downloaded and exercised this release's exact public assets. Prereleases never move it.
-      - name: Publish a non-latest GitHub release with install files
+      - name: Create release draft with install files
         if: github.ref_type == 'tag'
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           generate_release_notes: true
           prerelease: ${{ steps.version.outputs.stable != 'true' }}
+          draft: true
           make_latest: false
           fail_on_unmatched_files: true
           files: |
             release/compose.yml
             release/selfhost.env.example
             release/image-digest.txt
+            release/SHA256SUMS
+
+      - name: Publish release for anonymous verification
+        if: github.ref_type == 'tag'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "$GITHUB_REF_NAME" --draft=false --latest=false
 
       - name: Download and exercise the public release bundle anonymously
         if: github.ref_type == 'tag'

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -94,21 +94,7 @@ jobs:
             exit 1
           fi
           docker pull "$ref"
-          id=$(docker run -d -p 127.0.0.1:18080:8080 "$ref")
-          trap 'docker rm -f "$id" >/dev/null 2>&1 || true' EXIT
-          for _ in $(seq 1 30); do
-            if curl -fsS http://127.0.0.1:18080/readyz >/dev/null; then
-              curl -fsS http://127.0.0.1:18080/healthz >/dev/null
-              curl -fsS http://127.0.0.1:18080/ >/dev/null
-              test "$(docker inspect -f '{{.Config.User}}' "$ref")" = node
-              docker exec "$id" node --import tsx src/server-cli.ts backup /tmp/release-backup
-              docker exec "$id" node --import tsx src/server-cli.ts verify-backup /tmp/release-backup
-              exit 0
-            fi
-            sleep 2
-          done
-          docker logs "$id"
-          exit 1
+          scripts/test-selfhost-quickstart.sh "$ref" 18080
 
       - name: Prepare release install files
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+deploy/backups/
 data/
 dist/
 *.log

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,5 +1,10 @@
 # Deploying Derive
 
+For a new single-container installation, follow [QUICKSTART.md](QUICKSTART.md). It covers the
+released-image and source-build paths, creates the first operator while the service is offline,
+waits for readiness, and verifies a first backup. This document is the reference for choosing a
+topology and operating or extending an installation.
+
 ## Deployment tiers
 
 Pick the tier that matches your scale and infrastructure:
@@ -23,27 +28,19 @@ All tiers run the same codebase and are additive: Lite + `DATABASE_URL` = Node B
 One container gives you a complete, working Derive — sign-in, publish, comments, reviews,
 notifications, the sandboxed viewer — all served from `http://localhost:8080`.
 
-```bash
-cp deploy/selfhost.env.example deploy/.env
-# The image runs as uid/gid 1000; make the host backup directory writable only by it.
-sudo install -d -o 1000 -g 1000 -m 0700 deploy/backups
-# Edit deploy/.env: set BASE_URL and pin DERIVE_IMAGE to a release digest.
-docker compose -f deploy/compose.yml up -d
-
-# Create the first account + immutable-id instance operator without opening signup.
-read -rsp 'Operator password: ' DERIVE_BOOTSTRAP_PASSWORD
-printf '%s' "$DERIVE_BOOTSTRAP_PASSWORD" | docker compose -f deploy/compose.yml run --rm -T derive \
-  bootstrap-operator --email owner@example.com --name 'Owner' --password-stdin
-unset DERIVE_BOOTSTRAP_PASSWORD
-```
+Use the [self-hosting quick start](QUICKSTART.md#choose-one-path) for a fresh install. The
+commands there explicitly load the environment file, validate the rendered Compose model, create
+the first operator before the service starts, wait for readiness, and prove the first backup.
 
 The Compose file pulls the pinned release image from GHCR, persists `/data`, runs
-as a non-root user with an init process, binds to `127.0.0.1` by default, and waits
-for the database/blob readiness check. To
+as a non-root user with an init process, binds to `127.0.0.1` by default, and defines
+a database/blob readiness health check. To
 build the same image from a checkout instead:
 
 ```bash
-docker compose -f deploy/compose.yml -f deploy/compose.build.yml up --build -d
+docker compose --env-file deploy/.env \
+  -f deploy/compose.yml -f deploy/compose.build.yml \
+  up --build -d --wait
 ```
 
 That's the whole thing. The image bundles the built SPA and the API serves it
@@ -110,12 +107,15 @@ Create the host backup directory once (`mkdir -p deploy/backups`), then:
 
 ```bash
 # Online and safe while Derive is serving: SQLite snapshot first, immutable blobs second.
-docker compose -f deploy/compose.yml run --rm derive backup /backups/derive-$(date +%F)
-docker compose -f deploy/compose.yml run --rm derive verify-backup /backups/derive-$(date +%F)
+docker compose --env-file deploy/.env -f deploy/compose.yml run --rm derive \
+  backup /backups/derive-$(date +%F)
+docker compose --env-file deploy/.env -f deploy/compose.yml run --rm derive \
+  verify-backup /backups/derive-$(date +%F)
 
 # Recovery without putting the new password in shell history or the process list.
 read -rsp 'New password: ' DERIVE_RESET_PASSWORD
-printf '%s' "$DERIVE_RESET_PASSWORD" | docker compose -f deploy/compose.yml run --rm -T derive \
+printf '%s' "$DERIVE_RESET_PASSWORD" | docker compose \
+  --env-file deploy/.env -f deploy/compose.yml run --rm -T derive \
   reset-password --email owner@example.com --password-stdin
 unset DERIVE_RESET_PASSWORD
 ```
@@ -135,15 +135,16 @@ Restore into a new named volume and validate it before cutover. Keep the old vol
 you have signed in and opened representative artifacts on the restored instance:
 
 ```bash
-docker compose -f deploy/compose.yml down
+docker compose --env-file deploy/.env -f deploy/compose.yml down
 
 # Restore into a fresh volume; the existing derive-data volume is untouched.
-DERIVE_DATA_VOLUME=derive-data-restored docker compose -f deploy/compose.yml run --rm derive \
+DERIVE_DATA_VOLUME=derive-data-restored docker compose \
+  --env-file deploy/.env -f deploy/compose.yml run --rm derive \
   restore-backup /backups/derive-2026-08-11
 
 # Boot the restored copy on a temporary loopback port and test it.
 DERIVE_DATA_VOLUME=derive-data-restored DERIVE_PORT=18080 \
-  docker compose -f deploy/compose.yml up -d
+  docker compose --env-file deploy/.env -f deploy/compose.yml up -d --wait
 curl -fsS http://127.0.0.1:18080/readyz
 ```
 

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -20,27 +20,36 @@ All tiers run the same codebase and are additive: Lite + `DATABASE_URL` = Node B
 
 ## Lite: single container
 
-One command gives you a complete, working Derive — sign-in, publish, comments, reviews,
+One container gives you a complete, working Derive — sign-in, publish, comments, reviews,
 notifications, the sandboxed viewer — all served from `http://localhost:8080`.
 
 ```bash
-docker build -f deploy/Dockerfile -t derive .
+cp deploy/selfhost.env.example deploy/.env
+# The image runs as uid/gid 1000; make the host backup directory writable only by it.
+sudo install -d -o 1000 -g 1000 -m 0700 deploy/backups
+# Edit deploy/.env: set BASE_URL and pin DERIVE_IMAGE to a release digest.
+docker compose -f deploy/compose.yml up -d
 
-docker run -d -p 8080:8080 -v derive_data:/data \
-  -e DERIVE_AUTH_SECRET="$(openssl rand -hex 32)" \
-  -e BASE_URL="https://derive.example.com" \
-  derive
+# Create the first account + immutable-id instance operator without opening signup.
+read -rsp 'Operator password: ' DERIVE_BOOTSTRAP_PASSWORD
+printf '%s' "$DERIVE_BOOTSTRAP_PASSWORD" | docker compose -f deploy/compose.yml run --rm -T derive \
+  bootstrap-operator --email owner@example.com --name 'Owner' --password-stdin
+unset DERIVE_BOOTSTRAP_PASSWORD
 ```
 
-Or with Compose:
+The Compose file pulls the pinned release image from GHCR, persists `/data`, runs
+as a non-root user with an init process, binds to `127.0.0.1` by default, and waits
+for the database/blob readiness check. To
+build the same image from a checkout instead:
 
 ```bash
-docker compose -f deploy/compose.yml up -d
+docker compose -f deploy/compose.yml -f deploy/compose.build.yml up --build -d
 ```
 
 That's the whole thing. The image bundles the built SPA and the API serves it
 same-origin, so there's nothing else to host. State (SQLite + artifact blobs) lives
-in the `/data` volume — back that up and you've backed up the instance.
+in the `/data` volume. Use the online backup command below; copying a live WAL-mode
+volume is not a consistent backup.
 
 - **`BASE_URL`** is the public origin you'll reach it at. It signs auth cookies and
   builds artifact share links, so set it to your real URL (behind a proxy, the
@@ -80,10 +89,75 @@ cookies and share links work out of the box. Set `BASE_URL` only when you point 
 custom domain at it. Set `DERIVE_AUTH_SECRET` once so sessions survive redeploys on
 hosts with an ephemeral filesystem.
 
-### First user
+### Accounts and first user
 
-The first person to sign up becomes the workspace **owner**; everyone after joins at
-the default role. Sign up at `/login`.
+Every new account gets its own personal workspace as **owner**. People join another
+workspace only by accepting its invitation. `DERIVE_SIGNUP_MODE` controls who can
+create an account: `open` (default), `invite` (the browser must first present a live
+workspace/artifact invitation), or `closed` (offline bootstrap only). Existing users can
+always sign in. Keep Internet-facing hosts on `invite`; invite admission is a short-lived,
+signed HttpOnly capability minted from the invite token, not an email-address lookup.
+
+`bootstrap-operator` is the normal first-user path. It creates the account through the
+same Better Auth API as the app and stores instance-wide authority against the immutable
+user id. It refuses an existing account or a second operator unless you pass the explicit
+recovery flags shown by its usage error. `DERIVE_SUPERADMIN_EMAILS` is deprecated and only
+migrates an already-verified legacy account to the user-id record; it never admits signup.
+
+### Backup, restore, and password recovery
+
+Create the host backup directory once (`mkdir -p deploy/backups`), then:
+
+```bash
+# Online and safe while Derive is serving: SQLite snapshot first, immutable blobs second.
+docker compose -f deploy/compose.yml run --rm derive backup /backups/derive-$(date +%F)
+docker compose -f deploy/compose.yml run --rm derive verify-backup /backups/derive-$(date +%F)
+
+# Recovery without putting the new password in shell history or the process list.
+read -rsp 'New password: ' DERIVE_RESET_PASSWORD
+printf '%s' "$DERIVE_RESET_PASSWORD" | docker compose -f deploy/compose.yml run --rm -T derive \
+  reset-password --email owner@example.com --password-stdin
+unset DERIVE_RESET_PASSWORD
+```
+
+Each backup contains a SQLite online snapshot, all content-addressed local blobs, the
+Lite instance identity files, and an exhaustive checksum manifest. `verify-backup` rejects
+unmanifested files, links and unexpected topology, checks every blob's content address,
+and runs SQLite integrity checking. Copy the completed directory to an independent,
+preferably immutable backup store. Checksums detect corruption; they are not signatures.
+When an identity is supplied by `DERIVE_AUTH_SECRET` or `DERIVE_DEFAULT_ORG_ID` instead of
+a data-volume file, the manifest records only its fingerprint and restore requires the
+same environment value.
+`restore-backup` only accepts a new, empty `DATA_DIR`, so a restore cannot overwrite a
+running instance accidentally.
+
+Restore into a new named volume and validate it before cutover. Keep the old volume until
+you have signed in and opened representative artifacts on the restored instance:
+
+```bash
+docker compose -f deploy/compose.yml down
+
+# Restore into a fresh volume; the existing derive-data volume is untouched.
+DERIVE_DATA_VOLUME=derive-data-restored docker compose -f deploy/compose.yml run --rm derive \
+  restore-backup /backups/derive-2026-08-11
+
+# Boot the restored copy on a temporary loopback port and test it.
+DERIVE_DATA_VOLUME=derive-data-restored DERIVE_PORT=18080 \
+  docker compose -f deploy/compose.yml up -d
+curl -fsS http://127.0.0.1:18080/readyz
+```
+
+After validation, stop it, set `DERIVE_DATA_VOLUME=derive-data-restored` in `deploy/.env`,
+and start normally. Rollback is the inverse volume selection; neither volume is deleted by
+`docker compose down` unless you explicitly add `--volumes`.
+
+For Postgres + S3/R2, the built-in Lite commands refuse to run: a local SQLite file or
+blob directory in that topology is not the source of truth. Take a provider-consistent
+Postgres snapshot first, then snapshot/version/replicate the object-store bucket, and
+retain the matching `DERIVE_AUTH_SECRET` and `DERIVE_DEFAULT_ORG_ID` in your secret
+manager. Test recovery into a new database, bucket and deployment before promoting it.
+Hybrid Postgres/local-blob and SQLite/S3 configurations are runtime-supported for
+specialized deployments, but are intentionally not covered by the built-in backup tool.
 
 ---
 
@@ -93,6 +167,8 @@ the default role. Sign up at `/login`.
 |---|---|---|
 | `BASE_URL` | `http://localhost:PORT` | Public origin of the instance (cookies + share links) |
 | `DERIVE_AUTH_SECRET` | generated, persisted | Session signing key (set in prod) |
+| `DERIVE_SIGNUP_MODE` | `open` | New-account admission: `open`, `invite`, or `closed` |
+| `DERIVE_SUPERADMIN_EMAILS` | (none) | Deprecated migration only: binds matching verified legacy accounts to immutable-id operator records |
 | `PORT` | `8080` | Listen port |
 | `DATA_DIR` | `/data` | SQLite + blob dir (single container) |
 | `DATABASE_URL` | (SQLite) | Postgres for metadata + auth (scale-out) |
@@ -202,6 +278,7 @@ fly secrets set \
   DATABASE_URL='postgres://...' \
   OBJECT_STORE_URL='s3://...' \
   DERIVE_AUTH_SECRET="$(openssl rand -hex 32)" \
+  DERIVE_DEFAULT_ORG_ID='ws_choose-one-stable-id' \
   BASE_URL='https://api.example.com'
 
 fly deploy --config deploy/fly.toml --dockerfile deploy/Dockerfile
@@ -209,7 +286,8 @@ fly deploy --config deploy/fly.toml --dockerfile deploy/Dockerfile
 
 With `DATABASE_URL` + `OBJECT_STORE_URL` set the container is stateless: scale it
 horizontally and drop the `[mounts]` volume from `fly.toml`. Each instance must share
-the same `DERIVE_AUTH_SECRET`.
+the same `DERIVE_AUTH_SECRET` and `DERIVE_DEFAULT_ORG_ID`; Node refuses to boot with
+Postgres if either is missing rather than silently giving replicas different identities.
 
 ### 3. (Optional) Serve the SPA from a CDN
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -52,7 +52,7 @@ contains `compose.yml` and `selfhost.env.example`. If those files are not availa
 
 ### 1. Download the release configuration
 
-Create a directory for the installation and download the two release files:
+Create a directory for the installation and download the release files:
 
 ```bash
 mkdir derive-selfhost
@@ -60,16 +60,38 @@ cd derive-selfhost
 
 curl -fsSLO https://github.com/derive-to/derive/releases/latest/download/compose.yml
 curl -fsSLO https://github.com/derive-to/derive/releases/latest/download/selfhost.env.example
+curl -fsSLO https://github.com/derive-to/derive/releases/latest/download/image-digest.txt
+curl -fsSLO https://github.com/derive-to/derive/releases/latest/download/SHA256SUMS
 ```
 
 The downloaded environment example pins `DERIVE_IMAGE` to the release's immutable image digest.
+Verify the release files before using them:
+
+```bash
+sha256sum -c SHA256SUMS
+```
+
+For a specific tagged release, GitHub CLI can also verify the immutable release and an asset:
+
+```bash
+gh release verify vX.Y.Z
+gh release verify-asset vX.Y.Z compose.yml
+```
+
+The image's signed build provenance can be checked with:
+
+```bash
+gh attestation verify "oci://$(cat image-digest.txt)" -R derive-to/derive
+```
 
 ### 2. Configure the instance
 
 Copy the example, then generate a session-signing secret:
 
 ```bash
+umask 077
 cp selfhost.env.example .env
+chmod 600 .env
 
 DERIVE_QUICKSTART_SECRET="$(openssl rand -hex 32)"
 printf '\nDERIVE_AUTH_SECRET=%s\n' "${DERIVE_QUICKSTART_SECRET:?}" >> .env
@@ -186,7 +208,9 @@ Clone the repository, or switch an existing checkout to the branch you want to t
 ```bash
 git clone https://github.com/derive-to/derive.git
 cd derive
+umask 077
 cp deploy/selfhost.env.example deploy/.env
+chmod 600 deploy/.env
 ```
 
 Open `deploy/.env`. For a local evaluation, set:

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,0 +1,289 @@
+# Quick start: self-host Derive
+
+This guide gets Derive running with one container, SQLite, and local artifact storage.
+At the end, you will have:
+
+- a Derive instance listening on `127.0.0.1:8080`;
+- an instance operator account created without opening public signup;
+- persistent data in a Docker volume; and
+- a verified first backup on the host.
+
+## Choose one path
+
+| Goal | Use |
+|---|---|
+| Run Derive on a server | [Install a published release](#install-a-published-release-recommended) |
+| Test `main`, a branch, or a pull request | [Build the current checkout](#build-the-current-checkout) |
+| Change Derive code with live reload | [CONTRIBUTING.md](CONTRIBUTING.md#setup) |
+| Use Postgres, S3/R2, multiple containers, or Cloudflare | [DEPLOY.md](DEPLOY.md#deployment-tiers) |
+
+Use only one installation procedure. A release is the normal server path because its image is
+versioned and pinned by digest. Build from a checkout when you intentionally need unreleased code.
+
+## Requirements
+
+The container supports 64-bit AMD and ARM hosts. Before you start, install:
+
+- Docker Engine with Docker Compose 2.24 or later, or Docker Desktop;
+- a Bash-compatible shell;
+- `curl`; and
+- `openssl` for generating the session-signing secret.
+
+Confirm that Docker and Compose are available:
+
+```bash
+docker version
+docker compose version
+```
+
+For an Internet-facing server, you also need a domain name and a TLS-terminating reverse proxy.
+Derive binds to loopback by default so it is not exposed before HTTPS is configured.
+
+## Install a published release (recommended)
+
+Use this path when the [latest GitHub release](https://github.com/derive-to/derive/releases/latest)
+contains `compose.yml` and `selfhost.env.example`. If those files are not available yet, use
+[Build the current checkout](#build-the-current-checkout).
+
+### 1. Download the release configuration
+
+Create a directory for the installation and download the two release files:
+
+```bash
+mkdir derive-selfhost
+cd derive-selfhost
+
+curl -fsSLO https://github.com/derive-to/derive/releases/latest/download/compose.yml
+curl -fsSLO https://github.com/derive-to/derive/releases/latest/download/selfhost.env.example
+```
+
+The downloaded environment example pins `DERIVE_IMAGE` to the release's immutable image digest.
+
+### 2. Configure the instance
+
+Copy the example, then generate a session-signing secret:
+
+```bash
+cp selfhost.env.example .env
+
+DERIVE_QUICKSTART_SECRET="$(openssl rand -hex 32)"
+printf '\nDERIVE_AUTH_SECRET=%s\n' "${DERIVE_QUICKSTART_SECRET:?}" >> .env
+unset DERIVE_QUICKSTART_SECRET
+```
+
+Open `.env` and set these values:
+
+| Variable | Local evaluation | Internet-facing server |
+|---|---|---|
+| `BASE_URL` | `http://localhost:8080` | Your public origin, such as `https://derive.example.com` |
+| `DERIVE_SIGNUP_MODE` | `invite` | `invite` |
+| `DERIVE_BIND_ADDRESS` | `127.0.0.1` | `127.0.0.1` when the proxy runs on this host |
+
+Keep the digest-pinned `DERIVE_IMAGE` from the release file. Do not replace it with `latest` on a
+production server.
+
+### 3. Create the host backup directory
+
+On a Linux server, create the directory with the uid and gid used by the non-root container:
+
+```bash
+sudo install -d -o 1000 -g 1000 -m 0700 backups
+```
+
+On Docker Desktop, create it with `mkdir -p backups`; Docker Desktop manages the host-to-container
+file ownership.
+
+### 4. Validate and pull the release
+
+Render the final Compose configuration before changing the host:
+
+```bash
+docker compose --env-file .env -f compose.yml config --quiet
+docker compose --env-file .env -f compose.yml pull
+```
+
+The first command prints nothing when the configuration is valid. The second pulls the exact image
+digest recorded in `.env`.
+
+### 5. Create the first operator while the service is offline
+
+Enter a password of 8–128 characters. It is passed through stdin and does not appear in shell
+history or the process list:
+
+```bash
+read -rsp 'Operator password: ' DERIVE_BOOTSTRAP_PASSWORD
+printf '%s' "${DERIVE_BOOTSTRAP_PASSWORD:?}" | docker compose \
+  --env-file .env -f compose.yml run --rm -T derive \
+  bootstrap-operator --email owner@example.com --name 'Owner' --password-stdin
+unset DERIVE_BOOTSTRAP_PASSWORD
+```
+
+Replace the email and name before running the command. A successful command prints the new user ID.
+
+### 6. Start Derive and wait for readiness
+
+Start the service in the background and wait for its health check:
+
+```bash
+docker compose --env-file .env -f compose.yml up -d --wait --wait-timeout 120
+curl -fsS http://127.0.0.1:8080/readyz
+```
+
+The readiness response is:
+
+```json
+{"ok":true}
+```
+
+For a local evaluation, open <http://localhost:8080> and sign in with the operator account.
+
+### 7. Put an Internet-facing instance behind HTTPS
+
+Point your existing reverse proxy at `127.0.0.1:8080`. For example, a minimal Caddy site is:
+
+```caddyfile
+derive.example.com {
+  reverse_proxy 127.0.0.1:8080
+}
+```
+
+Confirm that `.env` has the matching `BASE_URL=https://derive.example.com`, restart Derive after
+changing it, and then sign in through that HTTPS URL:
+
+```bash
+docker compose --env-file .env -f compose.yml up -d --wait --wait-timeout 120
+```
+
+### 8. Create and verify the first backup
+
+The backup command takes an online SQLite snapshot, copies local blobs and identity files, and
+verifies the completed directory:
+
+```bash
+DERIVE_BACKUP="/backups/derive-$(date -u +%Y%m%dT%H%M%SZ)"
+docker compose --env-file .env -f compose.yml run --rm derive backup "${DERIVE_BACKUP:?}"
+docker compose --env-file .env -f compose.yml run --rm derive verify-backup "${DERIVE_BACKUP:?}"
+unset DERIVE_BACKUP
+```
+
+Copy the resulting directory from `./backups` to a separate system. A backup stored only beside
+the live volume does not protect against losing the host.
+
+## Build the current checkout
+
+Use this path to test unreleased code. The resulting image is called `derive:local`; it is not a
+published or attested release image.
+
+### 1. Get the source and create the environment file
+
+Clone the repository, or switch an existing checkout to the branch you want to test:
+
+```bash
+git clone https://github.com/derive-to/derive.git
+cd derive
+cp deploy/selfhost.env.example deploy/.env
+```
+
+Open `deploy/.env`. For a local evaluation, set:
+
+```dotenv
+BASE_URL=http://localhost:8080
+DERIVE_SIGNUP_MODE=invite
+DERIVE_BIND_ADDRESS=127.0.0.1
+```
+
+Generate and append the session-signing secret:
+
+```bash
+DERIVE_QUICKSTART_SECRET="$(openssl rand -hex 32)"
+printf '\nDERIVE_AUTH_SECRET=%s\n' "${DERIVE_QUICKSTART_SECRET:?}" >> deploy/.env
+unset DERIVE_QUICKSTART_SECRET
+```
+
+### 2. Create the backup directory
+
+On a Linux host, create the bind-mounted directory for the non-root container:
+
+```bash
+sudo install -d -o 1000 -g 1000 -m 0700 deploy/backups
+```
+
+On Docker Desktop, use `mkdir -p deploy/backups`.
+
+### 3. Validate and build the image
+
+The second Compose file replaces the release image with a build of the current checkout:
+
+```bash
+docker compose --env-file deploy/.env \
+  -f deploy/compose.yml -f deploy/compose.build.yml config --quiet
+
+docker compose --env-file deploy/.env \
+  -f deploy/compose.yml -f deploy/compose.build.yml build
+```
+
+### 4. Create the first operator
+
+Create the operator before starting the service:
+
+```bash
+read -rsp 'Operator password: ' DERIVE_BOOTSTRAP_PASSWORD
+printf '%s' "${DERIVE_BOOTSTRAP_PASSWORD:?}" | docker compose \
+  --env-file deploy/.env \
+  -f deploy/compose.yml -f deploy/compose.build.yml \
+  run --rm -T derive \
+  bootstrap-operator --email owner@example.com --name 'Owner' --password-stdin
+unset DERIVE_BOOTSTRAP_PASSWORD
+```
+
+### 5. Start and verify the local build
+
+Start the image and wait until SQLite and the blob store are ready:
+
+```bash
+docker compose --env-file deploy/.env \
+  -f deploy/compose.yml -f deploy/compose.build.yml \
+  up -d --wait --wait-timeout 120
+
+curl -fsS http://127.0.0.1:8080/healthz
+curl -fsS http://127.0.0.1:8080/readyz
+```
+
+Open <http://localhost:8080> and sign in with the operator account. Then create and verify the
+first backup from the source-built image:
+
+```bash
+DERIVE_BACKUP="/backups/derive-$(date -u +%Y%m%dT%H%M%SZ)"
+docker compose --env-file deploy/.env \
+  -f deploy/compose.yml -f deploy/compose.build.yml \
+  run --rm derive backup "${DERIVE_BACKUP:?}"
+docker compose --env-file deploy/.env \
+  -f deploy/compose.yml -f deploy/compose.build.yml \
+  run --rm derive verify-backup "${DERIVE_BACKUP:?}"
+unset DERIVE_BACKUP
+```
+
+## If startup fails
+
+Inspect the rendered configuration, service state, and logs in that order:
+
+```bash
+docker compose --env-file .env -f compose.yml config
+docker compose --env-file .env -f compose.yml ps
+docker compose --env-file .env -f compose.yml logs --tail 200 derive
+```
+
+For a source build, use the `deploy/.env`, `deploy/compose.yml`, and
+`deploy/compose.build.yml` arguments shown above.
+
+Common causes are an unset `DERIVE_IMAGE`, an unwritable `backups` directory, port 8080 already in
+use, or a `BASE_URL` that does not match the URL in the browser.
+
+## Next steps
+
+- Read [DEPLOY.md](DEPLOY.md#backup-restore-and-password-recovery) for scheduled backups, restore,
+  password recovery, updates, Postgres/S3 deployments, SSO, Slack, and other optional features.
+- Read [CONTRIBUTING.md](CONTRIBUTING.md) if you want the live-reload development stack rather than
+  the production container build.
+- Keep Internet-facing instances on `DERIVE_SIGNUP_MODE=invite` or `closed`. Existing users can
+  still sign in in either mode.

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -29,6 +29,11 @@ The container supports 64-bit AMD and ARM hosts. Before you start, install:
 - `curl`; and
 - `openssl` for generating the session-signing secret.
 
+Allow at least 4 GB of free Docker storage to pull and run a published image. Building the
+current checkout also keeps build layers and needs at least 10 GB free during the first build.
+These figures leave working room beyond the approximately 2.2 GB unpacked runtime image measured
+on `linux/amd64`; your database, artifacts, and off-host backups need additional capacity.
+
 Confirm that Docker and Compose are available:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Permanent versioned URLs and a review loop your team and its agents share, on in
 <p align="center">
   <a href="https://derive.to"><b>Try free</b></a>
   &nbsp;·&nbsp;
-  <a href="#get-started">Self-host</a>
+  <a href="QUICKSTART.md">Self-host</a>
   &nbsp;·&nbsp;
   <a href="STANDARD.md">Docs</a>
 </p>
@@ -161,14 +161,12 @@ You get a library, in-browser publishing, and the comment loop in about a minute
 
 ### 🖥️ Self-host
 
-One container is the whole product.
+One container is the whole product: API, web, sign-in, publishing, comments, and the
+sandboxed viewer, with SQLite and blobs in one volume.
 
-```bash
-docker compose -f deploy/compose.yml up -d
-# → http://localhost:8080
-```
-
-API and web, sign-in, publishing, comments, and the sandboxed viewer, with SQLite and blobs in one volume. See [DEPLOY.md](DEPLOY.md) for Postgres, S3/R2, and cloud hosts.
+Follow the **[self-hosting quick start](QUICKSTART.md)** to install a digest-pinned release or
+build the current checkout. It includes secure first-user bootstrap, readiness checks, and a
+verified first backup. See [DEPLOY.md](DEPLOY.md) for Postgres, S3/R2, and cloud hosts.
 
 </td>
 </tr>
@@ -240,6 +238,9 @@ Every artifact ships OG and Twitter meta plus an oEmbed document, serves a live 
 ## Deploy
 
 The single-container image runs on any host with a persistent volume.
+
+For a fresh installation, start with **[QUICKSTART.md](QUICKSTART.md)**. The full deployment
+reference below covers managed hosts, external storage, scaling, and optional services.
 
 [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/new)
 &nbsp;&nbsp;

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "dev": "tsx watch src/node.ts",
     "start": "tsx src/node.ts",
+    "server": "tsx src/server-cli.ts",
     "build:web": "pnpm --filter @derive/web build && node scripts/prep-edge-assets.mjs",
     "deploy:schema": "node scripts/apply-d1-schema.mjs",
     "migrate:auth": "tsx migrate-auth-d1.ts",
@@ -53,6 +54,7 @@
     "better-sqlite3": "^12.11.1",
     "croner": "^10.0.1",
     "drizzle-orm": "^0.45.2",
+    "fflate": "^0.8.2",
     "hono": "^4.12.34",
     "hono-rate-limiter": "^0.5.3",
     "jose": "^6.1.0",
@@ -60,6 +62,7 @@
     "pg": "^8.13.1",
     "playwright": "^1.61.0",
     "stripe": "^22.3.2",
+    "tsx": "^4.19.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
@@ -69,8 +72,6 @@
     "@types/node": "^25.9.3",
     "@types/pg": "^8.11.10",
     "express": "^5.1.0",
-    "fflate": "^0.8.2",
-    "tsx": "^4.19.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9",
     "wrangler": "^4.40.0"

--- a/apps/api/src/admin.ts
+++ b/apps/api/src/admin.ts
@@ -1,0 +1,599 @@
+import { createHash, randomUUID } from "node:crypto"
+import { existsSync, constants as fsConstants } from "node:fs"
+import { lstat, mkdir, open, readdir, rename, rm, writeFile } from "node:fs/promises"
+import { basename, dirname, join, relative, resolve, sep } from "node:path"
+import { PgMetaStore } from "@derive/db/pg"
+import { SqliteMetaStore } from "@derive/db/sqlite"
+import { hashPassword } from "better-auth/crypto"
+import Database from "better-sqlite3"
+import { Pool } from "pg"
+import { type AuthDb, makeAuth, migrateAuth } from "./auth-config"
+import { resolveAuthSecret } from "./config"
+
+const MANIFEST = "derive-backup.json"
+const FORMAT = "derive-lite-backup-v2"
+
+interface BackupFile {
+  path: string
+  sha256: string
+  bytes: number
+}
+
+interface BackupIdentity {
+  source: "backup" | "environment"
+  path?: ".auth-secret" | ".org-id"
+  env?: "DERIVE_AUTH_SECRET" | "DERIVE_DEFAULT_ORG_ID"
+  fingerprint: string
+}
+
+export interface BackupManifest {
+  format: typeof FORMAT
+  createdAt: string
+  topology: "sqlite+filesystem"
+  identity: {
+    authSecret: BackupIdentity
+    defaultOrg: BackupIdentity
+  }
+  files: BackupFile[]
+  sqliteIntegrity: "ok"
+}
+
+const sha256File = async (path: string): Promise<{ sha256: string; bytes: number }> => {
+  const handle = await open(path, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW)
+  try {
+    const info = await handle.stat()
+    if (!info.isFile()) throw new Error(`not a regular file: ${path}`)
+    const bytes = await handle.readFile()
+    return { sha256: createHash("sha256").update(bytes).digest("hex"), bytes: bytes.byteLength }
+  } finally {
+    await handle.close()
+  }
+}
+
+const fingerprint = (value: string): string =>
+  createHash("sha256").update(`derive-backup-identity:${value}`).digest("hex")
+
+const manifestPath = (root: string, path: string): string =>
+  relative(root, path).split(sep).join("/")
+
+async function copyBlobTree(source: string, target: string, root: string, files: BackupFile[]) {
+  if (!existsSync(source)) return
+  const sourceInfo = await lstat(source)
+  if (sourceInfo.isSymbolicLink() || !sourceInfo.isDirectory())
+    throw new Error(`blob root must be a real directory: ${source}`)
+  await mkdir(target, { recursive: true })
+  for (const entry of await readdir(source, { withFileTypes: true })) {
+    const from = join(source, entry.name)
+    const to = join(target, entry.name)
+    if (entry.isSymbolicLink()) throw new Error(`refusing to follow blob symlink: ${from}`)
+    if (entry.isDirectory()) {
+      await copyBlobTree(from, to, root, files)
+      continue
+    }
+    if (!entry.isFile() || entry.name.includes(".tmp-")) continue
+    await writeFile(to, await readNoFollow(from), { mode: 0o600 })
+    const digest = await sha256File(to)
+    const key = `${basename(dirname(to))}${basename(to)}`
+    if (!/^[0-9a-f]{64}$/.test(key) || digest.sha256 !== key)
+      throw new Error(`blob content does not match its content-addressed key: ${from}`)
+    files.push({ path: manifestPath(root, to), ...digest })
+  }
+}
+
+const readNoFollow = async (path: string): Promise<Buffer> => {
+  const handle = await open(path, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW)
+  try {
+    const info = await handle.stat()
+    if (!info.isFile()) throw new Error(`not a regular file: ${path}`)
+    return await handle.readFile()
+  } finally {
+    await handle.close()
+  }
+}
+
+const sqliteIntegrity = (path: string): "ok" => {
+  const db = new Database(path, { readonly: true, fileMustExist: true })
+  try {
+    const result = db.pragma("integrity_check", { simple: true })
+    if (result !== "ok") throw new Error(`SQLite integrity_check failed: ${String(result)}`)
+    return "ok"
+  } finally {
+    db.close()
+  }
+}
+
+// SQLite's online backup preserves WAL journal mode. Opening that standalone
+// snapshot would manufacture unmanifested -wal/-shm sidecars, so normalize the
+// completed copy to a single-file journal before hashing and publishing it.
+const normalizeSqliteSnapshot = (path: string): void => {
+  const db = new Database(path, { fileMustExist: true })
+  try {
+    db.pragma("journal_mode = DELETE")
+  } finally {
+    db.close()
+  }
+}
+
+/** Online Lite backup: snapshot the WAL database first, then copy immutable,
+ * content-addressed blobs. Newer unreferenced blobs are harmless; a DB row can
+ * never point at a blob that was written after its transaction. */
+export async function createLiteBackup(
+  dataDir: string,
+  destination: string,
+): Promise<BackupManifest> {
+  const sourceDb = join(resolve(dataDir), "derive.db")
+  if (!existsSync(sourceDb)) throw new Error(`Lite database not found: ${sourceDb}`)
+  const sourceDbInfo = await lstat(sourceDb)
+  if (sourceDbInfo.isSymbolicLink() || !sourceDbInfo.isFile())
+    throw new Error(`Lite database must be a regular file, not a link: ${sourceDb}`)
+  const target = resolve(destination)
+  if (existsSync(target)) throw new Error(`backup destination already exists: ${target}`)
+  await mkdir(dirname(target), { recursive: true })
+  const partial = `${target}.partial-${process.pid}`
+  await mkdir(partial)
+  try {
+    const snapshot = join(partial, "derive.db")
+    const db = new Database(sourceDb, { readonly: true, fileMustExist: true })
+    try {
+      await db.backup(snapshot)
+    } finally {
+      db.close()
+    }
+    normalizeSqliteSnapshot(snapshot)
+    const files: BackupFile[] = [{ path: "derive.db", ...(await sha256File(snapshot)) }]
+    await copyBlobTree(join(resolve(dataDir), "blobs"), join(partial, "blobs"), partial, files)
+    const identities: Partial<BackupManifest["identity"]> = {}
+    for (const [field, name, envName] of [
+      ["authSecret", ".auth-secret", "DERIVE_AUTH_SECRET"],
+      ["defaultOrg", ".org-id", "DERIVE_DEFAULT_ORG_ID"],
+    ] as const) {
+      const source = join(resolve(dataDir), name)
+      if (existsSync(source)) {
+        const value = (await readNoFollow(source)).toString("utf8").trim()
+        if (!value) throw new Error(`Lite identity file is empty: ${source}`)
+        const targetFile = join(partial, name)
+        await writeFile(targetFile, value, { mode: 0o600 })
+        files.push({ path: name, ...(await sha256File(targetFile)) })
+        identities[field] = {
+          source: "backup",
+          path: name,
+          fingerprint: fingerprint(value),
+        }
+        continue
+      }
+      const value = process.env[envName]?.trim()
+      if (!value)
+        throw new Error(
+          `${name} is not persisted and ${envName} is unset; refusing an identity-incomplete backup`,
+        )
+      identities[field] = {
+        source: "environment",
+        env: envName,
+        fingerprint: fingerprint(value),
+      }
+    }
+    const manifest: BackupManifest = {
+      format: FORMAT,
+      createdAt: new Date().toISOString(),
+      topology: "sqlite+filesystem",
+      identity: identities as BackupManifest["identity"],
+      files: files.sort((a, b) => a.path.localeCompare(b.path)),
+      sqliteIntegrity: sqliteIntegrity(snapshot),
+    }
+    await writeFile(join(partial, MANIFEST), `${JSON.stringify(manifest, null, 2)}\n`, {
+      mode: 0o600,
+    })
+    await rename(partial, target)
+    return manifest
+  } catch (error) {
+    await rm(partial, { recursive: true, force: true })
+    throw error
+  }
+}
+
+const safeBackupFile = (root: string, path: string): string => {
+  if (path.startsWith("/") || path.includes("\\") || path.split("/").includes(".."))
+    throw new Error(`invalid backup manifest path: ${path}`)
+  const absolute = resolve(root, path)
+  if (absolute !== root && !absolute.startsWith(`${root}${sep}`))
+    throw new Error(`backup manifest path escapes its directory: ${path}`)
+  return absolute
+}
+
+const exactKeys = (value: object, keys: string[], label: string): void => {
+  const actual = Object.keys(value).sort()
+  const expected = [...keys].sort()
+  if (actual.length !== expected.length || actual.some((key, i) => key !== expected[i]))
+    throw new Error(`malformed ${label}`)
+}
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const validateIdentity = (value: unknown, field: "authSecret" | "defaultOrg"): BackupIdentity => {
+  if (!isObject(value)) throw new Error(`malformed backup identity.${field}`)
+  if (value.source === "backup") {
+    exactKeys(value, ["source", "path", "fingerprint"], `backup identity.${field}`)
+    const expectedPath = field === "authSecret" ? ".auth-secret" : ".org-id"
+    if (value.path !== expectedPath || !/^[0-9a-f]{64}$/.test(String(value.fingerprint)))
+      throw new Error(`malformed backup identity.${field}`)
+  } else if (value.source === "environment") {
+    exactKeys(value, ["source", "env", "fingerprint"], `backup identity.${field}`)
+    const expectedEnv = field === "authSecret" ? "DERIVE_AUTH_SECRET" : "DERIVE_DEFAULT_ORG_ID"
+    if (value.env !== expectedEnv || !/^[0-9a-f]{64}$/.test(String(value.fingerprint)))
+      throw new Error(`malformed backup identity.${field}`)
+  } else {
+    throw new Error(`malformed backup identity.${field}`)
+  }
+  return value as unknown as BackupIdentity
+}
+
+const parseManifest = (value: unknown): BackupManifest => {
+  if (!isObject(value)) throw new Error("unsupported or malformed Derive backup manifest")
+  exactKeys(
+    value,
+    ["format", "createdAt", "topology", "identity", "files", "sqliteIntegrity"],
+    "Derive backup manifest",
+  )
+  if (
+    value.format !== FORMAT ||
+    value.topology !== "sqlite+filesystem" ||
+    value.sqliteIntegrity !== "ok" ||
+    typeof value.createdAt !== "string" ||
+    Number.isNaN(Date.parse(value.createdAt)) ||
+    !Array.isArray(value.files) ||
+    !isObject(value.identity)
+  )
+    throw new Error("unsupported or malformed Derive backup manifest")
+  exactKeys(value.identity, ["authSecret", "defaultOrg"], "backup identity")
+  const identity = {
+    authSecret: validateIdentity(value.identity.authSecret, "authSecret"),
+    defaultOrg: validateIdentity(value.identity.defaultOrg, "defaultOrg"),
+  }
+  const files: BackupFile[] = []
+  const paths = new Set<string>()
+  for (const raw of value.files) {
+    if (!isObject(raw)) throw new Error("malformed backup file entry")
+    exactKeys(raw, ["path", "sha256", "bytes"], "backup file entry")
+    if (
+      typeof raw.path !== "string" ||
+      !/^[0-9a-f]{64}$/.test(String(raw.sha256)) ||
+      !Number.isSafeInteger(raw.bytes) ||
+      Number(raw.bytes) < 0 ||
+      paths.has(raw.path)
+    )
+      throw new Error("malformed or duplicate backup file entry")
+    paths.add(raw.path)
+    files.push({ path: raw.path, sha256: String(raw.sha256), bytes: Number(raw.bytes) })
+  }
+  if (!paths.has("derive.db")) throw new Error("backup manifest is missing derive.db")
+  for (const [field, identityValue] of Object.entries(identity)) {
+    const path = field === "authSecret" ? ".auth-secret" : ".org-id"
+    const included = paths.has(path)
+    if ((identityValue.source === "backup") !== included)
+      throw new Error(
+        identityValue.source === "backup"
+          ? `backup manifest is missing ${path}`
+          : `backup manifest must not include environment-supplied identity ${path}`,
+      )
+  }
+  return {
+    format: FORMAT,
+    createdAt: value.createdAt,
+    topology: "sqlite+filesystem",
+    identity,
+    files,
+    sqliteIntegrity: "ok",
+  }
+}
+
+const allowedBackupPath = (path: string): boolean =>
+  path === "derive.db" ||
+  path === ".auth-secret" ||
+  path === ".org-id" ||
+  /^blobs\/[0-9a-f]{2}\/[0-9a-f]{62}$/.test(path)
+
+const backupInventory = async (root: string, directory = root): Promise<string[]> => {
+  const files: string[] = []
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const absolute = join(directory, entry.name)
+    const info = await lstat(absolute)
+    const path = manifestPath(root, absolute)
+    if (info.isSymbolicLink()) throw new Error(`backup contains a symbolic link: ${path}`)
+    if (info.isDirectory()) {
+      if (path !== "blobs" && !/^blobs\/[0-9a-f]{2}$/.test(path))
+        throw new Error(`backup contains an unexpected directory: ${path}`)
+      files.push(...(await backupInventory(root, absolute)))
+      continue
+    }
+    if (!info.isFile()) throw new Error(`backup contains a non-regular entry: ${path}`)
+    files.push(path)
+  }
+  return files.sort()
+}
+
+export async function verifyLiteBackup(directory: string): Promise<BackupManifest> {
+  const root = resolve(directory)
+  const rootInfo = await lstat(root)
+  if (rootInfo.isSymbolicLink() || !rootInfo.isDirectory())
+    throw new Error(`backup root must be a real directory: ${root}`)
+  const parsed = parseManifest(
+    JSON.parse((await readNoFollow(join(root, MANIFEST))).toString("utf8")),
+  )
+  const inventory = await backupInventory(root)
+  const expected = [...parsed.files.map((file) => file.path), MANIFEST].sort()
+  if (inventory.length !== expected.length || inventory.some((path, i) => path !== expected[i]))
+    throw new Error("backup inventory does not exactly match its manifest")
+  for (const file of parsed.files) {
+    if (!allowedBackupPath(file.path)) throw new Error(`unexpected backup path: ${file.path}`)
+    const absolute = safeBackupFile(root, file.path)
+    const actual = await sha256File(absolute)
+    if (actual.sha256 !== file.sha256 || actual.bytes !== file.bytes)
+      throw new Error(`backup checksum mismatch: ${file.path}`)
+    if (file.path.startsWith("blobs/")) {
+      const parts = file.path.split("/")
+      const key = `${parts.at(-2) ?? ""}${parts.at(-1) ?? ""}`
+      if (key !== actual.sha256) throw new Error(`backup blob key mismatch: ${file.path}`)
+    }
+  }
+  for (const identity of Object.values(parsed.identity)) {
+    if (identity.source !== "backup") continue
+    const value = (await readNoFollow(safeBackupFile(root, identity.path ?? "")))
+      .toString("utf8")
+      .trim()
+    if (fingerprint(value) !== identity.fingerprint)
+      throw new Error(`backup identity fingerprint mismatch: ${identity.path}`)
+  }
+  sqliteIntegrity(join(root, "derive.db"))
+  return parsed
+}
+
+export async function restoreLiteBackup(directory: string, dataDir: string): Promise<void> {
+  const root = resolve(directory)
+  const manifest = await verifyLiteBackup(root)
+  for (const identity of Object.values(manifest.identity)) {
+    if (identity.source !== "environment") continue
+    const value = process.env[identity.env ?? ""]?.trim()
+    if (!value || fingerprint(value) !== identity.fingerprint)
+      throw new Error(`restore requires the same ${identity.env} value recorded by this backup`)
+  }
+  const target = resolve(dataDir)
+  await mkdir(target, { recursive: true })
+  const targetInfo = await lstat(target)
+  if (targetInfo.isSymbolicLink() || !targetInfo.isDirectory())
+    throw new Error(`restore target must be a real directory: ${target}`)
+  const entries = await readdir(target)
+  if (entries.length > 0)
+    throw new Error(
+      `restore target must be empty (stop Derive and use a fresh DATA_DIR): ${target}`,
+    )
+  for (const file of manifest.files) {
+    const source = safeBackupFile(root, file.path)
+    const destination = safeBackupFile(target, file.path)
+    await mkdir(dirname(destination), { recursive: true })
+    const bytes = await readNoFollow(source)
+    const actual = createHash("sha256").update(bytes).digest("hex")
+    if (actual !== file.sha256 || bytes.byteLength !== file.bytes)
+      throw new Error(`backup changed during restore: ${file.path}`)
+    await writeFile(destination, bytes, { mode: 0o600 })
+  }
+  sqliteIntegrity(join(target, "derive.db"))
+}
+
+async function passwordFromStdin(): Promise<string> {
+  if (process.stdin.isTTY)
+    throw new Error("refusing a password argument; pipe the new password with --password-stdin")
+  const chunks: Buffer[] = []
+  for await (const chunk of process.stdin) chunks.push(Buffer.from(chunk))
+  return Buffer.concat(chunks)
+    .toString("utf8")
+    .replace(/[\r\n]+$/, "")
+}
+
+/** Create the first human operator without exposing registration or trusting an
+ * email allow-list. Existing accounts and additional operators require explicit
+ * recovery flags at the CLI call site. */
+export async function bootstrapOperator(
+  databaseUrl: string | undefined,
+  dataDir: string,
+  baseUrl: string,
+  input: {
+    email: string
+    name: string
+    password?: string
+    adoptExisting?: boolean
+    allowAdditional?: boolean
+  },
+): Promise<{ userId: string; created: boolean }> {
+  await mkdir(resolve(dataDir), { recursive: true })
+  let meta: SqliteMetaStore | PgMetaStore
+  let authDb: AuthDb
+  let close: () => Promise<void>
+  if (databaseUrl) {
+    const pgMeta = await PgMetaStore.create(databaseUrl)
+    const pool = new Pool({ connectionString: databaseUrl, max: 1 })
+    meta = pgMeta
+    authDb = pool
+    close = async () => {
+      await pgMeta.close()
+      await pool.end()
+    }
+  } else {
+    const path = join(resolve(dataDir), "derive.db")
+    const sqliteMeta = new SqliteMetaStore(path)
+    const db = new Database(path)
+    db.pragma("journal_mode = WAL")
+    db.pragma("busy_timeout = 5000")
+    meta = sqliteMeta
+    authDb = db
+    close = async () => {
+      sqliteMeta.close()
+      db.close()
+    }
+  }
+
+  try {
+    if ((await meta.hasInstanceOperators()) && !input.allowAdditional)
+      throw new Error(
+        "an instance operator already exists; pass --allow-additional only for an intentional recovery/addition",
+      )
+    const auth = makeAuth(authDb, baseUrl, resolveAuthSecret(dataDir), {
+      usernameTaken: (username) => meta.getUserByUsername(username).then(Boolean),
+    })
+    await migrateAuth(auth)
+    const existing = await meta.findUserByEmail(input.email.trim().toLowerCase())
+    if (existing && !input.adoptExisting)
+      throw new Error(
+        "that account already exists; pass --adopt-existing only after verifying its identity",
+      )
+    let userId = existing?.id
+    if (!userId) {
+      if (!input.password) throw new Error("a password is required when creating the operator")
+      if (input.password.length < 8 || input.password.length > 128)
+        throw new Error("password must be between 8 and 128 characters")
+      const created = await auth.api.signUpEmail({
+        body: {
+          email: input.email.trim().toLowerCase(),
+          password: input.password,
+          name: input.name.trim() || input.email.trim().toLowerCase(),
+        },
+      })
+      userId = created.user.id
+    }
+    await meta.addInstanceOperator(userId)
+    return { userId, created: !existing }
+  } finally {
+    await close()
+  }
+}
+
+export async function resetPassword(
+  databaseUrl: string | undefined,
+  dataDir: string,
+  email: string,
+  password: string,
+): Promise<void> {
+  if (password.length < 8 || password.length > 128)
+    throw new Error("password must be between 8 and 128 characters")
+  const hashed = await hashPassword(password)
+  if (databaseUrl) {
+    const pool = new Pool({ connectionString: databaseUrl, max: 1 })
+    const client = await pool.connect()
+    try {
+      await client.query("BEGIN")
+      const found = await client.query<{ id: string }>(
+        'SELECT id FROM "user" WHERE lower(email) = lower($1) LIMIT 1',
+        [email],
+      )
+      const userId = found.rows[0]?.id
+      if (!userId) throw new Error(`no user found for ${email}`)
+      const updated = await client.query(
+        'UPDATE account SET password = $1, "updatedAt" = $2 WHERE "userId" = $3 AND "providerId" = \'credential\'',
+        [hashed, new Date(), userId],
+      )
+      if (updated.rowCount === 0)
+        await client.query(
+          'INSERT INTO account (id, "accountId", "providerId", "userId", password, "createdAt", "updatedAt") VALUES ($1,$2,\'credential\',$2,$3,$4,$4)',
+          [randomUUID(), userId, hashed, new Date()],
+        )
+      await client.query('DELETE FROM session WHERE "userId" = $1', [userId])
+      await client.query("COMMIT")
+    } catch (error) {
+      await client.query("ROLLBACK")
+      throw error
+    } finally {
+      client.release()
+      await pool.end()
+    }
+    return
+  }
+  const db = new Database(join(resolve(dataDir), "derive.db"), {
+    fileMustExist: true,
+  })
+  try {
+    db.transaction(() => {
+      const user = db
+        .prepare('SELECT id FROM "user" WHERE lower(email) = lower(?) LIMIT 1')
+        .get(email) as { id: string } | undefined
+      if (!user) throw new Error(`no user found for ${email}`)
+      const now = new Date().toISOString()
+      const result = db
+        .prepare(
+          'UPDATE account SET password = ?, "updatedAt" = ? WHERE "userId" = ? AND "providerId" = \'credential\'',
+        )
+        .run(hashed, now, user.id)
+      if (result.changes === 0)
+        db.prepare(
+          'INSERT INTO account (id, "accountId", "providerId", "userId", password, "createdAt", "updatedAt") VALUES (?, ?, \'credential\', ?, ?, ?, ?)',
+        ).run(randomUUID(), user.id, user.id, hashed, now, now)
+      db.prepare('DELETE FROM session WHERE "userId" = ?').run(user.id)
+    })()
+  } finally {
+    db.close()
+  }
+}
+
+const argValue = (args: string[], name: string): string | undefined => {
+  const index = args.indexOf(name)
+  return index >= 0 ? args[index + 1] : undefined
+}
+
+export async function runAdminCommand(command: string, args: string[]): Promise<string> {
+  const dataDir = process.env.DATA_DIR ?? "./data"
+  if (command === "backup") {
+    if (process.env.DATABASE_URL || process.env.OBJECT_STORE_URL)
+      throw new Error("backup is for the Lite (SQLite + local blobs) topology only")
+    const destination = args[0]
+    if (!destination) throw new Error("usage: derive-server backup <destination-directory>")
+    const manifest = await createLiteBackup(dataDir, destination)
+    return `backup created and verified: ${resolve(destination)} (${manifest.files.length} files)`
+  }
+  if (command === "verify-backup") {
+    const directory = args[0]
+    if (!directory) throw new Error("usage: derive-server verify-backup <directory>")
+    const manifest = await verifyLiteBackup(directory)
+    return `backup verified: ${resolve(directory)} (${manifest.files.length} files)`
+  }
+  if (command === "bootstrap-operator") {
+    const email = argValue(args, "--email")
+    const adoptExisting = args.includes("--adopt-existing")
+    const needsPassword = !adoptExisting
+    if (!email || (needsPassword && !args.includes("--password-stdin")))
+      throw new Error(
+        "usage: derive-server bootstrap-operator --email owner@example.com --password-stdin [--name 'Owner'] [--adopt-existing] [--allow-additional]",
+      )
+    const result = await bootstrapOperator(
+      process.env.DATABASE_URL,
+      dataDir,
+      process.env.BASE_URL ?? "http://localhost:8080",
+      {
+        email,
+        name: argValue(args, "--name") ?? email,
+        password: needsPassword ? await passwordFromStdin() : undefined,
+        adoptExisting,
+        allowAdditional: args.includes("--allow-additional"),
+      },
+    )
+    return `${result.created ? "created" : "adopted"} instance operator ${email} (${result.userId})`
+  }
+  if (command === "restore-backup") {
+    const directory = args[0]
+    if (!directory) throw new Error("usage: derive-server restore-backup <directory>")
+    if (process.env.DATABASE_URL || process.env.OBJECT_STORE_URL)
+      throw new Error("restore-backup is for the Lite (SQLite + local blobs) topology only")
+    await restoreLiteBackup(directory, dataDir)
+    return `backup restored into ${resolve(dataDir)}`
+  }
+  if (command === "reset-password") {
+    const email = argValue(args, "--email")
+    if (!email || !args.includes("--password-stdin"))
+      throw new Error(
+        "usage: derive-server reset-password --email user@example.com --password-stdin",
+      )
+    await resetPassword(process.env.DATABASE_URL, dataDir, email, await passwordFromStdin())
+    return `password reset and sessions revoked for ${email}`
+  }
+  throw new Error(
+    `unknown command: ${command}\ncommands: serve, bootstrap-operator, backup, verify-backup, restore-backup, reset-password`,
+  )
+}

--- a/apps/api/src/auth-config.ts
+++ b/apps/api/src/auth-config.ts
@@ -142,6 +142,8 @@ export type AuthDb = BetterAuthOptions["database"]
  */
 /** Optional integrations the auth layer needs from the surrounding app. */
 export interface AuthHooks {
+  /** Admission policy for NEW accounts. Runs for email, OAuth, and OIDC alike. */
+  signupAllowed?: (attempt: { email: string; cookieHeader: string | null }) => Promise<boolean>
   /** Is this handle already taken? Lets the auto-assign hook pick a free one.
    *  Omitted in schema-gen / tests (no real user table); the unique index backstops. */
   usernameTaken?: (username: string) => Promise<boolean>
@@ -308,10 +310,10 @@ export function makeAuth(db: AuthDb, baseUrl: string, secret: string, hooks: Aut
       // A reset re-establishes account control, so drop every other live session.
       revokeSessionsOnPasswordReset: true,
       resetPasswordTokenExpiresIn: 60 * 60, // 1h
-      // Self-serve "forgot password": render + enqueue the reset link on the outbox. With
-      // no real mail transport the link still rides the log sender (an operator reads it),
-      // and capabilities reports passwordReset:false so the SPA hides the self-serve flow —
-      // recovery is then the logged link + scripts/reset-password.mjs.
+      // Self-serve "forgot password": render + enqueue the reset link on the outbox.
+      // Without a real mail transport capabilities reports passwordReset:false and the
+      // SPA hides this flow; the log sender deliberately omits body/capability URLs, so
+      // recovery is the offline reset-password command rather than reading logs.
       sendResetPassword: async ({ user, url }) => {
         await hooks.sendAuthEmail?.("reset", { to: user.email, name: user.name ?? null, url })
       },
@@ -334,8 +336,22 @@ export function makeAuth(db: AuthDb, baseUrl: string, secret: string, hooks: Aut
     databaseHooks: {
       user: {
         create: {
-          before: async (user) => {
+          before: async (user, ctx) => {
             const u = user as typeof user & { username?: string | null; email?: string }
+            // Better Auth's database-hook context is the request-local endpoint
+            // context (despite its internal helper's historical name), so this
+            // forwards the actual cookie for email and OAuth/OIDC signups alike.
+            const cookieHeader =
+              ctx?.headers?.get("cookie") ?? ctx?.request?.headers.get("cookie") ?? null
+            if (
+              hooks.signupAllowed &&
+              !(await hooks.signupAllowed({ email: u.email ?? "", cookieHeader }))
+            )
+              throw new APIError("FORBIDDEN", {
+                message:
+                  "Account creation is not open on this Derive instance. Ask an operator for an invitation.",
+                code: "SIGNUP_NOT_ALLOWED",
+              })
             if (u.username) return { data: user }
             try {
               const taken = hooks.usernameTaken ?? (async () => false)

--- a/apps/api/src/config-manifest.ts
+++ b/apps/api/src/config-manifest.ts
@@ -176,8 +176,14 @@ const CONFIG_VARS: ConfigVar[] = [
   {
     name: "DERIVE_SUPERADMIN_EMAILS",
     group: "auth",
-    doc: "Instance operators (super-admins): comma-separated emails that get global powers\n(cross-workspace takedown, the reports/audit queue) on top of the DERIVE_TOKEN bearer.",
+    doc: "Deprecated migration only: matching verified legacy accounts are bound once to\nimmutable user-id operator records. This list never admits account creation.",
     example: "you@example.com,ops@example.com",
+  },
+  {
+    name: "DERIVE_SIGNUP_MODE",
+    group: "auth",
+    doc: "Account admission: open (anyone), invite (requires a live invitation capability),\nor closed (offline bootstrap only). Existing users can always sign in.",
+    example: "invite",
   },
   {
     name: "DERIVE_WEB_ORIGIN",

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -2,6 +2,7 @@ import { randomBytes } from "node:crypto"
 import { existsSync, readFileSync, writeFileSync } from "node:fs"
 import { join, resolve } from "node:path"
 import { slackFromEnv, subdomainBaseFromEnv, superAdminsFromEnv } from "./lib/env"
+import { parseSignupMode, type SignupMode } from "./lib/signup-policy"
 import { log } from "./log"
 
 /** Parse a positive-integer env var; unset/blank = "no limit". A set-but-invalid
@@ -54,10 +55,11 @@ export interface Config {
   baseUrl: string
   databaseUrl?: string
   token?: string
-  /** Operator (instance super-admin) emails: these accounts get global powers
-   *  (cross-workspace takedown, the global reports/audit queue) on top of the
-   *  DERIVE_TOKEN bearer. The people who run + host the deployment. */
+  /** Deprecated migration allow-list for already-verified legacy accounts.
+   *  Runtime authority itself is persisted against immutable user ids. */
   superAdmins: string[]
+  /** Who may create a new account. Existing users can always sign in. */
+  signupMode: SignupMode
   analytics: boolean
   rateLimit: boolean
   sandboxOrigin?: string
@@ -169,6 +171,23 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
   }
 
   const dataDir = env.DATA_DIR ?? "./data"
+  const databaseUrl = urlOr("DATABASE_URL", env.DATABASE_URL)
+  const objectStoreUrl = urlOr("OBJECT_STORE_URL", env.OBJECT_STORE_URL)
+  if (!!databaseUrl !== !!objectStoreUrl)
+    log.warn(
+      "hybrid storage topology configured (only one of DATABASE_URL / OBJECT_STORE_URL); runtime is supported, but the built-in Lite backup command is intentionally unavailable",
+    )
+  // A Postgres deployment is commonly ephemeral or replicated. Letting either of
+  // these identities fall back to a per-container file makes sessions and the
+  // bootstrap workspace disagree between replicas (and change on replacement).
+  if (databaseUrl) {
+    if (!env.DERIVE_AUTH_SECRET || env.DERIVE_AUTH_SECRET.length < 16)
+      throw new Error(
+        "DATABASE_URL requires DERIVE_AUTH_SECRET (at least 16 characters, shared by every replica)",
+      )
+    if (!env.DERIVE_DEFAULT_ORG_ID?.trim())
+      throw new Error("DATABASE_URL requires DERIVE_DEFAULT_ORG_ID (shared by every replica)")
+  }
   // Single-container self-host: when the web SPA has been built, this process
   // serves it. DERIVE_WEB_DIR overrides; default is the build output beside us.
   // TanStack Start's SPA build emits `_shell.html`; the edge prep copies it to
@@ -188,11 +207,11 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     port,
     dataDir,
     baseUrl,
-    databaseUrl: urlOr("DATABASE_URL", env.DATABASE_URL),
+    databaseUrl,
     token: env.DERIVE_TOKEN,
-    // Comma-separated operator emails (case-insensitive). More than one person
-    // can run + host a deployment, so this is a list, not a single owner.
+    // Deprecated verified-account migration list; never an admission bypass.
     superAdmins: superAdminsFromEnv(env),
+    signupMode: parseSignupMode(env.DERIVE_SIGNUP_MODE),
     backgroundWorkers: env.DERIVE_BACKGROUND_WORKERS !== "0",
     previews: env.DERIVE_PREVIEWS === "true",
     hostedRuns: env.DERIVE_HOSTED_RUNS === "true",
@@ -218,7 +237,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
       env.DERIVE_ANALYTICS_RETENTION_DAYS,
       365,
     ),
-    objectStoreUrl: urlOr("OBJECT_STORE_URL", env.OBJECT_STORE_URL),
+    objectStoreUrl,
     emailFrom: env.EMAIL_FROM,
     resendApiKey: env.RESEND_API_KEY,
     slack: slackFromEnv(env),

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -205,7 +205,8 @@ export interface AppDeps {
    *  operator IS the user. On a shared host this is what stops any workspace owner from
    *  enabling chat for themselves and spending the operator's key. */
   chatAllowlist?: string[]
-  /** Operator (instance super-admin) emails: global moderation powers, on top of `token`. */
+  /** Deprecated migration allow-list. A matching account is bound to immutable
+   *  user-id authority only after Better Auth says its email is verified. */
   superAdmins?: string[]
   /** Slack App credentials for the connect flow + inbound Events API. All three set ⇒
    *  the "Add to Slack" connect flow + reply-back are available; unset ⇒ Slack off. */
@@ -540,16 +541,20 @@ export function buildContext(deps: AppDeps) {
     return u
   }
 
-  // Instance super-admins: the people who run + host the deployment. The static
-  // DERIVE_TOKEN (automation) or any signed-in user whose email is in the operator
-  // allow-list. Super-admins get global moderation (cross-workspace takedown +
-  // the global reports/audit queue); a workspace Admin stays scoped to their own.
+  // Instance operators: the people who run + host the deployment. The static
+  // DERIVE_TOKEN remains an automation credential; human authority is persisted
+  // against an immutable Better Auth user id. The email list is migration-only:
+  // an already-verified legacy account may bind itself once, but merely submitting
+  // a configured address can never grant authority.
   const superAdminEmails = new Set((deps.superAdmins ?? []).map((e) => e.toLowerCase()))
   const isSuperAdmin = async (c: Context): Promise<boolean> => {
     if (isToken(c)) return true
-    if (superAdminEmails.size === 0) return false
     const me = await currentUser(c)
-    return !!me && superAdminEmails.has(me.email.toLowerCase())
+    if (!me) return false
+    if (await meta.isInstanceOperator(me.id)) return true
+    if (!me.emailVerified || !superAdminEmails.has(me.email.toLowerCase())) return false
+    await meta.addInstanceOperator(me.id)
+    return true
   }
 
   // The one identity resolution for a request (memoized): a typed `Principal` that folds

--- a/apps/api/src/lib/email.ts
+++ b/apps/api/src/lib/email.ts
@@ -149,7 +149,7 @@ export const buildBetaEmail = (input: { to: string; url: string }): EmailMsg => 
   <p><a href="${href}" style="display:inline-block;background:#111;color:#fff;padding:10px 18px;border-radius:6px;text-decoration:none">Create your account</a></p>
   <p style="color:#666;font-size:13px">Or paste this link into your browser:<br/><a href="${href}" style="color:#666">${href}</a></p>
   <hr style="border:none;border-top:1px solid #eee;margin:24px 0"/>
-  <p style="color:#999;font-size:12px">Prefer to run it yourself? Derive is open source: <a href="https://github.com/derive-to/derive" style="color:#999">github.com/derive-to/derive</a><br/>If you didn't request access, you can ignore this email.</p>
+  <p style="color:#999;font-size:12px">Prefer to run it yourself? Derive is Fair Source and self-hostable: <a href="https://github.com/derive-to/derive" style="color:#999">github.com/derive-to/derive</a><br/>If you didn't request access, you can ignore this email.</p>
   </body></html>`
   const text = [
     "You're in.",
@@ -158,7 +158,7 @@ export const buildBetaEmail = (input: { to: string; url: string }): EmailMsg => 
     "",
     `Create your account: ${input.url}`,
     "",
-    "Prefer to run it yourself? Derive is open source: https://github.com/derive-to/derive",
+    "Prefer to run it yourself? Derive is Fair Source and self-hostable: https://github.com/derive-to/derive",
     "If you didn't request access, you can ignore this email.",
   ].join("\n")
   return { to: input.to, subject: "Your Derive beta access", html, text }

--- a/apps/api/src/lib/signup-policy.ts
+++ b/apps/api/src/lib/signup-policy.ts
@@ -1,0 +1,105 @@
+import type { MetaStore } from "@derive/core"
+import type { Context } from "hono"
+import { setCookie } from "hono/cookie"
+import { signCapabilityToken, verifyCapabilityToken } from "./capability-token"
+
+export type SignupMode = "open" | "invite" | "closed"
+export type InviteKind = "workspace" | "artifact"
+
+export interface SignupAttempt {
+  email: string
+  cookieHeader: string | null
+}
+
+export const ADMISSION_COOKIE = "d_admission"
+const ADMISSION_DOMAIN = "derive-signup-admission:"
+const ADMISSION_TTL_MS = 15 * 60_000
+
+export function parseSignupMode(value: string | undefined): SignupMode {
+  const mode = value || "open"
+  if (mode === "open" || mode === "invite" || mode === "closed") return mode
+  throw new Error(`invalid DERIVE_SIGNUP_MODE: ${value} (expected open, invite, or closed)`)
+}
+
+const cookieFromHeader = (header: string | null, name: string): string | null => {
+  if (!header) return null
+  for (const part of header.split(";")) {
+    const equals = part.indexOf("=")
+    if (equals < 0 || part.slice(0, equals).trim() !== name) continue
+    try {
+      return decodeURIComponent(part.slice(equals + 1).trim())
+    } catch {
+      return null
+    }
+  }
+  return null
+}
+
+/** Arm the auth endpoint with a short-lived, signed capability after a valid
+ * invite preview. The raw invite token never enters a cookie or the auth hook. */
+export async function armInviteAdmission(
+  c: Context,
+  kind: InviteKind,
+  tokenHash: string,
+  inviteExpiresAt: string,
+  secret: string | undefined,
+  cookie: { baseUrl: string; crossSite?: boolean },
+): Promise<void> {
+  if (!secret) return
+  const now = Date.now()
+  const minted = await mintInviteAdmission(kind, tokenHash, inviteExpiresAt, secret, now)
+  if (!minted) return
+  setCookie(c, ADMISSION_COOKIE, minted.token, {
+    path: "/api/auth",
+    httpOnly: true,
+    // Match Better Auth's session-cookie policy. Without None+Secure here, an
+    // invite can be previewed on a split web/API deployment but its capability
+    // is silently withheld from the subsequent cross-site signup request.
+    sameSite: cookie.crossSite ? "None" : "Lax",
+    secure: cookie.crossSite || new URL(cookie.baseUrl).protocol === "https:",
+    maxAge: Math.max(1, Math.floor((minted.expiresAt - now) / 1000)),
+  })
+}
+
+/** Pure token mint used by the route wrapper above and focused policy tests. */
+export async function mintInviteAdmission(
+  kind: InviteKind,
+  tokenHash: string,
+  inviteExpiresAt: string,
+  secret: string,
+  now = Date.now(),
+): Promise<{ token: string; expiresAt: number } | null> {
+  const expiresAt = Math.min(Date.parse(inviteExpiresAt), now + ADMISSION_TTL_MS)
+  if (!Number.isFinite(expiresAt) || expiresAt <= now) return null
+  return {
+    token: await signCapabilityToken(ADMISSION_DOMAIN, secret, [kind, tokenHash], expiresAt),
+    expiresAt,
+  }
+}
+
+/** One provider-independent gate for Better Auth's user-create hook. In invite
+ * mode the authority is possession of a live invitation capability, not
+ * knowledge of the invitee's email. Closed mode is bootstrap-CLI only. */
+export function signupPolicy(
+  mode: SignupMode,
+  secret: string,
+  meta: Pick<MetaStore, "getInvitationByToken" | "getArtifactInviteByToken">,
+): (attempt: SignupAttempt) => Promise<boolean> {
+  return async ({ cookieHeader }) => {
+    if (mode === "open") return true
+    if (mode === "closed") return false
+    const encoded = cookieFromHeader(cookieHeader, ADMISSION_COOKIE)
+    if (!encoded) return false
+    const verified = await verifyCapabilityToken(ADMISSION_DOMAIN, secret, encoded, Date.now())
+    if (!verified) return false
+    const [kind, tokenHash, extra] = verified.rest.split(".")
+    if (extra !== undefined || !/^[0-9a-f]{64}$/.test(tokenHash ?? "")) return false
+    const invite =
+      kind === "workspace"
+        ? await meta.getInvitationByToken(tokenHash ?? "")
+        : kind === "artifact"
+          ? await meta.getArtifactInviteByToken(tokenHash ?? "")
+          : null
+    return !!invite && invite.accepted_at === null && Date.parse(invite.expires_at) > Date.now()
+  }
+}

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -30,6 +30,7 @@ import { makeGithubCommentSender } from "./lib/github-comments"
 import { catalogFromGateway, type GatewayConfig } from "./lib/model-catalog"
 import { getInstanceSlot, modelSource, readLibrary } from "./lib/model-library"
 import { mountWeb } from "./lib/serve-web"
+import { signupPolicy } from "./lib/signup-policy"
 import { makeSlackIngestSender, makeSlackSender } from "./lib/slack-comments"
 import { makeSlackDmSender } from "./lib/slack-dm"
 import { loopSubstrate } from "./lib/substrate-loop"
@@ -94,7 +95,10 @@ if (remoteDb && (process.env.npm_lifecycle_event ?? "").startsWith("dev")) {
   log.warn("dev mode is using a REMOTE database (DERIVE_ALLOW_REMOTE_DB=1)")
 }
 
-mkdirSync(join(cfg.dataDir, "blobs"), { recursive: true })
+// Postgres + object storage is genuinely stateless. Do not manufacture a /data
+// dependency in that topology merely because the Lite topology needs one.
+if (!cfg.databaseUrl || !cfg.objectStoreUrl)
+  mkdirSync(join(cfg.dataDir, "blobs"), { recursive: true })
 
 // Metadata + auth share one datastore: Postgres when DATABASE_URL is set (the
 // stateless multi-instance topology), else embedded SQLite (zero-config).
@@ -201,15 +205,16 @@ if (cfg.databaseUrl) {
 }
 
 const authSecret = resolveAuthSecret(cfg.dataDir)
-// A real transactional email transport (Resend) is configured — else the log sender
-// still records each message (an operator can read a reset link from the container logs),
-// but the SPA hides the self-serve mail flows (see `emailEnabled` in createApp deps).
+// A real transactional email transport (Resend) is configured — otherwise the safe
+// log sender records only recipient + subject (never capability URLs), and the SPA
+// hides self-serve mail flows (see `emailEnabled` in createApp deps).
 const emailEnabled = !!(cfg.resendApiKey && cfg.emailFrom)
 // Hoisted above makeAuth (rather than built inline down at createApp's `billing:` dep,
 // where it lived before) so the account-deletion hook below and the billing routes
 // share the exact same driver instance instead of constructing two.
 const billing = makeBillingDriver(cfg.stripeSecretKey, cfg.stripeWebhookSecret)
 const auth = makeAuth(authDb, cfg.baseUrl, authSecret, {
+  signupAllowed: signupPolicy(cfg.signupMode, authSecret, meta),
   usernameTaken: (u) => meta.getUserByUsername(u).then(Boolean),
   // Render + enqueue transactional auth emails (reset / verify / change-email) onto the
   // same retrying outbox as notifications; the configured sender transports them.

--- a/apps/api/src/routes/sharing.ts
+++ b/apps/api/src/routes/sharing.ts
@@ -23,6 +23,7 @@ import {
   looksLikeEmail,
 } from "../lib/invite"
 import { resolveUserRef } from "../lib/resolve-user"
+import { armInviteAdmission } from "../lib/signup-policy"
 import { enqueueSlackShareDm } from "../lib/slack-dm"
 import { ArtifactMember, roleEnum } from "../schemas"
 import { enqueueChannelDelivery } from "../webhooks"
@@ -386,6 +387,14 @@ export const sharingRoutes = (ctx: AppContext) => {
       const live = await liveArtifactInvite(c)
       if (!live) return bail(fail(c, 404, "this invitation is invalid or has expired"))
       const { inv, artifact } = live
+      await armInviteAdmission(
+        c,
+        "artifact",
+        sha256(c.req.param("token")),
+        inv.expires_at,
+        deps.encryptionKey,
+        { baseUrl: deps.baseUrl, crossSite: deps.crossSite },
+      )
       const inviter = inv.invited_by ? (await meta.getUsers([inv.invited_by]))[0] : undefined
       return c.json({
         title: artifact.title,
@@ -425,6 +434,9 @@ export const sharingRoutes = (ctx: AppContext) => {
       const { inv, artifact } = live
       const mismatch = await emailMismatch409(c, inv.email, me.email)
       if (mismatch) return bail(mismatch)
+      const now = new Date().toISOString()
+      if (!(await meta.consumeArtifactInvite(inv.id, now)))
+        return bail(fail(c, 409, "this invitation has already been accepted"))
       // An existing share only ever upgrades — accepting a commenter invite while
       // already an editor member must not downgrade the real grant.
       const existing = await meta.getArtifactMember(artifact.id, me.id)
@@ -436,7 +448,6 @@ export const sharingRoutes = (ctx: AppContext) => {
           user_id: me.id,
           role: granted,
         })
-      await meta.markArtifactInviteAccepted(inv.id)
       // Any OTHER pending invites for this email on the artifact are now moot.
       await meta.deletePendingArtifactInvitesFor(artifact.id, inv.email)
       return c.json({ short_id: artifact.short_id, role: granted })

--- a/apps/api/src/routes/system.ts
+++ b/apps/api/src/routes/system.ts
@@ -32,8 +32,9 @@ export const systemRoutes = (ctx: AppContext) => {
    * if-statement do not.
    *
    * `isSuperAdmin` is DERIVE_TOKEN (the static operator bearer) or a signed-in account whose
-   * email is in DERIVE_OPERATORS. A workspace Admin is NOT an operator here, deliberately: they
-   * administer a tenant, and this spends the operator's credential for every tenant at once.
+   * immutable user id is in instance_operator. A workspace Admin is NOT an operator here,
+   * deliberately: they administer a tenant, and this spends the operator's credential for every
+   * tenant at once.
    */
   const operatorOnly = async (c: Parameters<typeof isSuperAdmin>[0]): Promise<Response | null> =>
     isToken(c) || (await isSuperAdmin(c))

--- a/apps/api/src/routes/workspace.ts
+++ b/apps/api/src/routes/workspace.ts
@@ -22,6 +22,7 @@ import {
 } from "../lib/invite"
 import { resolveUserRef } from "../lib/resolve-user"
 import { syncSeats } from "../lib/seats"
+import { armInviteAdmission } from "../lib/signup-policy"
 import { ArtifactMember, BrandprintSchema, roleEnum } from "../schemas"
 import { enqueueChannelDelivery } from "../webhooks"
 
@@ -520,9 +521,14 @@ export const workspaceRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      const inv = await meta.getInvitationByToken(sha256(c.req.param("token")))
+      const tokenHash = sha256(c.req.param("token"))
+      const inv = await meta.getInvitationByToken(tokenHash)
       if (!inv || !isLiveInvite(inv))
         return bail(fail(c, 404, "this invitation is invalid or has expired"))
+      await armInviteAdmission(c, "workspace", tokenHash, inv.expires_at, deps.encryptionKey, {
+        baseUrl: deps.baseUrl,
+        crossSite: deps.crossSite,
+      })
       const ws = await meta.getWorkspace(inv.org_id)
       const inviter = inv.invited_by ? (await meta.getUsers([inv.invited_by]))[0] : undefined
       return c.json({
@@ -559,6 +565,9 @@ export const workspaceRoutes = (ctx: AppContext) => {
         return bail(fail(c, 404, "this invitation is invalid or has expired"))
       const mismatch = await emailMismatch409(c, inv.email, me.email)
       if (mismatch) return bail(mismatch)
+      const now = new Date().toISOString()
+      if (!(await meta.consumeInvitation(inv.id, now)))
+        return bail(fail(c, 409, "this invitation has already been accepted"))
       const existing = await meta.getMembership(inv.org_id, me.id)
       if (!existing) {
         await meta.setMembership({
@@ -569,7 +578,6 @@ export const workspaceRoutes = (ctx: AppContext) => {
         })
         await syncSeats({ meta, billing }, inv.org_id)
       }
-      await meta.markInvitationAccepted(inv.id)
       return c.json({ org_id: inv.org_id, role: existing?.role ?? inv.role })
     },
   )

--- a/apps/api/src/server-cli.ts
+++ b/apps/api/src/server-cli.ts
@@ -1,0 +1,26 @@
+import { join, resolve } from "node:path"
+
+const [command = "serve", ...args] = process.argv.slice(2)
+
+try {
+  if (command === "serve") await import("./node")
+  else {
+    // Match node.ts's zero-friction local .env behavior for administrative
+    // commands. The serve path deliberately lets node.ts load the file after it
+    // snapshots the remote-database escape hatch, so .env cannot enable it.
+    for (const envPath of [join(import.meta.dirname, "../../../.env"), resolve(".env")]) {
+      try {
+        process.loadEnvFile(envPath)
+        break
+      } catch {
+        // Deployments normally inject the environment; no local file is expected.
+      }
+    }
+
+    const { runAdminCommand } = await import("./admin")
+    process.stdout.write(`${await runAdminCommand(command, args)}\n`)
+  }
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+  process.exitCode = 1
+}

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -38,6 +38,7 @@ import { catalogFromGateway, type GatewayConfig } from "./lib/model-catalog"
 import { getInstanceSlot } from "./lib/model-library"
 import { nativeLimiter } from "./lib/rate-limit"
 import { liveD1, requestD1 } from "./lib/request-d1"
+import { parseSignupMode, signupPolicy } from "./lib/signup-policy"
 import { STATIC_NAMESPACE_PREFIXES } from "./lib/static-namespaces"
 import { containerSubstrateFromEnv } from "./lib/substrate-container"
 import { loopSubstrate } from "./lib/substrate-loop"
@@ -176,6 +177,7 @@ export interface Env {
   DERIVE_LOOP_MODEL?: string
   DERIVE_SANDBOX_URL?: string
   DERIVE_SUPERADMIN_EMAILS?: string
+  DERIVE_SIGNUP_MODE?: string
   // Base domain for vanity subdomains (domain mode); unset = off.
   DERIVE_SUBDOMAIN_BASE?: string
   // Cloudflare for SaaS (BYO custom domains); all three unset = custom domains off.
@@ -285,6 +287,7 @@ const handle = (req: Request, env: Env, ctx: ExecutionContext): Response | Promi
       // routes share the exact same driver instance instead of constructing two.
       const billing = makeBillingDriver(env.STRIPE_SECRET_KEY, env.STRIPE_WEBHOOK_SECRET)
       const auth = makeAuth(authDb, baseUrl, secret, {
+        signupAllowed: signupPolicy(parseSignupMode(env.DERIVE_SIGNUP_MODE), secret, meta),
         usernameTaken: (u) => meta.getUserByUsername(u).then(Boolean),
         // Transactional auth emails ride the same outbox; the WebhookOutbox DO drains it
         // with the Cloudflare Email sender (env.SEND_EMAIL). See webhook-do.ts.

--- a/apps/api/test/admin.test.ts
+++ b/apps/api/test/admin.test.ts
@@ -1,0 +1,171 @@
+import { createHash } from "node:crypto"
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { verifyPassword } from "better-auth/crypto"
+import Database from "better-sqlite3"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import {
+  bootstrapOperator,
+  createLiteBackup,
+  resetPassword,
+  restoreLiteBackup,
+  verifyLiteBackup,
+} from "../src/admin"
+
+const roots: string[] = []
+const temp = () => {
+  const path = mkdtempSync(join(tmpdir(), "derive-admin-test-"))
+  roots.push(path)
+  return path
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+  vi.unstubAllEnvs()
+})
+
+describe("Lite backup lifecycle", () => {
+  it("online-snapshots SQLite, verifies blobs, and restores into an empty directory", async () => {
+    const root = temp()
+    const data = join(root, "data")
+    mkdirSync(data)
+    const live = new Database(join(data, "derive.db"))
+    live.pragma("journal_mode = WAL")
+    live.exec("CREATE TABLE note (value TEXT); INSERT INTO note VALUES ('safe')")
+    const blob = Buffer.from("immutable artifact")
+    const key = createHash("sha256").update(blob).digest("hex")
+    mkdirSync(join(data, "blobs", key.slice(0, 2)), { recursive: true })
+    writeFileSync(join(data, "blobs", key.slice(0, 2), key.slice(2)), blob)
+    writeFileSync(join(data, ".auth-secret"), "persistent-secret")
+    writeFileSync(join(data, ".org-id"), "ws_persistent")
+
+    const backup = join(root, "backup")
+    await createLiteBackup(data, backup)
+    await expect(verifyLiteBackup(backup)).resolves.toMatchObject({
+      format: "derive-lite-backup-v2",
+      topology: "sqlite+filesystem",
+      sqliteIntegrity: "ok",
+    })
+
+    const restored = join(root, "restored")
+    await restoreLiteBackup(backup, restored)
+    const restoredDb = new Database(join(restored, "derive.db"), { readonly: true })
+    expect(restoredDb.prepare("SELECT value FROM note").pluck().get()).toBe("safe")
+    restoredDb.close()
+    expect(readFileSync(join(restored, "blobs", key.slice(0, 2), key.slice(2)))).toEqual(blob)
+    expect(readFileSync(join(restored, ".auth-secret"), "utf8")).toBe("persistent-secret")
+    expect(readFileSync(join(restored, ".org-id"), "utf8")).toBe("ws_persistent")
+    live.close()
+  })
+
+  it("detects a corrupted backup", async () => {
+    const root = temp()
+    const data = join(root, "data")
+    mkdirSync(data)
+    const db = new Database(join(data, "derive.db"))
+    db.exec("CREATE TABLE note (value TEXT)")
+    db.close()
+    writeFileSync(join(data, ".auth-secret"), "persistent-secret")
+    writeFileSync(join(data, ".org-id"), "ws_persistent")
+    const backup = join(root, "backup")
+    await createLiteBackup(data, backup)
+    writeFileSync(join(backup, "derive.db"), "not a database")
+    await expect(verifyLiteBackup(backup)).rejects.toThrow(/checksum mismatch/)
+  })
+
+  it("rejects files that are not declared by the manifest", async () => {
+    const root = temp()
+    const data = join(root, "data")
+    mkdirSync(data)
+    const db = new Database(join(data, "derive.db"))
+    db.exec("CREATE TABLE note (value TEXT)")
+    db.close()
+    writeFileSync(join(data, ".auth-secret"), "persistent-secret")
+    writeFileSync(join(data, ".org-id"), "ws_persistent")
+    const backup = join(root, "backup")
+    await createLiteBackup(data, backup)
+    writeFileSync(join(backup, ".unmanifested"), "surprise")
+    await expect(verifyLiteBackup(backup)).rejects.toThrow(/inventory/)
+  })
+
+  it("rejects a manifest that smuggles an environment-supplied identity file", async () => {
+    vi.stubEnv("DERIVE_AUTH_SECRET", "environment-secret-for-test")
+    vi.stubEnv("DERIVE_DEFAULT_ORG_ID", "ws_environment")
+    const root = temp()
+    const data = join(root, "data")
+    mkdirSync(data)
+    const db = new Database(join(data, "derive.db"))
+    db.exec("CREATE TABLE note (value TEXT)")
+    db.close()
+    const backup = join(root, "backup")
+    await createLiteBackup(data, backup)
+
+    const secret = "smuggled-secret"
+    writeFileSync(join(backup, ".auth-secret"), secret)
+    const manifestPath = join(backup, "derive-backup.json")
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as {
+      files: { path: string; sha256: string; bytes: number }[]
+    }
+    manifest.files.push({
+      path: ".auth-secret",
+      sha256: createHash("sha256").update(secret).digest("hex"),
+      bytes: Buffer.byteLength(secret),
+    })
+    writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+
+    await expect(verifyLiteBackup(backup)).rejects.toThrow(/environment-supplied identity/)
+  })
+})
+
+describe("operator password recovery", () => {
+  it("updates the credential hash and revokes every session", async () => {
+    const data = temp()
+    const db = new Database(join(data, "derive.db"))
+    db.exec(`
+      CREATE TABLE "user" (id TEXT PRIMARY KEY, email TEXT NOT NULL);
+      CREATE TABLE account (id TEXT PRIMARY KEY, "accountId" TEXT NOT NULL,
+        "providerId" TEXT NOT NULL, "userId" TEXT NOT NULL, password TEXT,
+        "createdAt" TEXT NOT NULL, "updatedAt" TEXT NOT NULL);
+      CREATE TABLE session (id TEXT PRIMARY KEY, "userId" TEXT NOT NULL);
+      INSERT INTO "user" VALUES ('u1', 'person@example.com');
+      INSERT INTO account VALUES ('a1','u1','credential','u1','old','now','now');
+      INSERT INTO session VALUES ('s1','u1'), ('s2','u1');
+    `)
+    db.close()
+
+    await resetPassword(undefined, data, "PERSON@example.com", "new-safe-password")
+
+    const check = new Database(join(data, "derive.db"), { readonly: true })
+    const password = check.prepare("SELECT password FROM account").pluck().get() as string
+    expect(await verifyPassword({ hash: password, password: "new-safe-password" })).toBe(true)
+    expect(check.prepare("SELECT count(*) FROM session").pluck().get()).toBe(0)
+    check.close()
+  })
+})
+
+describe("instance operator bootstrap", () => {
+  it("creates the account and binds authority to its immutable id", async () => {
+    const data = temp()
+    const result = await bootstrapOperator(undefined, data, "http://derive.test", {
+      email: "Owner@Example.com",
+      name: "Owner",
+      password: "safe-bootstrap-password",
+    })
+    expect(result.created).toBe(true)
+    const db = new Database(join(data, "derive.db"), { readonly: true })
+    expect(
+      db.prepare('SELECT id FROM "user" WHERE email = ?').pluck().get("owner@example.com"),
+    ).toBe(result.userId)
+    expect(db.prepare("SELECT user_id FROM instance_operator").pluck().get()).toBe(result.userId)
+    db.close()
+
+    await expect(
+      bootstrapOperator(undefined, data, "http://derive.test", {
+        email: "second@example.com",
+        name: "Second",
+        password: "safe-bootstrap-password",
+      }),
+    ).rejects.toThrow(/operator already exists/)
+  })
+})

--- a/apps/api/test/config.test.ts
+++ b/apps/api/test/config.test.ts
@@ -30,6 +30,26 @@ describe("config: fail-fast env validation", () => {
     expect(() => loadConfig({ ...base, DATABASE_URL: "not a url" })).toThrow(/DATABASE_URL/)
   })
 
+  it("requires shared identity settings with Postgres", () => {
+    const database = "postgres://derive:password@db.example.com:5432/derive"
+    expect(() => loadConfig({ ...base, DATABASE_URL: database })).toThrow(/DERIVE_AUTH_SECRET/)
+    expect(() =>
+      loadConfig({
+        ...base,
+        DATABASE_URL: database,
+        DERIVE_AUTH_SECRET: "shared-secret-0123456789",
+      }),
+    ).toThrow(/DERIVE_DEFAULT_ORG_ID/)
+    expect(
+      loadConfig({
+        ...base,
+        DATABASE_URL: database,
+        DERIVE_AUTH_SECRET: "shared-secret-0123456789",
+        DERIVE_DEFAULT_ORG_ID: "ws_shared",
+      }).databaseUrl,
+    ).toBe(database)
+  })
+
   it("rejects a malformed OBJECT_STORE_URL", () => {
     expect(() => loadConfig({ ...base, OBJECT_STORE_URL: "::::" })).toThrow(/OBJECT_STORE_URL/)
   })

--- a/apps/api/test/helpers.ts
+++ b/apps/api/test/helpers.ts
@@ -46,6 +46,7 @@ type Seat = { user_id: string; role: Role }
 // longer name the same schema, and leftovers stay in the schema of the file that made them.
 const pgStores: TestStore[] = []
 const pgSchemas = new Set<string>()
+const appSeeds: Promise<void>[] = []
 const workerKey = (process.env.VITEST_POOL_ID ?? String(process.pid)).replace(/[^a-z0-9]+/gi, "_")
 const fileKey = randomUUID().replace(/-/g, "").slice(0, 10)
 const schemaFor = (name: string) =>
@@ -218,9 +219,16 @@ export const app = authProxy(sharedApp)
 export const anonApp = sharedApp
 
 afterAll(async () => {
-  if (PG_URL) await Promise.all(pgStores.map((s) => Promise.resolve(s.close()).catch(() => {})))
-  else meta.close()
-  rmSync(dir, { recursive: true, force: true })
+  try {
+    // makeAuthedApp starts its seed immediately so direct context users see the same initialized
+    // store as HTTP callers. Some tests never make a request, so teardown must wait for every
+    // seed explicitly before closing any shared Postgres pool.
+    await Promise.all(appSeeds)
+  } finally {
+    if (PG_URL) await Promise.all(pgStores.map((s) => Promise.resolve(s.close()).catch(() => {})))
+    else meta.close()
+    rmSync(dir, { recursive: true, force: true })
+  }
 })
 
 export const upload = (
@@ -359,6 +367,7 @@ export const makeAuthedApp = (
     if (current)
       await m.setOrgSettings("default", { ...current, automateBeta: true }).catch(() => undefined)
   })()
+  appSeeds.push(planReady)
   const deps: AppDeps = {
     meta: m,
     blobs: new FsBlobStore(join(dir, "blobs")),

--- a/apps/api/test/helpers.ts
+++ b/apps/api/test/helpers.ts
@@ -261,6 +261,7 @@ export type TestUser = {
   image?: string | null
   username?: string | null
   discoverable?: boolean
+  emailVerified?: boolean
 }
 
 const fakeAuth = (users: TestUser[]): AppDeps["auth"] =>
@@ -309,7 +310,13 @@ export const makeAuthedApp = (
   name: string,
   users: TestUser[],
   defaultRole?: AppDeps["defaultRole"],
-  opts?: { isolated?: boolean; deps?: Partial<AppDeps>; noPlan?: boolean; noAutomate?: boolean },
+  opts?: {
+    isolated?: boolean
+    deps?: Partial<AppDeps>
+    noPlan?: boolean
+    noAutomate?: boolean
+    operatorIds?: string[]
+  },
 ) => {
   // Seed a shared "default" workspace so the user list collaborates (the single-
   // mode default before always-multi): users[0] is the Admin/owner, the rest take
@@ -342,6 +349,8 @@ export const makeAuthedApp = (
   // deliberately in automate-gate.test.ts, which builds apps WITHOUT this seed, instead of being
   // proved incidentally by every other suite having to remember.
   const planReady = (async () => {
+    const authorityStore = opts?.deps?.meta ?? m
+    for (const userId of opts?.operatorIds ?? []) await authorityStore.addInstanceOperator(userId)
     if (!opts?.noPlan) await connectPoolPlan(m, "default").catch(() => undefined)
     // `noAutomate` opts OUT: the suite that asserts the shipped DEFAULTS has to see the real ones,
     // and a blanket seed would have made that assertion quietly lie about this exact field.

--- a/apps/api/test/model-catalog.test.ts
+++ b/apps/api/test/model-catalog.test.ts
@@ -31,15 +31,20 @@ describe("gateway extras reach the request", () => {
 
 describe("the operator's deploy-wide model", () => {
   const setup = () =>
-    makeAuthedApp("instance-model", [{ id: "u-op", email: "op@x.com", name: "Op" }], undefined, {
-      deps: {
-        models: catalogOf([
-          { id: "fast", label: "Fast", isDefault: true, build: () => async () => THE_TURN },
-          { id: "slow", label: "Slow", isDefault: false, build: () => async () => THE_TURN },
-        ]),
-        superAdmins: ["op@x.com"],
+    makeAuthedApp(
+      "instance-model",
+      [{ id: "u-op", email: "op@x.com", name: "Op", emailVerified: true }],
+      undefined,
+      {
+        operatorIds: ["u-op"],
+        deps: {
+          models: catalogOf([
+            { id: "fast", label: "Fast", isDefault: true, build: () => async () => THE_TURN },
+            { id: "slow", label: "Slow", isDefault: false, build: () => async () => THE_TURN },
+          ]),
+        },
       },
-    })
+    )
 
   it("is refused to somebody who does not run the instance", async () => {
     // A workspace Admin is still not an operator: the model is the operator's credential to

--- a/apps/api/test/model-library.test.ts
+++ b/apps/api/test/model-library.test.ts
@@ -38,11 +38,12 @@ const setup = (name: string, opts?: { operators?: string[]; gateway?: GatewayCon
   makeAuthedApp(
     name,
     [
-      { id: "u-op", email: "op@x.com", name: "Olive" },
+      { id: "u-op", email: "op@x.com", name: "Olive", emailVerified: true },
       { id: "u-mem", email: "mem@x.com", name: "Mem" },
     ],
     undefined,
     {
+      operatorIds: opts?.operators ?? ["u-op"],
       deps: {
         models: catalogOf([
           {
@@ -53,7 +54,6 @@ const setup = (name: string, opts?: { operators?: string[]; gateway?: GatewayCon
           },
         ]),
         ...(opts?.gateway === null ? {} : { modelGateway: opts?.gateway ?? GATEWAY }),
-        superAdmins: opts?.operators ?? ["op@x.com"],
         rateLimiters: inMemoryRateLimiters(),
       },
     },
@@ -480,9 +480,10 @@ describe("probing", () => {
     // opposite of what this page exists to tell somebody.
     const { app, meta } = makeAuthedApp(
       "lib-probe-down",
-      [{ id: "u-op", email: "op@x.com", name: "Olive" }],
+      [{ id: "u-op", email: "op@x.com", name: "Olive", emailVerified: true }],
       undefined,
       {
+        operatorIds: ["u-op"],
         deps: {
           models: catalogOf([
             {
@@ -495,7 +496,6 @@ describe("probing", () => {
             },
           ]),
           modelGateway: GATEWAY,
-          superAdmins: ["op@x.com"],
         },
       },
     )
@@ -582,16 +582,16 @@ describe("what a turn costs to route", () => {
     const { app } = makeAuthedApp(
       "lib-view-one-read-probe",
       [
-        { id: "u-op", email: "op@x.com", name: "Olive" },
+        { id: "u-op", email: "op@x.com", name: "Olive", emailVerified: true },
         { id: "u-mem", email: "mem@x.com", name: "Mem" },
       ],
       undefined,
       {
+        operatorIds: ["u-op"],
         deps: {
           meta: proxy,
           models: catalogOf([ONLY]),
           modelGateway: GATEWAY,
-          superAdmins: ["op@x.com"],
           rateLimiters: inMemoryRateLimiters(),
         },
       },

--- a/apps/api/test/signup-policy.test.ts
+++ b/apps/api/test/signup-policy.test.ts
@@ -1,0 +1,147 @@
+import type { ArtifactInviteRecord, InvitationRecord } from "@derive/core"
+import Database from "better-sqlite3"
+import { Hono } from "hono"
+import { describe, expect, it } from "vitest"
+import { makeAuth, migrateAuth } from "../src/auth-config"
+import {
+  ADMISSION_COOKIE,
+  armInviteAdmission,
+  mintInviteAdmission,
+  parseSignupMode,
+  signupPolicy,
+} from "../src/lib/signup-policy"
+
+const SECRET = "test-secret-0123456789abcd"
+const HASH = "a".repeat(64)
+
+describe("self-host signup admission", () => {
+  it("defaults to open and rejects misspelled modes", () => {
+    expect(parseSignupMode(undefined)).toBe("open")
+    expect(() => parseSignupMode("invte")).toThrow(/DERIVE_SIGNUP_MODE/)
+  })
+
+  it("does not let a configured-looking email bypass closed mode", async () => {
+    const allowed = signupPolicy("closed", SECRET, {
+      getInvitationByToken: async () => null,
+      getArtifactInviteByToken: async () => null,
+    })
+    await expect(allowed({ email: "owner@example.com", cookieHeader: null })).resolves.toBe(false)
+  })
+
+  it("requires possession of a signed capability for a live invite", async () => {
+    const expiresAt = new Date(Date.now() + 60_000).toISOString()
+    const invite = {
+      token: HASH,
+      expires_at: expiresAt,
+      accepted_at: null,
+    } as InvitationRecord
+    const allowed = signupPolicy("invite", SECRET, {
+      getInvitationByToken: async (hash) => (hash === HASH ? invite : null),
+      getArtifactInviteByToken: async () => null,
+    })
+    const minted = await mintInviteAdmission("workspace", HASH, expiresAt, SECRET)
+    expect(minted).not.toBeNull()
+    await expect(
+      allowed({
+        // Admission follows possession of the link, not a claim about this address.
+        email: "stranger@example.com",
+        cookieHeader: `${ADMISSION_COOKIE}=${minted?.token}`,
+      }),
+    ).resolves.toBe(true)
+    await expect(allowed({ email: "invited@example.com", cookieHeader: null })).resolves.toBe(false)
+  })
+
+  it("accepts artifact capabilities and rejects a capability after the invite is spent", async () => {
+    const expiresAt = new Date(Date.now() + 60_000).toISOString()
+    const invite = { token: HASH, expires_at: expiresAt, accepted_at: null } as ArtifactInviteRecord
+    const allowed = signupPolicy("invite", SECRET, {
+      getInvitationByToken: async () => null,
+      getArtifactInviteByToken: async (hash) => (hash === HASH ? invite : null),
+    })
+    const minted = await mintInviteAdmission("artifact", HASH, expiresAt, SECRET)
+    const attempt = {
+      email: "person@example.com",
+      cookieHeader: `${ADMISSION_COOKIE}=${minted?.token}`,
+    }
+    await expect(allowed(attempt)).resolves.toBe(true)
+    invite.accepted_at = new Date().toISOString()
+    await expect(allowed(attempt)).resolves.toBe(false)
+  })
+
+  it("uses the session cookie policy for split web/API deployments", async () => {
+    const app = new Hono()
+    app.get("/invite", async (c) => {
+      await armInviteAdmission(
+        c,
+        "workspace",
+        HASH,
+        new Date(Date.now() + 60_000).toISOString(),
+        SECRET,
+        { baseUrl: "https://api.derive.test", crossSite: true },
+      )
+      return c.body(null, 204)
+    })
+    const response = await app.request("http://internal/invite")
+    expect(response.headers.get("set-cookie")).toMatch(
+      /^d_admission=.*; Max-Age=\d+; Path=\/api\/auth; HttpOnly; Secure; SameSite=None$/,
+    )
+  })
+
+  it("enforces the policy in Better Auth's provider-independent user-create hook", async () => {
+    const db = new Database(":memory:")
+    const auth = makeAuth(db, "http://derive.test", "test-secret-0123456789abcd", {
+      signupAllowed: async () => false,
+    })
+    await migrateAuth(auth)
+    const response = await auth.handler(
+      new Request("http://derive.test/api/auth/sign-up/email", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          name: "Blocked Person",
+          email: "blocked@example.com",
+          password: "valid-password",
+        }),
+      }),
+    )
+    expect(response.status).toBe(403)
+    expect(db.prepare('SELECT count(*) FROM "user"').pluck().get()).toBe(0)
+    db.close()
+  })
+
+  it("forwards the admission cookie through Better Auth's user-create hook", async () => {
+    const expiresAt = new Date(Date.now() + 60_000).toISOString()
+    const invite = {
+      token: HASH,
+      expires_at: expiresAt,
+      accepted_at: null,
+    } as InvitationRecord
+    const db = new Database(":memory:")
+    const auth = makeAuth(db, "http://derive.test", SECRET, {
+      signupAllowed: signupPolicy("invite", SECRET, {
+        getInvitationByToken: async (hash) => (hash === HASH ? invite : null),
+        getArtifactInviteByToken: async () => null,
+      }),
+    })
+    await migrateAuth(auth)
+    const minted = await mintInviteAdmission("workspace", HASH, expiresAt, SECRET)
+    const response = await auth.handler(
+      new Request("http://derive.test/api/auth/sign-up/email", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          cookie: `${ADMISSION_COOKIE}=${minted?.token}`,
+          origin: "http://derive.test",
+        },
+        body: JSON.stringify({
+          name: "Invited Person",
+          email: "invited@example.com",
+          password: "valid-password",
+        }),
+      }),
+    )
+    expect(response.status, await response.clone().text()).toBe(200)
+    expect(db.prepare('SELECT count(*) FROM "user"').pluck().get()).toBe(1)
+    db.close()
+  })
+})

--- a/apps/api/test/signup-policy.test.ts
+++ b/apps/api/test/signup-policy.test.ts
@@ -11,7 +11,7 @@ import {
   signupPolicy,
 } from "../src/lib/signup-policy"
 
-const SECRET = "test-secret-0123456789abcd"
+const SECRET = "test-secret-0123456789abcd" // gitleaks:allow -- deterministic test fixture, not a credential
 const HASH = "a".repeat(64)
 
 describe("self-host signup admission", () => {

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -286,6 +286,7 @@ DERIVE_LOOP_RUNS = "1"
 # the addresses out of a public repo instead, move the same value to a Cloudflare
 # dashboard variable — no code change, and it overrides nothing else.
 DERIVE_SUPERADMIN_EMAILS = "anir@derive.to,rob@derive.to,mert@derive.to"
+DERIVE_SIGNUP_MODE = "open"
 # HOSTED EXECUTION ROLLOUT. This is an immutable workspace id, not the editable display name.
 # The Worker fails closed when this variable is absent or blank, and the dispatcher applies the
 # scope before schedule materialization, stale-run recovery, queue scans, asks, and Run now.

--- a/apps/web/public/security.html
+++ b/apps/web/public/security.html
@@ -131,7 +131,7 @@ footer a:hover{color:var(--fg)}
     <a class="addr" href="mailto:security@derive.to">security@derive.to</a>
     <p>For vulnerabilities in Derive itself — the app, the API, or the hosting of user content. Please give
     us a reasonable window to remediate before public disclosure. The server is
-    <a href="https://github.com/derive-to/derive">open source</a>; issues in the code are also welcome there.</p>
+    <a href="https://github.com/derive-to/derive">source available</a>; issues in the code are also welcome there.</p>
   </section>
 </main>
 <footer>

--- a/apps/web/public/site/index.html
+++ b/apps/web/public/site/index.html
@@ -14,10 +14,10 @@
   c.toggle('light', light); c.toggle('dark', !light);
 })();
 </script>
-<title>Derive — The open source home for AI artifacts.</title>
+<title>Derive — The self-hostable home for AI artifacts.</title>
 <meta name="description" content="You've never made more, and never kept less. Derive is where your team and its agents publish, review, and revise work. Open source and self-hostable.">
 <meta property="og:type" content="website">
-<meta property="og:title" content="Derive — The open source home for AI artifacts.">
+<meta property="og:title" content="Derive — The self-hostable home for AI artifacts.">
 <meta property="og:description" content="You've never made more, and never kept less. Derive is where your team and its agents publish, review, and revise work.">
 <meta property="og:url" content="https://derive.to/">
 <meta property="og:image" content="https://derive.to/site/og.png">
@@ -751,7 +751,7 @@ footer{margin-top:170px;position:relative;overflow:hidden;border-top:1px solid v
 <header class="hero" id="hero">
   <div class="stage">
     <div class="eyebrow hero-eyebrow">Make things worth keeping</div>
-    <h1 class="derivation grad-ink">The open source home for&nbsp;AI&nbsp;artifacts.</h1>
+    <h1 class="derivation grad-ink">The self-hostable home for&nbsp;AI&nbsp;artifacts.</h1>
     <p class="sub"><strong>You've never made more, and never kept less.</strong> Derive is your team's library for the work you and your agents make: publish it, share it anywhere with a link, and revise it together until it's right. One URL, every version, yours.</p>
     <div class="cta-row">
       <button class="btn btn-primary hero-cta" type="button" data-copy-from="agentPrompt" data-copied-label="Copied — now paste it into your agent">
@@ -1076,7 +1076,7 @@ footer{margin-top:170px;position:relative;overflow:hidden;border-top:1px solid v
     <div>
       <p class="ch-lede reveal">Yours, not the model's, not ours.</p>
       <p class="ch-text reveal">Claude's artifacts live in Claude. ChatGPT's canvases live in ChatGPT. If half your team runs one and half runs the other, the work ends up split across two walled gardens. <strong>Derive doesn't care which model made what</strong>: context lives with the artifact, so a page Claude drafts on Monday gets revised by Codex on Tuesday, and your team reads both in one library.</p>
-      <p class="ch-text reveal">The same openness goes all the way down. The product is <strong>open source and runs as a single container on your own infrastructure</strong> if you want it to, and everything exports in open formats: artifacts, versions, and comments. If you ever leave, the record leaves with you.</p>
+      <p class="ch-text reveal">The same openness goes all the way down. The product is <strong>Fair Source and runs as a single container on your own infrastructure</strong> if you want it to, and everything exports in open formats: artifacts, versions, and comments. If you ever leave, the record leaves with you.</p>
     </div>
     <div class="ch-spec reveal">
       <div class="spec-card">

--- a/apps/web/public/site/pricing.html
+++ b/apps/web/public/site/pricing.html
@@ -295,7 +295,7 @@ footer{margin-top:130px;border-top:1px solid var(--border-soft)}
     </div>
     <div class="principle">
       <h3>Self-hosting is free, forever.</h3>
-      <p>The whole product is open source and runs as one container. The hosted tier pays for the service, not the software.</p>
+      <p>The whole product is Fair Source and runs as one container. The hosted tier pays for the service, not the software.</p>
     </div>
   </div>
 </section>
@@ -319,7 +319,7 @@ footer{margin-top:130px;border-top:1px solid var(--border-soft)}
       <p class="a">Yes. <strong>One container is the whole product</strong>: SQLite and local disk by default, Postgres and S3 at scale. The hosted tier exists for teams who would rather not run it themselves.</p>
     </details>
     <details>
-      <summary>Is Derive open source?</summary>
+      <summary>What is Derive's license?</summary>
       <p class="a">Derive is fair source (<strong>FSL-1.1-ALv2</strong>): use, modify, and self-host it freely for anything except selling Derive itself as a service. Every release converts to <strong>Apache-2.0</strong> two years after it ships.</p>
     </details>
     <details>

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,38 +1,51 @@
-# Derive — one self-contained container: the publish API, comment + review loops,
-# the sandboxed artifact viewer, AND the web app, all on one origin. Point a
-# domain at it and you have a working Derive. (Scale-out split: see DEPLOY.md.)
-FROM node:24-slim AS base
+# syntax=docker/dockerfile:1.7
+# Derive Lite: one non-root image containing the API, SPA, SQLite/local-blob
+# storage, and optional Playwright preview renderer.
+FROM node:24-bookworm-slim AS build
 ENV CI=true
 RUN corepack enable
-WORKDIR /app
+WORKDIR /src
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc tsconfig.base.json ./
+COPY patches ./patches
+RUN pnpm fetch
 COPY . .
-# better-sqlite3 v11 ships prebuilt binaries; pg is pure JS — no compiler needed.
-RUN pnpm install --frozen-lockfile --prod=false
-
-# Install Playwright's Chromium + its OS libraries (apt) so DERIVE_PREVIEWS=true works
-# out of the box. --with-deps installs the system libraries that Chromium requires
-# (libnss3, libatk, etc.) via apt — fine here because the base image is Debian slim
-# and we're running as root. PLAYWRIGHT_BROWSERS_PATH stays at the default (~/.cache/ms-playwright)
-# which the runtime Node process (also root) resolves identically at startup.
-RUN corepack pnpm --filter @derive/api exec playwright install --with-deps chromium
-
-# Build the SPA into apps/web/dist/client. VITE_DERIVE_API is intentionally unset
-# so the bundle calls the API same-origin (no CORS, no cross-site cookies). The
-# Node entry auto-detects this build and serves it. ipv4first keeps TanStack
-# Start's prerender loopback (server bind vs fetch) on the same address in the
-# slim image, which otherwise splits ::1 / 127.0.0.1 and ECONNREFUSEs.
+# A CI canary creates these paths immediately before the build. If a future
+# ignore-file edit uploads either one, fail before dependency or source build.
+RUN test ! -e deploy/.env && test ! -e deploy/backups/build-context-canary
+RUN pnpm install --offline --frozen-lockfile
 RUN NODE_OPTIONS=--dns-result-order=ipv4first pnpm --filter @derive/web build
+# A production-only, portable dependency graph. The legacy deploy mode is
+# intentional until this workspace opts into pnpm's injected-workspace layout.
+RUN pnpm --filter @derive/api deploy --legacy --prod /runtime/apps/api && \
+    mkdir -p /runtime/apps/web/dist && \
+    cp -R /src/apps/web/dist/client /runtime/apps/web/dist/client
 
+FROM node:24-bookworm-slim AS runtime
+ARG VERSION=dev
+ARG REVISION=unknown
+LABEL org.opencontainers.image.title="Derive" \
+      org.opencontainers.image.description="Self-hosted Derive artifact workspace" \
+      org.opencontainers.image.source="https://github.com/derive-to/derive" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${REVISION}" \
+      org.opencontainers.image.licenses="FSL-1.1-ALv2"
 ENV NODE_ENV=production \
     PORT=8080 \
-    DATA_DIR=/data
-# Only used in the SQLite fallback; ignored when DATABASE_URL + OBJECT_STORE_URL are set.
+    DATA_DIR=/data \
+    PLAYWRIGHT_BROWSERS_PATH=/ms-playwright \
+    DERIVE_BUILD_SHA=${REVISION}
+COPY --from=build --chown=node:node /runtime /app
+WORKDIR /app/apps/api
+# Only the smaller headless shell is needed. Playwright installs the matching
+# browser and Debian runtime libraries; app code and package managers stay out
+# of the final image except for the production graph copied above.
+RUN node node_modules/playwright/cli.js install --with-deps --only-shell chromium && \
+    mkdir -p /data && \
+    chown -R node:node /data /ms-playwright
+USER node
 VOLUME /data
 EXPOSE 8080
-# Run node directly as PID 1, NOT via `pnpm ... start`: pnpm doesn't forward
-# SIGTERM to the node child, so on `docker stop` / Fly's auto-stop / a redeploy the
-# process would die instantly without running node.ts's graceful-shutdown handler
-# (drain in-flight requests, close the DB pool). tsx supplies the TS loader and the
-# app runs in this same process, so SIGTERM reaches our handler.
-WORKDIR /app/apps/api
-CMD ["node", "--import", "tsx", "src/node.ts"]
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD ["node", "-e", "fetch('http://127.0.0.1:8080/healthz').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"]
+ENTRYPOINT ["node", "--import", "tsx", "src/server-cli.ts"]
+CMD ["serve"]

--- a/deploy/Dockerfile.dockerignore
+++ b/deploy/Dockerfile.dockerignore
@@ -1,0 +1,30 @@
+# Deny by default. The self-host build must never upload deploy/.env, backups,
+# repository history, or unrelated workspace data to a builder/cache.
+**
+
+!package.json
+!pnpm-lock.yaml
+!pnpm-workspace.yaml
+!.npmrc
+!tsconfig.base.json
+
+!patches/
+!patches/**
+
+!apps/
+!apps/api/
+!apps/api/**
+!apps/web/
+!apps/web/**
+
+!packages/
+!packages/broker/
+!packages/broker/**
+!packages/core/
+!packages/core/**
+!packages/db/
+!packages/db/**
+!packages/facts/
+!packages/facts/**
+!packages/storage/
+!packages/storage/**

--- a/deploy/compose.build.yml
+++ b/deploy/compose.build.yml
@@ -1,0 +1,11 @@
+# Contributor/source-build override:
+#   docker compose -f deploy/compose.yml -f deploy/compose.build.yml up --build
+services:
+  derive:
+    build:
+      context: ..
+      dockerfile: deploy/Dockerfile
+      args:
+        VERSION: dev
+        REVISION: local
+    image: derive:local

--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -1,21 +1,36 @@
-# The whole app (API + web + sandboxed viewer) in one container: zero external
-# dependencies — SQLite + local blobs in one volume. Open http://localhost:8080.
-# Uncomment DATABASE_URL / OBJECT_STORE_URL to use Postgres + S3/R2 instead.
+# Release install: copy this file plus selfhost.env.example to `.env`, fill in
+# BASE_URL, then `docker compose up -d`. Release bundles pin DERIVE_IMAGE by digest.
 services:
   derive:
-    build:
-      context: ..
-      dockerfile: deploy/Dockerfile
+    image: ${DERIVE_IMAGE:?Set DERIVE_IMAGE to a released tag or digest}
+    init: true
+    restart: unless-stopped
     ports:
-      - "8080:8080"
+      - "${DERIVE_BIND_ADDRESS:-127.0.0.1}:${DERIVE_PORT:-8080}:8080"
     volumes:
       - derive-data:/data
+      - ./backups:/backups
+    env_file:
+      - path: .env
+        required: false
     environment:
-      BASE_URL: http://localhost:8080
-      # Set a stable session secret in production (any 32-byte hex):
-      # DERIVE_AUTH_SECRET: change-me
-      # DATABASE_URL: postgres://...
-      # OBJECT_STORE_URL: s3://...
+      PORT: "8080"
+      DATA_DIR: /data
+    healthcheck:
+      test:
+        - CMD
+        - node
+        - -e
+        - "fetch('http://127.0.0.1:8080/readyz').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"
+      interval: 30s
+      timeout: 5s
+      start_period: 20s
+      retries: 3
+    security_opt:
+      - no-new-privileges:true
+    shm_size: 1gb
+    stop_grace_period: 30s
 
 volumes:
   derive-data:
+    name: ${DERIVE_DATA_VOLUME:-derive-data}

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -307,6 +307,11 @@ CREATE TABLE IF NOT EXISTS signup_attribution (
   UNIQUE (user_id)
 );
 
+CREATE TABLE IF NOT EXISTS instance_operator (
+  user_id TEXT PRIMARY KEY,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+
 CREATE TABLE IF NOT EXISTS oauth_client_workspace (
   id TEXT PRIMARY KEY,
   user_id TEXT NOT NULL,

--- a/deploy/selfhost.env.example
+++ b/deploy/selfhost.env.example
@@ -1,0 +1,28 @@
+# Release image. Prefer the digest shipped with a GitHub release.
+DERIVE_IMAGE=ghcr.io/derive-to/derive:latest
+
+# Public URL used for cookies and links. HTTPS is strongly recommended off localhost.
+BASE_URL=https://derive.example.com
+
+# Keep registration invite-only. Create the first immutable-id operator with the
+# offline `bootstrap-operator` command documented in DEPLOY.md.
+DERIVE_SIGNUP_MODE=invite
+
+# Loopback-only by default, for a reverse proxy on the same host. Set 0.0.0.0 only
+# when the host firewall/TLS setup intentionally exposes this port directly.
+DERIVE_BIND_ADDRESS=127.0.0.1
+
+# Lite persists a generated secret in the data volume. Set this explicitly when
+# restoring independently, using Postgres, or running more than one replica.
+# DERIVE_AUTH_SECRET=replace-with-at-least-32-random-characters
+
+# Optional features:
+# DERIVE_PREVIEWS=true
+# EMAIL_FROM=Derive <derive@example.com>
+# RESEND_API_KEY=...
+
+# Scale topology (all identities must be shared across replicas):
+# DATABASE_URL=postgres://derive:password@postgres:5432/derive
+# OBJECT_STORE_URL=s3://ACCESS_KEY:SECRET_KEY@host/bucket?region=auto
+# DERIVE_AUTH_SECRET=replace-with-at-least-32-random-characters
+# DERIVE_DEFAULT_ORG_ID=ws_replace_with_one_stable_id

--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "workspaces": {
+    ".": {
+      "entry": ["scripts/selfhost-smoke-client.mjs"]
+    },
     "apps/api": {
       "entry": [
         "gen-auth-schema.ts",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "format": "biome format --write",
     "check": "biome check",
     "check:fix": "biome check --write",
-    "ci": "biome ci && pnpm lint:tokens && pnpm lint:frontend && pnpm lint:interaction && pnpm lint:mutations && pnpm lint:reload && pnpm lint:surfaces && pnpm lint:testids && pnpm lint:api && pnpm lint:schema && pnpm lint:hyperdrive && pnpm lint:filesize && pnpm lint:anchor-client && pnpm lint:deadcode && pnpm lint:boundaries && pnpm lint:env && pnpm lint:api-types && pnpm lint:agent-skill && pnpm lint:agent-package-files && pnpm lint:skills && pnpm lint:deck-template && pnpm lint:app-map && pnpm lint:mcp-coercion && pnpm lint:local-data && pnpm lint:delete-cascade && pnpm lint:facts-visibility && pnpm lint:facts-portable && pnpm lint:derived-exclusion && pnpm lint:deploy-verified",
+    "ci": "biome ci && pnpm lint:tokens && pnpm lint:frontend && pnpm lint:interaction && pnpm lint:mutations && pnpm lint:reload && pnpm lint:surfaces && pnpm lint:testids && pnpm lint:api && pnpm lint:schema && pnpm lint:hyperdrive && pnpm lint:filesize && pnpm lint:anchor-client && pnpm lint:deadcode && pnpm lint:boundaries && pnpm lint:env && pnpm lint:api-types && pnpm lint:agent-skill && pnpm lint:agent-package-files && pnpm lint:skills && pnpm lint:deck-template && pnpm lint:app-map && pnpm lint:mcp-coercion && pnpm lint:local-data && pnpm lint:delete-cascade && pnpm lint:facts-visibility && pnpm lint:facts-portable && pnpm lint:derived-exclusion && pnpm lint:selfhost-quickstart && pnpm lint:deploy-verified",
     "verify": "pnpm run ci && pnpm typecheck && pnpm test:coverage",
     "precommit": "pnpm run ci",
     "prepare": "git config core.hooksPath .githooks || true",
@@ -91,6 +91,7 @@
     "lint:facts-visibility": "node scripts/check-facts-visibility.mjs",
     "lint:facts-portable": "node scripts/check-facts-portable.mjs",
     "lint:derived-exclusion": "node scripts/check-derived-exclusion.mjs",
+    "lint:selfhost-quickstart": "node scripts/check-selfhost-quickstart.mjs",
     "lint:deploy-verified": "node scripts/check-deploy-verified.mjs"
   },
   "devDependencies": {

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -1585,6 +1585,12 @@ export interface DirectoryStore {
   // ---- User directory (reads Better Auth's `user` table) ----------------
   findUserByEmail(email: string): Promise<UserDir | null>
   getUsers(ids: string[]): Promise<UserDir[]>
+  /** Instance-wide authority is bound to Better Auth's immutable user id, never
+   *  to a submitted email address. The offline bootstrap command is the normal
+   *  writer; the verified-email migration path may also bind a legacy operator. */
+  isInstanceOperator(userId: string): Promise<boolean>
+  hasInstanceOperators(): Promise<boolean>
+  addInstanceOperator(userId: string): Promise<void>
   /** Map GitHub numeric user ids (as strings) to the Derive accounts that signed in with
    *  GitHub — joins Better Auth's `account` (providerId='github', accountId IN ids) to
    *  `user`. Lets a synced artifact's commit author resolve to a Derive profile/handle.
@@ -1968,8 +1974,8 @@ export interface AgentStore {
   deletePendingInvitationsFor(orgId: string, email: string): Promise<void>
   /** Revoke a specific pending invitation (Admin), scoped to its workspace. */
   deleteInvitation(id: string, orgId: string): Promise<void>
-  /** Stamp accepted_at so the invite can't be redeemed twice. */
-  markInvitationAccepted(id: string): Promise<void>
+  /** Atomically spend a still-live invite. Exactly one concurrent caller wins. */
+  consumeInvitation(id: string, now: string): Promise<boolean>
 
   // ---- Artifact invitations (share-by-email → accept) ---------------------
   /** Create a pending per-artifact invite. Any prior pending invite for the same
@@ -1984,8 +1990,8 @@ export interface AgentStore {
   deletePendingArtifactInvitesFor(artifactId: string, email: string): Promise<void>
   /** Revoke one pending invite, scoped to its artifact. */
   deleteArtifactInvite(id: string, artifactId: string): Promise<void>
-  /** Stamp accepted_at so the invite can't be redeemed twice. */
-  markArtifactInviteAccepted(id: string): Promise<void>
+  /** Atomically spend a still-live invite. Exactly one concurrent caller wins. */
+  consumeArtifactInvite(id: string, now: string): Promise<boolean>
   // ---- Beta signups (the marketing site's request-access form) ------------
   /** Record a beta signup (idempotent per email). Returns true when the email is
    *  new, false when it was already on the list — the caller resends the access

--- a/packages/db/src/parity.ts
+++ b/packages/db/src/parity.ts
@@ -111,6 +111,7 @@ export type JunctionTable =
   | "artifactTag"
   | "collectionItem"
   | "oauthClientWorkspace"
+  | "instanceOperator"
 
 type ClassifiedKey = keyof TypedTables | JunctionTable
 

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -399,6 +399,12 @@ export const signupAttribution = pgTable(
   (t) => [uniqueIndex("signup_attribution_user").on(t.user_id)],
 )
 
+// Immutable instance authority; see the SQLite twin for the trust-boundary note.
+export const instanceOperator = pgTable("instance_operator", {
+  user_id: text("user_id").primaryKey(),
+  created_at: text("created_at").notNull().$defaultFn(isoNow),
+})
+
 export const agentMention = pgTable("agent_mention", {
   id: text("id").primaryKey(),
   agent_id: text("agent_id").notNull(),
@@ -970,6 +976,7 @@ const TABLES = [
   artifactInvite,
   betaSignup,
   signupAttribution,
+  instanceOperator,
   oauthClientWorkspace,
   artifactFavorite,
   follow,

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -184,6 +184,7 @@ import {
   follow,
   githubApp,
   githubInstallation,
+  instanceOperator,
   invitation,
   membership,
   modelCredential,
@@ -256,6 +257,7 @@ export const schema = {
   invitation,
   betaSignup,
   signupAttribution,
+  instanceOperator,
   subscription,
   oauthClientWorkspace,
   context,
@@ -5131,6 +5133,25 @@ export class PgMetaStore implements MetaStore {
     // See the SQLite store: a stable thread-reply id makes an outbox recovery idempotent.
     await this.db.insert(agentMention).values(m).onConflictDoNothing()
   }
+  // ---- Instance operators ------------------------------------------------
+  async isInstanceOperator(userId: string): Promise<boolean> {
+    const rows = await this.db
+      .select({ user_id: instanceOperator.user_id })
+      .from(instanceOperator)
+      .where(eq(instanceOperator.user_id, userId))
+      .limit(1)
+    return rows.length > 0
+  }
+  async hasInstanceOperators(): Promise<boolean> {
+    const rows = await this.db
+      .select({ user_id: instanceOperator.user_id })
+      .from(instanceOperator)
+      .limit(1)
+    return rows.length > 0
+  }
+  async addInstanceOperator(userId: string): Promise<void> {
+    await this.db.insert(instanceOperator).values({ user_id: userId }).onConflictDoNothing()
+  }
   // ---- Workspace invitations ---------------------------------------------
   async createInvitation(i: NewInvitation): Promise<InvitationRecord> {
     const rows = await this.db.insert(invitation).values(i).returning()
@@ -5161,11 +5182,15 @@ export class PgMetaStore implements MetaStore {
   async deleteInvitation(id: string, orgId: string): Promise<void> {
     await this.db.delete(invitation).where(and(eq(invitation.id, id), eq(invitation.org_id, orgId)))
   }
-  async markInvitationAccepted(id: string): Promise<void> {
-    await this.db
+  async consumeInvitation(id: string, now: string): Promise<boolean> {
+    const rows = await this.db
       .update(invitation)
-      .set({ accepted_at: new Date().toISOString() })
-      .where(eq(invitation.id, id))
+      .set({ accepted_at: now })
+      .where(
+        and(eq(invitation.id, id), isNull(invitation.accepted_at), gt(invitation.expires_at, now)),
+      )
+      .returning({ id: invitation.id })
+    return rows.length > 0
   }
 
   // ---- Beta signups --------------------------------------------------------
@@ -5231,14 +5256,23 @@ export class PgMetaStore implements MetaStore {
       .delete(artifactInvite)
       .where(and(eq(artifactInvite.id, id), eq(artifactInvite.artifact_id, artifactId)))
   }
-  async markArtifactInviteAccepted(id: string): Promise<void> {
-    await this.db
+  async consumeArtifactInvite(id: string, now: string): Promise<boolean> {
+    const rows = await this.db
       .update(artifactInvite)
-      .set({ accepted_at: new Date().toISOString() })
-      .where(eq(artifactInvite.id, id))
+      .set({ accepted_at: now })
+      .where(
+        and(
+          eq(artifactInvite.id, id),
+          isNull(artifactInvite.accepted_at),
+          gt(artifactInvite.expires_at, now),
+        ),
+      )
+      .returning({ id: artifactInvite.id })
+    return rows.length > 0
   }
   // ---- Account deletion cascade (see MetaStore.deleteUserData) ------------
   async deleteUserData(userId: string): Promise<void> {
+    await this.db.delete(instanceOperator).where(eq(instanceOperator.user_id, userId))
     await this.db.delete(membership).where(eq(membership.user_id, userId))
     await this.db.delete(artifactMember).where(eq(artifactMember.user_id, userId))
     await this.db.delete(collectionMember).where(eq(collectionMember.user_id, userId))

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -171,6 +171,7 @@ import {
   follow,
   githubApp,
   githubInstallation,
+  instanceOperator,
   invitation,
   membership,
   modelCredential,
@@ -317,6 +318,7 @@ export const schema = {
   invitation,
   betaSignup,
   signupAttribution,
+  instanceOperator,
   subscription,
   oauthClientWorkspace,
   context,
@@ -4138,6 +4140,24 @@ export function makeRepos(db: SqliteDb) {
     await db.insert(agentMention).values(m).onConflictDoNothing().run()
   }
 
+  // ---- Instance operators ------------------------------------------------
+  const isInstanceOperator = async (userId: string): Promise<boolean> =>
+    (await db
+      .select({ user_id: instanceOperator.user_id })
+      .from(instanceOperator)
+      .where(eq(instanceOperator.user_id, userId))
+      .limit(1)
+      .get()) !== undefined
+  const hasInstanceOperators = async (): Promise<boolean> =>
+    (await db
+      .select({ user_id: instanceOperator.user_id })
+      .from(instanceOperator)
+      .limit(1)
+      .get()) !== undefined
+  const addInstanceOperator = async (userId: string): Promise<void> => {
+    await db.insert(instanceOperator).values({ user_id: userId }).onConflictDoNothing().run()
+  }
+
   // ---- Workspace invitations ---------------------------------------------
   const createInvitation = async (i: NewInvitation): Promise<InvitationRecord> =>
     (await db.insert(invitation).values(i).returning().get()) as InvitationRecord
@@ -4168,12 +4188,16 @@ export function makeRepos(db: SqliteDb) {
       .where(and(eq(invitation.id, id), eq(invitation.org_id, orgId)))
       .run()
   }
-  const markInvitationAccepted = async (id: string): Promise<void> => {
-    await db
+  const consumeInvitation = async (id: string, now: string): Promise<boolean> => {
+    const row = await db
       .update(invitation)
-      .set({ accepted_at: new Date().toISOString() })
-      .where(eq(invitation.id, id))
-      .run()
+      .set({ accepted_at: now })
+      .where(
+        and(eq(invitation.id, id), isNull(invitation.accepted_at), gt(invitation.expires_at, now)),
+      )
+      .returning({ id: invitation.id })
+      .get()
+    return row !== undefined
   }
 
   // ---- Beta signups --------------------------------------------------------
@@ -4241,17 +4265,26 @@ export function makeRepos(db: SqliteDb) {
       .where(and(eq(artifactInvite.id, id), eq(artifactInvite.artifact_id, artifactId)))
       .run()
   }
-  const markArtifactInviteAccepted = async (id: string): Promise<void> => {
-    await db
+  const consumeArtifactInvite = async (id: string, now: string): Promise<boolean> => {
+    const row = await db
       .update(artifactInvite)
-      .set({ accepted_at: new Date().toISOString() })
-      .where(eq(artifactInvite.id, id))
-      .run()
+      .set({ accepted_at: now })
+      .where(
+        and(
+          eq(artifactInvite.id, id),
+          isNull(artifactInvite.accepted_at),
+          gt(artifactInvite.expires_at, now),
+        ),
+      )
+      .returning({ id: artifactInvite.id })
+      .get()
+    return row !== undefined
   }
 
   // ---- Account deletion cascade (see MetaStore.deleteUserData) ------------
   const deleteUserData = async (userId: string): Promise<void> => {
     // The user's own association rows go entirely.
+    await db.delete(instanceOperator).where(eq(instanceOperator.user_id, userId)).run()
     await db.delete(membership).where(eq(membership.user_id, userId)).run()
     await db.delete(artifactMember).where(eq(artifactMember.user_id, userId)).run()
     await db.delete(collectionMember).where(eq(collectionMember.user_id, userId)).run()
@@ -4762,12 +4795,15 @@ export function makeRepos(db: SqliteDb) {
     createAgentMention,
     listPendingAgentMentions,
     ackAgentMention,
+    isInstanceOperator,
+    hasInstanceOperators,
+    addInstanceOperator,
     createInvitation,
     getInvitationByToken,
     listPendingInvitations,
     deletePendingInvitationsFor,
     deleteInvitation,
-    markInvitationAccepted,
+    consumeInvitation,
     recordBetaSignup,
     recordSignupAttribution,
     getSignupAttribution,
@@ -4776,7 +4812,7 @@ export function makeRepos(db: SqliteDb) {
     listPendingArtifactInvites,
     deletePendingArtifactInvitesFor,
     deleteArtifactInvite,
-    markArtifactInviteAccepted,
+    consumeArtifactInvite,
     deleteUserData,
     createReport,
     getReport,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -488,6 +488,14 @@ export const signupAttribution = sqliteTable(
   (t) => [uniqueIndex("signup_attribution_user").on(t.user_id)],
 )
 
+// Instance-wide authority belongs to an immutable Better Auth user id. There is
+// deliberately no email column: changing or reusing an address cannot transfer
+// operator powers. Better Auth owns `user`, so this cross-owner relation has no FK.
+export const instanceOperator = sqliteTable("instance_operator", {
+  user_id: text("user_id").primaryKey(),
+  created_at: text("created_at").notNull().default(now),
+})
+
 // An agent's pull inbox: one row per explicit mention or reply to a thread it owns.
 export const agentMention = sqliteTable("agent_mention", {
   id: text("id").primaryKey(),
@@ -1192,6 +1200,7 @@ const TABLES = [
   artifactInvite,
   betaSignup,
   signupAttribution,
+  instanceOperator,
   oauthClientWorkspace,
   artifactFavorite,
   follow,

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -4399,6 +4399,70 @@ export function runStoreContract(
     })
   })
 
+  describe(`${label}: invitation consumption`, () => {
+    it("lets exactly one caller atomically spend a live invitation", async () => {
+      const orgId = `invite_org_${uuid()}`
+      await store.setWorkspace(orgId, "Invitation Contract")
+      const invitedArtifact = newArtifact({
+        id: uuid(),
+        short_id: uuid().slice(0, 8),
+        org_id: orgId,
+      })
+      await store.createArtifact(invitedArtifact)
+      const future = new Date(Date.now() + 60_000).toISOString()
+      const past = new Date(Date.now() - 60_000).toISOString()
+      const workspaceInvitation = await store.createInvitation({
+        id: uuid(),
+        org_id: orgId,
+        email: "workspace@example.com",
+        role: "editor",
+        token: uuid(),
+        invited_by: null,
+        expires_at: future,
+      })
+      const artifactInvitation = await store.createArtifactInvite({
+        id: uuid(),
+        artifact_id: invitedArtifact.id,
+        email: "artifact@example.com",
+        role: "commenter",
+        token: uuid(),
+        invited_by: null,
+        expires_at: future,
+      })
+      const expiredInvitation = await store.createInvitation({
+        id: uuid(),
+        org_id: orgId,
+        email: "expired@example.com",
+        role: "viewer",
+        token: uuid(),
+        invited_by: null,
+        expires_at: past,
+      })
+
+      const now = new Date().toISOString()
+      const [first, second] = await Promise.all([
+        store.consumeInvitation(workspaceInvitation.id, now),
+        store.consumeInvitation(workspaceInvitation.id, now),
+      ])
+      expect([first, second].sort()).toEqual([false, true])
+      await expect(store.consumeArtifactInvite(artifactInvitation.id, now)).resolves.toBe(true)
+      await expect(store.consumeArtifactInvite(artifactInvitation.id, now)).resolves.toBe(false)
+      await expect(store.consumeInvitation(expiredInvitation.id, now)).resolves.toBe(false)
+    })
+  })
+
+  describe(`${label}: instance operators`, () => {
+    it("binds authority idempotently to an immutable user id", async () => {
+      const userId = `operator_${uuid()}`
+      await expect(store.hasInstanceOperators()).resolves.toBe(false)
+      await store.addInstanceOperator(userId)
+      await store.addInstanceOperator(userId)
+      await expect(store.isInstanceOperator(userId)).resolves.toBe(true)
+      await expect(store.isInstanceOperator(`${userId}_other`)).resolves.toBe(false)
+      await expect(store.hasInstanceOperators()).resolves.toBe(true)
+    })
+  })
+
   describe(`${label}: signup attribution`, () => {
     it("records the signup source once per user (first write wins) and reads it back", async () => {
       const userId = `u_${uuid()}`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,9 @@ importers:
       drizzle-orm:
         specifier: 0.45.2
         version: 0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0)
+      fflate:
+        specifier: ^0.8.2
+        version: 0.8.3
       hono:
         specifier: ^4.12.34
         version: 4.13.1
@@ -139,6 +142,9 @@ importers:
       stripe:
         specifier: ^22.3.2
         version: 22.3.2(@types/node@25.9.3)
+      tsx:
+        specifier: ^4.19.0
+        version: 4.22.4
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -161,12 +167,6 @@ importers:
       express:
         specifier: ^5.1.0
         version: 5.2.1
-      fflate:
-        specifier: ^0.8.2
-        version: 0.8.3
-      tsx:
-        specifier: ^4.19.0
-        version: 4.22.4
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -181,7 +181,7 @@ importers:
     dependencies:
       '@better-auth/passkey':
         specifier: 1.6.19
-        version: 1.6.19(@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.22(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9))(better-call@1.3.7(zod@4.4.3))(nanostores@1.3.0)
+        version: 1.6.19(@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.22(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9))(better-call@1.3.7(zod@3.25.76))(nanostores@1.3.0)
       '@codemirror/autocomplete':
         specifier: ^6.20.3
         version: 6.20.3
@@ -4453,8 +4453,8 @@ packages:
     engines: {node: ^22||^24||>=26}
     hasBin: true
 
-  deslop-js@0.9.6:
-    resolution: {integrity: sha512-ADY8/3JsK0epUcdXez54MhY4CGWeppT032Ko1fJkwFfmHog5hBJtMeihUeHs5PF7eG6Y17YbKcNQXSp3B67GRA==}
+  deslop-js@0.9.11:
+    resolution: {integrity: sha512-0hXU8GImv3uJZY25jeXQ1JOcajpuKyzdNTK7FTyxyGR/GtjpGPmiVM+8d+5Tacb702UzVtAHhB5xMBl/pOGxKQ==}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -5735,8 +5735,8 @@ packages:
   oxc-resolver@11.24.2:
     resolution: {integrity: sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==}
 
-  oxlint-plugin-react-doctor@0.9.6:
-    resolution: {integrity: sha512-kk39ffbDFaL0UfAx7ndltBsxal1hRkr+qYYsSv57PsD+9DnjcV0Y0jZ6NYMhBmHuvPC7so2CN6dNml+fOGrpxw==}
+  oxlint-plugin-react-doctor@0.9.11:
+    resolution: {integrity: sha512-ZhW15wfFjQlUwAO6zG3jVZKse4/PBTCArhbibiidHmTlvOpPHPM1AjdYG13023pfsbbtVdy7Tb7KHfqbKt8rHg==}
     engines: {node: ^20.19.0 || >=22.13.0}
 
   oxlint@1.76.0:
@@ -6031,8 +6031,8 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
-  react-doctor@0.9.6:
-    resolution: {integrity: sha512-X3ZLL6UQfzqIyY1HDKEgUOnoxKreEfy9KphiV2aYhiotgCsR81LBl92XgyZUbZeRgpQuwbIDOiyxQnRRkcX42A==}
+  react-doctor@0.9.11:
+    resolution: {integrity: sha512-y5DQ+ILL6mawXpKtAvJYrrqznl6nasXd4Xs9JGJsY4GWlplzs5UCozKaZgFS5AWzZ7KNrX88GZTuV4Vj47k+IQ==}
     engines: {node: ^20.19.0 || >=22.13.0}
     hasBin: true
 
@@ -7263,6 +7263,21 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
+  '@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)':
+    dependencies:
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@standard-schema/spec': 1.1.0
+      better-call: 1.3.7(zod@3.25.76)
+      jose: 6.2.3
+      kysely: 0.29.2
+      nanostores: 1.3.0
+      zod: 4.4.3
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20260615.1
+      '@opentelemetry/api': 1.9.1
+
   '@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)':
     dependencies:
       '@better-auth/utils': 0.4.2
@@ -7310,6 +7325,18 @@ snapshots:
       better-auth: 1.6.22(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9)
       better-call: 1.3.7(zod@4.4.3)
       jose: 6.2.3
+      zod: 4.4.3
+
+  '@better-auth/passkey@1.6.19(@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.22(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9))(better-call@1.3.7(zod@3.25.76))(nanostores@1.3.0)':
+    dependencies:
+      '@better-auth/core': 1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@3.25.76))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      '@simplewebauthn/browser': 13.3.0
+      '@simplewebauthn/server': 13.3.2
+      better-auth: 1.6.22(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9)
+      better-call: 1.3.7(zod@3.25.76)
+      nanostores: 1.3.0
       zod: 4.4.3
 
   '@better-auth/passkey@1.6.19(@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.22(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.11.1)(gel@2.2.0)(kysely@0.29.2)(pg@8.21.0))(pg@8.21.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9))(better-call@1.3.7(zod@4.4.3))(nanostores@1.3.0)':
@@ -10348,6 +10375,15 @@ snapshots:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
 
+  better-call@1.3.7(zod@3.25.76):
+    dependencies:
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      rou3: 0.7.12
+      set-cookie-parser: 3.1.0
+    optionalDependencies:
+      zod: 3.25.76
+
   better-call@1.3.7(zod@4.4.3):
     dependencies:
       '@better-auth/utils': 0.4.2
@@ -10679,7 +10715,7 @@ snapshots:
       tsconfig-paths-webpack-plugin: 4.2.0
       watskeburt: 6.0.0
 
-  deslop-js@0.9.6:
+  deslop-js@0.9.11:
     dependencies:
       '@oxc-project/types': 0.142.0
       fast-glob: 3.3.3
@@ -11917,7 +11953,7 @@ snapshots:
       '@oxc-resolver/binding-win32-arm64-msvc': 11.24.2
       '@oxc-resolver/binding-win32-x64-msvc': 11.24.2
 
-  oxlint-plugin-react-doctor@0.9.6:
+  oxlint-plugin-react-doctor@0.9.11:
     dependencies:
       '@shaderfrog/glsl-parser': 7.0.1
       '@typescript-eslint/types': 8.66.0
@@ -12277,7 +12313,7 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-doctor@0.9.6(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(eslint@10.5.0(jiti@2.7.0)):
+  react-doctor@0.9.11(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
       '@astrojs/compiler': 4.0.0
       '@babel/code-frame': 7.29.7
@@ -12285,14 +12321,14 @@ snapshots:
       agent-install: 0.0.5
       conf: 15.1.0
       confbox: 0.2.4
-      deslop-js: 0.9.6
+      deslop-js: 0.9.11
       eslint-plugin-react-hooks: 7.1.1(eslint@10.5.0(jiti@2.7.0))
       figures: 6.1.0
       jiti: 2.7.0
       magicast: 0.5.4
       oxc-resolver: 11.24.2
       oxlint: 1.76.0
-      oxlint-plugin-react-doctor: 0.9.6
+      oxlint-plugin-react-doctor: 0.9.11
       prompts: 2.4.2
       typescript: 5.9.3
       vscode-languageserver: 9.0.1
@@ -12351,7 +12387,7 @@ snapshots:
       preact: 10.29.2
       prompts: 2.4.2
       react: 19.2.7
-      react-doctor: 0.9.6(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(eslint@10.5.0(jiti@2.7.0))
+      react-doctor: 0.9.11(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(eslint@10.5.0(jiti@2.7.0))
       react-dom: 19.2.7(react@19.2.7)
       react-grab: 0.1.50(react@19.2.7)
     optionalDependencies:

--- a/scripts/check-selfhost-quickstart.mjs
+++ b/scripts/check-selfhost-quickstart.mjs
@@ -9,6 +9,9 @@ const DEPLOY = "DEPLOY.md"
 const COMPOSE = "deploy/compose.yml"
 const BUILD_COMPOSE = "deploy/compose.build.yml"
 const RELEASE = ".github/workflows/release-images.yml"
+const CI = ".github/workflows/ci.yml"
+const SMOKE = "scripts/test-selfhost-quickstart.sh"
+const SMOKE_CLIENT = "scripts/selfhost-smoke-client.mjs"
 
 const read = (path) => readFileSync(path, "utf8")
 const quickstart = read(QUICKSTART)
@@ -17,6 +20,9 @@ const deploy = read(DEPLOY)
 const compose = read(COMPOSE)
 const buildCompose = read(BUILD_COMPOSE)
 const release = read(RELEASE)
+const ci = read(CI)
+const smoke = read(SMOKE)
+const smokeClient = read(SMOKE_CLIENT)
 
 const failures = []
 const fail = (message) => failures.push(message)
@@ -79,6 +85,9 @@ for (const variable of [
 ])
   requireText(quickstart, variable, QUICKSTART)
 
+for (const capacity of ["4 GB of free Docker storage", "10 GB free"])
+  requireText(quickstart, capacity, `${QUICKSTART} capacity requirements`)
+
 for (const target of ["CONTRIBUTING.md", "DEPLOY.md"])
   requireText(quickstart, target, `${QUICKSTART} path chooser`)
 
@@ -91,6 +100,29 @@ requireText(release, "DERIVE_IMAGE=ghcr.io/derive-to/derive@$DIGEST", RELEASE)
 requireText(compose, "${DERIVE_IMAGE:?", COMPOSE)
 requireText(compose, "http://127.0.0.1:8080/readyz", COMPOSE)
 requireText(buildCompose, "image: derive:local", BUILD_COMPOSE)
+
+for (const workflow of [
+  [CI, ci],
+  [RELEASE, release],
+])
+  requireText(workflow[1], SMOKE, `${workflow[0]} self-host integration gate`)
+
+for (const operation of [
+  "bootstrap-operator",
+  "up -d --wait --wait-timeout 120",
+  "backup /backups/quickstart-smoke",
+  "verify-backup /backups/quickstart-smoke",
+  "restore-backup /backups/quickstart-smoke",
+])
+  requireText(smoke, operation, SMOKE)
+
+for (const boundary of [
+  "/api/auth/sign-in/email",
+  "/api/auth/sign-up/email",
+  "SIGNUP_NOT_ALLOWED",
+  "/v1/artifacts",
+])
+  requireText(smokeClient, boundary, SMOKE_CLIENT)
 
 requireText(readme, "[self-hosting quick start](QUICKSTART.md)", README)
 requireText(deploy, "[QUICKSTART.md](QUICKSTART.md)", DEPLOY)
@@ -112,6 +144,6 @@ if (failures.length > 0) {
   process.exitCode = 1
 } else {
   console.log(
-    "check-selfhost-quickstart: ok — release + source paths configure, bootstrap, wait, and back up",
+    "check-selfhost-quickstart: ok — docs and CI cover bootstrap, auth, publish, backup, and restore",
   )
 }

--- a/scripts/check-selfhost-quickstart.mjs
+++ b/scripts/check-selfhost-quickstart.mjs
@@ -100,6 +100,13 @@ for (const asset of ["compose.yml", "selfhost.env.example"]) {
 
 requireText(release, "DERIVE_IMAGE=ghcr.io/derive-to/derive@$DIGEST", RELEASE)
 requireText(release, "make_latest: false", `${RELEASE} pre-promotion release`)
+requireText(release, "draft: true", `${RELEASE} immutable-release draft`)
+requireText(release, "actions/attest@v4", `${RELEASE} build attestation`)
+requireText(
+  release,
+  "sha256sum compose.yml selfhost.env.example image-digest.txt > SHA256SUMS",
+  `${RELEASE} release checksums`,
+)
 requireText(release, PUBLISHED_SMOKE, `${RELEASE} published-bundle gate`)
 requireText(
   release,
@@ -113,7 +120,7 @@ requireText(
 )
 requireText(
   release,
-  'gh release edit "$GITHUB_REF_NAME" --latest',
+  'gh release edit "$GITHUB_REF_NAME" --draft=false --latest=false',
   `${RELEASE} verified release promotion`,
 )
 requireText(
@@ -124,7 +131,8 @@ requireText(
 requireOrder(
   release,
   [
-    "Publish a non-latest GitHub release with install files",
+    "Create release draft with install files",
+    "Publish release for anonymous verification",
     "Download and exercise the public release bundle anonymously",
     "Promote the verified stable image and release to latest",
     "Verify the documented latest download path",
@@ -152,6 +160,8 @@ for (const operation of [
 for (const boundary of [
   "env -u GH_TOKEN -u GITHUB_TOKEN curl -q",
   'cmp "$staged_file" "$download_dir/$asset"',
+  "assets=(compose.yml selfhost.env.example image-digest.txt SHA256SUMS)",
+  "sha256sum -c SHA256SUMS",
   '"$download_dir/compose.yml" "$download_dir/selfhost.env.example"',
 ])
   requireText(publishedSmoke, boundary, PUBLISHED_SMOKE)

--- a/scripts/check-selfhost-quickstart.mjs
+++ b/scripts/check-selfhost-quickstart.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+// The quick start is an executable interface, not marketing copy. Keep the two supported paths
+// complete and keep their commands aligned with the Compose and release files that implement them.
+import { existsSync, readFileSync } from "node:fs"
+
+const QUICKSTART = "QUICKSTART.md"
+const README = "README.md"
+const DEPLOY = "DEPLOY.md"
+const COMPOSE = "deploy/compose.yml"
+const BUILD_COMPOSE = "deploy/compose.build.yml"
+const RELEASE = ".github/workflows/release-images.yml"
+
+const read = (path) => readFileSync(path, "utf8")
+const quickstart = read(QUICKSTART)
+const readme = read(README)
+const deploy = read(DEPLOY)
+const compose = read(COMPOSE)
+const buildCompose = read(BUILD_COMPOSE)
+const release = read(RELEASE)
+
+const failures = []
+const fail = (message) => failures.push(message)
+const requireText = (source, text, where) => {
+  if (!source.includes(text)) fail(`${where} must contain ${JSON.stringify(text)}`)
+}
+
+const section = (heading, nextHeading) => {
+  const start = quickstart.indexOf(heading)
+  if (start === -1) {
+    fail(`${QUICKSTART} is missing ${heading}`)
+    return ""
+  }
+  const end = nextHeading ? quickstart.indexOf(nextHeading, start + heading.length) : -1
+  return quickstart.slice(start, end === -1 ? undefined : end)
+}
+
+const requireOrder = (source, labels, where) => {
+  let cursor = -1
+  for (const label of labels) {
+    const at = source.indexOf(label, cursor + 1)
+    if (at === -1) {
+      fail(`${where} must contain ${JSON.stringify(label)} after the preceding setup step`)
+      return
+    }
+    cursor = at
+  }
+}
+
+const releasePath = section(
+  "## Install a published release (recommended)",
+  "## Build the current checkout",
+)
+const sourcePath = section("## Build the current checkout", "## If startup fails")
+
+for (const [label, body, envFile] of [
+  ["release path", releasePath, ".env"],
+  ["source path", sourcePath, "deploy/.env"],
+]) {
+  requireText(body, `--env-file ${envFile}`, `${QUICKSTART} ${label}`)
+  requireText(body, "config --quiet", `${QUICKSTART} ${label}`)
+  requireText(body, "bootstrap-operator", `${QUICKSTART} ${label}`)
+  requireText(body, "up -d --wait --wait-timeout 120", `${QUICKSTART} ${label}`)
+  requireText(body, "/readyz", `${QUICKSTART} ${label}`)
+  requireText(body, " backup ", `${QUICKSTART} ${label}`)
+  requireText(body, "verify-backup", `${QUICKSTART} ${label}`)
+  requireOrder(
+    body,
+    ["config --quiet", "bootstrap-operator", "up -d --wait", "/readyz", "verify-backup"],
+    `${QUICKSTART} ${label}`,
+  )
+}
+
+for (const variable of [
+  "DERIVE_IMAGE",
+  "BASE_URL",
+  "DERIVE_AUTH_SECRET",
+  "DERIVE_SIGNUP_MODE",
+  "DERIVE_BIND_ADDRESS",
+])
+  requireText(quickstart, variable, QUICKSTART)
+
+for (const target of ["CONTRIBUTING.md", "DEPLOY.md"])
+  requireText(quickstart, target, `${QUICKSTART} path chooser`)
+
+for (const asset of ["compose.yml", "selfhost.env.example"]) {
+  requireText(quickstart, `releases/latest/download/${asset}`, `${QUICKSTART} release download`)
+  requireText(release, `release/${asset}`, `${RELEASE} attached install files`)
+}
+
+requireText(release, "DERIVE_IMAGE=ghcr.io/derive-to/derive@$DIGEST", RELEASE)
+requireText(compose, "${DERIVE_IMAGE:?", COMPOSE)
+requireText(compose, "http://127.0.0.1:8080/readyz", COMPOSE)
+requireText(buildCompose, "image: derive:local", BUILD_COMPOSE)
+
+requireText(readme, "[self-hosting quick start](QUICKSTART.md)", README)
+requireText(deploy, "[QUICKSTART.md](QUICKSTART.md)", DEPLOY)
+if (readme.includes("docker compose -f deploy/compose.yml up -d"))
+  fail(
+    `${README} contains the old incomplete start command; new users need image selection, ` +
+      "operator bootstrap, readiness, and backup",
+  )
+
+// Catch renamed or moved local Markdown targets before a reader finds the dead link.
+for (const match of quickstart.matchAll(/\]\(([^)]+\.md)(?:#[^)]+)?\)/g)) {
+  const target = match[1]
+  if (!target.startsWith("http") && !existsSync(target))
+    fail(`${QUICKSTART} links to missing local file ${target}`)
+}
+
+if (failures.length > 0) {
+  for (const failure of failures) console.error(`check-selfhost-quickstart: ${failure}`)
+  process.exitCode = 1
+} else {
+  console.log(
+    "check-selfhost-quickstart: ok — release + source paths configure, bootstrap, wait, and back up",
+  )
+}

--- a/scripts/check-selfhost-quickstart.mjs
+++ b/scripts/check-selfhost-quickstart.mjs
@@ -11,6 +11,7 @@ const BUILD_COMPOSE = "deploy/compose.build.yml"
 const RELEASE = ".github/workflows/release-images.yml"
 const CI = ".github/workflows/ci.yml"
 const SMOKE = "scripts/test-selfhost-quickstart.sh"
+const PUBLISHED_SMOKE = "scripts/test-published-selfhost-bundle.sh"
 const SMOKE_CLIENT = "scripts/selfhost-smoke-client.mjs"
 
 const read = (path) => readFileSync(path, "utf8")
@@ -22,6 +23,7 @@ const buildCompose = read(BUILD_COMPOSE)
 const release = read(RELEASE)
 const ci = read(CI)
 const smoke = read(SMOKE)
+const publishedSmoke = read(PUBLISHED_SMOKE)
 const smokeClient = read(SMOKE_CLIENT)
 
 const failures = []
@@ -97,15 +99,46 @@ for (const asset of ["compose.yml", "selfhost.env.example"]) {
 }
 
 requireText(release, "DERIVE_IMAGE=ghcr.io/derive-to/derive@$DIGEST", RELEASE)
+requireText(release, "make_latest: false", `${RELEASE} pre-promotion release`)
+requireText(release, PUBLISHED_SMOKE, `${RELEASE} published-bundle gate`)
+requireText(
+  release,
+  `scripts/test-published-selfhost-bundle.sh "$GITHUB_REF_NAME" "$ref" 18080 release`,
+  `${RELEASE} tag-specific public bundle test`,
+)
+requireText(
+  release,
+  'docker buildx imagetools create --tag ghcr.io/derive-to/derive:latest "$ref"',
+  `${RELEASE} verified image promotion`,
+)
+requireText(
+  release,
+  'gh release edit "$GITHUB_REF_NAME" --latest',
+  `${RELEASE} verified release promotion`,
+)
+requireText(
+  release,
+  `scripts/test-published-selfhost-bundle.sh latest "$ref" 18080 release assets-only`,
+  `${RELEASE} documented latest-download check`,
+)
+requireOrder(
+  release,
+  [
+    "Publish a non-latest GitHub release with install files",
+    "Download and exercise the public release bundle anonymously",
+    "Promote the verified stable image and release to latest",
+    "Verify the documented latest download path",
+  ],
+  `${RELEASE} safe release order`,
+)
+if (release.includes("type=raw,value=latest"))
+  fail(`${RELEASE} must not publish the latest image before its public bundle passes`)
 requireText(compose, "${DERIVE_IMAGE:?", COMPOSE)
 requireText(compose, "http://127.0.0.1:8080/readyz", COMPOSE)
 requireText(buildCompose, "image: derive:local", BUILD_COMPOSE)
 
-for (const workflow of [
-  [CI, ci],
-  [RELEASE, release],
-])
-  requireText(workflow[1], SMOKE, `${workflow[0]} self-host integration gate`)
+requireText(ci, PUBLISHED_SMOKE, `${CI} PR-safe published-bundle integration gate`)
+requireText(release, SMOKE, `${RELEASE} self-host integration gate`)
 
 for (const operation of [
   "bootstrap-operator",
@@ -115,6 +148,13 @@ for (const operation of [
   "restore-backup /backups/quickstart-smoke",
 ])
   requireText(smoke, operation, SMOKE)
+
+for (const boundary of [
+  "env -u GH_TOKEN -u GITHUB_TOKEN curl -q",
+  'cmp "$staged_file" "$download_dir/$asset"',
+  '"$download_dir/compose.yml" "$download_dir/selfhost.env.example"',
+])
+  requireText(publishedSmoke, boundary, PUBLISHED_SMOKE)
 
 for (const boundary of [
   "/api/auth/sign-in/email",

--- a/scripts/selfhost-smoke-client.mjs
+++ b/scripts/selfhost-smoke-client.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+// HTTP half of the self-host smoke test. Drive the public API like a browser instead of
+// reaching into SQLite, so a green test proves that bootstrap credentials, cookies, signup
+// policy, publishing, blob reads, and restored data all agree at the deployed boundary.
+
+const mode = process.argv[2]
+const origin = process.env.DERIVE_SMOKE_ORIGIN
+const email = process.env.DERIVE_SMOKE_EMAIL
+const password = process.env.DERIVE_SMOKE_PASSWORD
+
+if (!origin || !email || !password || !["publish", "verify"].includes(mode))
+  throw new Error(
+    "usage: DERIVE_SMOKE_ORIGIN=... DERIVE_SMOKE_EMAIL=... " +
+      "DERIVE_SMOKE_PASSWORD=... selfhost-smoke-client.mjs publish|verify",
+  )
+
+const expectedContent =
+  "<!doctype html><title>Quick-start recovery proof</title><h1>Recovered content</h1>"
+
+const expect = (condition, message) => {
+  if (!condition) throw new Error(message)
+}
+
+const responseText = async (response) => `${response.status} ${await response.text()}`
+const expectStatus = async (response, status, label) => {
+  if (response.status !== status)
+    throw new Error(`${label}: expected ${status}, received ${await responseText(response)}`)
+}
+
+const health = await fetch(`${origin}/healthz`)
+await expectStatus(health, 200, "health check failed")
+const healthBody = await health.json()
+expect(healthBody.ok === true && typeof healthBody.build === "string", "malformed /healthz")
+
+const readiness = await fetch(`${origin}/readyz`)
+await expectStatus(readiness, 200, "readiness check failed")
+expect((await readiness.json()).ok === true, "malformed /readyz")
+
+const app = await fetch(`${origin}/`)
+await expectStatus(app, 200, "SPA request failed")
+expect((await app.text()).toLowerCase().includes("<!doctype html>"), "SPA response is not HTML")
+
+const authHeaders = { "content-type": "application/json", origin }
+let response = await fetch(`${origin}/api/auth/sign-in/email`, {
+  method: "POST",
+  headers: authHeaders,
+  body: JSON.stringify({ email, password }),
+})
+await expectStatus(response, 200, "operator sign-in failed")
+const setCookie = response.headers.getSetCookie?.()[0] ?? response.headers.get("set-cookie") ?? ""
+expect(setCookie.length > 0, "operator sign-in returned no session cookie")
+const cookie = setCookie.split(";", 1)[0]
+
+response = await fetch(`${origin}/api/auth/get-session`, { headers: { cookie, origin } })
+await expectStatus(response, 200, "session read failed")
+const session = await response.json()
+expect(session.user?.email === email, "session belongs to the wrong operator")
+
+if (mode === "publish") {
+  response = await fetch(`${origin}/api/auth/sign-in/email`, {
+    method: "POST",
+    headers: authHeaders,
+    body: JSON.stringify({ email, password: `${password}-wrong` }),
+  })
+  expect(response.status >= 400, "an incorrect operator password was accepted")
+
+  response = await fetch(`${origin}/api/auth/sign-up/email`, {
+    method: "POST",
+    headers: authHeaders,
+    body: JSON.stringify({
+      email: `uninvited-${email}`,
+      password,
+      name: "Uninvited",
+    }),
+  })
+  const signupBody = await response.json()
+  expect(
+    response.status === 403 && signupBody.code === "SIGNUP_NOT_ALLOWED",
+    `invite-only signup was not rejected: ${response.status} ${JSON.stringify(signupBody)}`,
+  )
+
+  const form = new FormData()
+  form.append("file", new Blob([expectedContent], { type: "text/html" }), "recovery-proof.html")
+  form.append("title", "Quick-start recovery proof")
+  response = await fetch(`${origin}/v1/artifacts`, {
+    method: "POST",
+    headers: { accept: "application/json", cookie, origin },
+    body: form,
+  })
+  const artifact = await response.json()
+  expect(response.status === 201, `artifact publish failed: ${JSON.stringify(artifact)}`)
+  expect(/^[a-z0-9]+$/.test(artifact.short_id ?? ""), "publish returned no valid short id")
+
+  response = await fetch(`${origin}/v1/artifacts/${artifact.short_id}/content`, {
+    headers: { cookie },
+  })
+  await expectStatus(response, 200, "artifact read failed")
+  expect((await response.text()) === expectedContent, "published artifact content changed")
+  process.stdout.write(artifact.short_id)
+} else {
+  const artifactId = process.env.DERIVE_SMOKE_ARTIFACT_ID
+  expect(/^[a-z0-9]+$/.test(artifactId ?? ""), "verify mode needs DERIVE_SMOKE_ARTIFACT_ID")
+  response = await fetch(`${origin}/v1/artifacts/${artifactId}/content`, { headers: { cookie } })
+  await expectStatus(response, 200, "restored artifact read failed")
+  expect((await response.text()) === expectedContent, "restored artifact content changed")
+}

--- a/scripts/test-published-selfhost-bundle.sh
+++ b/scripts/test-published-selfhost-bundle.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Download a public release exactly as a new operator does, compare it with the files that were
+# uploaded, then run the normal quick-start smoke against the downloaded copies. A tag release is
+# intentionally tested before it is promoted to GitHub/GHCR "latest".
+
+release_selector=${1:-}
+expected_image=${2:-}
+port=${3:-18080}
+staged_dir=${4:-release}
+test_scope=${5:-full}
+default_download_base=https://github.com/derive-to/derive/releases/download
+download_base=${DERIVE_RELEASE_DOWNLOAD_BASE:-$default_download_base}
+
+if [[ "$release_selector" != latest ]] &&
+  [[ ! "$release_selector" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+  echo "release selector must be latest or v-prefixed semver (for example v1.2.3)" >&2
+  exit 1
+fi
+if [[ -z "$expected_image" || "$expected_image" == *[[:space:]]* ]]; then
+  echo "expected image reference must be one non-empty argument" >&2
+  exit 1
+fi
+if [[ "$download_base" == "$default_download_base" ]] &&
+  [[ ! "$expected_image" =~ ^ghcr\.io/derive-to/derive@sha256:[0-9a-f]{64}$ ]]; then
+  echo "published bundles must use an immutable derive GHCR digest" >&2
+  exit 1
+fi
+if [[ ! -d "$staged_dir" || -L "$staged_dir" ]]; then
+  echo "staged release directory does not exist or is unsafe: $staged_dir" >&2
+  exit 1
+fi
+if [[ "$test_scope" != full && "$test_scope" != assets-only ]]; then
+  echo "test scope must be full or assets-only" >&2
+  exit 1
+fi
+
+if [[ "$download_base" == "$default_download_base" && "$release_selector" == latest ]]; then
+  release_url=https://github.com/derive-to/derive/releases/latest/download
+else
+  release_url="$download_base/$release_selector"
+fi
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+download_dir=$(mktemp -d "${TMPDIR:-/tmp}/derive-release-download.XXXXXX")
+
+cleanup() {
+  local status=$?
+  case "$download_dir" in
+    "${TMPDIR:-/tmp}"/derive-release-download.*)
+      if [[ -d "$download_dir" && ! -L "$download_dir" ]]; then
+        find -P "$download_dir" -depth -delete
+      fi
+      ;;
+    *) echo "refusing to remove unexpected download directory $download_dir" >&2 ;;
+  esac
+  exit "$status"
+}
+trap cleanup EXIT
+
+assets=(compose.yml selfhost.env.example image-digest.txt)
+for asset in "${assets[@]}"; do
+  staged_file="$staged_dir/$asset"
+  if [[ ! -f "$staged_file" || -L "$staged_file" ]]; then
+    echo "staged release asset does not exist or is unsafe: $staged_file" >&2
+    exit 1
+  fi
+
+  # -q ignores a runner's curl config. GitHub tokens are deliberately removed: success must prove
+  # the release and its assets are available to an anonymous quick-start user.
+  env -u GH_TOKEN -u GITHUB_TOKEN curl -q --fail --silent --show-error --location \
+    --retry 12 --retry-delay 2 --retry-all-errors \
+    --output "$download_dir/$asset" "$release_url/$asset"
+  cmp "$staged_file" "$download_dir/$asset"
+done
+
+downloaded_image=$(tr -d '\r\n' <"$download_dir/image-digest.txt")
+if [[ "$downloaded_image" != "$expected_image" ]]; then
+  echo "published image-digest.txt does not contain the image that was built" >&2
+  exit 1
+fi
+
+env_image=$(sed -n 's/^DERIVE_IMAGE=//p' "$download_dir/selfhost.env.example")
+if [[ "$env_image" != "$expected_image" ]]; then
+  echo "published selfhost.env.example does not contain exactly one expected DERIVE_IMAGE" >&2
+  exit 1
+fi
+
+rendered_image=$(docker compose \
+  --env-file "$download_dir/selfhost.env.example" \
+  -f "$download_dir/compose.yml" config --images)
+if [[ "$rendered_image" != "$expected_image" ]]; then
+  echo "published Compose bundle does not render exactly the expected image" >&2
+  exit 1
+fi
+
+if [[ "$test_scope" == full ]]; then
+  "$repo_root/scripts/test-selfhost-quickstart.sh" \
+    "$expected_image" "$port" \
+    "$download_dir/compose.yml" "$download_dir/selfhost.env.example"
+fi
+
+echo "published self-host bundle: ok — anonymous download, exact assets, and $test_scope test"

--- a/scripts/test-published-selfhost-bundle.sh
+++ b/scripts/test-published-selfhost-bundle.sh
@@ -59,7 +59,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-assets=(compose.yml selfhost.env.example image-digest.txt)
+assets=(compose.yml selfhost.env.example image-digest.txt SHA256SUMS)
 for asset in "${assets[@]}"; do
   staged_file="$staged_dir/$asset"
   if [[ ! -f "$staged_file" || -L "$staged_file" ]]; then
@@ -74,6 +74,8 @@ for asset in "${assets[@]}"; do
     --output "$download_dir/$asset" "$release_url/$asset"
   cmp "$staged_file" "$download_dir/$asset"
 done
+
+(cd "$download_dir" && sha256sum -c SHA256SUMS)
 
 downloaded_image=$(tr -d '\r\n' <"$download_dir/image-digest.txt")
 if [[ "$downloaded_image" != "$expected_image" ]]; then

--- a/scripts/test-selfhost-quickstart.sh
+++ b/scripts/test-selfhost-quickstart.sh
@@ -118,7 +118,8 @@ artifact_id=$(env \
 
 "${compose[@]}" run --rm derive backup /backups/quickstart-smoke
 "${compose[@]}" run --rm derive verify-backup /backups/quickstart-smoke
-grep -q '"path": "blobs/' "$backup_dir/quickstart-smoke/derive-backup.json"
+docker run --rm --entrypoint grep -v "$backup_dir:/backups:ro" "$image" \
+  -q '"path": "blobs/' /backups/quickstart-smoke/derive-backup.json
 
 "${compose[@]}" down
 docker volume inspect "$data_volume" >/dev/null

--- a/scripts/test-selfhost-quickstart.sh
+++ b/scripts/test-selfhost-quickstart.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Exercise the release-shaped Compose path with a built image. This is deliberately broader than
+# an image boot check: it follows the operator sequence through bootstrap, auth, policy, publish,
+# online backup, fresh-volume restore, and restored blob readback.
+
+image=${1:-derive:ci}
+port=${2:-18080}
+
+if [[ ! "$port" =~ ^[0-9]+$ ]] || ((port < 1024 || port > 65535)); then
+  echo "port must be an integer from 1024 through 65535" >&2
+  exit 1
+fi
+if [[ -z "$image" || "$image" == *[[:space:]]* ]]; then
+  echo "image reference must be one non-empty argument" >&2
+  exit 1
+fi
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+work_dir=$(mktemp -d "${TMPDIR:-/tmp}/derive-selfhost-smoke.XXXXXX")
+project="derive-quickstart-smoke-$$"
+data_volume="${project}-data"
+restored_volume="${project}-restored"
+compose_file="$work_dir/compose.yml"
+env_file="$work_dir/.env"
+backup_dir="$work_dir/backups"
+origin="http://127.0.0.1:$port"
+email="owner-$$@example.invalid"
+password="Quickstart-smoke-$$-password"
+secret=$(openssl rand -hex 32)
+
+if [[ ! "$project" =~ ^derive-quickstart-smoke-[0-9]+$ ]]; then
+  echo "refusing unsafe Compose project name: $project" >&2
+  exit 1
+fi
+
+compose=(docker compose --env-file "$env_file" -f "$compose_file")
+
+remove_test_volume() {
+  local volume=$1
+  local expected=$2
+  if ! docker volume inspect "$volume" >/dev/null 2>&1; then
+    return
+  fi
+  local owner
+  owner=$(docker volume inspect "$volume" --format '{{index .Labels "com.docker.compose.project"}}')
+  if [[ "$volume" != "$expected" || "$owner" != "$project" ]]; then
+    echo "refusing to remove unexpected Docker volume $volume (project=$owner)" >&2
+    return
+  fi
+  docker volume rm "$volume" >/dev/null
+}
+
+cleanup() {
+  local status=$?
+  set +e
+  if [[ -f "$compose_file" && -f "$env_file" ]]; then
+    DERIVE_DATA_VOLUME="$restored_volume" "${compose[@]}" down --remove-orphans >/dev/null 2>&1
+    "${compose[@]}" down --remove-orphans >/dev/null 2>&1
+  fi
+  remove_test_volume "$data_volume" "$data_volume"
+  remove_test_volume "$restored_volume" "$restored_volume"
+  if [[ -d "$backup_dir" && ! -L "$backup_dir" ]]; then
+    docker run --rm --user 0 --entrypoint chown -v "$backup_dir:/target" "$image" \
+      -R "$(id -u):$(id -g)" /target >/dev/null 2>&1
+  fi
+  case "$work_dir" in
+    "${TMPDIR:-/tmp}"/derive-selfhost-smoke.*)
+      if [[ -d "$work_dir" && ! -L "$work_dir" ]]; then
+        find -P "$work_dir" -depth -delete
+      fi
+      ;;
+    *) echo "refusing to remove unexpected smoke directory $work_dir" >&2 ;;
+  esac
+  exit "$status"
+}
+trap cleanup EXIT
+
+cp "$repo_root/deploy/compose.yml" "$compose_file"
+mkdir -p "$backup_dir"
+docker run --rm --user 0 --entrypoint sh -v "$backup_dir:/target" "$image" -c \
+  'chown 1000:1000 /target && chmod 0700 /target'
+
+{
+  printf 'DERIVE_IMAGE=%s\n' "$image"
+  printf 'BASE_URL=%s\n' "$origin"
+  printf 'DERIVE_SIGNUP_MODE=invite\n'
+  printf 'DERIVE_BIND_ADDRESS=127.0.0.1\n'
+  printf 'DERIVE_PORT=%s\n' "$port"
+  printf 'DERIVE_AUTH_SECRET=%s\n' "$secret"
+  printf 'COMPOSE_PROJECT_NAME=%s\n' "$project"
+  printf 'DERIVE_DATA_VOLUME=%s\n' "$data_volume"
+} >"$env_file"
+chmod 0600 "$env_file"
+
+"${compose[@]}" config --quiet
+if [[ "$image" == *@sha256:* ]]; then
+  "${compose[@]}" pull
+fi
+
+printf '%s' "$password" | "${compose[@]}" run --rm -T derive \
+  bootstrap-operator --email "$email" --name Owner --password-stdin
+
+"${compose[@]}" up -d --wait --wait-timeout 120
+container_id=$("${compose[@]}" ps -q derive)
+[[ -n "$container_id" ]]
+[[ $(docker inspect "$container_id" --format '{{.State.Health.Status}}') == healthy ]]
+[[ $(docker inspect "$container_id" --format '{{.Config.User}}') == node ]]
+[[ $(docker inspect "$container_id" --format '{{json .HostConfig.SecurityOpt}}') == *no-new-privileges* ]]
+[[ $(docker port "$container_id" 8080/tcp) == "127.0.0.1:$port" ]]
+
+artifact_id=$(env \
+  DERIVE_SMOKE_ORIGIN="$origin" \
+  DERIVE_SMOKE_EMAIL="$email" \
+  DERIVE_SMOKE_PASSWORD="$password" \
+  node "$repo_root/scripts/selfhost-smoke-client.mjs" publish)
+
+"${compose[@]}" run --rm derive backup /backups/quickstart-smoke
+"${compose[@]}" run --rm derive verify-backup /backups/quickstart-smoke
+grep -q '"path": "blobs/' "$backup_dir/quickstart-smoke/derive-backup.json"
+
+"${compose[@]}" down
+docker volume inspect "$data_volume" >/dev/null
+DERIVE_DATA_VOLUME="$restored_volume" "${compose[@]}" run --rm derive \
+  restore-backup /backups/quickstart-smoke
+DERIVE_DATA_VOLUME="$restored_volume" "${compose[@]}" up -d --wait --wait-timeout 120
+docker volume inspect "$data_volume" >/dev/null
+
+env \
+  DERIVE_SMOKE_ORIGIN="$origin" \
+  DERIVE_SMOKE_EMAIL="$email" \
+  DERIVE_SMOKE_PASSWORD="$password" \
+  DERIVE_SMOKE_ARTIFACT_ID="$artifact_id" \
+  node "$repo_root/scripts/selfhost-smoke-client.mjs" verify
+
+echo "selfhost quick-start smoke: ok — bootstrap, auth, policy, publish, backup, and restore"

--- a/scripts/test-selfhost-quickstart.sh
+++ b/scripts/test-selfhost-quickstart.sh
@@ -7,6 +7,8 @@ set -euo pipefail
 
 image=${1:-derive:ci}
 port=${2:-18080}
+compose_source=${3:-}
+env_source=${4:-}
 
 if [[ ! "$port" =~ ^[0-9]+$ ]] || ((port < 1024 || port > 65535)); then
   echo "port must be an integer from 1024 through 65535" >&2
@@ -18,6 +20,14 @@ if [[ -z "$image" || "$image" == *[[:space:]]* ]]; then
 fi
 
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+compose_source=${compose_source:-"$repo_root/deploy/compose.yml"}
+env_source=${env_source:-"$repo_root/deploy/selfhost.env.example"}
+for source_file in "$compose_source" "$env_source"; do
+  if [[ ! -f "$source_file" ]]; then
+    echo "self-host bundle file does not exist: $source_file" >&2
+    exit 1
+  fi
+done
 work_dir=$(mktemp -d "${TMPDIR:-/tmp}/derive-selfhost-smoke.XXXXXX")
 project="derive-quickstart-smoke-$$"
 data_volume="${project}-data"
@@ -77,7 +87,8 @@ cleanup() {
 }
 trap cleanup EXIT
 
-cp "$repo_root/deploy/compose.yml" "$compose_file"
+cp "$compose_source" "$compose_file"
+cp "$env_source" "$env_file"
 mkdir -p "$backup_dir"
 docker run --rm --user 0 --entrypoint sh -v "$backup_dir:/target" "$image" -c \
   'chown 1000:1000 /target && chmod 0700 /target'
@@ -91,7 +102,7 @@ docker run --rm --user 0 --entrypoint sh -v "$backup_dir:/target" "$image" -c \
   printf 'DERIVE_AUTH_SECRET=%s\n' "$secret"
   printf 'COMPOSE_PROJECT_NAME=%s\n' "$project"
   printf 'DERIVE_DATA_VOLUME=%s\n' "$data_volume"
-} >"$env_file"
+} >>"$env_file"
 chmod 0600 "$env_file"
 
 "${compose[@]}" config --quiet


### PR DESCRIPTION
## Summary

- replace email-derived superadmin authority with durable instance operators keyed by immutable user ID, plus offline bootstrap/password-reset CLI flows
- enforce open/invite/closed signup policy at the identity-creation boundary across email, OAuth, and OIDC; make invitation consumption atomic
- add a verified Lite backup/restore contract with exhaustive manifests, checksums, SQLite snapshots, identity preservation, and fresh-target-only restore
- harden the runtime image and Compose defaults, then add multi-architecture image releases with SBOM, provenance, digest-pinned assets, and an end-to-end install smoke test
- publish release bundles as non-Latest first, download and exercise their exact public assets anonymously, and promote stable GitHub/GHCR aliases only after the test passes
- add a canonical `QUICKSTART.md` with separate published-release and current-checkout paths, plus a deterministic guard against documentation drift
- document the complete self-host operator path and consistently describe the project as Fair Source/self-hostable

## Implementation brief

[Self-hosting changes in PR #697](https://derive.to/artifacts/self-hosting-changes-in-pr-697-me53l6ue) maps the original failure modes to the ground-up solutions, recovery contract, operator flow, verification evidence, and intentionally retained boundaries. It is a workspace-only Derive artifact.

## Notable operational changes

- production deployments should pin `DERIVE_IMAGE` to a released digest
- Compose binds to loopback by default; public deployments need a TLS reverse proxy
- the initial operator is bootstrapped offline with `bootstrap-operator --password-stdin`
- built-in backup/restore supports the owned SQLite Lite topology and refuses partial backup of external Postgres/S3 services
- restore targets must be empty; the runbook uses a staged named-volume cutover

## Verification

- `pnpm verify` passed twice on the final change
  - static and architectural guardrails passed
  - workspace typecheck passed
  - 3,874 tests passed per run with the per-package coverage ratchet
- `git diff --check`
- Docker Compose configuration render for both published-release and source-checkout paths
- [GitHub CI](https://github.com/derive-to/derive/actions/runs/31587981858) passed on the final head
  - gitleaks, CodeQL, dependency audit, and the embedded-SQLite coverage gate
  - the full API behavior suite on real Postgres, plus D1 and workerd contracts
  - production and runner image builds
  - the production image running the release-shaped download and complete quickstart smoke below

## Quickstart and release-bundle audit

I followed the source-checkout path in `QUICKSTART.md` from a clean, disposable Compose project on `linux/amd64`. The production image built successfully and the documented flow completed:

- rendered the Compose configuration and bootstrapped the first operator offline
- started healthy on loopback as the non-root `node` user with `no-new-privileges`
- signed in with the bootstrap password, rejected a wrong password, and rejected an uninvited signup in invite mode
- published a real HTML artifact and read its exact blob content through HTTP
- created and verified an online backup containing both the database and blob
- restarted without losing the operator, then restored into a fresh named volume
- signed in after restore and read the exact artifact content; the original volume remained available for rollback
- removed the disposable containers, networks, volumes, credentials, and backup files

The first source build also exposed an undocumented capacity requirement, so the quickstart now calls for at least 10 GB of Docker storage when building and 4 GB when installing a published image.

The bundle downloader was tested positively through a disposable unauthenticated HTTP endpoint and negatively with an altered downloaded asset; it completed the full quickstart in the first case and failed closed on the byte mismatch in the second. PR CI now repeats the same download-and-handoff path against its freshly built production image.

There is still no public non-draft GitHub release, so the repository's real GitHub CDN URL cannot be probed before a tag without publishing a release. The tag workflow now owns that final boundary: it publishes `compose.yml`, `selfhost.env.example`, and `image-digest.txt` as a public non-Latest release; removes GitHub credentials from the downloader; retries CDN propagation; compares the downloaded bytes and digest wiring; runs bootstrap, auth, publish, backup, fresh-volume restore, and restored blob readback from the downloaded files; then promotes a stable release and image to Latest and rechecks the documented `/releases/latest/download/...` route. Prereleases are tested but never promoted.

## Deliberate boundaries

- external Postgres/S3 backup remains the operator/provider's coordinated responsibility
- Node realtime remains instance-local; horizontal fan-out is outside this single-host scope
- archive checksums prove integrity/completeness, not authenticity of an untrusted archive