### PR TITLE
fix: name workspace in switch action

### DIFF
--- a/apps/web/src/pages/artifact/artifact-states.test.ts
+++ b/apps/web/src/pages/artifact/artifact-states.test.ts
@@ -15,7 +15,7 @@ describe("ArtifactWrongWorkspace", () => {
 
     expect(html).toContain("Switch to Acme")
     expect(html).toContain("This artifact belongs to Acme")
-    expect(html).toContain('data-testid="artifact-workspace-switch"')
+    expect(html).toContain('data-testid="artifact-workspace-switch">Switch to Acme</button>')
     expect(html).toContain('data-testid="artifact-workspace-back"')
   })
 })

--- a/apps/web/src/pages/artifact/artifact-states.tsx
+++ b/apps/web/src/pages/artifact/artifact-states.tsx
@@ -41,7 +41,7 @@ export function ArtifactWrongWorkspace({
       action={
         <div className="flex gap-2">
           <Button data-testid="artifact-workspace-switch" onClick={onSwitch}>
-            Switch workspace
+            Switch to {workspaceName}
           </Button>
           <Button variant="outline" data-testid="artifact-workspace-back" onClick={onBack}>
             Back to library


### PR DESCRIPTION
Updates the wrong-workspace action to name its destination, for example: Switch to Acme. The component test now locks the dynamic button label to the workspace name.\n\nValidation: pnpm verify

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/710"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789234332&installation_model_id=428097&pr_number=710&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F710&signature=63bfb73b98477d815a562c8665033283f8c6593facb1de1b241f564dd505320c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->