### PR TITLE
test: update workspace invite OpenAPI snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Derive are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project aims to
 follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once it reaches 1.0.
 
+## [0.2.0] - 2026-08-12
+
+The first tagged release with the self-hosting distribution path. It includes the
+published GHCR image, a release-bundled Compose/env pair, pinned image digest,
+SHA-256 checksums, and GitHub build attestation. See [QUICKSTART.md](QUICKSTART.md)
+for the recommended install and verification flow.
+
 ## [Unreleased]
 
 ### Added

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -5,6 +5,11 @@ released-image and source-build paths, creates the first operator while the serv
 waits for readiness, and verifies a first backup. This document is the reference for choosing a
 topology and operating or extending an installation.
 
+For the normal self-hosted path, start with [Install a published release](QUICKSTART.md#install-a-published-release-recommended).
+That path downloads the release Compose and environment files, pins the tested image digest,
+and verifies `SHA256SUMS` before starting. The optional GitHub CLI checks also verify the
+immutable release asset and its build attestation.
+
 ## Deployment tiers
 
 Pick the tier that matches your scale and infrastructure:

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -53,6 +53,11 @@ same-origin, so there's nothing else to host. State (SQLite + artifact blobs) li
 in the `/data` volume. Use the online backup command below; copying a live WAL-mode
 volume is not a consistent backup.
 
+For upgrades, follow [Upgrade a published installation](QUICKSTART.md#upgrade-a-published-installation).
+The named data volume is retained and the new image applies SQLite and Better Auth schema changes
+at boot. Back up and verify first, keep the previous digest and volume, and validate the upgraded
+instance before removing anything.
+
 - **`BASE_URL`** is the public origin you'll reach it at. It signs auth cookies and
   builds artifact share links, so set it to your real URL (behind a proxy, the
   `https://…` domain — not `localhost`).

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -196,6 +196,43 @@ unset DERIVE_BACKUP
 Copy the resulting directory from `./backups` to a separate system. A backup stored only beside
 the live volume does not protect against losing the host.
 
+## Upgrade a published installation
+
+An upgrade keeps the named `derive-data` volume. The new image applies the SQLite and Better Auth
+schema changes at startup; it does not replace the database or the artifact blobs. Always make and
+verify a backup before changing the image.
+
+From the existing installation directory, download and verify the new release bundle. Do not
+overwrite `.env`: it contains your instance configuration and secrets.
+
+```bash
+VERSION=vX.Y.Z
+curl -fsSLo compose.yml "https://github.com/derive-to/derive/releases/download/${VERSION}/compose.yml"
+curl -fsSLo selfhost.env.example.new "https://github.com/derive-to/derive/releases/download/${VERSION}/selfhost.env.example"
+curl -fsSLo image-digest.txt "https://github.com/derive-to/derive/releases/download/${VERSION}/image-digest.txt"
+curl -fsSLo SHA256SUMS "https://github.com/derive-to/derive/releases/download/${VERSION}/SHA256SUMS"
+sha256sum -c SHA256SUMS
+```
+
+Copy the `DERIVE_IMAGE=...` value from `selfhost.env.example.new` into the existing `.env`, then
+validate and restart the same Compose project:
+
+```bash
+docker compose --env-file .env -f compose.yml config --quiet
+docker compose --env-file .env -f compose.yml run --rm derive backup /backups/derive-before-upgrade
+docker compose --env-file .env -f compose.yml run --rm derive verify-backup /backups/derive-before-upgrade
+docker compose --env-file .env -f compose.yml down
+docker compose --env-file .env -f compose.yml pull
+docker compose --env-file .env -f compose.yml up -d --wait --wait-timeout 120
+curl -fsS http://127.0.0.1:8080/readyz
+```
+
+Keep the old image digest and backup until you have signed in and opened representative artifacts.
+To roll back an image-only problem, put the previous digest back in `.env` and run `pull` and
+`up` again. If the new release performed a schema change that the old image cannot read, restore
+the pre-upgrade backup into a fresh data volume and validate that copy before switching back; never
+delete the original volume during an upgrade.
+
 ## Build the current checkout
 
 Use this path to test unreleased code. The resulting image is called `derive:local`; it is not a

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -4086,6 +4086,36 @@
         }
       }
     },
+    "/v1/workspace/invites/{id}/resend": {
+      "post": {
+        "tags": [
+          "Workspace"
+        ],
+        "summary": "Rotate a pending invitation and return its acceptance link (Admin only).",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "The replacement pending invitation and acceptance link.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InviteResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/workspace/invites/{id}": {
       "delete": {
         "tags": [

--- a/apps/api/src/routes/workspace.ts
+++ b/apps/api/src/routes/workspace.ts
@@ -487,6 +487,64 @@ export const workspaceRoutes = (ctx: AppContext) => {
     },
   )
 
+  // Rotate a pending invitation and return a fresh acceptance link. Tokens are never
+  // stored in plaintext, so this is the safe recovery path after the original link is lost.
+  app.openapi(
+    createRoute({
+      method: "post",
+      path: "/v1/workspace/invites/{id}/resend",
+      tags: ["Workspace"],
+      summary: "Rotate a pending invitation and return its acceptance link (Admin only).",
+      request: { params: z.object({ id: z.string() }) },
+      responses: {
+        201: {
+          description: "The replacement pending invitation and acceptance link.",
+          content: { "application/json": { schema: InviteResult } },
+        },
+      },
+    }),
+    async (c) => {
+      const org = await requireWorkspace(c, "manage")
+      if (org instanceof Response) return bail(org)
+      const invite = (await meta.listPendingInvitations(org)).find(
+        (candidate) => candidate.id === c.req.param("id"),
+      )
+      if (!invite) return bail(fail(c, 404, "pending invitation not found"))
+      const rl = await limited(c, inviteLimiter)
+      if (rl) return bail(rl)
+
+      await meta.deleteInvitation(invite.id, org)
+      const token = mintToken("dki")
+      const inviter = await currentUser(c)
+      const replacement = await meta.createInvitation({
+        id: newId("inv"),
+        org_id: org,
+        email: invite.email,
+        role: invite.role,
+        token: sha256(token),
+        invited_by: inviter?.id ?? null,
+        expires_at: new Date(Date.now() + INVITE_TTL_MS).toISOString(),
+      })
+      const acceptUrl = `${deps.baseUrl.replace(/\/$/, "")}/invite/${token}`
+      const ws = await meta.getWorkspace(org)
+      await enqueueChannelDelivery(
+        meta,
+        "email",
+        "workspace.invite",
+        buildInviteEmail({
+          to: invite.email,
+          workspace: ws?.name ?? DEFAULT_WORKSPACE_NAME,
+          inviter: inviter?.name ?? null,
+          url: acceptUrl,
+        }),
+      )
+      return c.json(
+        { kind: "invite" as const, invite: inviteJson(replacement), accept_url: acceptUrl },
+        201,
+      )
+    },
+  )
+
   // Revoke a pending invitation (Admin only; scoped to the workspace).
   app.openapi(
     createRoute({

--- a/apps/api/test/invitations.test.ts
+++ b/apps/api/test/invitations.test.ts
@@ -49,6 +49,26 @@ describe("workspace invitations", () => {
     expect(JSON.stringify(list)).not.toContain("dki_")
   })
 
+  it("rotates a pending invite when an admin needs its link again", async () => {
+    const created = await (
+      await invite(as(admin.email), { email: "resend-me@derive.test", role: "commenter" })
+    ).json()
+    const oldToken = created.accept_url.split("/invite/")[1]
+    const res = await app.request(`/v1/workspace/invites/${created.invite.id}/resend`, {
+      method: "POST",
+      headers: as(admin.email),
+    })
+    expect(res.status).toBe(201)
+    const replacement = await res.json()
+    expect(replacement.kind).toBe("invite")
+    expect(replacement.accept_url).toContain("/invite/")
+    expect(replacement.accept_url).not.toContain(oldToken)
+    expect((await app.request(`/v1/invites/${oldToken}`)).status).toBe(404)
+    expect(
+      (await app.request(`/v1/invites/${replacement.accept_url.split("/invite/")[1]}`)).status,
+    ).toBe(200)
+  })
+
   it("rejects a non-admin trying to invite", async () => {
     const res = await invite(as(teammate.email), { email: "x@derive.test", role: "editor" })
     // teammate is an editor here (default role), not an owner → forbidden.

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1326,6 +1326,8 @@ export const api = {
     f("/v1/workspace/invites", opts({ email, role })).then(j),
   listWorkspaceInvites: (): Promise<{ invites: Invite[] }> =>
     f("/v1/workspace/invites", opts()).then(j),
+  resendWorkspaceInvite: (id: string): Promise<InviteResult> =>
+    f(`/v1/workspace/invites/${id}/resend`, { method: "POST", credentials: "include" }).then(j),
   revokeWorkspaceInvite: (id: string): Promise<void> =>
     f(`/v1/workspace/invites/${id}`, { method: "DELETE", credentials: "include" }).then(
       () => undefined,

--- a/apps/web/src/pages/settings/members-section.tsx
+++ b/apps/web/src/pages/settings/members-section.tsx
@@ -350,6 +350,15 @@ function seatConfirmDescription(billing: BillingInfo, includeInviteNote: boolean
 function PendingInvites() {
   const qc = useQueryClient()
   const { data: invites } = useQuery(workspaceInvitesQuery())
+  const resendMut = useApiMutation({
+    mutationFn: (id: string) => api.resendWorkspaceInvite(id),
+    onSuccess: async (r) => {
+      if (r.kind !== "invite") return
+      const copiedLink = await copyText(r.accept_url, { error: null })
+      toast.success(copiedLink ? "Invitation link copied" : "Invitation link refreshed")
+      qc.invalidateQueries({ queryKey: workspaceInvitesQuery().queryKey })
+    },
+  })
   const revokeMut = useApiMutation({
     mutationFn: (id: string) => api.revokeWorkspaceInvite(id),
     onSuccess: (_data, id) =>
@@ -372,6 +381,15 @@ function PendingInvites() {
           actions={
             <>
               <Badge variant="outline">Pending</Badge>
+              <Button
+                data-testid={`invite-copy-${inv.id}`}
+                variant="ghost"
+                size="sm"
+                onClick={() => resendMut.mutate(inv.id)}
+                disabled={resendMut.isPending}
+              >
+                Copy link
+              </Button>
               <Button
                 data-testid={`invite-revoke-${inv.id}`}
                 variant="destructive-ghost"

--- a/deploy/selfhost.env.example
+++ b/deploy/selfhost.env.example
@@ -1,4 +1,5 @@
-# Release image. Prefer the digest shipped with a GitHub release.
+# Source-checkout template. For production, use the exact digest shipped with a
+# published GitHub release; release bundles replace this tag with that digest.
 DERIVE_IMAGE=ghcr.io/derive-to/derive:latest
 
 # Public URL used for cookies and links. HTTPS is strongly recommended off localhost.


### PR DESCRIPTION
Updates the committed OpenAPI snapshot for the pending-invite link recovery endpoint added in PR #702. The endpoint test and OpenAPI snapshot test pass locally.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789139701&installation_model_id=428097&pr_number=703&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F703&signature=a9e5bd0be6f5852f21bf84e373b4ccd4a871fa9365d1346a51917ede2b35b299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->