### PR TITLE
fix: scope artifact ownership to active workspace

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,13 +35,19 @@ Derive ships safe defaults, but a few choices matter for an internet-facing depl
   URL confers on anyone, including people outside the workspace (`none` = no world
   link). **`listed`** (`none` / workspace / public): pure discoverability — the
   workspace library or the public directory — with no access meaning of its own.
-  The effective role is `max(explicit share, workspace seat if a member, world
-  link)`; an anonymous holder of a live link is always clamped to view. The
-  effective capability by who's asking:
+  The active workspace is part of the authorization context: workspace seats and
+  owner-level artifact/collection grants apply only while the artifact's workspace
+  is active. Switching workspaces therefore never carries private ownership along.
+  Explicit viewer/commenter/editor shares and world links remain portable; an owner
+  may only be assigned to a member of the artifact's workspace.
+
+  Within that context, the effective role is `max(explicit share, workspace seat
+  if a member, world link)`; an anonymous holder of a live link is always clamped
+  to view. The effective capability by who's asking:
 
   | Field state                    | Anonymous (no account) | Signed in outside the workspace | Workspace member          | Explicit share          |
   |--------------------------------|------------------------|---------------------------------|---------------------------|-------------------------|
-  | workspace_access none, link none | No access            | No access                       | Their share role only¹    | Their share role        |
+  | workspace_access none, link none | No access            | No access                       | Their portable share only¹ | Their share role       |
   | workspace_access member          | No access            | No access                       | max(seat, share)          | max(seat², share)       |
   | link_role viewer                 | View                 | View                            | max(seat/share, view)     | max(share, view)        |
   | link_role commenter              | View (sign in to comment) | View + comment             | max(seat/share, comment)  | max(share, comment)     |
@@ -49,6 +55,7 @@ Derive ships safe defaults, but a few choices matter for an internet-facing depl
 
   ¹ workspace_access=none withholds the seat grant, so a workspace owner cannot
   open a teammate's invite-only draft by role alone — only an explicit share does.
+  Owner grants are not portable shares: they require this workspace to be active.
   ² A shared-with outsider isn't a workspace member, so their seat grant is nil;
   their share role alone applies.
 

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -1109,40 +1109,46 @@ export function buildContext(deps: AppDeps) {
   // The caller's active workspace for this request (memoized). Single mode: always
   // the bootstrap org. Multi mode: the derive_ws cookie (validated against
   // membership), else the user's first workspace, provisioning one if they have none.
-  const wsCache = new WeakMap<Context, string>()
-  const activeWorkspace = async (c: Context): Promise<string> => {
+  const wsCache = new WeakMap<Context, Promise<string>>()
+  const activeWorkspace = (c: Context): Promise<string> => {
     const cached = wsCache.get(c)
     if (cached) return cached
-    // An agent acts within its own workspace, never a cookie's.
-    const ag = await agentFor(c)
-    const me = ag ? null : await currentUser(c)
-    let ws: string
-    if (ag) {
-      // agentFor already re-homed an OAuth agent's org_id when a validated
-      // X-Derive-Workspace header was present, so authorize() and this resolver
-      // can never disagree on the workspace.
-      ws = ag.org_id
-    } else if (!me) {
-      ws = reserved(getCookie(c, WS_COOKIE)) || defaultOrg
-    } else {
-      const ck = reserved(getCookie(c, WS_COOKIE))
-      if (ck && (await cachedMembership(c, ck, me.id))) ws = ck
-      else {
-        const mine = await cachedWorkspaces(c, me.id)
-        if (mine[0]) ws = mine[0].id
+    // Cache the PROMISE, not just the answer. Document open starts workspace resolution
+    // beside its artifact+grants read; caching only after resolution would let actorFor
+    // launch the same membership lookup again while the first one was still in flight.
+    const pending = (async () => {
+      // An agent acts within its own workspace, never a cookie's.
+      const ag = await agentFor(c)
+      const me = ag ? null : await currentUser(c)
+      let ws: string
+      if (ag) {
+        // agentFor already re-homed an OAuth agent's org_id when a validated
+        // X-Derive-Workspace header was present, so authorize() and this resolver
+        // can never disagree on the workspace.
+        ws = ag.org_id
+      } else if (!me) {
+        ws = reserved(getCookie(c, WS_COOKIE)) || defaultOrg
+      } else {
+        const ck = reserved(getCookie(c, WS_COOKIE))
+        if (ck && (await cachedMembership(c, ck, me.id))) ws = ck
         else {
-          ws = await provisionPersonal(me)
-          // Drop the memoized EMPTY list: it predates the workspace we just created, and
-          // GET /v1/workspaces reads the list again for its body in this same request —
-          // it would have answered "you have no workspaces" moments after making one.
-          // Exactly the invalidation `ensureMembership` does after provisioning a row.
-          workspacesCache.get(c)?.delete(me.id)
+          const mine = await cachedWorkspaces(c, me.id)
+          if (mine[0]) ws = mine[0].id
+          else {
+            ws = await provisionPersonal(me)
+            // Drop the memoized EMPTY list: it predates the workspace we just created, and
+            // GET /v1/workspaces reads the list again for its body in this same request —
+            // it would have answered "you have no workspaces" moments after making one.
+            // Exactly the invalidation `ensureMembership` does after provisioning a row.
+            workspacesCache.get(c)?.delete(me.id)
+          }
         }
       }
-    }
-    wsCache.set(c, ws)
-    c.set("orgId", ws)
-    return ws
+      c.set("orgId", ws)
+      return ws
+    })()
+    wsCache.set(c, pending)
+    return pending
   }
   // Persist the active-workspace choice. Same cross-site handling as the viewer
   // cookie so it survives the hosted SPA↔API split.
@@ -1214,7 +1220,12 @@ export function buildContext(deps: AppDeps) {
    *  else (an agent bearer alongside a session cookie, a token, an anonymous visitor)
    *  ignores it and takes the normal path, so a mis-supplied `pre` can cost a wasted
    *  query but cannot produce the wrong actor. */
-  type PreGrants = { userId: string; orgRole: Role | null; artifactRoles: Role[] }
+  type PreGrants = {
+    userId: string
+    orgRole: Role | null
+    artifactRoles: Role[]
+    portableArtifactRoles: Role[]
+  }
 
   const actorFor = (c: Context, a: ArtifactRecord, pre?: PreGrants): Promise<Actor> => {
     let perArtifact = actorCache.get(c)
@@ -1262,18 +1273,24 @@ export function buildContext(deps: AppDeps) {
         derived = capRole(maxRole(m?.role ?? null, ...cRoles), ag.role)
       }
       const orgRole = ag.org_id === a.org_id ? ag.role : null
+      // Historical rows written directly to an agent id remain explicit grants, but
+      // ownership is workspace-bound even for that legacy shape. Lower collaborator
+      // roles remain portable, matching human shares.
+      const ownRole = ag.org_id === a.org_id || own?.role !== "owner" ? (own?.role ?? null) : null
       return {
         kind: "user",
         userId: ag.id,
-        artifactRole: maxRole(own?.role ?? null, derived),
+        artifactRole: maxRole(ownRole, derived),
         orgRole,
         locked,
       }
     }
-    // A signed-in human. Baseline role = membership in the ARTIFACT's workspace. Opening a
-    // shared link never auto-joins you into someone else's workspace; you only carry an org
-    // role where you're explicitly a member.
+    // A signed-in human. Workspace authority belongs to the ACTIVE workspace, not
+    // merely to the account: switching away drops the artifact workspace's seat and
+    // every owner-level artifact/collection grant. Deliberate lower collaborator
+    // shares remain portable, as does the separately-evaluated world link.
     const me = p.user
+    const workspaceActive = (await activeWorkspace(c)) === a.org_id
     // ONE ROUND TRIP WHERE THE STORE CAN, four where it cannot. The reads below are the
     // membership, the per-artifact share and the collection shares — and the last is itself two
     // queries, so this is four trips to decide one boolean, on every authorize. A store that can
@@ -1288,8 +1305,11 @@ export function buildContext(deps: AppDeps) {
       return {
         kind: "user",
         userId: me.id,
-        artifactRole: maxRole(null, ...pre.artifactRoles),
-        orgRole: pre.orgRole,
+        artifactRole: maxRole(
+          null,
+          ...(workspaceActive ? pre.artifactRoles : pre.portableArtifactRoles),
+        ),
+        orgRole: workspaceActive ? pre.orgRole : null,
         locked,
         unlocked,
       }
@@ -1298,18 +1318,27 @@ export function buildContext(deps: AppDeps) {
       return {
         kind: "user",
         userId: me.id,
-        artifactRole: maxRole(null, ...g.artifactRoles),
-        orgRole: g.orgRole,
+        artifactRole: maxRole(
+          null,
+          ...(workspaceActive ? g.artifactRoles : g.portableArtifactRoles),
+        ),
+        orgRole: workspaceActive ? g.orgRole : null,
         locked,
         unlocked,
       }
     }
-    const orgRole = (await meta.getMembership(a.org_id, me.id))?.role ?? null
+    const orgRole = workspaceActive
+      ? ((await meta.getMembership(a.org_id, me.id))?.role ?? null)
+      : null
     const am = await meta.getArtifactMember(a.id, me.id)
     // A collection share grants its role on every artifact in the collection,
     // folded in alongside any per-artifact share (the higher wins).
-    const cRoles = await meta.collectionRolesForArtifact(a.id, me.id)
-    const artifactRole = maxRole(am?.role ?? null, ...cRoles)
+    const cRoles = await meta.collectionRolesForArtifact(a.id, me.id, {
+      includeWorkspaceSeats: workspaceActive,
+    })
+    const portable = (role: Role | null | undefined): Role | null =>
+      workspaceActive || role !== "owner" ? (role ?? null) : null
+    const artifactRole = maxRole(portable(am?.role), ...cRoles.map(portable))
     return { kind: "user", userId: me.id, artifactRole, orgRole, locked, unlocked }
   }
 
@@ -1405,16 +1434,15 @@ export function buildContext(deps: AppDeps) {
     return data ? new TextDecoder().decode(data) : null
   }
 
-  // A caller's role on a collection: the static token is owner; otherwise the
-  // creator, else their explicit collection-member role, else — when the
-  // collection's own workspace_access is `member` — their workspace SEAT role,
-  // else null (no access). Shared by the collections routes and the artifact
-  // listing (collection scoping).
+  // A caller's role on a collection: the static token is owner; in the active
+  // workspace the creator/explicit owner and workspace seat apply. Outside it,
+  // only explicit viewer/commenter/editor shares travel with the person.
   const collectionRole = async (c: Context, col: CollectionRecord): Promise<Role | null> => {
     if (isToken(c)) return "owner"
     const me = await currentUser(c)
     if (!me) return null
-    if (col.created_by === me.id) return "owner"
+    const workspaceActive = (await activeWorkspace(c)) === col.org_id
+    if (workspaceActive && col.created_by === me.id) return "owner"
     // A collection lives in a workspace, so — same share experience as an
     // artifact's workspace_access — its members reach it at their SEAT role when
     // it's workspace-open; an invite-only collection (workspace_access=none)
@@ -1425,9 +1453,10 @@ export function buildContext(deps: AppDeps) {
     // collectionRolesForArtifact mirrors this exact rule (explicit membership OR a
     // seat on a workspace-open collection), so visibility of the collection and of
     // its contents stay in lockstep (no phantom-empty collections).
-    const explicit = (await meta.getCollectionMember(col.id, me.id))?.role ?? null
+    const memberRole = (await meta.getCollectionMember(col.id, me.id))?.role ?? null
+    const explicit = workspaceActive || memberRole !== "owner" ? memberRole : null
     const seat =
-      col.workspace_access === "member"
+      workspaceActive && col.workspace_access === "member"
         ? ((await meta.getMembership(col.org_id, me.id))?.role ?? null)
         : null
     return maxRole(explicit, seat)

--- a/apps/api/src/lib/account.ts
+++ b/apps/api/src/lib/account.ts
@@ -2,16 +2,19 @@ import type { MembershipRecord, MetaStore } from "@derive/core"
 import type { BillingDriver } from "./billing"
 import { isBillableRole, syncSeats } from "./seats"
 
-// Account-deletion guard: the workspaces a user SOLELY owns that still have other members.
-// Deleting the account would leave those workspaces without an admin, so we block until the
-// user transfers ownership or removes the others. A personal / solo workspace (no other
-// members) is fine — it's dropped by the deleteUserData cascade. Returns the blocking
-// workspace names for a clear error message; empty ⇒ deletion is safe.
+// Account-deletion guard: workspaces where removing this person would strand either
+// workspace administration or workspace-bound artifact/collection ownership. Better Auth's
+// purge bypasses the ordinary member-removal route and deletes memberships + owner rows
+// directly, so it must enforce the same handoff invariant here. Personal-workspace resources
+// count too: deleteUserData removes that workspace's label, but intentionally preserves its
+// artifacts. Returns blocking workspace names for a clear error message; empty ⇒ deletion
+// is safe.
 export async function workspacesBlockingDeletion(
   meta: MetaStore,
   userId: string,
 ): Promise<string[]> {
-  const owned = (await meta.listWorkspaces(userId)).filter((ws) => ws.role === "owner")
+  const mine = await meta.listWorkspaces(userId)
+  const owned = mine.filter((ws) => ws.role === "owner")
   // Every owned workspace's members in ONE query, grouped by org — not a listMemberships
   // per workspace.
   const membersByOrg = new Map<string, MembershipRecord[]>()
@@ -20,14 +23,22 @@ export async function workspacesBlockingDeletion(
     if (arr) arr.push(m)
     else membersByOrg.set(m.org_id, [m])
   }
-  const blocking: string[] = []
+  const blocking = new Set<string>()
   for (const ws of owned) {
     const others = (membersByOrg.get(ws.id) ?? []).filter((m) => m.user_id !== userId)
-    // Solo workspace → fine. Others exist but at least one is also an owner → fine. Only
-    // block when the leaving user is the LAST owner of a shared workspace.
-    if (others.length > 0 && !others.some((m) => m.role === "owner")) blocking.push(ws.name)
+    // Others exist but no other workspace owner → deleting this account removes the
+    // workspace's last administrator. A solo non-personal workspace is handled by the
+    // resource check below; when empty, leaving it ownerless is the existing behavior.
+    if (others.length > 0 && !others.some((m) => m.role === "owner")) blocking.add(ws.name)
   }
-  return blocking
+  const resourceBlocks = await Promise.all(
+    mine.map(async (ws) => {
+      const resources = await meta.workspaceOwnershipBlockers(ws.id, userId)
+      return { ws, blocked: resources.artifacts > 0 || resources.collections > 0 }
+    }),
+  )
+  for (const { ws, blocked } of resourceBlocks) if (blocked) blocking.add(ws.name)
+  return [...blocking]
 }
 
 // Account deletion: purge the user's data, then heal Stripe seat counts.

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -220,11 +220,11 @@ const auth = makeAuth(authDb, cfg.baseUrl, authSecret, {
   // same retrying outbox as notifications; the configured sender transports them.
   sendAuthEmail: (kind, input) =>
     enqueueChannelDelivery(meta, "email", `auth.${kind}`, buildAuthEmail(kind, input)),
-  // Account deletion: block if they'd orphan a shared workspace, else purge domain data.
+  // Account deletion: block if they'd orphan workspace or resource ownership, else purge.
   blockUserDeletion: async (userId) => {
     const blocking = await workspacesBlockingDeletion(meta, userId)
     return blocking.length
-      ? `Transfer ownership or remove the other members of ${blocking.join(", ")} before deleting your account.`
+      ? `Resolve owned work or workspace ownership in ${blocking.join(", ")} before deleting your account.`
       : null
   },
   // Purge, then heal Stripe seat counts on every workspace the deleted account was

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -19,6 +19,7 @@ import {
   heavyAssetsAdvisory,
   isHtmlLike,
   isMarkdownBundle,
+  maxRole,
   missingBlobAdvisory,
   newId,
   newShortId,
@@ -279,8 +280,10 @@ export const artifactRoutes = (ctx: AppContext) => {
       // your active one — so scope the listing to the collection's org (gated by
       // access), or a direct/cold link to a collection in another workspace reads as
       // empty. Unknown collection ⇒ nothing.
-      let listOrg = await activeWorkspace(c)
+      const activeOrg = await activeWorkspace(c)
+      let listOrg = activeOrg
       let collectionAccess = false
+      let collectionGrant: Role | null = null
       // Carry the collection's title so the client can label the view even when the
       // collection lives in another workspace (it's absent from the local sidebar list).
       // Only for a caller who actually has access — otherwise the title (and the fact
@@ -297,7 +300,8 @@ export const artifactRoutes = (ctx: AppContext) => {
         // seat, conditionally on the collection's OWN workspace_access — see context.ts):
         // plain isMember(org) would grant access to an Invited-only collection to every
         // workspace member, defeating the toggle entirely.
-        collectionAccess = (await collectionRole(c, col)) !== null
+        collectionGrant = await collectionRole(c, col)
+        collectionAccess = collectionGrant !== null
         if (collectionAccess) collectionInfo = { id: col.id, title: col.title }
       }
       // Author filter narrows to artifacts last changed by a GitHub login, scoped to the
@@ -307,15 +311,19 @@ export const artifactRoutes = (ctx: AppContext) => {
 
       // The caller's baseline standing in the listing's workspace — reused for the
       // public-only clamp below and the per-row `my_role` (which needs the ROLE, so
-      // the boolean isMember helper doesn't fit). A user's standing is their
-      // membership row; an agent's is its registered role, valid only in its home
-      // workspace (the same scoping actorFor applies).
+      // the boolean isMember helper doesn't fit). Workspace seats only apply when
+      // this is also the active workspace. A portable collection share can make a
+      // foreign collection the listing scope, but must not bring that workspace's
+      // seat along with it (the same scoping actorFor applies).
       const isOperator = isToken(c)
-      const baselineRole = me
-        ? ((await membershipOf(c, listOrg, me.id))?.role ?? null)
-        : agent && agent.org_id === listOrg
-          ? agent.role
-          : null
+      const baselineRole =
+        listOrg !== activeOrg
+          ? null
+          : me
+            ? ((await membershipOf(c, listOrg, me.id))?.role ?? null)
+            : agent && agent.org_id === listOrg
+              ? agent.role
+              : null
       // A listing only shows non-public artifacts to a MEMBER of that workspace (or the
       // operator token). Anyone else — a non-member user, a foreign-workspace agent —
       // sees public artifacts only, so org/link titles never leak via the list or ?query=.
@@ -397,6 +405,10 @@ export const artifactRoutes = (ctx: AppContext) => {
       const feedback = enrichment.signals
       const proposalCounts = enrichment.proposals
       const shareRoles = enrichment.shareRoles
+      const scopedShareRole = (artifact: ArtifactRecord): Role | null => {
+        const role = shareRoles[artifact.id] ?? null
+        return artifact.org_id === activeOrg || role !== "owner" ? role : null
+      }
       // Page-scoped and taken from the batch, for BOTH paths — including the favorites
       // feed, whose `favIds` above is a narrowing input, not the row decoration. One
       // source of truth means the star a row renders can't disagree with the star the
@@ -413,9 +425,9 @@ export const artifactRoutes = (ctx: AppContext) => {
           favorite: favorites.has(a.id),
           has_preview: previews[a.id] === true,
           // Which actions the client may surface on the row (the card's quick-actions
-          // menu gates delete/tags on it). Workspace seat + per-artifact shares + the
-          // world-link floor; collection-share roles aren't folded in at list
-          // granularity, so the detail response's my_role stays authoritative.
+          // menu gates delete/tags on it). A collection-scoped listing has already
+          // resolved the caller's role on that collection, so fold the same grant into
+          // every item instead of rendering cards weaker than their detail pages.
           my_role: isOperator
             ? "owner"
             : effectiveRole(
@@ -425,9 +437,9 @@ export const artifactRoutes = (ctx: AppContext) => {
                       userId: memberKey,
                       artifactRole:
                         agent?.created_by != null
-                          ? capRole(shareRoles[a.id] ?? null, agent.role)
-                          : (shareRoles[a.id] ?? null),
-                      orgRole: a.org_id === listOrg ? baselineRole : null,
+                          ? capRole(maxRole(scopedShareRole(a), collectionGrant), agent.role)
+                          : maxRole(scopedShareRole(a), collectionGrant),
+                      orgRole: a.org_id === activeOrg ? baselineRole : null,
                     }
                   : { kind: "anon" },
                 a.workspace_access,
@@ -1378,6 +1390,11 @@ export const artifactRoutes = (ctx: AppContext) => {
       // costs one round trip instead of two. Optional, like `artifactGrants` beneath it:
       // a store without it takes the read-by-read path unchanged.
       const viewer = await currentUser(c)
+      // Active-workspace validation is another independent read. Start it beside the
+      // artifact query so workspace-scoped authorization does not put a new serial trip
+      // on the document-open critical path. activeWorkspace memoizes this promise, so
+      // actorFor below consumes the same result rather than starting it again.
+      const activeOrg = viewer ? activeWorkspace(c) : Promise.resolve<string | null>(null)
       const combined =
         viewer && meta.artifactWithGrants
           ? await meta.artifactWithGrants(shortId, viewer.id)
@@ -1397,16 +1414,62 @@ export const artifactRoutes = (ctx: AppContext) => {
         c,
         artifact,
         combined && viewer
-          ? { userId: viewer.id, orgRole: combined.orgRole, artifactRoles: combined.artifactRoles }
+          ? {
+              userId: viewer.id,
+              orgRole: combined.orgRole,
+              artifactRoles: combined.artifactRoles,
+              portableArtifactRoles: combined.portableArtifactRoles,
+            }
           : undefined,
       )
-      if (!can(actor, "read", artifact.workspace_access, artifact.link_role))
+      if (!can(actor, "read", artifact.workspace_access, artifact.link_role)) {
+        // A workspace mismatch is recoverable without weakening the boundary. Tell
+        // a signed-in member where to switch only when their full standing would
+        // actually read the artifact there. The response carries no artifact data;
+        // strangers and members without artifact access keep the indistinguishable
+        // 404 below.
+        const resolvedActiveOrg = await activeOrg
+        const destinationSeat =
+          viewer && resolvedActiveOrg !== artifact.org_id
+            ? await membershipOf(c, artifact.org_id, viewer.id)
+            : null
+        const readableInDestination =
+          viewer && destinationSeat
+            ? combined
+              ? can(
+                  {
+                    kind: "user",
+                    userId: viewer.id,
+                    artifactRole: maxRole(null, ...combined.artifactRoles),
+                    orgRole: combined.orgRole,
+                  },
+                  "read",
+                  artifact.workspace_access,
+                  "none",
+                )
+              : await authorizeUserStanding(viewer.id, "read", artifact)
+            : false
+        if (viewer && readableInDestination) {
+          const workspace = await meta.getWorkspace(artifact.org_id)
+          if (workspace)
+            return bail(
+              fail(c, 409, "Switch workspaces to view this artifact.", {
+                code: "workspace_mismatch",
+                workspace: {
+                  id: workspace.id,
+                  name: workspace.name,
+                  personal: workspace.id === `ws_p_${viewer.id}`,
+                },
+              }),
+            )
+        }
         // A locked artifact isn't hidden, it's lockable: tell the client to prompt for
         // the password (401) rather than claim it doesn't exist (404). A lock only ever
         // sits on a world link, so a stored hash means the world-link path is gated.
         return bail(
           artifact.password_hash ? fail(c, 401, "password required") : fail(c, 404, "not found"),
         )
+      }
       // Taken down: serve a minimal tombstone, not the full record. A takedown is a
       // moderation action and the title is often the very thing being removed
       // (harassment/doxxing), so drop title, author, the slug in the URL, and the
@@ -1491,18 +1554,29 @@ export const artifactRoutes = (ctx: AppContext) => {
       // Anonymous link readers can never see a row (no role, no standing) — skip the
       // lookups entirely on that hot path.
       if (collections.length > 0 && (me !== null || isToken(c) || canManageArtifact)) {
-        const [colRecords, rolesById] = await Promise.all([
-          meta.getCollections(collections),
-          me
+        const workspaceActive = isToken(c) || (await activeWorkspace(c)) === artifact.org_id
+        const roles = me
+          ? workspaceActive
             ? meta.collectionRolesForUser(collections, me)
-            : Promise.resolve<Record<string, Role>>({}),
-        ])
-        // Fold in the two sources the batched query can't know (mirrors collectionRole).
+            : meta
+                .collectionRolesForUser(collections, me, { includeWorkspaceSeats: false })
+                .then((byId) =>
+                  Object.fromEntries(Object.entries(byId).filter(([, role]) => role !== "owner")),
+                )
+          : Promise.resolve<Record<string, Role>>({})
+        const [colRecords, rolesById] = await Promise.all([meta.getCollections(collections), roles])
+        // Fold in creator ownership only in the collection's active workspace. On a
+        // portable artifact open, the role map above likewise contains only explicit
+        // non-owner collection shares — never a foreign workspace seat.
         const roleOf = (col: (typeof colRecords)[number]): Role | null =>
-          isToken(c) ? "owner" : col.created_by === me ? "owner" : (rolesById[col.id] ?? null)
+          isToken(c)
+            ? "owner"
+            : workspaceActive && col.created_by === me
+              ? "owner"
+              : (rolesById[col.id] ?? null)
         const visible = colRecords
           .map((col) => ({ col, role: roleOf(col) }))
-          .filter(({ role }) => role !== null || canManageArtifact)
+          .filter(({ role }) => role !== null || (workspaceActive && canManageArtifact))
         const [memberCounts, creatorNames] = await Promise.all([
           meta.collectionMemberCounts(visible.map(({ col }) => col.id)),
           resolveUserBylines(meta, [...new Set(visible.map(({ col }) => col.created_by))]),

--- a/apps/api/src/routes/collections.ts
+++ b/apps/api/src/routes/collections.ts
@@ -584,6 +584,10 @@ export const collectionRoutes = (ctx: AppContext) => {
       // their role isn't a member row anyone can rewrite — reject demoting them.
       if (user.id === col.created_by)
         return bail(fail(c, 409, "the collection owner's role can't be changed"))
+      // Like artifact ownership, collection ownership is authority inside this
+      // workspace. Portable cross-workspace shares stop at editor.
+      if (b.role === "owner" && !(await meta.getMembership(col.org_id, user.id)))
+        return bail(fail(c, 400, "a collection owner must belong to its workspace"))
       await meta.setCollectionMember({
         id: newId("cm"),
         collection_id: col.id,

--- a/apps/api/src/routes/contexts.ts
+++ b/apps/api/src/routes/contexts.ts
@@ -5,9 +5,11 @@ import {
   decodeCursor,
   effectiveRole,
   encodeCursor,
+  maxRole,
   newId,
   normalizeSelector,
   parseSubject,
+  type Role,
   roleAllows,
   type SessionMessageRecord,
   type SessionRecord,
@@ -113,6 +115,15 @@ export const contextRoutes = (ctx: AppContext) => {
   /** How many past conversations the history picker offers. A picker, not an archive: far
    *  enough back to find last week's thread, short enough to stay one batched read. */
   const CHAT_HISTORY_PAGE = 50
+
+  // A document conversation carries artifact content in its transcript and can
+  // publish on a follow-up. Treat it like the document itself: a browser may use it
+  // only while that workspace is active. Plain workspace chats and packaged-context
+  // sessions keep their own explicit workspace/context gates.
+  const artifactSessionIsActive = async (c: Context, s: SessionRecord): Promise<boolean> => {
+    const subject = parseSubject(s.subject_ref)
+    return subject?.kind !== "artifact" || (await activeWorkspace(c)) === s.org_id
+  }
 
   /**
    * WHICH MODEL this conversation was last answered with, read off the transcript.
@@ -385,7 +396,7 @@ export const contextRoutes = (ctx: AppContext) => {
     agentId: string | null,
     /** What the caller asked for on THIS turn. `modelId` is the person's model pick; absent
      *  means "whatever this conversation was already using", then the deploy's default. */
-    opts?: { modelId?: string | null },
+    opts?: { modelId?: string | null; activeOrg?: string },
   ) => {
     const subject = parseSubject(s.subject_ref)
     // WHAT THIS LANE WILL SERVE, and what it must leave alone.
@@ -503,12 +514,19 @@ export const contextRoutes = (ctx: AppContext) => {
       // from the doc still holds the id, and without this they would keep reading the CURRENT
       // contents back and keep publishing to it. `canRead`/`canWrite` are resolved for the
       // asker, not for whoever opened the session.
-      const seat = await meta.getMembership(artifact.org_id, me.id)
+      const workspaceActive = opts?.activeOrg === artifact.org_id
+      const seat = workspaceActive ? await meta.getMembership(artifact.org_id, me.id) : null
+      const member = await meta.getArtifactMember(artifact.id, me.id)
+      const collectionRoles = await meta.collectionRolesForArtifact(artifact.id, me.id, {
+        includeWorkspaceSeats: workspaceActive,
+      })
+      const portable = (role: Role | null | undefined) =>
+        workspaceActive || role !== "owner" ? (role ?? null) : null
       const role = effectiveRole(
         {
           kind: "user",
           orgRole: seat?.role,
-          artifactRole: (await meta.getArtifactMember(artifact.id, me.id))?.role,
+          artifactRole: maxRole(portable(member?.role), ...collectionRoles.map(portable)),
         },
         artifact.workspace_access,
         artifact.link_role,
@@ -1647,7 +1665,12 @@ export const contextRoutes = (ctx: AppContext) => {
         // Ask-access to the CONTEXT is not read-access to the DOCUMENT. Re-check the
         // artifact separately, or a session becomes a way to read anything by naming it.
         const target = await meta.getByShortId(subject.id)
-        if (!target || target.current_version === 0 || !(await authorize(c, "read", target)))
+        if (
+          !target ||
+          target.current_version === 0 ||
+          target.org_id !== (await activeWorkspace(c)) ||
+          !(await authorize(c, "read", target))
+        )
           return bail(fail(c, 404, "not found"))
         // Publishing to it is a stronger grant than reading it, checked separately so a
         // reader cannot request `mode:"publish"` and have the gate be the only thing
@@ -1957,7 +1980,9 @@ export const contextRoutes = (ctx: AppContext) => {
       // in the transcript. On Node (and tests) it awaits inline, which is what keeps the suite
       // deterministic. The comments and the polling UI both describe THIS, and previously the
       // code did not do it.
-      await ctx.background(serveAttended(session, me, null))
+      await ctx.background(
+        serveAttended(session, me, null, { activeOrg: await activeWorkspace(c) }),
+      )
       return c.json({ session: sessionJson(session), messages: [messageJson(first)] }, 201)
     },
   )
@@ -2075,7 +2100,12 @@ export const contextRoutes = (ctx: AppContext) => {
       )
       // Detached, exactly like the document lane: the transcript is what the surface follows,
       // so closing the tab mid-turn loses nothing.
-      await ctx.background(serveAttended(created.session, me, null, { modelId: b.model ?? null }))
+      await ctx.background(
+        serveAttended(created.session, me, null, {
+          modelId: b.model ?? null,
+          activeOrg: await activeWorkspace(c),
+        }),
+      )
       return c.json(
         { session: sessionJson(created.session), messages: [messageJson(created.message)] },
         201,
@@ -2347,10 +2377,12 @@ export const contextRoutes = (ctx: AppContext) => {
       // asker and nobody else — including a workspace owner, who has no standing here that
       // a context would otherwise have conferred. Without this branch every poll on a chat
       // session 404s and the reply never appears, which is exactly what dogfooding caught.
-      const mine = !!s && !s.context_id && s.asker_id === me.id
+      const active = !!s && (await artifactSessionIsActive(c, s))
+      const mine = active && !s.context_id && s.asker_id === me.id
       const allowed =
         mine ||
-        (!!s &&
+        (active &&
+          !!s &&
           !!linked &&
           (await canAskContext(c, linked.context)) &&
           (linked.context.created_by === me.id || s.asker_id === me.id))
@@ -2473,7 +2505,11 @@ export const contextRoutes = (ctx: AppContext) => {
       // not keep querying through it — canAskContext re-checks membership + policy.
       // Contextless: ownership IS the whole gate. With a context, re-check the ask grant
       // too, so someone removed from the roster cannot keep querying through an old session.
-      if (s.asker_id !== me.id || (linked && !(await canAskContext(c, linked.context))))
+      if (
+        !(await artifactSessionIsActive(c, s)) ||
+        s.asker_id !== me.id ||
+        (linked && !(await canAskContext(c, linked.context)))
+      )
         return bail(fail(c, 404, "not found"))
       // (Membership for the contextless CHAT lane is re-checked per turn inside serveAttended,
       // alongside the document ACL, so the refusal lands in the transcript with a reason rather
@@ -2543,7 +2579,10 @@ export const contextRoutes = (ctx: AppContext) => {
         if (!st?.chatBeta) return c.json({ message: messageJson(m) }, 201)
       }
       await ctx.background(
-        serveAttended(s, me, linked?.context.agent_id ?? null, { modelId: b.model ?? null }),
+        serveAttended(s, me, linked?.context.agent_id ?? null, {
+          modelId: b.model ?? null,
+          activeOrg: await activeWorkspace(c),
+        }),
       )
       return c.json({ message: messageJson(m) }, 201)
     },
@@ -2593,12 +2632,14 @@ export const contextRoutes = (ctx: AppContext) => {
       // asker's call alone — same carve-out the session read already makes. Without this,
       // Stop 404s on every workspace-chat turn (the ask, not just the poll, matters here):
       // a hung answer had no way to end early short of the ten-minute reaper.
-      const mine = !s.context_id && s.asker_id === me.id
+      const active = await artifactSessionIsActive(c, s)
+      const mine = active && !s.context_id && s.asker_id === me.id
       // Same membership floor as the session read: a removed asker/creator can't
       // touch the session at all (close included) once they're out of the workspace.
       const allowed =
         mine ||
-        (!!linked &&
+        (active &&
+          !!linked &&
           (await canAskContext(c, linked.context)) &&
           (linked.context.created_by === me.id || s.asker_id === me.id))
       if (!allowed) return bail(fail(c, 404, "not found"))

--- a/apps/api/src/routes/sharing.ts
+++ b/apps/api/src/routes/sharing.ts
@@ -209,6 +209,11 @@ export const sharingRoutes = (ctx: AppContext) => {
         const email = ref.trim().toLowerCase()
         if (!looksLikeEmail(email))
           return bail(fail(c, 404, "no Derive user with that username or email"))
+        // Ownership is workspace authority, not a portable artifact share. An
+        // unknown invitee cannot already hold a seat, so invite them to the
+        // workspace before transferring ownership.
+        if (b.role === "owner")
+          return bail(fail(c, 400, "an artifact owner must belong to its workspace"))
         // Each invite emails an arbitrary address with the caller's artifact title
         // in the subject — rate-limited so an account can't run a spam cannon.
         const rl = await limited(c, inviteLimiter)
@@ -246,6 +251,8 @@ export const sharingRoutes = (ctx: AppContext) => {
           201,
         )
       }
+      if (b.role === "owner" && !(await meta.getMembership(artifact.org_id, user.id)))
+        return bail(fail(c, 400, "an artifact owner must belong to its workspace"))
       // A direct share supersedes any pending invite for the same person.
       if (user.email)
         await meta.deletePendingArtifactInvitesFor(artifact.id, user.email.toLowerCase())
@@ -434,6 +441,11 @@ export const sharingRoutes = (ctx: AppContext) => {
       const { inv, artifact } = live
       const mismatch = await emailMismatch409(c, inv.email, me.email)
       if (mismatch) return bail(mismatch)
+      // Historical owner invitations may predate the workspace-bound ownership
+      // invariant. Refuse them without consuming the token; joining the workspace
+      // first makes the same invite redeemable.
+      if (inv.role === "owner" && !(await meta.getMembership(artifact.org_id, me.id)))
+        return bail(fail(c, 400, "an artifact owner must belong to its workspace"))
       const now = new Date().toISOString()
       if (!(await meta.consumeArtifactInvite(inv.id, now)))
         return bail(fail(c, 409, "this invitation has already been accepted"))

--- a/apps/api/src/routes/workspace.ts
+++ b/apps/api/src/routes/workspace.ts
@@ -357,6 +357,24 @@ export const workspaceRoutes = (ctx: AppContext) => {
       if (!existing) return c.body(null, 204)
       if (existing.role === "owner" && (await isLastOwner(org, userId)))
         return bail(fail(c, 409, "the workspace needs at least one admin"))
+      const owned = await meta.workspaceOwnershipBlockers(org, userId)
+      if (owned.artifacts > 0 || owned.collections > 0) {
+        const resources = [
+          owned.artifacts > 0
+            ? `${owned.artifacts} artifact${owned.artifacts === 1 ? "" : "s"}`
+            : null,
+          owned.collections > 0
+            ? `${owned.collections} collection${owned.collections === 1 ? "" : "s"}`
+            : null,
+        ].filter((resource) => resource !== null)
+        return bail(
+          fail(
+            c,
+            409,
+            `Transfer or add another owner to ${resources.join(" and ")} before removing this member.`,
+          ),
+        )
+      }
       await meta.removeMembership(org, userId)
       await syncSeats({ meta, billing }, org)
       return c.body(null, 204)

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -296,7 +296,7 @@ const handle = (req: Request, env: Env, ctx: ExecutionContext): Response | Promi
         blockUserDeletion: async (userId) => {
           const blocking = await workspacesBlockingDeletion(meta, userId)
           return blocking.length
-            ? `Transfer ownership or remove the other members of ${blocking.join(", ")} before deleting your account.`
+            ? `Resolve owned work or workspace ownership in ${blocking.join(", ")} before deleting your account.`
             : null
         },
         // Purge, then heal Stripe seat counts on every workspace the deleted account was

--- a/apps/api/test/account-deletion.test.ts
+++ b/apps/api/test/account-deletion.test.ts
@@ -3,17 +3,48 @@ import { SqliteMetaStore } from "@derive/db/sqlite"
 import { describe, expect, it } from "vitest"
 import { workspacesBlockingDeletion } from "../src/lib/account"
 
-// The sole-owner guard behind account deletion: a user may not delete their account while
-// they're the LAST owner of a workspace that still has other members (it would strand that
-// workspace with no admin). A solo/personal workspace, or one with a co-owner, is fine.
+// The ownership guard behind account deletion: purging an account removes its workspace,
+// artifact, and collection owner rows directly, so every one of those authorities needs a
+// live handoff first. Personal-workspace artifacts survive account deletion, so they count too.
 describe("workspacesBlockingDeletion", () => {
   const store = () => new SqliteMetaStore(":memory:")
 
-  it("allows deletion when the user only owns solo/personal workspaces", async () => {
+  it("allows deletion when the user only owns an empty personal workspace", async () => {
     const s = store()
     const me = `u_${uuid()}`
     await s.setWorkspace(`ws_p_${me}`, "Mine")
     await s.setMembership({ id: uuid(), org_id: `ws_p_${me}`, user_id: me, role: "owner" })
+    expect(await workspacesBlockingDeletion(s, me)).toEqual([])
+  })
+
+  it("blocks when account purge would orphan a personal-workspace artifact", async () => {
+    const s = store()
+    const me = `u_${uuid()}`
+    const personal = `ws_p_${me}`
+    await s.setWorkspace(personal, "Mine")
+    await s.setMembership({ id: uuid(), org_id: personal, user_id: me, role: "owner" })
+    const artifact = await s.createArtifact({
+      id: uuid(),
+      short_id: uuid().slice(0, 8),
+      org_id: personal,
+      slug: null,
+      title: "Private draft",
+      workspace_access: "none",
+      link_role: "none",
+      listed: "none",
+      kind: "file",
+      spa: 0,
+    })
+    await s.setArtifactMember({
+      id: uuid(),
+      artifact_id: artifact.id,
+      user_id: me,
+      role: "owner",
+    })
+
+    expect(await workspacesBlockingDeletion(s, me)).toEqual(["Mine"])
+
+    await s.deleteArtifact(artifact.id, personal)
     expect(await workspacesBlockingDeletion(s, me)).toEqual([])
   })
 
@@ -44,6 +75,62 @@ describe("workspacesBlockingDeletion", () => {
     await s.setWorkspace("shared", "Team Space")
     await s.setMembership({ id: uuid(), org_id: "shared", user_id: owner, role: "owner" })
     await s.setMembership({ id: uuid(), org_id: "shared", user_id: me, role: "editor" })
+    expect(await workspacesBlockingDeletion(s, me)).toEqual([])
+  })
+
+  it("blocks when account purge would orphan owned artifacts or collections", async () => {
+    const s = store()
+    const me = `u_${uuid()}`
+    const admin = `u_${uuid()}`
+    await s.setWorkspace("shared", "Team Space")
+    await s.setMembership({ id: uuid(), org_id: "shared", user_id: admin, role: "owner" })
+    await s.setMembership({ id: uuid(), org_id: "shared", user_id: me, role: "editor" })
+    const artifact = await s.createArtifact({
+      id: uuid(),
+      short_id: uuid().slice(0, 8),
+      org_id: "shared",
+      slug: null,
+      title: "Private draft",
+      workspace_access: "none",
+      link_role: "none",
+      listed: "none",
+      kind: "file",
+      spa: 0,
+    })
+    await s.setArtifactMember({
+      id: uuid(),
+      artifact_id: artifact.id,
+      user_id: me,
+      role: "owner",
+    })
+    const collection = await s.createCollection({
+      id: uuid(),
+      org_id: "shared",
+      title: "Private collection",
+      created_by: me,
+      workspace_access: "none",
+    })
+    await s.setCollectionMember({
+      id: uuid(),
+      collection_id: collection.id,
+      user_id: me,
+      role: "owner",
+    })
+
+    expect(await workspacesBlockingDeletion(s, me)).toEqual(["Team Space"])
+
+    await s.setArtifactMember({
+      id: uuid(),
+      artifact_id: artifact.id,
+      user_id: admin,
+      role: "owner",
+    })
+    await s.setCollectionMember({
+      id: uuid(),
+      collection_id: collection.id,
+      user_id: admin,
+      role: "owner",
+    })
     expect(await workspacesBlockingDeletion(s, me)).toEqual([])
   })
 })

--- a/apps/api/test/chat-attended.test.ts
+++ b/apps/api/test/chat-attended.test.ts
@@ -4,7 +4,7 @@ import { createInProcessBackplane } from "../src/bus"
 import { catalogOf } from "../src/lib/model-catalog"
 import { setInstanceSlot } from "../src/lib/model-library"
 import { inMemoryRateLimiters } from "../src/lib/rate-limit"
-import { as, makeAuthedApp } from "./helpers"
+import { as, jsonAs, makeAuthedApp } from "./helpers"
 
 // CHAT, END TO END through the real routes: open a session on a document, send a message, and
 // the document changes. This is the attended path — no queue, no runner, no dispatch tick — so
@@ -221,6 +221,40 @@ describe("chatting with a document", () => {
     expect(fresh?.current_version).toBe(2)
   })
 
+  it("hides an artifact transcript and refuses follow-ups after switching workspaces", async () => {
+    const { app, meta, artifact } = await setup(
+      "chat-workspace-switch",
+      revision("# Should not publish"),
+    )
+    const opened = await app.request("/v1/artifacts/chat-session", {
+      method: "POST",
+      headers: { ...as("ed@x.com"), "content-type": "application/json" },
+      body: JSON.stringify({ short_id: artifact.short_id, body_md: "hello", mode: "publish" }),
+    })
+    expect(opened.status).toBe(201)
+    const { session } = (await opened.json()) as { session: { id: string } }
+    const before = (await meta.getByShortId(artifact.short_id))?.current_version
+
+    const switched = await app.request("/v1/workspaces", {
+      ...jsonAs(as("ed@x.com"), { name: "Elsewhere" }),
+      method: "POST",
+    })
+    expect(switched.status).toBe(201)
+    const cookie = (switched.headers.get("set-cookie") ?? "").match(/derive_ws=([^;]+)/)?.[1]
+    expect(cookie).toBeTruthy()
+    const elsewhere = { ...as("ed@x.com"), cookie: `derive_ws=${cookie}` }
+
+    expect((await app.request(`/v1/sessions/${session.id}`, { headers: elsewhere })).status).toBe(
+      404,
+    )
+    const followup = await app.request(`/v1/sessions/${session.id}/messages`, {
+      ...jsonAs(elsewhere, { body_md: "rewrite it now" }),
+      method: "POST",
+    })
+    expect(followup.status).toBe(404)
+    expect((await meta.getByShortId(artifact.short_id))?.current_version).toBe(before)
+  })
+
   it("answers a QUESTION without touching the document", async () => {
     const { app, meta, artifact, cx } = await setup("chat-ask", "It is one line long.")
     const { msgs } = await chat(
@@ -419,20 +453,17 @@ describe("access is re-checked on every turn, not just at session open", () => {
     await meta.removeMembership("default", "u-mo")
 
     const before = (await meta.getByShortId(short_id))?.current_version
-    await app.request(`/v1/sessions/${session.id}/messages`, {
+    const transcriptSize = (await meta.listSessionMessages(session.id)).length
+    const followup = await app.request(`/v1/sessions/${session.id}/messages`, {
       method: "POST",
       headers: { ...as("mo@x.com"), "content-type": "application/json" },
       body: JSON.stringify({ body_md: "rewrite the whole thing" }),
     })
-    for (let i = 0; i < 60; i++) {
-      const msgs = await meta.listSessionMessages(session.id)
-      if (msgs.some((m) => m.author_kind === "agent")) break
-      await new Promise((r) => setTimeout(r, 20))
-    }
-    // The document is untouched, and the transcript says why rather than going silent.
+    // Losing the workspace hides the transcript itself, so the follow-up cannot
+    // append either the person's prompt or a response containing document context.
+    expect(followup.status).toBe(404)
     expect((await meta.getByShortId(short_id))?.current_version).toBe(before)
-    const last = (await meta.listSessionMessages(session.id)).at(-1)
-    expect(last?.body_md ?? "").toMatch(/no longer have access|not found/i)
+    expect(await meta.listSessionMessages(session.id)).toHaveLength(transcriptSize)
   })
 })
 
@@ -581,21 +612,16 @@ describe("chat requires membership, not merely read access", () => {
 
     await meta.removeMembership("default", stranger.id)
     const before = (await meta.getByShortId(short_id))?.current_version
+    const transcriptSize = (await meta.listSessionMessages(session.id)).length
 
-    await app.request(`/v1/sessions/${session.id}/messages`, {
+    const followup = await app.request(`/v1/sessions/${session.id}/messages`, {
       method: "POST",
       headers: { ...as(stranger.email), "content-type": "application/json" },
       body: JSON.stringify({ body_md: "now rewrite the whole thing" }),
     })
-    for (let i = 0; i < 60; i++) {
-      const msgs = await meta.listSessionMessages(session.id)
-      if (msgs.filter((m) => m.author_kind === "agent").length > 1) break
-      await new Promise((r) => setTimeout(r, 20))
-    }
-    // The document is untouched, and the transcript says why rather than going silent.
+    expect(followup.status).toBe(404)
     expect((await meta.getByShortId(short_id))?.current_version).toBe(before)
-    const last = (await meta.listSessionMessages(session.id)).at(-1)
-    expect(last?.body_md ?? "").toMatch(/not a member/i)
+    expect(await meta.listSessionMessages(session.id)).toHaveLength(transcriptSize)
   })
 })
 

--- a/apps/api/test/move-artifact.test.ts
+++ b/apps/api/test/move-artifact.test.ts
@@ -8,6 +8,11 @@ import { as, jsonAs, makeAuthedApp, publishAs, type TestUser } from "./helpers"
 const ana: TestUser = { id: "u_move_ana", email: "ana@move.test", name: "Ana" }
 const ben: TestUser = { id: "u_move_ben", email: "ben@move.test", name: "Ben" }
 
+const workspaceCookie = (res: Response): string => {
+  const match = (res.headers.get("set-cookie") ?? "").match(/derive_ws=([^;]+)/)
+  return match ? `derive_ws=${match[1]}` : ""
+}
+
 describe("move an artifact to a different workspace", () => {
   // ana is the Admin/owner of "default"; ben is an editor there (makeAuthedApp's
   // default team seeding: users[0] = owner, the rest = defaultRole).
@@ -42,13 +47,29 @@ describe("move an artifact to a different workspace", () => {
     expect(moved.status).toBe(200)
     expect((await moved.json()).org_id).toBe("acme")
 
-    // The detail response reflects the new workspace. Ana's role stays "owner"
-    // here — not because of her (editor) membership in "acme", but because
-    // publishing wrote her a per-artifact owner share, which a move doesn't
-    // touch (a direct share is independent of org membership, same as a
-    // private-artifact invite outlives the sharer's own workspace role).
+    // Moving does not silently switch the whole application. The artifact leaves
+    // the active workspace immediately, so even its creator cannot keep opening
+    // it through an owner row that belongs to another workspace.
+    const leftBehind = await app.request(`/v1/artifacts/${a.short_id}`, {
+      headers: as(ana.email),
+    })
+    expect(leftBehind.status).toBe(409)
+    expect(await leftBehind.json()).toMatchObject({
+      code: "workspace_mismatch",
+      workspace: { id: "acme", name: "Acme" },
+    })
+
+    // In the destination workspace, the workspace-bound owner row applies again.
+    // Ana only has an editor seat there, so this also proves ownership comes from
+    // the artifact grant without making that grant portable across workspaces.
+    const switched = await app.request(
+      "/v1/workspace/switch",
+      jsonAs(as(ana.email), { id: "acme" }),
+    )
+    expect(switched.status).toBe(200)
+    const inAcme = { ...as(ana.email), cookie: workspaceCookie(switched) }
     const detail = await (
-      await app.request(`/v1/artifacts/${a.short_id}`, { headers: as(ana.email) })
+      await app.request(`/v1/artifacts/${a.short_id}`, { headers: inAcme })
     ).json()
     expect(detail.org_id).toBe("acme")
     expect(detail.my_role).toBe("owner")
@@ -56,7 +77,7 @@ describe("move an artifact to a different workspace", () => {
     // Moving into the workspace it's already in is a no-op error, not a 200.
     const noop = await app.request(
       `/v1/artifacts/${a.short_id}/move`,
-      jsonAs(as(ana.email), { targetOrgId: "acme" }),
+      jsonAs(inAcme, { targetOrgId: "acme" }),
     )
     expect(noop.status).toBe(400)
   })

--- a/apps/api/test/workspace-artifact-access.test.ts
+++ b/apps/api/test/workspace-artifact-access.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it } from "vitest"
+import { as, jsonAs, makeAuthedApp, publishAs, type TestUser } from "./helpers"
+
+// A workspace switch changes the authorization context, not just the library query.
+// Ownership and workspace seats stay with the artifact's workspace; deliberate
+// collaborator shares (viewer/commenter/editor) and world links remain portable.
+describe("artifact access follows the active workspace", () => {
+  const owner: TestUser = {
+    id: "u_ws_art_owner",
+    email: "owner@ws-art.test",
+    name: "Owner",
+  }
+  const collaborator: TestUser = {
+    id: "u_ws_art_collab",
+    email: "collab@ws-art.test",
+    name: "Collaborator",
+  }
+  const unsharedMember: TestUser = {
+    id: "u_ws_art_unshared",
+    email: "unshared@ws-art.test",
+    name: "Unshared member",
+  }
+  // Isolated gives each person a distinct personal workspace. The owner creates a
+  // second workspace below, which lets the same signed-in identity switch contexts.
+  const { app, meta } = makeAuthedApp(
+    "workspace-artifact-access",
+    [owner, collaborator, unsharedMember],
+    undefined,
+    { isolated: true },
+  )
+
+  const workspaceCookie = (res: Response): string => {
+    const match = (res.headers.get("set-cookie") ?? "").match(/derive_ws=([^;]+)/)
+    return match ? `derive_ws=${match[1]}` : ""
+  }
+  const inWorkspace = (email: string, cookie: string) => ({ ...as(email), cookie })
+  const publish = async (fields: Record<string, string>) => {
+    const res = await publishAs(app, "<h1>workspace-bound</h1>", fields, as(owner.email))
+    expect(res.status).toBe(201)
+    return (await res.json()) as { short_id: string }
+  }
+
+  it("binds ownership and seats while preserving explicit shares and world links", async () => {
+    const initial = await (await app.request("/v1/workspaces", { headers: as(owner.email) })).json()
+    const origin = initial.workspaces[0] as { id: string }
+    const unsharedSpaces = await (
+      await app.request("/v1/workspaces", { headers: as(unsharedMember.email) })
+    ).json()
+    const unsharedPersonal = unsharedSpaces.workspaces[0] as { id: string }
+    await meta.setMembership({
+      id: "m_ws_art_unshared_origin",
+      org_id: origin.id,
+      user_id: unsharedMember.id,
+      role: "viewer",
+    })
+    const unsharedSwitch = await app.request(
+      "/v1/workspace/switch",
+      jsonAs(as(unsharedMember.email), { id: unsharedPersonal.id }),
+    )
+    const unsharedElsewhere = inWorkspace(unsharedMember.email, workspaceCookie(unsharedSwitch))
+
+    // One team draft exercises the workspace seat + creator owner row. The second
+    // is invite-only, so its creator owner row is the only non-public way in.
+    const team = await publish({
+      title: "Team draft",
+      workspace_access: "member",
+      link_role: "none",
+      listed: "none",
+    })
+    const invited = await publish({
+      title: "Invited draft",
+      workspace_access: "none",
+      link_role: "none",
+      listed: "none",
+    })
+    const world = await publish({
+      title: "World link",
+      workspace_access: "none",
+      link_role: "viewer",
+      listed: "none",
+    })
+    // The reported product path: "Use as template" creates a derived artifact
+    // with the same human owner row as any other publish.
+    const derivedRes = await app.request(`/v1/artifacts/${world.short_id}/use`, {
+      method: "POST",
+      headers: as(owner.email),
+    })
+    expect(derivedRes.status).toBe(201)
+    const derived = (await derivedRes.json()) as { short_id: string }
+
+    // Ownership is a workspace capability, so it cannot be handed to someone who
+    // has no seat in the artifact's workspace. A collaborator role remains valid.
+    const foreignOwner = await app.request(`/v1/artifacts/${invited.short_id}/members`, {
+      ...jsonAs(as(owner.email), { email: collaborator.email, role: "owner" }),
+      method: "PUT",
+    })
+    expect(foreignOwner.status).toBe(400)
+    const unknownOwner = await app.request(`/v1/artifacts/${invited.short_id}/members`, {
+      ...jsonAs(as(owner.email), { email: "future-owner@ws-art.test", role: "owner" }),
+      method: "PUT",
+    })
+    expect(unknownOwner.status).toBe(400)
+    const share = await app.request(`/v1/artifacts/${invited.short_id}/members`, {
+      ...jsonAs(as(owner.email), { email: collaborator.email, role: "editor" }),
+      method: "PUT",
+    })
+    expect(share.status).toBe(201)
+
+    // A collection creator is also an owner. Putting the invite-only artifact in
+    // their collection must not turn that owner role into a cross-workspace title leak.
+    const collectionRes = await app.request(
+      "/v1/collections",
+      jsonAs(as(owner.email), { title: "Origin collection" }),
+    )
+    expect(collectionRes.status).toBe(201)
+    const collection = (await collectionRes.json()) as { id: string }
+    await meta.setCollectionAccess(collection.id, "none")
+    const foreignCollectionOwner = await app.request(`/v1/collections/${collection.id}/members`, {
+      ...jsonAs(as(owner.email), { email: collaborator.email, role: "owner" }),
+      method: "PUT",
+    })
+    expect(foreignCollectionOwner.status).toBe(400)
+    expect(
+      (
+        await app.request(`/v1/collections/${collection.id}/items/${invited.short_id}`, {
+          method: "PUT",
+          headers: as(owner.email),
+        })
+      ).status,
+    ).toBe(200)
+    expect(
+      (
+        await app.request(`/v1/collections/${collection.id}/items/${world.short_id}`, {
+          method: "PUT",
+          headers: as(owner.email),
+        })
+      ).status,
+    ).toBe(200)
+    const portableCollectionShare = await app.request(`/v1/collections/${collection.id}/members`, {
+      ...jsonAs(as(owner.email), { email: collaborator.email, role: "viewer" }),
+      method: "PUT",
+    })
+    expect(portableCollectionShare.status).toBe(201)
+    const wrappedEditorShare = await app.request(`/v1/artifacts/${world.short_id}/members`, {
+      ...jsonAs(as(owner.email), { email: collaborator.email, role: "editor" }),
+      method: "PUT",
+    })
+    expect(wrappedEditorShare.status).toBe(201)
+
+    // A workspace-open collection is a useful negative control: an origin seat
+    // can reveal it only while origin is active, even when its artifact has a
+    // portable world link.
+    const openCollectionRes = await app.request(
+      "/v1/collections",
+      jsonAs(as(owner.email), { title: "Workspace collection" }),
+    )
+    expect(openCollectionRes.status).toBe(201)
+    const openCollection = (await openCollectionRes.json()) as { id: string }
+    expect(
+      (
+        await app.request(`/v1/collections/${openCollection.id}/items/${world.short_id}`, {
+          method: "PUT",
+          headers: as(owner.email),
+        })
+      ).status,
+    ).toBe(200)
+
+    // Creating the second workspace switches the active-workspace cookie to it.
+    const create = await app.request(
+      "/v1/workspaces",
+      jsonAs(as(owner.email), { name: "Other workspace" }),
+    )
+    expect(create.status).toBe(201)
+    const otherCookie = workspaceCookie(create)
+    expect(otherCookie).not.toBe("")
+    const elsewhere = inWorkspace(owner.email, otherCookie)
+
+    // Neither the seat nor the creator's owner row follows the person into the
+    // other workspace. The central gate covers detail and content, not just lists.
+    const teamMismatch = await app.request(`/v1/artifacts/${team.short_id}`, {
+      headers: elsewhere,
+    })
+    expect(teamMismatch.status).toBe(409)
+    expect(await teamMismatch.json()).toMatchObject({
+      code: "workspace_mismatch",
+      workspace: { id: origin.id },
+    })
+    const invitedMismatch = await app.request(`/v1/artifacts/${invited.short_id}`, {
+      headers: elsewhere,
+    })
+    expect(invitedMismatch.status).toBe(409)
+    expect(await invitedMismatch.json()).toMatchObject({
+      code: "workspace_mismatch",
+      workspace: { id: origin.id },
+    })
+    const derivedMismatch = await app.request(`/v1/artifacts/${derived.short_id}`, {
+      headers: elsewhere,
+    })
+    expect(derivedMismatch.status).toBe(409)
+    const derivedHint = await derivedMismatch.json()
+    expect(derivedHint).toMatchObject({
+      code: "workspace_mismatch",
+      workspace: { id: origin.id },
+    })
+    expect(derivedHint).not.toHaveProperty("short_id")
+    expect(derivedHint).not.toHaveProperty("title")
+    // Membership alone does not reveal an invite-only artifact. The switch hint
+    // is offered only when switching would genuinely make the artifact readable.
+    const noOracle = await app.request(`/v1/artifacts/${invited.short_id}`, {
+      headers: unsharedElsewhere,
+    })
+    expect(noOracle.status).toBe(404)
+    expect(await noOracle.json()).not.toHaveProperty("workspace")
+    expect(
+      (await app.request(`/v1/artifacts/${invited.short_id}/content`, { headers: elsewhere }))
+        .status,
+    ).toBe(404)
+
+    // The collection's workspace-bound owner role cannot be used to enumerate the
+    // old workspace's private artifact either.
+    const foreignCollection = await (
+      await app.request(`/v1/artifacts?collection=${collection.id}`, { headers: elsewhere })
+    ).json()
+    expect(foreignCollection.artifacts).toEqual([])
+    expect(foreignCollection).not.toHaveProperty("collection")
+
+    // A live world link is portable, but the old owner authority is not: in the
+    // foreign workspace the same person opens at the link's viewer floor.
+    const worldElsewhere = await app.request(`/v1/artifacts/${world.short_id}`, {
+      headers: elsewhere,
+    })
+    expect(worldElsewhere.status).toBe(200)
+    const worldElsewhereBody = await worldElsewhere.json()
+    expect(worldElsewhereBody.my_role).toBe("viewer")
+    // Neither creator ownership nor a foreign workspace seat may disclose the
+    // collection metadata wrapped around an otherwise portable artifact.
+    expect(worldElsewhereBody.collection_access).toEqual([])
+
+    const seatedWorldElsewhere = await app.request(`/v1/artifacts/${world.short_id}`, {
+      headers: unsharedElsewhere,
+    })
+    expect(seatedWorldElsewhere.status).toBe(200)
+    expect((await seatedWorldElsewhere.json()).collection_access).toEqual([])
+
+    // A deliberate non-owner share is portable and remains discoverable through
+    // Shared with me even though the collaborator's active workspace is elsewhere.
+    const sharedDetail = await app.request(`/v1/artifacts/${invited.short_id}`, {
+      headers: as(collaborator.email),
+    })
+    expect(sharedDetail.status).toBe(200)
+    const sharedDetailBody = await sharedDetail.json()
+    expect(sharedDetailBody.my_role).toBe("editor")
+    expect(sharedDetailBody.collection_access).toEqual([
+      expect.objectContaining({ id: collection.id, my_role: "viewer" }),
+    ])
+    const wrappedEditor = await app.request(`/v1/artifacts/${world.short_id}`, {
+      headers: as(collaborator.email),
+    })
+    expect(wrappedEditor.status).toBe(200)
+    expect((await wrappedEditor.json()).collection_access).toEqual([
+      expect.objectContaining({ id: collection.id, my_role: "viewer" }),
+    ])
+    const sharedFeed = await (
+      await app.request("/v1/artifacts?scope=shared", { headers: as(collaborator.email) })
+    ).json()
+    expect(sharedFeed.artifacts.map((a: { short_id: string }) => a.short_id)).toContain(
+      invited.short_id,
+    )
+
+    // Switching back restores the workspace-bound owner grant.
+    const back = await app.request("/v1/workspace/switch", jsonAs(elsewhere, { id: origin.id }))
+    expect(back.status).toBe(200)
+    const atOrigin = inWorkspace(owner.email, workspaceCookie(back))
+    const restored = await app.request(`/v1/artifacts/${invited.short_id}`, {
+      headers: atOrigin,
+    })
+    expect(restored.status).toBe(200)
+    expect((await restored.json()).my_role).toBe("owner")
+  })
+})

--- a/apps/api/test/workspace-scoping.test.ts
+++ b/apps/api/test/workspace-scoping.test.ts
@@ -6,10 +6,15 @@ import { as, makeAuthedApp, publishAs, type TestUser } from "./helpers"
 // the (workspace-scoped) favorites list. Regression tests for the two scoping bugs.
 describe("workspace scoping: collections + favorites", () => {
   const owner: TestUser = { id: "u_ws_owner", email: "owner@ws.test", name: "Owner" }
+  const collaborator: TestUser = {
+    id: "u_ws_collab",
+    email: "collab@ws.test",
+    name: "Collaborator",
+  }
   const outsider: TestUser = { id: "u_ws_out", email: "out@ws.test", name: "Outsider" }
   // Both seed into the shared "default" workspace (owner = admin); their ACTIVE
   // workspace (no cookie) is "default".
-  const { app, meta } = makeAuthedApp("ws-scoping", [owner, outsider])
+  const { app, meta } = makeAuthedApp("ws-scoping", [owner, collaborator, outsider])
 
   // A second workspace B with one artifact + a collection holding it. owner is a
   // member of B; outsider is not. Seeded once for the whole describe.
@@ -17,6 +22,12 @@ describe("workspace scoping: collections + favorites", () => {
   beforeAll(async () => {
     await meta.setWorkspace("wsB", "Workspace B")
     await meta.setMembership({ id: "m_wsB_owner", org_id: "wsB", user_id: owner.id, role: "owner" })
+    await meta.setMembership({
+      id: "m_wsB_collab",
+      org_id: "wsB",
+      user_id: collaborator.id,
+      role: "owner",
+    })
     const art = await meta.createArtifact({
       id: "a_inB",
       short_id: "binb01",
@@ -37,6 +48,14 @@ describe("workspace scoping: collections + favorites", () => {
       author: "Owner",
       message: null,
     })
+    // Historical owner rows can exist from before ownership became workspace-
+    // bound. This one must not leak authority into the default workspace.
+    await meta.setArtifactMember({
+      id: "am_inB_collab",
+      artifact_id: art.id,
+      user_id: collaborator.id,
+      role: "owner",
+    })
     const col = await meta.createCollection({
       id: "col_inB",
       org_id: "wsB",
@@ -44,22 +63,43 @@ describe("workspace scoping: collections + favorites", () => {
       created_by: owner.id,
     })
     await meta.addCollectionItem(col.id, art.id)
+    await meta.setCollectionMember({
+      id: "cm_inB_collab",
+      collection_id: col.id,
+      user_id: collaborator.id,
+      role: "editor",
+    })
   })
 
-  it("loads a collection's artifacts from the collection's workspace, regardless of active ws", async () => {
-    // owner's active workspace is "default", but the collection lives in wsB. The
-    // listing must scope to wsB (it used to scope to the active ws → empty).
+  it("binds collection ownership to its workspace while preserving collaborator shares", async () => {
+    // The owner's active workspace is "default", while their collection lives in
+    // wsB. Creator ownership must not cross that workspace boundary.
     const res = await app.request(`/v1/artifacts?collection=${colId}`, { headers: as(owner.email) })
     expect(res.status).toBe(200)
     const body = await res.json()
-    expect(body.artifacts.map((a: { short_id: string }) => a.short_id)).toContain("binb01")
-    // The response carries the collection's title so the view can label itself even
-    // for a collection in another workspace (not in the active sidebar list).
-    expect(body.collection).toMatchObject({ id: colId, title: "B Collection" })
+    expect(body.artifacts).toEqual([])
+    expect(body).not.toHaveProperty("collection")
 
-    // in-collection search (?query=) works the same way.
+    // A deliberate non-owner collection share is portable. Its listing scopes to
+    // the collection's workspace and carries the title for the cold-linked view.
+    const shared = await app.request(`/v1/artifacts?collection=${colId}`, {
+      headers: as(collaborator.email),
+    })
+    const sharedBody = await shared.json()
+    expect(sharedBody.artifacts.map((a: { short_id: string }) => a.short_id)).toContain("binb01")
+    expect(sharedBody.collection).toMatchObject({ id: colId, title: "B Collection" })
+    // The card carries the portable collection grant, not the foreign workspace's
+    // stronger owner seat, and therefore matches the detail page.
+    expect(sharedBody.artifacts[0]?.my_role).toBe("editor")
+    const sharedDetail = await app.request("/v1/artifacts/binb01", {
+      headers: as(collaborator.email),
+    })
+    expect(sharedDetail.status).toBe(200)
+    expect((await sharedDetail.json()).my_role).toBe("editor")
+
+    // In-collection search follows the same portable share.
     const res2 = await app.request(`/v1/artifacts?collection=${colId}&query=Doc%20in%20B`, {
-      headers: as(owner.email),
+      headers: as(collaborator.email),
     })
     expect((await res2.json()).artifacts.map((a: { short_id: string }) => a.short_id)).toContain(
       "binb01",

--- a/apps/api/test/workspace.test.ts
+++ b/apps/api/test/workspace.test.ts
@@ -157,6 +157,67 @@ describe("workspace: edge conditions", () => {
   })
 })
 
+describe("workspace: ownership handoff", () => {
+  const admin: TestUser = {
+    id: "u_handoff_admin",
+    email: "handoff-admin@derive.test",
+    name: "Admin",
+  }
+  const leaver: TestUser = {
+    id: "u_handoff_leaver",
+    email: "handoff-leaver@derive.test",
+    name: "Leaver",
+  }
+  const { app, meta } = makeAuthedApp("ws-ownership-handoff", [admin, leaver], "editor")
+
+  it("does not remove the sole owner of workspace resources", async () => {
+    const published = await publishAs(
+      app,
+      "<h1>Private</h1>",
+      { title: "Private", workspace_access: "none", link_role: "none", listed: "none" },
+      as(leaver.email),
+    )
+    expect(published.status).toBe(201)
+    const artifact = (await published.json()) as { short_id: string }
+    const record = await meta.getByShortId(artifact.short_id)
+    expect(record).not.toBeNull()
+
+    const madeCollection = await app.request(
+      "/v1/collections",
+      jsonAs(as(leaver.email), { title: "Leaver's collection" }),
+    )
+    expect(madeCollection.status).toBe(201)
+    const collection = (await madeCollection.json()) as { id: string }
+
+    const blocked = await app.request(`/v1/workspace/members/${leaver.id}`, {
+      method: "DELETE",
+      headers: as(admin.email),
+    })
+    expect(blocked.status).toBe(409)
+    expect((await blocked.json()).error).toMatch(/another owner.*1 artifact.*1 collection/i)
+    expect(await meta.getMembership("default", leaver.id)).not.toBeNull()
+
+    await meta.setArtifactMember({
+      id: "am_handoff_admin",
+      artifact_id: record?.id ?? "",
+      user_id: admin.id,
+      role: "owner",
+    })
+    await meta.setCollectionMember({
+      id: "cm_handoff_admin",
+      collection_id: collection.id,
+      user_id: admin.id,
+      role: "owner",
+    })
+    const removed = await app.request(`/v1/workspace/members/${leaver.id}`, {
+      method: "DELETE",
+      headers: as(admin.email),
+    })
+    expect(removed.status).toBe(204)
+    expect(await meta.getMembership("default", leaver.id)).toBeNull()
+  })
+})
+
 describe("workspace: anonymous lockout + token mode", () => {
   it("a no-token instance still does NOT trust anonymous callers (can't manage)", async () => {
     const noTokenApp = createApp({

--- a/apps/web/src/api-workspace-hint.test.ts
+++ b/apps/web/src/api-workspace-hint.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { ApiError, api } from "./api"
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe("workspace mismatch API hint", () => {
+  it("preserves the validated destination on an artifact refusal", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              error: "Switch workspaces to view this artifact.",
+              code: "workspace_mismatch",
+              workspace: { id: "ws_a", name: "Acme", personal: false },
+            }),
+            { status: 409, headers: { "content-type": "application/json" } },
+          ),
+      ),
+    )
+
+    const error = await api.getArtifact("private-doc").catch((cause: unknown) => cause)
+    expect(error).toBeInstanceOf(ApiError)
+    expect(error).toMatchObject({
+      status: 409,
+      code: "workspace_mismatch",
+      workspace: { id: "ws_a", name: "Acme", personal: false },
+    })
+  })
+
+  it("drops malformed workspace metadata", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              error: "not found",
+              code: "workspace_mismatch",
+              workspace: { id: "ws_a" },
+            }),
+            { status: 409, headers: { "content-type": "application/json" } },
+          ),
+      ),
+    )
+
+    const error = (await api
+      .getArtifact("private-doc")
+      .catch((cause: unknown) => cause)) as ApiError
+    expect(error.workspace).toBeUndefined()
+  })
+})

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -496,6 +496,7 @@ export class ApiError extends Error {
     message: string,
     readonly status: number,
     readonly code?: string,
+    readonly workspace?: { id: string; name: string; personal: boolean },
   ) {
     super(message)
   }
@@ -503,7 +504,13 @@ export class ApiError extends Error {
 const j = async (r: Response) => {
   if (!r.ok) {
     const body = await r.json().catch(() => ({}))
-    throw new ApiError(body.error ?? `HTTP ${r.status}`, r.status, body.code)
+    const workspace =
+      typeof body.workspace?.id === "string" &&
+      typeof body.workspace?.name === "string" &&
+      typeof body.workspace?.personal === "boolean"
+        ? body.workspace
+        : undefined
+    throw new ApiError(body.error ?? `HTTP ${r.status}`, r.status, body.code, workspace)
   }
   return r.json()
 }

--- a/apps/web/src/components/chrome/app-shell.tsx
+++ b/apps/web/src/components/chrome/app-shell.tsx
@@ -140,6 +140,10 @@ export function AppShell({ children }: { children: ReactNode }) {
     if (id === workspaces?.active) return
     try {
       await api.switchWorkspace(id)
+      // Reload in place. If this is a private artifact from another workspace,
+      // its detail request returns only a workspace-switch hint (never content),
+      // so the page can offer a one-click return instead of dumping the person in
+      // the library with no explanation.
       reloadAfterWorkspaceChange()
     } catch {
       /* surfaced elsewhere */

--- a/apps/web/src/pages/artifact/artifact-states.test.ts
+++ b/apps/web/src/pages/artifact/artifact-states.test.ts
@@ -1,0 +1,21 @@
+import { createElement } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it, vi } from "vitest"
+import { ArtifactWrongWorkspace } from "./artifact-states"
+
+describe("ArtifactWrongWorkspace", () => {
+  it("names the destination and offers the one-click switch", () => {
+    const html = renderToStaticMarkup(
+      createElement(ArtifactWrongWorkspace, {
+        workspaceName: "Acme",
+        onSwitch: vi.fn(),
+        onBack: vi.fn(),
+      }),
+    )
+
+    expect(html).toContain("Switch to Acme")
+    expect(html).toContain("This artifact belongs to Acme")
+    expect(html).toContain('data-testid="artifact-workspace-switch"')
+    expect(html).toContain('data-testid="artifact-workspace-back"')
+  })
+})

--- a/apps/web/src/pages/artifact/artifact-states.tsx
+++ b/apps/web/src/pages/artifact/artifact-states.tsx
@@ -23,6 +23,35 @@ export function ArtifactNotFound({ onBack }: { onBack: () => void }) {
   )
 }
 
+export function ArtifactWrongWorkspace({
+  workspaceName,
+  onSwitch,
+  onBack,
+}: {
+  workspaceName: string
+  onSwitch: () => void
+  onBack: () => void
+}) {
+  return (
+    <EmptyState
+      className="h-full"
+      icon={<Icon name="workspace" strokeWidth={1.75} />}
+      title={`Switch to ${workspaceName}`}
+      description={`This artifact belongs to ${workspaceName}. Switch workspaces to view it.`}
+      action={
+        <div className="flex gap-2">
+          <Button data-testid="artifact-workspace-switch" onClick={onSwitch}>
+            Switch workspace
+          </Button>
+          <Button variant="outline" data-testid="artifact-workspace-back" onClick={onBack}>
+            Back to library
+          </Button>
+        </div>
+      }
+    />
+  )
+}
+
 // A TRANSIENT failure (network blip, a 5xx, the server briefly unhealthy) — distinct
 // from a real 404/403. The query already auto-retries with backoff; this is the
 // recoverable fallback once those are exhausted, so the page comes back with one

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -31,7 +31,12 @@ import { ArtifactChat, type RailTab } from "./artifact-chat"
 import { ArtifactComments } from "./artifact-comments"
 import { ArtifactDocument } from "./artifact-document"
 import { ArtifactInspect } from "./artifact-inspect"
-import { ArtifactLoadError, ArtifactNotFound, ArtifactRemoved } from "./artifact-states"
+import {
+  ArtifactLoadError,
+  ArtifactNotFound,
+  ArtifactRemoved,
+  ArtifactWrongWorkspace,
+} from "./artifact-states"
 import { ArtifactTopBar } from "./artifact-top-bar"
 import { BundleBar } from "./bundle-bar"
 import { ActionsCtx } from "./comment-actions"
@@ -110,6 +115,7 @@ function FocusShellSync({ focus }: { focus: boolean }) {
 }
 
 export function Artifact() {
+  const { switchWorkspace } = useShell()
   const { ref } = useParams({ from: "/artifacts/$ref" })
   const search = useSearch({ from: "/artifacts/$ref" })
   const { shortId, version } = parseRef(ref)
@@ -672,6 +678,17 @@ export function Artifact() {
   // background-refetch failure sets isError while react-query keeps `art` (e.g. a blip right
   // after a publish invalidates the query) — keep the loaded workbench, don't flash the error.
   if (failed && !art) {
+    if (error instanceof ApiError && error.code === "workspace_mismatch" && error.workspace) {
+      const workspace = error.workspace
+      const name = workspace.personal ? "Personal" : workspace.name
+      return (
+        <ArtifactWrongWorkspace
+          workspaceName={name}
+          onSwitch={() => switchWorkspace(workspace.id)}
+          onBack={() => nav({ to: "/" })}
+        />
+      )
+    }
     // A genuine 404/403 is "not found / no access". Anything else (a 5xx, a
     // network blip, the server briefly unhealthy) is transient — the query already
     // auto-retried with backoff, so offer a clean "Try again" rather than a

--- a/docs/access-model.md
+++ b/docs/access-model.md
@@ -27,6 +27,19 @@ Every artifact carries, independently:
 Plus, unchanged: `password_hash` (locks the world link), and explicit
 `artifact_member` / collection shares.
 
+The **active workspace** scopes authority. Workspace seats and owner-level
+artifact/collection grants count only when the artifact's workspace is active;
+switching away drops both. Explicit viewer/commenter/editor shares and world links
+remain portable, so a deliberate collaborator or link holder can still open the
+artifact from another workspace. Owner grants may only target members of the
+artifact's workspace.
+
+When a signed-in member would be able to read a private artifact after switching
+to its workspace, the detail endpoint returns a content-free `workspace_mismatch`
+hint. The client offers that switch directly. Everyone else still receives the
+ordinary not-found response, so the recovery path does not become an existence
+oracle.
+
 ## effectiveRole — the one gate
 
 Three grants, maxed. No coherence rule; no illegal combinations.
@@ -34,9 +47,10 @@ Three grants, maxed. No coherence rule; no illegal combinations.
 ```ts
 effectiveRole(actor, workspaceAccess, linkRole):
   if actor is a token        -> "owner"          // operator/internal
-  explicit = actor.artifactRole                   // a share or collection role, always
-  seat     = workspaceAccess === "member" && actor is a signed-in member of THIS
-             workspace ? actor.orgRole : null      // their SEAT role
+  explicit = actor.artifactRole                   // portable non-owner share, or owner
+                                                  // only in the active workspace
+  seat     = workspaceAccess === "member" && THIS workspace is active
+             && actor is its signed-in member ? actor.orgRole : null
   world    = linkRole === "none"        ? null     // link off
            : locked && !unlocked        ? null     // password gate
            : actor is a signed-in user  ? linkRole // any holder, member or not
@@ -60,7 +74,8 @@ artifact uses, so "who can open the collection" and "who can open what's inside"
 never diverge:
 
 - **Explicit** `collection_member` rows grant that role on every artifact in the
-  collection (can cross workspaces).
+  collection. Viewer/commenter/editor roles can cross workspaces; owner remains
+  bound to the collection's active workspace.
 - A **workspace-open** collection (`workspace_access = member`) additionally hands
   every workspace member their **seat role** on every artifact inside — the Share
   dialog's promise, "Everyone in the workspace opens this at their role." An
@@ -71,9 +86,10 @@ never diverge:
 effective role, and `collectionRole` gates collection visibility on the same rule —
 so a raw `COUNT(collection_item)` is always truthful for anyone who can see the
 collection (no "· 1 but empty"). The **creator** (`created_by`) is permanently
-owner and can never be demoted or removed; workspace admins may otherwise manage
-membership. Collections omit `listed`/`link_role` (a collection isn't individually
-link-servable — it's a grouping of artifacts, each with its own link).
+owner while that collection's workspace is active and can never be demoted or
+removed; workspace admins may otherwise manage membership. Collections omit
+`listed`/`link_role` (a collection isn't individually link-servable — it's a
+grouping of artifacts, each with its own link).
 
 ## Listing preconditions (the only invariants)
 

--- a/packages/core/src/permissions.ts
+++ b/packages/core/src/permissions.ts
@@ -58,7 +58,8 @@ export function capRole(role: Role | null, cap: Role): Role | null {
 export interface Actor {
   kind: "user" | "token" | "anon"
   userId?: string
-  /** Per-artifact role override (a share), if any. Beats the workspace role. */
+  /** Already-scoped per-artifact role. Request adapters remove workspace-bound
+   *  owner/seat grants before constructing an actor outside the active workspace. */
   artifactRole?: Role | null
   /** Baseline role from membership in the artifact's workspace, if any. */
   orgRole?: Role | null
@@ -75,7 +76,9 @@ export interface Actor {
  *
  *   access = max( explicit share , workspace seat , world link )
  *
- * EXPLICIT (`artifactRole`) — a per-artifact or collection share. Always counts.
+ * EXPLICIT (`artifactRole`) — an already-scoped per-artifact or collection grant.
+ * Portable collaborator shares always count; request adapters omit workspace-bound
+ * owner grants when the artifact's workspace is not active.
  *
  * WORKSPACE SEAT — when `workspaceAccess === "member"`, a signed-in member of the
  * ARTIFACT's workspace opens at their OWN seat role (`orgRole`): an editor edits,

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -930,13 +930,21 @@ export interface WorkspaceStore {
   countMemberships(orgId: string): Promise<number>
   /** Insert or update a member's workspace role. */
   setMembership(m: NewMembership): Promise<MembershipRecord>
+  /** Owned resources that would have no remaining workspace member able to
+   *  own them if this membership were removed. Used to make offboarding fail safe
+   *  instead of silently marooning workspace-bound ownership. */
+  workspaceOwnershipBlockers(
+    orgId: string,
+    userId: string,
+  ): Promise<{ artifacts: number; collections: number }>
   /** Remove a member from the workspace. */
   removeMembership(orgId: string, userId: string): Promise<void>
 
   getArtifactMember(artifactId: string, userId: string): Promise<ArtifactMemberRecord | null>
   listArtifactMembers(artifactId: string): Promise<ArtifactMemberRecord[]>
-  /** Artifact ids explicitly shared with a user (they hold a per-artifact
-   *  membership) — the "Shared with you" set; can span workspaces. */
+  /** Artifact ids explicitly shared with a user at a portable collaborator role
+   *  (viewer/commenter/editor) — the "Shared with you" set; can span workspaces.
+   *  Owner rows are workspace-bound ownership, not shares, and are excluded. */
   artifactIdsSharedWith(userId: string): Promise<string[]>
   /** Insert or update a per-artifact role override (a share). */
   setArtifactMember(m: NewArtifactMember): Promise<ArtifactMemberRecord>
@@ -1043,17 +1051,28 @@ export interface CollectionStore {
    *  ids with no member rows are absent from the map. Empty ids ⇒ {}. Drives the
    *  share dialog's collection-disclosure rows ("n collection members"). */
   collectionMemberCounts(collectionIds: string[]): Promise<Record<string, number>>
-  /** One user's role per collection over a set of collections, in TWO queries
-   *  (explicit member rows + the workspace seat on workspace-open collections,
-   *  higher wins) — the batched face of context.ts's collectionRole for the
-   *  artifact detail's disclosure rows. The caller still folds in created_by
-   *  (permanent owner) and the static token. Ids with no role are absent. */
-  collectionRolesForUser(collectionIds: string[], userId: string): Promise<Record<string, Role>>
+  /** One user's role per collection over a set of collections (explicit member rows
+   *  + the workspace seat on workspace-open collections, higher wins) — the batched
+   *  face of context.ts's collectionRole for artifact disclosure rows. Set
+   *  `includeWorkspaceSeats` false outside the active workspace. The caller still
+   *  folds in created_by (workspace-bound owner) and the static token. Ids with no
+   *  role are absent. */
+  collectionRolesForUser(
+    collectionIds: string[],
+    userId: string,
+    opts?: { includeWorkspaceSeats?: boolean },
+  ): Promise<Record<string, Role>>
   setCollectionMember(m: NewCollectionMember): Promise<CollectionMemberRecord>
   removeCollectionMember(collectionId: string, userId: string): Promise<void>
-  /** This user's collection-member roles over collections containing the
-   *  artifact — folded into their effective artifact role (collection sharing). */
-  collectionRolesForArtifact(artifactId: string, userId: string): Promise<Role[]>
+  /** This user's collection roles over collections containing the artifact — folded
+   *  into their effective artifact role. Set `includeWorkspaceSeats` false when the
+   *  artifact's workspace is not active: only portable explicit collection shares
+   *  are returned; workspace-open collection seats are workspace-bound. */
+  collectionRolesForArtifact(
+    artifactId: string,
+    userId: string,
+    opts?: { includeWorkspaceSeats?: boolean },
+  ): Promise<Role[]>
 
   /**
    * OPTIONAL FAST PATH: every grant one user holds over one artifact, in ONE round trip.
@@ -1071,14 +1090,15 @@ export interface CollectionStore {
    *
    * It never changes the ANSWER. `can()` remains the only place a decision is made; this only
    * changes how its inputs arrive. Returns exactly what the four calls would: the org role (null
-   * when not a member) and every artifact-level role — explicit and collection-derived —
-   * unreduced, so the caller folds them with maxRole as before.
+   * when not a member), every artifact-level role, and the portable subset (explicit non-owner
+   * artifact/collection shares, with seats and owners removed). Both role arrays are unreduced,
+   * so the caller folds them with maxRole as before.
    */
   artifactGrants?(
     artifactId: string,
     orgId: string,
     userId: string,
-  ): Promise<{ orgRole: Role | null; artifactRoles: Role[] }>
+  ): Promise<{ orgRole: Role | null; artifactRoles: Role[]; portableArtifactRoles: Role[] }>
 
   /**
    * `getByShortId` + `artifactGrants`, keyed on the SHORT ID, in one statement.
@@ -1155,7 +1175,12 @@ export interface CollectionStore {
   artifactWithGrants?(
     shortId: string,
     userId: string,
-  ): Promise<{ artifact: ArtifactRecord; orgRole: Role | null; artifactRoles: Role[] } | null>
+  ): Promise<{
+    artifact: ArtifactRecord
+    orgRole: Role | null
+    artifactRoles: Role[]
+    portableArtifactRoles: Role[]
+  } | null>
 
   // ---- Folders (organize a collection's artifacts; inherit its access, grant nothing) --
   createFolder(f: NewFolder): Promise<FolderRecord>

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -2176,6 +2176,68 @@ export class PgMetaStore implements MetaStore {
       .returning()
     return one(rows)
   }
+  async workspaceOwnershipBlockers(
+    orgId: string,
+    userId: string,
+  ): Promise<{ artifacts: number; collections: number }> {
+    const res = await this.db.execute(sql`
+      select 'artifacts' as kind, count(*) as n
+        from artifact a
+        join artifact_member mine
+          on mine.artifact_id = a.id
+         and mine.user_id = ${userId}
+         and mine.role = 'owner'
+       where a.org_id = ${orgId}
+         and not exists (
+           select 1
+             from artifact_member other
+             join membership active
+               on active.org_id = a.org_id
+              and active.user_id = other.user_id
+            where other.artifact_id = a.id
+              and other.user_id <> ${userId}
+              and other.role = 'owner'
+         )
+      union all
+      select 'collections', count(*)
+        from collection c
+       where c.org_id = ${orgId}
+         and (
+           c.created_by = ${userId}
+           or exists (
+             select 1 from collection_member mine
+              where mine.collection_id = c.id
+                and mine.user_id = ${userId}
+                and mine.role = 'owner'
+           )
+         )
+         and not exists (
+           select 1
+             from membership active
+            where active.org_id = c.org_id
+              and active.user_id <> ${userId}
+              and (
+                active.user_id = c.created_by
+                or exists (
+                  select 1 from collection_member other
+                   where other.collection_id = c.id
+                     and other.user_id = active.user_id
+                     and other.role = 'owner'
+                )
+              )
+         )
+    `)
+    const rows =
+      (
+        res as unknown as {
+          rows?: { kind: "artifacts" | "collections"; n: string | number }[]
+        }
+      ).rows ?? []
+    return {
+      artifacts: Number(rows.find((row) => row.kind === "artifacts")?.n ?? 0),
+      collections: Number(rows.find((row) => row.kind === "collections")?.n ?? 0),
+    }
+  }
   async removeMembership(orgId: string, userId: string): Promise<void> {
     await this.db
       .delete(membership)
@@ -2285,17 +2347,19 @@ export class PgMetaStore implements MetaStore {
     artifactId: string,
     orgId: string,
     userId: string,
-  ): Promise<{ orgRole: Role | null; artifactRoles: Role[] }> {
+  ): Promise<{ orgRole: Role | null; artifactRoles: Role[]; portableArtifactRoles: Role[] }> {
     const res = await this.db.execute(sql`
       select 'org' as kind, m.role as role
         from membership m
        where m.org_id = ${orgId} and m.user_id = ${userId}
       union all
-      select 'artifact' as kind, am.role as role
+      select case when am.role = 'owner' then 'artifact' else 'portable' end as kind,
+             am.role as role
         from artifact_member am
        where am.artifact_id = ${artifactId} and am.user_id = ${userId}
       union all
-      select 'artifact' as kind, cm.role as role
+      select case when cm.role = 'owner' then 'artifact' else 'portable' end as kind,
+             cm.role as role
         from collection_member cm
         join collection_item ci on ci.collection_id = cm.collection_id
        where ci.artifact_id = ${artifactId} and cm.user_id = ${userId}
@@ -2311,11 +2375,15 @@ export class PgMetaStore implements MetaStore {
     const rows = (res as unknown as { rows?: { kind: string; role: Role }[] }).rows ?? []
     let orgRole: Role | null = null
     const artifactRoles: Role[] = []
+    const portableArtifactRoles: Role[] = []
     for (const r of rows) {
       if (r.kind === "org") orgRole = r.role
-      else artifactRoles.push(r.role)
+      else {
+        artifactRoles.push(r.role)
+        if (r.kind === "portable") portableArtifactRoles.push(r.role)
+      }
     }
-    return { orgRole, artifactRoles }
+    return { orgRole, artifactRoles, portableArtifactRoles }
   }
   // `getByShortId` + `artifactGrants` as ONE statement — see the port doc. The artifact
   // resolves in a CTE and every grant arm joins to it, so the caller's standing comes back
@@ -2325,7 +2393,12 @@ export class PgMetaStore implements MetaStore {
   async artifactWithGrants(
     shortId: string,
     userId: string,
-  ): Promise<{ artifact: ArtifactRecord; orgRole: Role | null; artifactRoles: Role[] } | null> {
+  ): Promise<{
+    artifact: ArtifactRecord
+    orgRole: Role | null
+    artifactRoles: Role[]
+    portableArtifactRoles: Role[]
+  } | null> {
     const res = await this.db.execute(sql`
       with a as (select * from artifact where short_id = ${shortId})
       select 'artifact' as kind, to_jsonb(a) as doc from a
@@ -2333,10 +2406,10 @@ export class PgMetaStore implements MetaStore {
       select 'org', to_jsonb(m.role)
         from a join membership m on m.org_id = a.org_id and m.user_id = ${userId}
       union all
-      select 'grant', to_jsonb(am.role)
+      select case when am.role = 'owner' then 'grant' else 'portable' end, to_jsonb(am.role)
         from a join artifact_member am on am.artifact_id = a.id and am.user_id = ${userId}
       union all
-      select 'grant', to_jsonb(cm.role)
+      select case when cm.role = 'owner' then 'grant' else 'portable' end, to_jsonb(cm.role)
         from a
         join collection_item ci on ci.artifact_id = a.id
         join collection_member cm on cm.collection_id = ci.collection_id and cm.user_id = ${userId}
@@ -2351,14 +2424,18 @@ export class PgMetaStore implements MetaStore {
     let record: ArtifactRecord | null = null
     let orgRole: Role | null = null
     const artifactRoles: Role[] = []
+    const portableArtifactRoles: Role[] = []
     for (const r of rows) {
       if (r.kind === "artifact") record = r.doc as ArtifactRecord
       else if (r.kind === "org") orgRole = r.doc as Role
-      else artifactRoles.push(r.doc as Role)
+      else {
+        artifactRoles.push(r.doc as Role)
+        if (r.kind === "portable") portableArtifactRoles.push(r.doc as Role)
+      }
     }
     // No artifact row means no such short id — and then no grant arm could have matched
     // either, since every one of them joins through it.
-    return record ? { artifact: record, orgRole, artifactRoles } : null
+    return record ? { artifact: record, orgRole, artifactRoles, portableArtifactRoles } : null
   }
   async artifactRolesFor(userId: string, artifactIds: string[]): Promise<Record<string, Role>> {
     if (artifactIds.length === 0) return {}
@@ -2370,10 +2447,10 @@ export class PgMetaStore implements MetaStore {
       )
     return Object.fromEntries(rows.map((r) => [r.artifact_id, r.role]))
   }
-  // Artifacts explicitly shared with a user (per-artifact membership) — can span
-  // workspaces; drives the home's "Shared with you" section. Excludes what they
-  // authored: the creator's own owner-member row (written at publish) is
-  // ownership, not a share (see repos.ts).
+  // Artifacts explicitly shared with a user at a portable collaborator role — can
+  // span workspaces and drive the home's "Shared with you" section. Owner rows are
+  // workspace-bound ownership, not shares. The author check additionally protects
+  // historical creator rows (see repos.ts).
   async artifactIdsSharedWith(userId: string): Promise<string[]> {
     const rows = await this.db
       .select({ id: artifactMember.artifact_id })
@@ -2382,6 +2459,7 @@ export class PgMetaStore implements MetaStore {
       .where(
         and(
           eq(artifactMember.user_id, userId),
+          ne(artifactMember.role, "owner"),
           or(isNull(artifact.author_id), ne(artifact.author_id, userId)),
         ),
       )
@@ -3052,7 +3130,11 @@ export class PgMetaStore implements MetaStore {
         and(eq(collectionMember.collection_id, collectionId), eq(collectionMember.user_id, userId)),
       )
   }
-  async collectionRolesForArtifact(artifactId: string, userId: string): Promise<Role[]> {
+  async collectionRolesForArtifact(
+    artifactId: string,
+    userId: string,
+    opts?: { includeWorkspaceSeats?: boolean },
+  ): Promise<Role[]> {
     // Explicit collectionMember rows on any collection holding this artifact.
     const explicit = await this.db
       .select({ role: collectionMember.role })
@@ -3063,32 +3145,49 @@ export class PgMetaStore implements MetaStore {
     // inside it — "Everyone in the workspace opens this at their role" (the Share
     // dialog's promise; see access-model.md). Join the artifact's collections to the
     // viewer's membership in each collection's org, keeping only workspace-open ones.
-    const seat = await this.db
-      .select({ role: membership.role })
-      .from(collectionItem)
-      .innerJoin(collection, eq(collection.id, collectionItem.collection_id))
-      .innerJoin(membership, eq(membership.org_id, collection.org_id))
-      .where(
-        and(
-          eq(collectionItem.artifact_id, artifactId),
-          eq(collection.workspace_access, "member"),
-          eq(membership.user_id, userId),
-        ),
-      )
+    const seat =
+      opts?.includeWorkspaceSeats === false
+        ? []
+        : await this.db
+            .select({ role: membership.role })
+            .from(collectionItem)
+            .innerJoin(collection, eq(collection.id, collectionItem.collection_id))
+            .innerJoin(membership, eq(membership.org_id, collection.org_id))
+            .where(
+              and(
+                eq(collectionItem.artifact_id, artifactId),
+                eq(collection.workspace_access, "member"),
+                eq(membership.user_id, userId),
+              ),
+            )
     return [...explicit, ...seat].map((r) => r.role)
   }
   async collectionRolesForUser(
     collectionIds: string[],
     userId: string,
+    opts?: { includeWorkspaceSeats?: boolean },
   ): Promise<Record<string, Role>> {
     if (collectionIds.length === 0) return {}
     // Same two sources as collectionRolesForArtifact, keyed per collection: the user's
     // explicit member rows, and their SEAT on each workspace-open collection — a UNION ALL
     // instead of two sequential awaits, since both are scoped to the same collectionIds.
-    const { rows } = await this.pool.query<{ id: string; role: Role }>(
-      collectionRolesSql("SELECT unnest($1::text[])", "$2"),
-      [collectionIds, userId],
-    )
+    const rows =
+      opts?.includeWorkspaceSeats === false
+        ? await this.db
+            .select({ id: collectionMember.collection_id, role: collectionMember.role })
+            .from(collectionMember)
+            .where(
+              and(
+                inArray(collectionMember.collection_id, collectionIds),
+                eq(collectionMember.user_id, userId),
+              ),
+            )
+        : (
+            await this.pool.query<{ id: string; role: Role }>(
+              collectionRolesSql("SELECT unnest($1::text[])", "$2"),
+              [collectionIds, userId],
+            )
+          ).rows
     const out: Record<string, Role> = {}
     for (const r of rows) out[r.id] = maxRole(out[r.id] ?? null, r.role) as Role
     return out

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -1514,6 +1514,62 @@ export function makeRepos(db: SqliteDb) {
       })
       .returning()
       .get()) as MembershipRecord
+  const workspaceOwnershipBlockers = async (
+    orgId: string,
+    userId: string,
+  ): Promise<{ artifacts: number; collections: number }> => {
+    const rows = (await db.all(sql`
+      SELECT 'artifacts' AS kind, count(*) AS n
+        FROM artifact a
+        JOIN artifact_member mine
+          ON mine.artifact_id = a.id
+         AND mine.user_id = ${userId}
+         AND mine.role = 'owner'
+       WHERE a.org_id = ${orgId}
+         AND NOT EXISTS (
+           SELECT 1
+             FROM artifact_member other
+             JOIN membership active
+               ON active.org_id = a.org_id
+              AND active.user_id = other.user_id
+            WHERE other.artifact_id = a.id
+              AND other.user_id <> ${userId}
+              AND other.role = 'owner'
+         )
+      UNION ALL
+      SELECT 'collections', count(*)
+        FROM collection c
+       WHERE c.org_id = ${orgId}
+         AND (
+           c.created_by = ${userId}
+           OR EXISTS (
+             SELECT 1 FROM collection_member mine
+              WHERE mine.collection_id = c.id
+                AND mine.user_id = ${userId}
+                AND mine.role = 'owner'
+           )
+         )
+         AND NOT EXISTS (
+           SELECT 1
+             FROM membership active
+            WHERE active.org_id = c.org_id
+              AND active.user_id <> ${userId}
+              AND (
+                active.user_id = c.created_by
+                OR EXISTS (
+                  SELECT 1 FROM collection_member other
+                   WHERE other.collection_id = c.id
+                     AND other.user_id = active.user_id
+                     AND other.role = 'owner'
+                )
+              )
+         )
+    `)) as { kind: "artifacts" | "collections"; n: number }[]
+    return {
+      artifacts: Number(rows.find((row) => row.kind === "artifacts")?.n ?? 0),
+      collections: Number(rows.find((row) => row.kind === "collections")?.n ?? 0),
+    }
+  }
   const removeMembership = async (orgId: string, userId: string): Promise<void> => {
     await db
       .delete(membership)
@@ -1569,6 +1625,52 @@ export function makeRepos(db: SqliteDb) {
       .get()) ?? null
   const listArtifactMembers = async (artifactId: string): Promise<ArtifactMemberRecord[]> =>
     db.select().from(artifactMember).where(eq(artifactMember.artifact_id, artifactId)).all()
+  // The embedded-store fast path mirrors Postgres's four-arm UNION. It matters less
+  // for local latency, but keeps active-workspace authorization from adding another
+  // store call on the document-open path and gives both dialects one grant shape.
+  const artifactGrants = async (
+    artifactId: string,
+    orgId: string,
+    userId: string,
+  ): Promise<{
+    orgRole: Role | null
+    artifactRoles: Role[]
+    portableArtifactRoles: Role[]
+  }> => {
+    const rows = (await db.all(sql`
+      SELECT 'org' AS kind, m.role AS role
+        FROM membership m
+       WHERE m.org_id = ${orgId} AND m.user_id = ${userId}
+      UNION ALL
+      SELECT CASE WHEN am.role = 'owner' THEN 'artifact' ELSE 'portable' END, am.role
+        FROM artifact_member am
+       WHERE am.artifact_id = ${artifactId} AND am.user_id = ${userId}
+      UNION ALL
+      SELECT CASE WHEN cm.role = 'owner' THEN 'artifact' ELSE 'portable' END, cm.role
+        FROM collection_member cm
+        JOIN collection_item ci ON ci.collection_id = cm.collection_id
+       WHERE ci.artifact_id = ${artifactId} AND cm.user_id = ${userId}
+      UNION ALL
+      SELECT 'artifact', m2.role
+        FROM collection_item ci2
+        JOIN collection c ON c.id = ci2.collection_id
+        JOIN membership m2 ON m2.org_id = c.org_id
+       WHERE ci2.artifact_id = ${artifactId}
+         AND c.workspace_access = 'member'
+         AND m2.user_id = ${userId}
+    `)) as { kind: "org" | "artifact" | "portable"; role: Role }[]
+    let orgRole: Role | null = null
+    const artifactRoles: Role[] = []
+    const portableArtifactRoles: Role[] = []
+    for (const row of rows) {
+      if (row.kind === "org") orgRole = row.role
+      else {
+        artifactRoles.push(row.role)
+        if (row.kind === "portable") portableArtifactRoles.push(row.role)
+      }
+    }
+    return { orgRole, artifactRoles, portableArtifactRoles }
+  }
   const artifactRolesFor = async (
     userId: string,
     artifactIds: string[],
@@ -1583,8 +1685,9 @@ export function makeRepos(db: SqliteDb) {
       .all()
     return Object.fromEntries(rows.map((r) => [r.artifact_id, r.role]))
   }
-  // Artifacts explicitly shared with a user (they hold a per-artifact membership) —
-  // the "Shared with you" set, which can span workspaces.
+  // Artifacts explicitly shared with a user at a portable collaborator role —
+  // the "Shared with you" set, which can span workspaces. Owner rows are
+  // workspace-bound ownership, not shares.
   // "Shared with me" excludes what I authored: publishing writes the creator an
   // owner-member row (that's how `private` knows its owner), and without the
   // author check every artifact you make would land in your own shared feed.
@@ -1597,6 +1700,7 @@ export function makeRepos(db: SqliteDb) {
         .where(
           and(
             eq(artifactMember.user_id, userId),
+            ne(artifactMember.role, "owner"),
             // NULL-safe: a token-published artifact (author_id null) shared with
             // you still counts — plain != would drop the NULL rows.
             or(isNull(artifact.author_id), ne(artifact.author_id, userId)),
@@ -2347,6 +2451,7 @@ export function makeRepos(db: SqliteDb) {
   const collectionRolesForArtifact = async (
     artifactId: string,
     userId: string,
+    opts?: { includeWorkspaceSeats?: boolean },
   ): Promise<Role[]> => {
     // Explicit collectionMember rows on any collection holding this artifact.
     const explicit = await db
@@ -2359,24 +2464,28 @@ export function makeRepos(db: SqliteDb) {
     // inside it — "Everyone in the workspace opens this at their role" (the Share
     // dialog's promise; see access-model.md). Join the artifact's collections to the
     // viewer's membership in each collection's org, keeping only workspace-open ones.
-    const seat = await db
-      .select({ role: membership.role })
-      .from(collectionItem)
-      .innerJoin(collection, eq(collection.id, collectionItem.collection_id))
-      .innerJoin(membership, eq(membership.org_id, collection.org_id))
-      .where(
-        and(
-          eq(collectionItem.artifact_id, artifactId),
-          eq(collection.workspace_access, "member"),
-          eq(membership.user_id, userId),
-        ),
-      )
-      .all()
+    const seat =
+      opts?.includeWorkspaceSeats === false
+        ? []
+        : await db
+            .select({ role: membership.role })
+            .from(collectionItem)
+            .innerJoin(collection, eq(collection.id, collectionItem.collection_id))
+            .innerJoin(membership, eq(membership.org_id, collection.org_id))
+            .where(
+              and(
+                eq(collectionItem.artifact_id, artifactId),
+                eq(collection.workspace_access, "member"),
+                eq(membership.user_id, userId),
+              ),
+            )
+            .all()
     return [...explicit, ...seat].map((r) => r.role)
   }
   const collectionRolesForUser = async (
     collectionIds: string[],
     userId: string,
+    opts?: { includeWorkspaceSeats?: boolean },
   ): Promise<Record<string, Role>> => {
     if (collectionIds.length === 0) return {}
     // Same two sources as collectionRolesForArtifact, keyed per collection: the
@@ -2391,18 +2500,21 @@ export function makeRepos(db: SqliteDb) {
         ),
       )
       .all()
-    const seat = await db
-      .select({ id: collection.id, role: membership.role })
-      .from(collection)
-      .innerJoin(membership, eq(membership.org_id, collection.org_id))
-      .where(
-        and(
-          inArray(collection.id, collectionIds),
-          eq(collection.workspace_access, "member"),
-          eq(membership.user_id, userId),
-        ),
-      )
-      .all()
+    const seat =
+      opts?.includeWorkspaceSeats === false
+        ? []
+        : await db
+            .select({ id: collection.id, role: membership.role })
+            .from(collection)
+            .innerJoin(membership, eq(membership.org_id, collection.org_id))
+            .where(
+              and(
+                inArray(collection.id, collectionIds),
+                eq(collection.workspace_access, "member"),
+                eq(membership.user_id, userId),
+              ),
+            )
+            .all()
     const out: Record<string, Role> = {}
     for (const r of [...explicit, ...seat]) out[r.id] = maxRole(out[r.id] ?? null, r.role) as Role
     return out
@@ -4584,6 +4696,7 @@ export function makeRepos(db: SqliteDb) {
     listMembershipsForOrgs,
     countMemberships,
     setMembership,
+    workspaceOwnershipBlockers,
     removeMembership,
     getWorkspace,
     setWorkspace,
@@ -4591,6 +4704,7 @@ export function makeRepos(db: SqliteDb) {
     listWorkspaces,
     getArtifactMember,
     listArtifactMembers,
+    artifactGrants,
     artifactRolesFor,
     artifactIdsSharedWith,
     setArtifactMember,

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -88,6 +88,67 @@ export function runStoreContract(
       expect(await store.getMembership(ORG, "temp")).toBeNull()
     })
 
+    it("finds ownership that must be handed off before a member leaves", async () => {
+      const org = `org_handoff_${uuid()}`
+      const leaver = `leaver_${uuid()}`
+      const successor = `successor_${uuid()}`
+      await store.setWorkspace(org, "Handoff")
+      await store.setMembership({ id: uuid(), org_id: org, user_id: leaver, role: "editor" })
+      await store.setMembership({ id: uuid(), org_id: org, user_id: successor, role: "owner" })
+
+      const artifact = await store.createArtifact(
+        newArtifact({ org_id: org, author_id: leaver, workspace_access: "none" }),
+      )
+      await store.setArtifactMember({
+        id: uuid(),
+        artifact_id: artifact.id,
+        user_id: leaver,
+        role: "owner",
+      })
+      const collection = await store.createCollection({
+        id: uuid(),
+        org_id: org,
+        title: "Private collection",
+        created_by: leaver,
+        workspace_access: "none",
+      })
+      await store.setCollectionMember({
+        id: uuid(),
+        collection_id: collection.id,
+        user_id: leaver,
+        role: "owner",
+      })
+
+      expect(await store.workspaceOwnershipBlockers(org, leaver)).toEqual({
+        artifacts: 1,
+        collections: 1,
+      })
+
+      await store.setArtifactMember({
+        id: uuid(),
+        artifact_id: artifact.id,
+        user_id: successor,
+        role: "owner",
+      })
+      await store.setCollectionMember({
+        id: uuid(),
+        collection_id: collection.id,
+        user_id: successor,
+        role: "owner",
+      })
+      expect(await store.workspaceOwnershipBlockers(org, leaver)).toEqual({
+        artifacts: 0,
+        collections: 0,
+      })
+
+      // A stale owner row belonging to someone who has left is not a handoff.
+      await store.removeMembership(org, successor)
+      expect(await store.workspaceOwnershipBlockers(org, leaver)).toEqual({
+        artifacts: 1,
+        collections: 1,
+      })
+    })
+
     it("workspacesAndOauthBinding matches the two calls it replaces", async () => {
       const orgA = `org_${uuid()}`
       const orgB = `org_${uuid()}`
@@ -898,6 +959,24 @@ export function runStoreContract(
       expect(await store.getArtifactMember(a.id, "bob")).toBeNull()
     })
 
+    it("treats collaborator rows, but not owner rows, as cross-workspace shares", async () => {
+      const a = await store.createArtifact(newArtifact({ author_id: "amy" }))
+      await store.setArtifactMember({
+        id: uuid(),
+        artifact_id: a.id,
+        user_id: "bob",
+        role: "owner",
+      })
+      expect(await store.artifactIdsSharedWith("bob")).not.toContain(a.id)
+      await store.setArtifactMember({
+        id: uuid(),
+        artifact_id: a.id,
+        user_id: "bob",
+        role: "editor",
+      })
+      expect(await store.artifactIdsSharedWith("bob")).toContain(a.id)
+    })
+
     it("stars + unstars an artifact", async () => {
       const a = await store.createArtifact(newArtifact())
       await store.setFavorite(a.id, "amy")
@@ -1616,6 +1695,9 @@ export function runStoreContract(
       expect(await store.getCollectionMember(col.id, "bob")).toMatchObject({ role: "viewer" })
       expect(await store.listCollectionMembers(col.id)).toHaveLength(1)
       expect(await store.collectionRolesForArtifact(a.id, "bob")).toContain("viewer")
+      expect(
+        await store.collectionRolesForArtifact(a.id, "bob", { includeWorkspaceSeats: false }),
+      ).toContain("viewer")
 
       const renamed = await store.updateCollection(col.id, { title: "Renamed" })
       expect(renamed?.title).toBe("Renamed")
@@ -1645,6 +1727,11 @@ export function runStoreContract(
       })
       await store.addCollectionItem(open.id, priv.id)
       expect(await store.collectionRolesForArtifact(priv.id, "carol")).toContain("editor")
+      expect(
+        await store.collectionRolesForArtifact(priv.id, "carol", {
+          includeWorkspaceSeats: false,
+        }),
+      ).toHaveLength(0)
 
       // An invite-only collection (workspace_access=none) grants a bare seat nothing —
       // only its explicit members reach it.
@@ -2138,6 +2225,11 @@ export function runStoreContract(
       expect(roles[seated.id]).toBe("viewer") // seat only
       expect(roles[inviteOnly.id]).toBe("owner") // explicit share only
       expect(roles[untouched.id]).toBeUndefined() // neither
+      expect(
+        await store.collectionRolesForUser([seated.id, inviteOnly.id, untouched.id], "bob", {
+          includeWorkspaceSeats: false,
+        }),
+      ).toEqual({ [inviteOnly.id]: "owner" })
     })
 
     it("notificationsPage matches listNotifications + unreadNotificationCount, and unread counts the WHOLE history not just the page", async () => {
@@ -5105,12 +5197,26 @@ export function runStoreContract(
         const orgRole = (await store.getMembership(orgId, userId))?.role ?? null
         const am = await store.getArtifactMember(art.id, userId)
         const cRoles = await store.collectionRolesForArtifact(art.id, userId)
-        return { orgRole, artifactRole: maxRole(am?.role ?? null, ...cRoles) }
+        const portableCollectionRoles = await store.collectionRolesForArtifact(art.id, userId, {
+          includeWorkspaceSeats: false,
+        })
+        return {
+          orgRole,
+          artifactRole: maxRole(am?.role ?? null, ...cRoles),
+          portableArtifactRole: maxRole(
+            am?.role === "owner" ? null : (am?.role ?? null),
+            ...portableCollectionRoles.filter((role) => role !== "owner"),
+          ),
+        }
       }
       const fast = async (orgId: string, userId: string) => {
         const g = await store.artifactGrants?.(art.id, orgId, userId)
         if (!g) throw new Error("artifactGrants vanished mid-test")
-        return { orgRole: g.orgRole, artifactRole: maxRole(null, ...g.artifactRoles) }
+        return {
+          orgRole: g.orgRole,
+          artifactRole: maxRole(null, ...g.artifactRoles),
+          portableArtifactRole: maxRole(null, ...g.portableArtifactRoles),
+        }
       }
 
       // The THIRD path: the same grants, resolved by SHORT ID alongside the artifact row,
@@ -5119,7 +5225,11 @@ export function runStoreContract(
       const combined = async (userId: string) => {
         const r = await store.artifactWithGrants?.(art.short_id, userId)
         if (!r) throw new Error("artifactWithGrants found no artifact")
-        return { orgRole: r.orgRole, artifactRole: maxRole(null, ...r.artifactRoles) }
+        return {
+          orgRole: r.orgRole,
+          artifactRole: maxRole(null, ...r.artifactRoles),
+          portableArtifactRole: maxRole(null, ...r.portableArtifactRoles),
+        }
       }
 
       for (const u of [owner, member, sharee, collab, stranger]) {
@@ -5214,11 +5324,22 @@ export function runStoreContract(
           const orgRole = (await store.getMembership(org, u))?.role ?? null
           const am = await store.getArtifactMember(art.id, u)
           const cRoles = await store.collectionRolesForArtifact(art.id, u)
-          const slow = { orgRole, artifactRole: maxRole(am?.role ?? null, ...cRoles) }
+          const portableCollectionRoles = await store.collectionRolesForArtifact(art.id, u, {
+            includeWorkspaceSeats: false,
+          })
+          const slow = {
+            orgRole,
+            artifactRole: maxRole(am?.role ?? null, ...cRoles),
+            portableArtifactRole: maxRole(
+              am?.role === "owner" ? null : (am?.role ?? null),
+              ...portableCollectionRoles.filter((role) => role !== "owner"),
+            ),
+          }
           const g = await store.artifactGrants?.(art.id, org, u)
           const fast = {
             orgRole: g?.orgRole ?? null,
             artifactRole: maxRole(null, ...(g?.artifactRoles ?? [])),
+            portableArtifactRole: maxRole(null, ...(g?.portableArtifactRoles ?? [])),
           }
           expect(fast, `round ${round} (seed ${startSeed}) disagreed for ${u}`).toEqual(slow)
         }


### PR DESCRIPTION
## Summary

- scope implicit workspace, artifact-owner, and collection-owner authority to the active workspace while keeping explicit shares and public links portable
- return a content-free workspace-switch hint only when switching would grant access, and render a direct switch-workspace action in the artifact UI
- apply the same boundary to artifact detail/raw access, chat, collections, copying/templates, ownership assignment, member offboarding, and account deletion
- prevent account deletion from orphaning private artifacts or collections, including surviving personal-workspace artifacts
- document the access model and add API, database-contract, and web regression coverage

## Testing

- `pnpm verify`
  - API: 2,334 passed, 3 skipped
  - MCP: 34 passed
  - all lint/guardrail, typecheck, and package coverage gates passed
