### PR TITLE
chore(web): claim the Glama connector listing

### DIFF
--- a/apps/web/public/.well-known/glama.json
+++ b/apps/web/public/.well-known/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/connector.json",
+  "maintainers": [{ "email": "connor@derive.to" }]
+}


### PR DESCRIPTION
Glama already lists us. Their crawler picked the server up automatically from
our official MCP registry entry, so there is a live page at
[glama.ai/mcp/connectors/to.derive/derive](https://glama.ai/mcp/connectors/to.derive/derive)
that nobody here created or controls.

An unclaimed listing sits in their anonymous-crawl tier. We cannot correct the
categories (it currently guesses "Version Control"), cannot reply in the
discussion thread on our own page, and cannot keep the description in step with
the server as tools change.

## How claiming works

A domain proof, the same shape as the `mcp-registry-auth` file sitting next to
this one: serve a JSON document naming a maintainer email, and Glama matches it
against the account that asks to claim. Schema is theirs, linked in `$schema`.

The address is on our own domain rather than a personal one, so the listing can
be reassigned by changing mail routing rather than going through Glama support
if whoever holds it moves on.

After this merges and deploys, the remaining step is manual and off-repo: create
a Glama account on that address, then hitge.

## If it ever looks broken

derive.to serves the SPA shell with a 200a typo in this
filename reads as a JSON parse error on their side, never a 404. Do not conclude
from a 200 that the file is being served,

Static assets under `public/.well-known/`h the Worker
(Cloudflare Static Assets) and the Node self-host path (`serve-web.ts` mounts
`/.well-known/*` ahead of the shell fallbthis resolve
at all.

## Unrelated but worth recording

The listing shows a red **Unhealthy** status. It is cosmetic and category-wide,
not a bug on our side. Glama's prober can OAuth-gated
server is red: Linear, Notion, Atlassian and Sentry all return the identical 401
to an unauthenticated probe, the officialthe same red
dot, and Glama's own filter counts read "No Auth 7 / Healthy 3 / Unhealthy 6".
Our 401 carries a correct `WWW-Authenticapec-correct
response.

## Verification

One file, no code paths touched. `pnpm verify` passed in full on the identical
tree; the only subsequent change was the g reads.