### PR TITLE
Add collection link and password sharing

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1438,6 +1438,24 @@
             ],
             "description": "Workspace share scope: \"member\" (all members) or \"none\" (invite-only)."
           },
+          "link_role": {
+            "type": "string",
+            "enum": [
+              "none",
+              "viewer",
+              "commenter",
+              "editor"
+            ],
+            "description": "What merely holding the canonical collection link grants."
+          },
+          "password_protected": {
+            "type": "boolean",
+            "description": "Whether the collection world link requires a password."
+          },
+          "url": {
+            "type": "string",
+            "description": "Canonical share URL for this collection."
+          },
           "my_role": {
             "type": "string",
             "nullable": true,
@@ -1448,7 +1466,11 @@
               "owner",
               null
             ],
-            "description": "Caller's own role on the collection; drives the Share dialog. Null if none."
+            "description": "Caller's effective role on the collection. Null if none."
+          },
+          "can_share": {
+            "type": "boolean",
+            "description": "Whether the caller has standing (not merely a world-link role) to change collection sharing."
           },
           "starred": {
             "type": "boolean",
@@ -5659,6 +5681,85 @@
         }
       }
     },
+    "/v1/collections/{id}": {
+      "get": {
+        "tags": [
+          "Collections"
+        ],
+        "summary": "Get one collection through standing or its world link.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The collection.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Collection"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Collections"
+        ],
+        "summary": "Rename a collection.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The updated collection.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Collection"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Collections"
+        ],
+        "summary": "Delete a collection.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The collection was deleted."
+          }
+        }
+      }
+    },
     "/v1/collections": {
       "get": {
         "tags": [
@@ -5782,63 +5883,12 @@
         }
       }
     },
-    "/v1/collections/{id}": {
-      "patch": {
-        "tags": [
-          "Collections"
-        ],
-        "summary": "Rename a collection.",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "id",
-            "in": "path"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "The updated collection.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Collection"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Collections"
-        ],
-        "summary": "Delete a collection.",
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "id",
-            "in": "path"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "The collection was deleted."
-          }
-        }
-      }
-    },
     "/v1/collections/{id}/access": {
       "patch": {
         "tags": [
           "Collections"
         ],
-        "summary": "Change a collection's workspace access.",
+        "summary": "Change a collection's workspace and link access.",
         "parameters": [
           {
             "schema": {
@@ -5864,10 +5914,62 @@
                         "member"
                       ],
                       "description": "The collection's new workspace share scope."
+                    },
+                    "link_role": {
+                      "type": "string",
+                      "enum": [
+                        "none",
+                        "viewer",
+                        "commenter",
+                        "editor"
+                      ]
+                    },
+                    "locked": {
+                      "type": "boolean"
                     }
                   },
                   "required": [
-                    "workspace_access"
+                    "workspace_access",
+                    "link_role",
+                    "locked"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/collections/{id}/unlock": {
+      "post": {
+        "tags": [
+          "Collections"
+        ],
+        "summary": "Unlock a password-protected collection link.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Unlocked.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
                   ]
                 }
               }
@@ -6045,11 +6147,48 @@
                       "items": {
                         "$ref": "#/components/schemas/ArtifactMember"
                       }
+                    },
+                    "invites": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "email": {
+                            "type": "string"
+                          },
+                          "role": {
+                            "type": "string",
+                            "enum": [
+                              "viewer",
+                              "commenter",
+                              "editor",
+                              "owner"
+                            ]
+                          },
+                          "created_at": {
+                            "type": "string"
+                          },
+                          "expires_at": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "email",
+                          "role",
+                          "created_at",
+                          "expires_at"
+                        ]
+                      }
                     }
                   },
                   "required": [
                     "created_by",
-                    "members"
+                    "members",
+                    "invites"
                   ]
                 }
               }
@@ -6074,11 +6213,82 @@
         ],
         "responses": {
           "201": {
-            "description": "The added member.",
+            "description": "The member added directly, or a pending emailed invite.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ArtifactMember"
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "member"
+                          ]
+                        },
+                        "member": {
+                          "$ref": "#/components/schemas/ArtifactMember"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "member"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "invite"
+                          ]
+                        },
+                        "invite": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string"
+                            },
+                            "email": {
+                              "type": "string"
+                            },
+                            "role": {
+                              "type": "string",
+                              "enum": [
+                                "viewer",
+                                "commenter",
+                                "editor",
+                                "owner"
+                              ]
+                            },
+                            "created_at": {
+                              "type": "string"
+                            },
+                            "expires_at": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "email",
+                            "role",
+                            "created_at",
+                            "expires_at"
+                          ]
+                        },
+                        "accept_url": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "invite",
+                        "accept_url"
+                      ]
+                    }
+                  ]
                 }
               }
             }
@@ -6113,6 +6323,142 @@
         "responses": {
           "204": {
             "description": "The member was removed."
+          }
+        }
+      }
+    },
+    "/v1/collections/{id}/invites/{inviteId}": {
+      "delete": {
+        "tags": [
+          "Collections"
+        ],
+        "summary": "Revoke a pending collection invitation.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "inviteId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The invitation was revoked."
+          }
+        }
+      }
+    },
+    "/v1/collection-invites/{token}": {
+      "get": {
+        "tags": [
+          "Collections"
+        ],
+        "summary": "Preview a collection invitation.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "token",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The collection and role the token grants.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    },
+                    "role": {
+                      "type": "string",
+                      "enum": [
+                        "viewer",
+                        "commenter",
+                        "editor",
+                        "owner"
+                      ]
+                    },
+                    "email": {
+                      "type": "string"
+                    },
+                    "inviter": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  },
+                  "required": [
+                    "title",
+                    "role",
+                    "email",
+                    "inviter"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/collection-invites/{token}/accept": {
+      "post": {
+        "tags": [
+          "Collections"
+        ],
+        "summary": "Accept a collection invitation.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "token",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The collection joined and granted role.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "collection_id": {
+                      "type": "string"
+                    },
+                    "role": {
+                      "type": "string",
+                      "enum": [
+                        "viewer",
+                        "commenter",
+                        "editor",
+                        "owner"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "collection_id",
+                    "role"
+                  ]
+                }
+              }
+            }
           }
         }
       }

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -393,6 +393,7 @@ export function createApp(deps: AppDeps): Hono {
     /^\/v1\/artifacts\/[^/]+\/cursor$/, // ephemeral live cursor (viral viewing)
     /^\/v1\/artifacts\/[^/]+\/view$/, // de-duped, anonymous-safe view counter
     /^\/v1\/artifacts\/[^/]+\/unlock$/, // password unlock — the password is the gate
+    /^\/v1\/collections\/[^/]+\/unlock$/, // collection password unlock — password is the gate
     /^\/v1\/vitals$/, // anonymous Core Web Vitals beacon (telemetry, no state)
     /^\/v1\/beta\/signup$/, // marketing-site beta signup — anonymous is the point; IP-capped
     /^\/v1\/sync\/github\/webhook$/, // GitHub App webhook — HMAC signature is the gate

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -11,9 +11,11 @@ import {
   can,
   capRole,
   DEFAULT_VERSION_WINDOW_MS,
+  effectiveRole,
   FREE_SEAT_LIMIT,
   isAuthenticated,
   isBundleContentType,
+  type LinkRole,
   type MembershipRecord,
   type MetaStore,
   maxRole,
@@ -39,7 +41,14 @@ import type { BillingDriver } from "./lib/billing"
 import type { CustomDomainProvider } from "./lib/cloudflare-saas"
 import type { Sandbox } from "./lib/code-sandbox"
 import { answerDeriveMention } from "./lib/comment-turn"
-import { AGENT_TOKEN_PREFIX, safeEqual, sha256, unlockCookie, unlockToken } from "./lib/crypto"
+import {
+  AGENT_TOKEN_PREFIX,
+  safeEqual,
+  sha256,
+  subjectUnlockCookie,
+  unlockCookie,
+  unlockToken,
+} from "./lib/crypto"
 import { fail, VIEWER_COOKIE, WS_COOKIE } from "./lib/http"
 import { INSTANCE_SETTINGS_ID } from "./lib/instance-settings"
 import { catalogOf, type GatewayConfig, type ModelCatalog } from "./lib/model-catalog"
@@ -1242,6 +1251,48 @@ export function buildContext(deps: AppDeps) {
     return pending
   }
 
+  const openCollectionLinkRole = (
+    c: Context,
+    col: CollectionRecord,
+  ): Exclude<LinkRole, "none"> | null => {
+    if (col.link_role === "none") return null
+    if (!col.password_hash) return col.link_role
+    const unlocked = safeEqual(
+      getCookie(c, subjectUnlockCookie("collection", col.id)) ?? "",
+      unlockToken(col.id, col.password_hash),
+    )
+    return unlocked ? col.link_role : null
+  }
+
+  // A collection's world link is an additive grant on every artifact it contains.
+  // Resolve all containing collections in one join, then reuse maxRole/effectiveRole;
+  // there is no second collection-specific permission ladder.
+  const inheritedCollectionLinkRole = async (
+    c: Context,
+    artifactId: string,
+  ): Promise<Exclude<LinkRole, "none"> | null> => {
+    const roles = (await meta.collectionsForArtifact(artifactId))
+      .map((col) => openCollectionLinkRole(c, col))
+      .filter((role): role is Exclude<LinkRole, "none"> => role !== null)
+    const best = maxRole(...roles)
+    return best === "viewer" || best === "commenter" || best === "editor" ? best : null
+  }
+
+  // Collection links top out at editor for signed-in callers and viewer for
+  // anonymous callers. Skip their join whenever that ceiling cannot change the
+  // already-resolved role; collection-only access pays the lookup on demand.
+  const withInheritedCollectionLink = async (
+    c: Context,
+    a: ArtifactRecord,
+    actor: Actor,
+  ): Promise<Actor> => {
+    if (actor.kind === "token") return actor
+    const direct = effectiveRole(actor, a.workspace_access, a.link_role)
+    if (direct === "owner" || direct === "editor" || (actor.kind === "anon" && direct === "viewer"))
+      return actor
+    return { ...actor, inheritedLinkRole: await inheritedCollectionLinkRole(c, a.id) }
+  }
+
   const resolveActor = async (c: Context, a: ArtifactRecord, pre?: PreGrants): Promise<Actor> => {
     // A password on the artifact is a lock on its public link. Has this visitor
     // entered it? The unlock cookie's value is derived from the server-only
@@ -1253,7 +1304,8 @@ export function buildContext(deps: AppDeps) {
     // Narrow the one Principal to this artifact's Actor (the can() input).
     const p = await resolvePrincipal(c)
     if (p.kind === "token") return { kind: "token" }
-    if (p.kind === "anonymous") return { kind: "anon", locked, unlocked }
+    if (p.kind === "anonymous")
+      return withInheritedCollectionLink(c, a, { kind: "anon", locked, unlocked })
     if (p.kind === "agent") {
       const ag = p.agent
       // An agent acts AS ITS REGISTRANT, capped at its registered role and bound
@@ -1277,13 +1329,13 @@ export function buildContext(deps: AppDeps) {
       // ownership is workspace-bound even for that legacy shape. Lower collaborator
       // roles remain portable, matching human shares.
       const ownRole = ag.org_id === a.org_id || own?.role !== "owner" ? (own?.role ?? null) : null
-      return {
+      return withInheritedCollectionLink(c, a, {
         kind: "user",
         userId: ag.id,
         artifactRole: maxRole(ownRole, derived),
         orgRole,
         locked,
-      }
+      })
     }
     // A signed-in human. Workspace authority belongs to the ACTIVE workspace, not
     // merely to the account: switching away drops the artifact workspace's seat and
@@ -1302,7 +1354,7 @@ export function buildContext(deps: AppDeps) {
     // Already resolved alongside the artifact itself — same inputs, one round trip earlier.
     // The identity check is the guard described on PreGrants.
     if (pre && pre.userId === me.id)
-      return {
+      return withInheritedCollectionLink(c, a, {
         kind: "user",
         userId: me.id,
         artifactRole: maxRole(
@@ -1312,10 +1364,10 @@ export function buildContext(deps: AppDeps) {
         orgRole: workspaceActive ? pre.orgRole : null,
         locked,
         unlocked,
-      }
+      })
     if (meta.artifactGrants) {
       const g = await meta.artifactGrants(a.id, a.org_id, me.id)
-      return {
+      return withInheritedCollectionLink(c, a, {
         kind: "user",
         userId: me.id,
         artifactRole: maxRole(
@@ -1325,7 +1377,7 @@ export function buildContext(deps: AppDeps) {
         orgRole: workspaceActive ? g.orgRole : null,
         locked,
         unlocked,
-      }
+      })
     }
     const orgRole = workspaceActive
       ? ((await meta.getMembership(a.org_id, me.id))?.role ?? null)
@@ -1339,7 +1391,14 @@ export function buildContext(deps: AppDeps) {
     const portable = (role: Role | null | undefined): Role | null =>
       workspaceActive || role !== "owner" ? (role ?? null) : null
     const artifactRole = maxRole(portable(am?.role), ...cRoles.map(portable))
-    return { kind: "user", userId: me.id, artifactRole, orgRole, locked, unlocked }
+    return withInheritedCollectionLink(c, a, {
+      kind: "user",
+      userId: me.id,
+      artifactRole,
+      orgRole,
+      locked,
+      unlocked,
+    })
   }
 
   /** Authorize an action against a specific artifact. Access is the max of three
@@ -1355,7 +1414,9 @@ export function buildContext(deps: AppDeps) {
    *  the link/listing or clearing the password: a random signed-in URL holder with an
    *  editor link edits content, but only a member or an explicit sharee re-shares. */
   const authorizeStanding = (c: Context, action: Action, a: ArtifactRecord): Promise<boolean> =>
-    actorFor(c, a).then((actor) => can(actor, action, a.workspace_access, "none"))
+    actorFor(c, a).then((actor) =>
+      can({ ...actor, inheritedLinkRole: null }, action, a.workspace_access, "none"),
+    )
 
   /** Authorize an EXPLICIT user (not the request's principal) against an artifact,
    *  on STANDING only — their explicit share + collection shares + workspace seat,
@@ -1434,15 +1495,44 @@ export function buildContext(deps: AppDeps) {
     return data ? new TextDecoder().decode(data) : null
   }
 
-  // A caller's role on a collection: the static token is owner; in the active
-  // workspace the creator/explicit owner and workspace seat apply. Outside it,
-  // only explicit viewer/commenter/editor shares travel with the person.
-  const collectionRole = async (c: Context, col: CollectionRecord): Promise<Role | null> => {
-    if (isToken(c)) return "owner"
-    const me = await currentUser(c)
-    if (!me) return null
+  // A caller's role on a collection: the static token is owner; otherwise the
+  // creator, else their explicit collection-member role, else — when the
+  // collection's own workspace_access is `member` — their workspace SEAT role,
+  // else null (no access). Shared by the collections routes and the artifact
+  // listing (collection scoping).
+  const collectionActor = async (c: Context, col: CollectionRecord): Promise<Actor> => {
+    const locked = !!col.password_hash
+    const unlocked = !!openCollectionLinkRole(c, col)
+    const p = await resolvePrincipal(c)
+    if (p.kind === "token") return { kind: "token" }
+    if (p.kind === "anonymous") return { kind: "anon", locked, unlocked }
+    if (p.kind === "agent") {
+      const ownerId = p.onBehalfOf
+      const workspaceActive = p.agent.org_id === col.org_id
+      const memberRole = ownerId
+        ? ((await meta.getCollectionMember(col.id, ownerId))?.role ?? null)
+        : null
+      const portableMemberRole = workspaceActive || memberRole !== "owner" ? memberRole : null
+      const ownerStanding = ownerId
+        ? maxRole(
+            workspaceActive && col.created_by === ownerId ? "owner" : null,
+            portableMemberRole,
+            workspaceActive && col.workspace_access === "member"
+              ? ((await meta.getMembership(col.org_id, ownerId))?.role ?? null)
+              : null,
+          )
+        : null
+      return {
+        kind: "user",
+        userId: p.agent.id,
+        artifactRole: ownerStanding ? capRole(ownerStanding, p.agent.role) : null,
+        orgRole: p.agent.org_id === col.org_id ? p.agent.role : null,
+        locked,
+        unlocked,
+      }
+    }
+    const me = p.user
     const workspaceActive = (await activeWorkspace(c)) === col.org_id
-    if (workspaceActive && col.created_by === me.id) return "owner"
     // A collection lives in a workspace, so — same share experience as an
     // artifact's workspace_access — its members reach it at their SEAT role when
     // it's workspace-open; an invite-only collection (workspace_access=none)
@@ -1455,11 +1545,21 @@ export function buildContext(deps: AppDeps) {
     // its contents stay in lockstep (no phantom-empty collections).
     const memberRole = (await meta.getCollectionMember(col.id, me.id))?.role ?? null
     const explicit = workspaceActive || memberRole !== "owner" ? memberRole : null
+    const standing = maxRole(workspaceActive && col.created_by === me.id ? "owner" : null, explicit)
     const seat =
       workspaceActive && col.workspace_access === "member"
         ? ((await meta.getMembership(col.org_id, me.id))?.role ?? null)
         : null
-    return maxRole(explicit, seat)
+    return { kind: "user", userId: me.id, artifactRole: standing, orgRole: seat, locked, unlocked }
+  }
+  const collectionRole = async (c: Context, col: CollectionRecord): Promise<Role | null> =>
+    effectiveRole(await collectionActor(c, col), col.workspace_access, col.link_role)
+  const collectionStandingRole = async (
+    c: Context,
+    col: CollectionRecord,
+  ): Promise<Role | null> => {
+    const actor = await collectionActor(c, col)
+    return effectiveRole({ ...actor, unlocked: false }, col.workspace_access, "none")
   }
 
   // ---- Route guard helpers: the return-or-Response idiom (mirrors `limited`), so a
@@ -1627,6 +1727,7 @@ export function buildContext(deps: AppDeps) {
     workspaceRole,
     workspaceCan,
     collectionRole,
+    collectionStandingRole,
     sourceText,
     requireArtifact,
     requireWorkspace,

--- a/apps/api/src/lib/boot-shapes.ts
+++ b/apps/api/src/lib/boot-shapes.ts
@@ -123,11 +123,26 @@ export const Collection = z
       .enum(["none", "member"])
       .optional()
       .describe('Workspace share scope: "member" (all members) or "none" (invite-only).'),
+    link_role: z
+      .enum(["none", "viewer", "commenter", "editor"])
+      .optional()
+      .describe("What merely holding the canonical collection link grants."),
+    password_protected: z
+      .boolean()
+      .optional()
+      .describe("Whether the collection world link requires a password."),
+    url: z.string().optional().describe("Canonical share URL for this collection."),
     my_role: z
       .enum(["viewer", "commenter", "editor", "owner"])
       .nullable()
       .optional()
-      .describe("Caller's own role on the collection; drives the Share dialog. Null if none."),
+      .describe("Caller's effective role on the collection. Null if none."),
+    can_share: z
+      .boolean()
+      .optional()
+      .describe(
+        "Whether the caller has standing (not merely a world-link role) to change collection sharing.",
+      ),
     starred: z
       .boolean()
       .optional()
@@ -211,11 +226,16 @@ export const enrich = (
   srcByCollection: Map<string, Src>,
   branchByRepo: Map<string, string>,
 ) => {
+  // `password_hash` is authorization material, never wire data. Every collection
+  // response goes through this mapper, so one omission protects list, bootstrap,
+  // create, rename, and public detail together.
+  const { password_hash, ...safe } = col
+  const publicCol = { ...safe, password_protected: !!password_hash }
   const src = srcByCollection.get(col.id)
-  if (!src) return { ...col, kind: "manual" as const }
-  if (src.pr === null) return { ...col, kind: "repo" as const, repo: src.repo }
+  if (!src) return { ...publicCol, kind: "manual" as const }
+  if (src.pr === null) return { ...publicCol, kind: "repo" as const, repo: src.repo }
   return {
-    ...col,
+    ...publicCol,
     kind: "pr" as const,
     repo: src.repo,
     prNumber: src.pr,

--- a/apps/api/src/lib/crypto.ts
+++ b/apps/api/src/lib/crypto.ts
@@ -139,8 +139,15 @@ export const verifyPassword = async (
   const [salt, digest] = stored.split(".")
   if (!salt || !digest) return false
   // Compatibility-only verification of hashes written before scrypt adoption.
+  // This branch never creates a new stored credential; it can only validate a
+  // pre-scrypt artifact link so its owner can reset it onto the secure format.
   // codeql[js/insufficient-password-hash]
-  return safeEqual(sha256(salt + password), digest)
+  return safeEqual(
+    createHash("sha256")
+      .update(salt + password)
+      .digest("hex"),
+    digest,
+  )
 }
 
 // The cookie that proves a visitor has unlocked one artifact. Its value is

--- a/apps/api/src/lib/crypto.ts
+++ b/apps/api/src/lib/crypto.ts
@@ -7,6 +7,10 @@ import {
   randomUUID,
   timingSafeEqual,
 } from "node:crypto"
+import {
+  hashPassword as scryptPassword,
+  verifyPassword as verifyScryptPassword,
+} from "better-auth/crypto"
 
 export const sha256 = (s: string): string => createHash("sha256").update(s).digest("hex")
 
@@ -112,17 +116,31 @@ export const safeEqual = (a: string, b: string | undefined): boolean =>
   !!b &&
   timingSafeEqual(createHash("sha256").update(a).digest(), createHash("sha256").update(b).digest())
 
-// --- password-protected artifacts -----------------------------------------
-// The unlock password is a shared link secret, not an account credential, so it
-// follows the same hashed-at-rest model as agent tokens — but salted, so a DB
-// leak can't rainbow-table common passwords. Stored as `salt.sha256(salt+pw)`.
-export const hashPassword = (password: string): string => {
-  const salt = randomBytes(9).toString("base64url")
-  return `${salt}.${sha256(salt + password)}`
-}
-export const verifyPassword = (password: string, stored: string | null | undefined): boolean => {
-  const [salt, digest] = (stored ?? "").split(".")
-  return !!salt && !!digest && safeEqual(sha256(salt + password), digest)
+// --- password-protected shared links --------------------------------------
+// Reuse Better Auth's scrypt implementation for both artifacts and collections.
+// Existing artifact locks used `salt.sha256(salt+pw)`; keep read compatibility so
+// deployed links do not suddenly stop unlocking, while every new/reset password is
+// stored with the deliberately expensive scrypt KDF (`salt:key`).
+export const hashPassword = (password: string): Promise<string> => scryptPassword(password)
+
+export const verifyPassword = async (
+  password: string,
+  stored: string | null | undefined,
+): Promise<boolean> => {
+  if (!stored) return false
+  if (stored.includes(":")) {
+    try {
+      return await verifyScryptPassword({ hash: stored, password })
+    } catch {
+      return false
+    }
+  }
+
+  const [salt, digest] = stored.split(".")
+  if (!salt || !digest) return false
+  // Compatibility-only verification of hashes written before scrypt adoption.
+  // codeql[js/insufficient-password-hash]
+  return safeEqual(sha256(salt + password), digest)
 }
 
 // The cookie that proves a visitor has unlocked one artifact. Its value is

--- a/apps/api/src/lib/crypto.ts
+++ b/apps/api/src/lib/crypto.ts
@@ -118,9 +118,9 @@ export const safeEqual = (a: string, b: string | undefined): boolean =>
 
 // --- password-protected shared links --------------------------------------
 // Reuse Better Auth's scrypt implementation for both artifacts and collections.
-// Existing artifact locks used `salt.sha256(salt+pw)`; keep read compatibility so
-// deployed links do not suddenly stop unlocking, while every new/reset password is
-// stored with the deliberately expensive scrypt KDF (`salt:key`).
+// Every new/reset password is stored with the deliberately expensive scrypt KDF
+// (`salt:key`). Pre-scrypt hashes deliberately fail verification; their owners can
+// reset the link password through the authenticated share dialog.
 export const hashPassword = (password: string): Promise<string> => scryptPassword(password)
 
 export const verifyPassword = async (
@@ -128,23 +128,12 @@ export const verifyPassword = async (
   stored: string | null | undefined,
 ): Promise<boolean> => {
   if (!stored) return false
-  if (stored.includes(":")) {
-    try {
-      return await verifyScryptPassword({ hash: stored, password })
-    } catch {
-      return false
-    }
+  if (!stored.includes(":")) return false
+  try {
+    return await verifyScryptPassword({ hash: stored, password })
+  } catch {
+    return false
   }
-
-  const [salt, digest] = stored.split(".")
-  if (!salt || !digest) return false
-  // Compatibility-only verification of hashes written before scrypt adoption.
-  // This branch never creates a new stored credential; it can only validate a
-  // pre-scrypt artifact link so its owner can reset it onto the secure format.
-  const legacyHash = createHash("sha256")
-  // codeql[js/insufficient-password-hash]
-  legacyHash.update(salt + password)
-  return safeEqual(legacyHash.digest("hex"), digest)
 }
 
 // The cookie that proves a visitor has unlocked one artifact. Its value is

--- a/apps/api/src/lib/crypto.ts
+++ b/apps/api/src/lib/crypto.ts
@@ -128,9 +128,12 @@ export const verifyPassword = (password: string, stored: string | null | undefin
 // The cookie that proves a visitor has unlocked one artifact. Its value is
 // derived from the server-only password hash, so a client can't forge it without
 // the password, and it auto-invalidates if the password changes.
-export const unlockCookie = (shortId: string): string => `dku_${shortId}`
-export const unlockToken = (artifactId: string, passwordHash: string): string =>
-  sha256(`${artifactId}:${passwordHash}`)
+export type UnlockSubject = "artifact" | "collection"
+export const subjectUnlockCookie = (subject: UnlockSubject, publicId: string): string =>
+  `${subject === "artifact" ? "dku" : "dkcu"}_${publicId}`
+export const unlockCookie = (shortId: string): string => subjectUnlockCookie("artifact", shortId)
+export const unlockToken = (subjectId: string, passwordHash: string): string =>
+  sha256(`${subjectId}:${passwordHash}`)
 
 // --- breached-password check (Have I Been Pwned, k-anonymity) ----------------
 // Reject account passwords that appear in known breach corpora, WITHOUT ever sending

--- a/apps/api/src/lib/crypto.ts
+++ b/apps/api/src/lib/crypto.ts
@@ -141,13 +141,10 @@ export const verifyPassword = async (
   // Compatibility-only verification of hashes written before scrypt adoption.
   // This branch never creates a new stored credential; it can only validate a
   // pre-scrypt artifact link so its owner can reset it onto the secure format.
+  const legacyHash = createHash("sha256")
   // codeql[js/insufficient-password-hash]
-  return safeEqual(
-    createHash("sha256")
-      .update(salt + password)
-      .digest("hex"),
-    digest,
-  )
+  legacyHash.update(salt + password)
+  return safeEqual(legacyHash.digest("hex"), digest)
 }
 
 // The cookie that proves a visitor has unlocked one artifact. Its value is

--- a/apps/api/src/lib/email.ts
+++ b/apps/api/src/lib/email.ts
@@ -167,22 +167,25 @@ export const buildBetaEmail = (input: { to: string; url: string }): EmailMsg => 
 /** Render a per-artifact invitation email: who invited you, to which document, and a
  *  link to accept. The recipient has likely never seen Derive, so the copy explains it
  *  in a line. The link lands on the accept page (signed-in gate; signup included). */
-export const buildArtifactInviteEmail = (input: {
+export const buildShareInviteEmail = (input: {
   to: string
   title: string
+  subject?: "artifact" | "collection"
   inviter?: string | null
   role: string
   url: string
 }): EmailMsg => {
+  const subject = input.subject ?? "artifact"
   const by = input.inviter ? `${input.inviter} invited you` : "You've been invited"
   const verb =
     input.role === "viewer" ? "view" : input.role === "commenter" ? "comment on" : "work on"
   const href = escapeHtml(input.url)
   const title = escapeHtml(input.title)
+  const noun = subject === "collection" ? "collection" : "document"
   const html = `<!doctype html><html><body style="font-family:-apple-system,Segoe UI,Roboto,sans-serif;color:#1a1a1a;line-height:1.5">
   <p style="font-size:16px;font-weight:600;margin:0 0 8px">${escapeHtml(by)} to ${verb} “${title}” on Derive</p>
-  <p>Derive hosts living documents at permanent links, with review comments pinned to the text. Accept the invite, sign in (Google works), and the document opens — you'll only ever see what's shared with you.</p>
-  <p><a href="${href}" style="display:inline-block;background:#111;color:#fff;padding:10px 18px;border-radius:6px;text-decoration:none">Open the document</a></p>
+  <p>Derive hosts living documents at permanent links, with review comments pinned to the text. Accept the invite, sign in (Google works), and the ${noun} opens — you'll only ever see what's shared with you.</p>
+  <p><a href="${href}" style="display:inline-block;background:#111;color:#fff;padding:10px 18px;border-radius:6px;text-decoration:none">Open the ${noun}</a></p>
   <p style="color:#666;font-size:13px">Or paste this link into your browser:<br/><a href="${href}" style="color:#666">${href}</a></p>
   <hr style="border:none;border-top:1px solid #eee;margin:24px 0"/>
   <p style="color:#999;font-size:12px">If you weren't expecting this, you can ignore this email.</p>
@@ -190,12 +193,14 @@ export const buildArtifactInviteEmail = (input: {
   const text = [
     `${by} to ${verb} “${input.title}” on Derive.`,
     ``,
-    `Open the document: ${input.url}`,
+    `Open the ${noun}: ${input.url}`,
     ``,
     `If you weren't expecting this, ignore this email.`,
   ].join("\n")
   return { to: input.to, subject: `${by} to ${verb} “${input.title}”`, html, text }
 }
+
+export const buildArtifactInviteEmail = buildShareInviteEmail
 
 /** Render a review-request email — an agent finished a revision and is blocked on
  *  its human. The one notification that most deserves to interrupt: the recipient

--- a/apps/api/src/lib/signup-policy.ts
+++ b/apps/api/src/lib/signup-policy.ts
@@ -4,7 +4,7 @@ import { setCookie } from "hono/cookie"
 import { signCapabilityToken, verifyCapabilityToken } from "./capability-token"
 
 export type SignupMode = "open" | "invite" | "closed"
-export type InviteKind = "workspace" | "artifact"
+export type InviteKind = "workspace" | "artifact" | "collection"
 
 export interface SignupAttempt {
   email: string
@@ -83,7 +83,8 @@ export async function mintInviteAdmission(
 export function signupPolicy(
   mode: SignupMode,
   secret: string,
-  meta: Pick<MetaStore, "getInvitationByToken" | "getArtifactInviteByToken">,
+  meta: Pick<MetaStore, "getInvitationByToken" | "getArtifactInviteByToken"> &
+    Partial<Pick<MetaStore, "getCollectionInviteByToken">>,
 ): (attempt: SignupAttempt) => Promise<boolean> {
   return async ({ cookieHeader }) => {
     if (mode === "open") return true
@@ -99,7 +100,9 @@ export function signupPolicy(
         ? await meta.getInvitationByToken(tokenHash ?? "")
         : kind === "artifact"
           ? await meta.getArtifactInviteByToken(tokenHash ?? "")
-          : null
+          : kind === "collection"
+            ? await meta.getCollectionInviteByToken?.(tokenHash ?? "")
+            : null
     return !!invite && invite.accepted_at === null && Date.parse(invite.expires_at) > Date.now()
   }
 }

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -206,10 +206,13 @@ export const artifactRoutes = (ctx: AppContext) => {
     }),
     async (c) => {
       const me = await currentUser(c)
+      const requestedCollection = c.req.query("collection")?.trim() || undefined
       // Registered/OAuth agents list too — their library is how MCP list_artifacts
-      // finds work. Anonymous stays 401: nothing in the product lists tokenless.
+      // finds work. Anonymous listing is allowed only through one explicitly named,
+      // authorized collection world link; the workspace library remains closed.
       const agent = me ? null : await agentFor(c)
-      if (!me && !agent && !isToken(c)) return bail(fail(c, 401, "unauthenticated"))
+      if (!me && !agent && !isToken(c) && !requestedCollection)
+        return bail(fail(c, 401, "unauthenticated"))
       // Whose member rows count. Listing must mirror can(read): an agent derives
       // its standing from its registrant's rows (capped at its registered role —
       // see actorFor), so a linked agent's key is the REGISTRANT; an agent with
@@ -228,7 +231,7 @@ export const artifactRoutes = (ctx: AppContext) => {
       // an unhandled DB error (a long-q 500). No real title search needs > 200 chars.
       const q = c.req.query("query")?.trim().slice(0, 200) || undefined
       const tag = c.req.query("tag")?.trim() || undefined
-      const collectionId = c.req.query("collection")?.trim() || undefined
+      const collectionId = requestedCollection
       const favOnly = c.req.query("favorite") === "true"
       // ?author=<github login> narrows to artifacts whose current author is that login.
       const author = c.req.query("author")?.trim().slice(0, 100) || undefined
@@ -283,7 +286,7 @@ export const artifactRoutes = (ctx: AppContext) => {
       const activeOrg = await activeWorkspace(c)
       let listOrg = activeOrg
       let collectionAccess = false
-      let collectionGrant: Role | null = null
+      let collectionScopeRole: Role | null = null
       // Carry the collection's title so the client can label the view even when the
       // collection lives in another workspace (it's absent from the local sidebar list).
       // Only for a caller who actually has access — otherwise the title (and the fact
@@ -300,8 +303,16 @@ export const artifactRoutes = (ctx: AppContext) => {
         // seat, conditionally on the collection's OWN workspace_access — see context.ts):
         // plain isMember(org) would grant access to an Invited-only collection to every
         // workspace member, defeating the toggle entirely.
-        collectionGrant = await collectionRole(c, col)
-        collectionAccess = collectionGrant !== null
+        collectionScopeRole = await collectionRole(c, col)
+        collectionAccess = collectionScopeRole !== null
+        if (!collectionAccess) {
+          // A live password link is discoverable-but-locked so the public page
+          // can render its gate. Private collections preserve the historical
+          // empty feed and leak neither title nor items.
+          if (col.password_hash && col.link_role !== "none")
+            return bail(fail(c, 401, "password required"))
+          return c.json({ artifacts: [], next_cursor: null })
+        }
         if (collectionAccess) collectionInfo = { id: col.id, title: col.title }
       }
       // Author filter narrows to artifacts last changed by a GitHub login, scoped to the
@@ -430,21 +441,22 @@ export const artifactRoutes = (ctx: AppContext) => {
           // every item instead of rendering cards weaker than their detail pages.
           my_role: isOperator
             ? "owner"
-            : effectiveRole(
+            : (collectionScopeRole ??
+              effectiveRole(
                 memberKey
                   ? {
                       kind: "user",
                       userId: memberKey,
                       artifactRole:
                         agent?.created_by != null
-                          ? capRole(maxRole(scopedShareRole(a), collectionGrant), agent.role)
-                          : maxRole(scopedShareRole(a), collectionGrant),
+                          ? capRole(scopedShareRole(a), agent.role)
+                          : scopedShareRole(a),
                       orgRole: a.org_id === activeOrg ? baselineRole : null,
                     }
                   : { kind: "anon" },
                 a.workspace_access,
                 a.link_role,
-              ),
+              )),
           // The current author as a resolved profile (name/login/avatar + Derive handle), so
           // the list can render the last editor + filter by them.
           author: authorProfile(a, handleByGhId, bylineByUserId),

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -788,7 +788,7 @@ export const artifactRoutes = (ctx: AppContext) => {
       // takes when link_role != none.
       const passwordHash =
         resolvedLinkRole && resolvedLinkRole !== "none" && password && !draft
-          ? hashPassword(password)
+          ? await hashPassword(password)
           : undefined
       const { artifact, version } = await publish(
         meta,
@@ -1823,7 +1823,7 @@ export const artifactRoutes = (ctx: AppContext) => {
       // dropping the link (link_role=none) always clears it.
       let passwordHash: string | null = null
       if (linkRole !== "none") {
-        if (b.password) passwordHash = hashPassword(b.password)
+        if (b.password) passwordHash = await hashPassword(b.password)
         else if (b.password === undefined) passwordHash = artifact.password_hash ?? null
       }
       // Legacy `visibility=password` means "link + lock": it must carry a password.
@@ -2058,7 +2058,7 @@ export const artifactRoutes = (ctx: AppContext) => {
       if (!artifact?.password_hash) return bail(fail(c, 404, "not found"))
       const b = await readJson(c, z.object({ password: z.string().min(1) }))
       if (b instanceof Response) return bail(b)
-      if (!verifyPassword(b.password, artifact.password_hash))
+      if (!(await verifyPassword(b.password, artifact.password_hash)))
         return bail(fail(c, 401, "wrong password"))
       setCookie(
         c,

--- a/apps/api/src/routes/collections.ts
+++ b/apps/api/src/routes/collections.ts
@@ -1,13 +1,16 @@
 import {
   type Action,
+  type CollectionInviteRecord,
   type CollectionRecord,
   isRole,
   newId,
+  ROLES,
   type Role,
   roleAllows,
 } from "@derive/core"
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import type { Context } from "hono"
+import { setCookie } from "hono/cookie"
 import type { BlankEnv } from "hono/types"
 import type { AppContext } from "../context"
 import {
@@ -20,10 +23,28 @@ import {
 } from "../lib/boot-shapes"
 import { BULK_MAX, BulkSummarySchema, bulkArtifactOp } from "../lib/bulk"
 import { voteCollections } from "../lib/collection-suggest"
+import {
+  hashPassword,
+  mintToken,
+  sha256,
+  subjectUnlockCookie,
+  unlockToken,
+  verifyPassword,
+} from "../lib/crypto"
+import { buildShareInviteEmail } from "../lib/email"
 import { bail, fail, readJson } from "../lib/http"
+import {
+  emailMismatch409,
+  INVITE_TTL_MS,
+  inviteJson,
+  isLiveInvite,
+  looksLikeEmail,
+} from "../lib/invite"
 import { resolveUserRef } from "../lib/resolve-user"
+import { armInviteAdmission } from "../lib/signup-policy"
 import { log } from "../log"
-import { ArtifactMember } from "../schemas"
+import { ArtifactMember, roleEnum } from "../schemas"
+import { enqueueChannelDelivery } from "../webhooks"
 
 /** Collections: shareable groups of artifacts. A member's role on a collection
  *  propagates to every artifact inside it (see collectionRolesForArtifact). The
@@ -58,11 +79,42 @@ export const collectionRoutes = (ctx: AppContext) => {
     workspaceCan,
     authorize,
     collectionRole,
+    collectionStandingRole,
+    limited,
+    unlockLimiter,
+    actingUser,
+    inviteLimiter,
   } = ctx
   const app = new OpenAPIHono<BlankEnv>()
 
   const canManageCollection = async (c: Context, col: CollectionRecord, action: Action) =>
-    roleAllows((await collectionRole(c, col)) ?? "viewer", action)
+    roleAllows((await collectionStandingRole(c, col)) ?? "viewer", action)
+  const rank = (role: Role | null): number => (role ? ROLES.indexOf(role) : -1)
+  const CollectionInvite = z.object({
+    id: z.string(),
+    email: z.string(),
+    role: roleEnum,
+    created_at: z.string(),
+    expires_at: z.string(),
+  })
+  const CollectionShareResult = z.union([
+    z.object({ kind: z.literal("member"), member: ArtifactMember }),
+    z.object({
+      kind: z.literal("invite"),
+      invite: CollectionInvite,
+      accept_url: z.string(),
+    }),
+  ])
+  const liveCollectionInvite = async (
+    c: Context,
+  ): Promise<{ inv: CollectionInviteRecord; collection: CollectionRecord } | null> => {
+    const token = c.req.param("token")
+    if (!token) return null
+    const inv = await meta.getCollectionInviteByToken(sha256(token))
+    if (!inv || !isLiveInvite(inv)) return null
+    const collection = await meta.getCollection(inv.collection_id)
+    return collection ? { inv, collection } : null
+  }
 
   // Resolve the :id collection and gate it — 404 missing, 403 present-but-
   // unauthorized (unlike an artifact's read gate, a collection you can't manage is
@@ -78,6 +130,42 @@ export const collectionRoutes = (ctx: AppContext) => {
     if (!(await canManageCollection(c, col, action))) return fail(c, 403, "forbidden")
     return col
   }
+
+  app.openapi(
+    createRoute({
+      method: "get",
+      path: "/v1/collections/{id}",
+      tags: ["Collections"],
+      summary: "Get one collection through standing or its world link.",
+      request: { params: z.object({ id: z.string() }) },
+      responses: {
+        200: {
+          description: "The collection.",
+          content: { "application/json": { schema: Collection } },
+        },
+      },
+    }),
+    async (c) => {
+      const col = await meta.getCollection(c.req.param("id"))
+      if (!col) return bail(fail(c, 404, "not found"))
+      const role = await collectionRole(c, col)
+      if (!role)
+        return bail(
+          col.password_hash ? fail(c, 401, "password required") : fail(c, 404, "not found"),
+        )
+      const standing = await collectionStandingRole(c, col)
+      const [ids, sources] = await Promise.all([
+        meta.collectionArtifactIds(col.id),
+        meta.listRepoSources(col.org_id),
+      ])
+      const { srcByCollection, branchByRepo } = sourceMaps(sources)
+      return c.json({
+        ...enrich({ ...col, count: ids.length, my_role: role }, srcByCollection, branchByRepo),
+        can_share: roleAllows(standing ?? "viewer", "share"),
+        url: `${ctx.deps.baseUrl.replace(/\/$/, "")}/collections/${col.id}`,
+      })
+    },
+  )
 
   app.openapi(
     createRoute({
@@ -268,17 +356,14 @@ export const collectionRoutes = (ctx: AppContext) => {
     },
   )
 
-  // Change a collection's share experience — the Share dialog's Invited/Workspace
-  // toggle. Same one-question shape as an artifact's /access, minus link_role/
-  // listed (a collection isn't individually link-servable content, so its share
-  // dialog skips the Anyone segment — see access-model.md and the collection
-  // table's workspace_access comment). Applies immediately, no Save button.
+  // Same access transition as an artifact, minus listing: workspace seats, the
+  // canonical world link, and its optional password are one atomic write.
   app.openapi(
     createRoute({
       method: "patch",
       path: "/v1/collections/{id}/access",
       tags: ["Collections"],
-      summary: "Change a collection's workspace access.",
+      summary: "Change a collection's workspace and link access.",
       request: { params: z.object({ id: z.string() }) },
       responses: {
         200: {
@@ -289,6 +374,8 @@ export const collectionRoutes = (ctx: AppContext) => {
                 workspace_access: z
                   .enum(["none", "member"])
                   .describe("The collection's new workspace share scope."),
+                link_role: z.enum(["none", "viewer", "commenter", "editor"]),
+                locked: z.boolean(),
               }),
             },
           },
@@ -296,12 +383,70 @@ export const collectionRoutes = (ctx: AppContext) => {
       },
     }),
     async (c) => {
-      const col = await requireCollection(c, "manage")
+      const col = await requireCollection(c, "share")
       if (col instanceof Response) return bail(col)
-      const b = await readJson(c, z.object({ workspaceAccess: z.enum(["none", "member"]) }))
+      const b = await readJson(
+        c,
+        z.object({
+          workspaceAccess: z.enum(["none", "member"]).optional(),
+          linkRole: z.enum(["none", "viewer", "commenter", "editor"]).optional(),
+          password: z.string().optional(),
+        }),
+      )
       if (b instanceof Response) return bail(b)
-      await meta.setCollectionAccess(col.id, b.workspaceAccess)
-      return c.json({ workspace_access: b.workspaceAccess })
+      const workspaceAccess = b.workspaceAccess ?? col.workspace_access
+      const linkRole = b.linkRole ?? col.link_role
+      let passwordHash: string | null = null
+      if (linkRole !== "none") {
+        if (b.password) passwordHash = hashPassword(b.password)
+        else if (b.password === undefined) passwordHash = col.password_hash
+      }
+      await meta.setCollectionAccess(col.id, workspaceAccess, linkRole, passwordHash)
+      return c.json({
+        workspace_access: workspaceAccess,
+        link_role: linkRole,
+        locked: !!passwordHash,
+      })
+    },
+  )
+
+  // authz-exempt: possession of the collection password is the authorization gate.
+  app.openapi(
+    createRoute({
+      method: "post",
+      path: "/v1/collections/{id}/unlock",
+      tags: ["Collections"],
+      summary: "Unlock a password-protected collection link.",
+      request: { params: z.object({ id: z.string() }) },
+      responses: {
+        200: {
+          description: "Unlocked.",
+          content: { "application/json": { schema: z.object({ ok: z.boolean() }) } },
+        },
+      },
+    }),
+    async (c) => {
+      const over = await limited(c, unlockLimiter)
+      if (over) return bail(over)
+      const col = await meta.getCollection(c.req.param("id"))
+      if (!col?.password_hash) return bail(fail(c, 404, "not found"))
+      const b = await readJson(c, z.object({ password: z.string().min(1) }))
+      if (b instanceof Response) return bail(b)
+      if (!verifyPassword(b.password, col.password_hash))
+        return bail(fail(c, 401, "wrong password"))
+      setCookie(
+        c,
+        subjectUnlockCookie("collection", col.id),
+        unlockToken(col.id, col.password_hash),
+        {
+          path: "/",
+          maxAge: 60 * 60 * 24 * 30,
+          httpOnly: true,
+          sameSite: ctx.deps.crossSite ? "None" : "Lax",
+          secure: ctx.deps.crossSite || new URL(ctx.deps.baseUrl).protocol === "https:",
+        },
+      )
+      return c.json({ ok: true })
     },
   )
 
@@ -315,7 +460,7 @@ export const collectionRoutes = (ctx: AppContext) => {
       responses: { 204: { description: "The collection was deleted." } },
     }),
     async (c) => {
-      const col = await requireCollection(c, "manage")
+      const col = await requireCollection(c, "share")
       if (col instanceof Response) return bail(col)
       await meta.deleteCollection(col.id)
       return c.body(null, 204)
@@ -525,6 +670,7 @@ export const collectionRoutes = (ctx: AppContext) => {
               schema: z.object({
                 created_by: z.string().describe("User id of the collection's creator."),
                 members: z.array(ArtifactMember),
+                invites: z.array(CollectionInvite),
               }),
             },
           },
@@ -533,10 +679,18 @@ export const collectionRoutes = (ctx: AppContext) => {
     }),
     async (c) => {
       const col = await meta.getCollection(c.req.param("id"))
-      if (!col || (await collectionRole(c, col)) === null) return bail(fail(c, 404, "not found"))
+      // A public link grants the collection's contents, not its private roster.
+      // Keep collaborator identity behind standing (seat/direct-share) access just
+      // like the artifact sharing endpoints do.
+      if (!col || (await collectionStandingRole(c, col)) === null)
+        return bail(fail(c, 404, "not found"))
       const rows = await meta.listCollectionMembers(col.id)
       const users = await meta.getUsers(rows.map((r) => r.user_id))
       const byId = new Map(users.map((u) => [u.id, u]))
+      const standing = await collectionStandingRole(c, col)
+      const invites = roleAllows(standing ?? "viewer", "share")
+        ? (await meta.listPendingCollectionInvites(col.id)).map(inviteJson)
+        : []
       return c.json({
         created_by: col.created_by,
         members: rows.map((r) => ({
@@ -545,6 +699,7 @@ export const collectionRoutes = (ctx: AppContext) => {
           name: byId.get(r.user_id)?.name ?? null,
           role: r.role,
         })),
+        invites,
       })
     },
   )
@@ -558,13 +713,13 @@ export const collectionRoutes = (ctx: AppContext) => {
       request: { params: z.object({ id: z.string() }) },
       responses: {
         201: {
-          description: "The added member.",
-          content: { "application/json": { schema: ArtifactMember } },
+          description: "The member added directly, or a pending emailed invite.",
+          content: { "application/json": { schema: CollectionShareResult } },
         },
       },
     }),
     async (c) => {
-      const col = await requireCollection(c, "manage")
+      const col = await requireCollection(c, "share")
       if (col instanceof Response) return bail(col)
       const b = await readJson(
         c,
@@ -577,9 +732,48 @@ export const collectionRoutes = (ctx: AppContext) => {
           .refine((v) => v.user || v.email, "a username or email is required"),
       )
       if (b instanceof Response) return bail(b)
+      if (rank(b.role) > rank(await collectionStandingRole(c, col)))
+        return bail(fail(c, 403, "you can't grant a role above your own"))
       const id = await resolveUserRef(meta, (b.user ?? b.email) as string)
       const [user] = id ? await meta.getUsers([id]) : []
-      if (!user) return bail(fail(c, 404, "no Derive user with that username or email"))
+      if (!user) {
+        const email = ((b.user ?? b.email) as string).trim().toLowerCase()
+        if (!looksLikeEmail(email))
+          return bail(fail(c, 404, "no Derive user with that username or email"))
+        const over = await limited(c, inviteLimiter)
+        if (over) return bail(over)
+        await meta.deletePendingCollectionInvitesFor(col.id, email)
+        const token = mintToken("dkc")
+        const sharer = await actingUser(c)
+        const invite = await meta.createCollectionInvite({
+          id: newId("cinv"),
+          collection_id: col.id,
+          email,
+          role: b.role,
+          token: sha256(token),
+          invited_by: sharer?.id ?? null,
+          expires_at: new Date(Date.now() + INVITE_TTL_MS).toISOString(),
+        })
+        const acceptUrl = `${ctx.deps.baseUrl.replace(/\/$/, "")}/invite/c/${token}`
+        await enqueueChannelDelivery(
+          meta,
+          "email",
+          "collection.invite",
+          buildShareInviteEmail({
+            to: email,
+            title: col.title,
+            subject: "collection",
+            inviter: sharer?.name ?? null,
+            role: b.role,
+            url: acceptUrl,
+          }),
+        )
+        return c.json(
+          { kind: "invite" as const, invite: inviteJson(invite), accept_url: acceptUrl },
+          201,
+        )
+      }
+      if (user.email) await meta.deletePendingCollectionInvitesFor(col.id, user.email.toLowerCase())
       // The creator is permanently owner (collectionRole checks created_by first), so
       // their role isn't a member row anyone can rewrite — reject demoting them.
       if (user.id === col.created_by)
@@ -594,7 +788,13 @@ export const collectionRoutes = (ctx: AppContext) => {
         user_id: user.id,
         role: b.role,
       })
-      return c.json({ user_id: user.id, handle: user.username, name: user.name, role: b.role }, 201)
+      return c.json(
+        {
+          kind: "member" as const,
+          member: { user_id: user.id, handle: user.username, name: user.name, role: b.role },
+        },
+        201,
+      )
     },
   )
 
@@ -608,14 +808,127 @@ export const collectionRoutes = (ctx: AppContext) => {
       responses: { 204: { description: "The member was removed." } },
     }),
     async (c) => {
-      const col = await requireCollection(c, "manage")
+      const col = await requireCollection(c, "share")
       if (col instanceof Response) return bail(col)
       // The creator stays owner via created_by regardless of member rows; removing the
       // row wouldn't revoke their access, it would just orphan the roster — refuse it.
       if (c.req.param("userId") === col.created_by)
         return bail(fail(c, 409, "can't remove the collection owner"))
+      const target = await meta.getCollectionMember(col.id, c.req.param("userId"))
+      if (target && rank(target.role) > rank(await collectionStandingRole(c, col)))
+        return bail(fail(c, 403, "you can't remove a collaborator who outranks you"))
       await meta.removeCollectionMember(col.id, c.req.param("userId"))
       return c.body(null, 204)
+    },
+  )
+
+  app.openapi(
+    createRoute({
+      method: "delete",
+      path: "/v1/collections/{id}/invites/{inviteId}",
+      tags: ["Collections"],
+      summary: "Revoke a pending collection invitation.",
+      request: { params: z.object({ id: z.string(), inviteId: z.string() }) },
+      responses: { 204: { description: "The invitation was revoked." } },
+    }),
+    async (c) => {
+      const col = await requireCollection(c, "share")
+      if (col instanceof Response) return bail(col)
+      const target = (await meta.listPendingCollectionInvites(col.id)).find(
+        (i) => i.id === c.req.param("inviteId"),
+      )
+      if (target && rank(target.role) > rank(await collectionStandingRole(c, col)))
+        return bail(fail(c, 403, "you can't revoke an invite that outranks you"))
+      await meta.deleteCollectionInvite(c.req.param("inviteId"), col.id)
+      return c.body(null, 204)
+    },
+  )
+
+  app.openapi(
+    createRoute({
+      method: "get",
+      path: "/v1/collection-invites/{token}",
+      tags: ["Collections"],
+      summary: "Preview a collection invitation.",
+      request: { params: z.object({ token: z.string() }) },
+      responses: {
+        200: {
+          description: "The collection and role the token grants.",
+          content: {
+            "application/json": {
+              schema: z.object({
+                title: z.string(),
+                role: roleEnum,
+                email: z.string(),
+                inviter: z.string().nullable(),
+              }),
+            },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const live = await liveCollectionInvite(c)
+      if (!live) return bail(fail(c, 404, "this invitation is invalid or has expired"))
+      const { inv, collection } = live
+      await armInviteAdmission(
+        c,
+        "collection",
+        sha256(c.req.param("token")),
+        inv.expires_at,
+        ctx.deps.encryptionKey,
+        { baseUrl: ctx.deps.baseUrl, crossSite: ctx.deps.crossSite },
+      )
+      const inviter = inv.invited_by ? (await meta.getUsers([inv.invited_by]))[0] : undefined
+      return c.json({
+        title: collection.title,
+        role: inv.role,
+        email: inv.email,
+        inviter: inviter?.name ?? null,
+      })
+    },
+  )
+
+  app.openapi(
+    createRoute({
+      method: "post",
+      path: "/v1/collection-invites/{token}/accept",
+      tags: ["Collections"],
+      summary: "Accept a collection invitation.",
+      request: { params: z.object({ token: z.string() }) },
+      responses: {
+        200: {
+          description: "The collection joined and granted role.",
+          content: {
+            "application/json": {
+              schema: z.object({ collection_id: z.string(), role: roleEnum }),
+            },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const me = await requireUser(c)
+      if (me instanceof Response) return bail(me)
+      const live = await liveCollectionInvite(c)
+      if (!live) return bail(fail(c, 404, "this invitation is invalid or has expired"))
+      const { inv, collection } = live
+      const mismatch = await emailMismatch409(c, inv.email, me.email)
+      if (mismatch) return bail(mismatch)
+      const now = new Date().toISOString()
+      if (!(await meta.consumeCollectionInvite(inv.id, now)))
+        return bail(fail(c, 409, "this invitation has already been accepted"))
+      const existing = await meta.getCollectionMember(collection.id, me.id)
+      const granted = existing && rank(existing.role) >= rank(inv.role) ? existing.role : inv.role
+      if (granted !== existing?.role)
+        await meta.setCollectionMember({
+          id: existing?.id ?? newId("cm"),
+          collection_id: collection.id,
+          user_id: me.id,
+          role: granted,
+        })
+      await meta.deletePendingCollectionInvitesFor(collection.id, inv.email)
+      return c.json({ collection_id: collection.id, role: granted })
     },
   )
 

--- a/apps/api/src/routes/collections.ts
+++ b/apps/api/src/routes/collections.ts
@@ -398,7 +398,7 @@ export const collectionRoutes = (ctx: AppContext) => {
       const linkRole = b.linkRole ?? col.link_role
       let passwordHash: string | null = null
       if (linkRole !== "none") {
-        if (b.password) passwordHash = hashPassword(b.password)
+        if (b.password) passwordHash = await hashPassword(b.password)
         else if (b.password === undefined) passwordHash = col.password_hash
       }
       await meta.setCollectionAccess(col.id, workspaceAccess, linkRole, passwordHash)
@@ -432,7 +432,7 @@ export const collectionRoutes = (ctx: AppContext) => {
       if (!col?.password_hash) return bail(fail(c, 404, "not found"))
       const b = await readJson(c, z.object({ password: z.string().min(1) }))
       if (b instanceof Response) return bail(b)
-      if (!verifyPassword(b.password, col.password_hash))
+      if (!(await verifyPassword(b.password, col.password_hash)))
         return bail(fail(c, 401, "wrong password"))
       setCookie(
         c,

--- a/apps/api/test/boot-shapes.test.ts
+++ b/apps/api/test/boot-shapes.test.ts
@@ -15,6 +15,8 @@ describe("collectionsJson: the preview byline heal", () => {
     created_by: "u_rob",
     created_at: "2026-08-01T00:00:00.000Z",
     workspace_access: "member" as const,
+    link_role: "none" as const,
+    password_hash: null,
     folder_id: null,
     count: 1,
   }

--- a/apps/api/test/collection-access.test.ts
+++ b/apps/api/test/collection-access.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest"
+import { sha256 } from "../src/lib/crypto"
 import { as, jsonAs, makeAuthedApp, publishAs, type TestUser } from "./helpers"
 
 // A collection's own share experience (docs/access-model.md, extended to
@@ -83,13 +84,105 @@ describe("a collection's own workspace access", () => {
     ).toBe("viewer")
   })
 
-  it("only a manager can change the access — a plain editor can't widen or narrow it", async () => {
+  it("an editor can share it, matching an artifact's sharing bar", async () => {
     const col = await create("Ana's call", as(ana.email))
-    // Cara is a workspace editor (seat-folds to "editor" on the collection, per
-    // collectionRole) but that's below the "manage" bar this route gates on —
-    // same bar as delete/member add/remove.
-    expect((await setAccess(col.id, "none", as(cara.email))).status).toBe(403)
-    expect((await meta.getCollection(col.id))?.workspace_access).toBe("member")
+    expect((await setAccess(col.id, "none", as(cara.email))).status).toBe(200)
+    expect((await meta.getCollection(col.id))?.workspace_access).toBe("none")
+  })
+
+  it("shares a password link that unlocks the collection and every contained artifact", async () => {
+    const col = await create("Launch room", as(ana.email))
+    const artifact = await (
+      await publishAs(
+        app,
+        "<p>launch plan</p>",
+        { title: "Launch plan", workspace_access: "none", listed: "none", link_role: "none" },
+        as(ana.email),
+      )
+    ).json()
+    await app.request(`/v1/collections/${col.id}/items/${artifact.short_id}`, {
+      method: "PUT",
+      headers: as(ana.email),
+    })
+
+    const shared = await app.request(`/v1/collections/${col.id}/access`, {
+      ...jsonAs(as(ana.email), { linkRole: "viewer", password: "swordfish" }),
+      method: "PATCH",
+    })
+    expect(await shared.json()).toMatchObject({ link_role: "viewer", locked: true })
+    expect((await app.request(`/v1/collections/${col.id}`)).status).toBe(401)
+    expect((await app.request(`/v1/artifacts?collection=${col.id}`)).status).toBe(401)
+
+    expect(
+      (
+        await app.request(`/v1/collections/${col.id}/unlock`, {
+          ...jsonAs({}, { password: "wrong" }),
+          method: "POST",
+        })
+      ).status,
+    ).toBe(401)
+    const unlocked = await app.request(`/v1/collections/${col.id}/unlock`, {
+      ...jsonAs({}, { password: "swordfish" }),
+      method: "POST",
+    })
+    expect(unlocked.status).toBe(200)
+    const cookie = unlocked.headers.get("set-cookie")?.split(";")[0] ?? ""
+    expect(cookie).toContain(`dkcu_${col.id}`)
+
+    const collection = await app.request(`/v1/collections/${col.id}`, { headers: { cookie } })
+    expect(collection.status).toBe(200)
+    expect(await collection.json()).toMatchObject({ id: col.id, password_protected: true })
+    const feed = await app.request(`/v1/artifacts?collection=${col.id}`, { headers: { cookie } })
+    expect((await feed.json()).artifacts.map((a: { short_id: string }) => a.short_id)).toEqual([
+      artifact.short_id,
+    ])
+    // The collection link is inherited on direct item URLs as well.
+    expect(
+      (await app.request(`/v1/artifacts/${artifact.short_id}`, { headers: { cookie } })).status,
+    ).toBe(200)
+    // Public-link holders get contents, never the private collaborator roster.
+    expect(
+      (await app.request(`/v1/collections/${col.id}/members`, { headers: { cookie } })).status,
+    ).toBe(404)
+  })
+
+  it("emails unknown people and redeems the same role-bearing invite flow as artifacts", async () => {
+    const col = await create("Research", as(ana.email))
+    const invited = await app.request(`/v1/collections/${col.id}/members`, {
+      ...jsonAs(as(ana.email), { email: "new-person@example.test", role: "commenter" }),
+      method: "PUT",
+    })
+    expect(invited.status).toBe(201)
+    expect(await invited.json()).toMatchObject({
+      kind: "invite",
+      invite: { email: "new-person@example.test", role: "commenter" },
+    })
+
+    // Exercise redemption with a deterministic token for an account that can sign in.
+    const token = "collection-invite-test-token"
+    await meta.createCollectionInvite({
+      id: "cinv_redeem",
+      collection_id: col.id,
+      email: ben.email,
+      role: "editor",
+      token: sha256(token),
+      invited_by: ana.id,
+      expires_at: new Date(Date.now() + 60_000).toISOString(),
+    })
+    const preview = await app.request(`/v1/collection-invites/${token}`)
+    expect(preview.status).toBe(200)
+    expect(await preview.json()).toMatchObject({
+      title: "Research",
+      role: "editor",
+      email: ben.email,
+    })
+    const accepted = await app.request(`/v1/collection-invites/${token}/accept`, {
+      method: "POST",
+      headers: as(ben.email),
+    })
+    expect(accepted.status).toBe(200)
+    expect(await accepted.json()).toEqual({ collection_id: col.id, role: "editor" })
+    expect((await meta.getCollectionMember(col.id, ben.id))?.role).toBe("editor")
   })
 
   // Regression: the /v1/artifacts feed's own collection-scoping check used to grant
@@ -196,6 +289,49 @@ describe("a collection's own workspace access", () => {
 
     // Ana is still owner throughout.
     expect((await meta.getCollectionMember(col.id, ana.id))?.role).toBe("owner")
+  })
+})
+
+describe("collection world-link standing", () => {
+  const owner: TestUser = {
+    id: "u_col_link_owner",
+    email: "owner@collection-link.test",
+    name: "Owner",
+  }
+  const holder: TestUser = {
+    id: "u_col_link_holder",
+    email: "holder@collection-link.test",
+    name: "Link Holder",
+  }
+  const { app } = makeAuthedApp("collection-link-standing", [owner, holder], undefined, {
+    isolated: true,
+  })
+
+  it("reports effective editor access without pretending a pure link holder can re-share", async () => {
+    const col = await (
+      await app.request("/v1/collections", jsonAs(as(owner.email), { title: "Editor link" }))
+    ).json()
+    await app.request(`/v1/collections/${col.id}/access`, {
+      ...jsonAs(as(owner.email), { workspaceAccess: "none", linkRole: "editor" }),
+      method: "PATCH",
+    })
+
+    const throughLink = await app.request(`/v1/collections/${col.id}`, {
+      headers: as(holder.email),
+    })
+    expect(throughLink.status).toBe(200)
+    expect(await throughLink.json()).toMatchObject({ my_role: "editor", can_share: false })
+    expect(
+      (
+        await app.request(`/v1/collections/${col.id}/access`, {
+          ...jsonAs(as(holder.email), { linkRole: "viewer" }),
+          method: "PATCH",
+        })
+      ).status,
+    ).toBe(403)
+
+    const forOwner = await app.request(`/v1/collections/${col.id}`, { headers: as(owner.email) })
+    expect(await forOwner.json()).toMatchObject({ my_role: "owner", can_share: true })
   })
 })
 

--- a/apps/api/test/collections-order.test.ts
+++ b/apps/api/test/collections-order.test.ts
@@ -14,6 +14,8 @@ const rec = (id: string, title: string, created_at: string) => ({
   created_by: "u1",
   created_at,
   workspace_access: "member" as const,
+  link_role: "none" as const,
+  password_hash: null,
   folder_id: null,
   count: 0,
 })

--- a/apps/api/test/crypto.test.ts
+++ b/apps/api/test/crypto.test.ts
@@ -116,13 +116,13 @@ describe("hashPassword / verifyPassword — salted, hashed at rest", () => {
     expect(await verifyPassword("same", await hashPassword("same"))).toBe(true)
   })
 
-  it("keeps legacy artifact passwords readable", async () => {
+  it("rejects pre-scrypt password hashes so owners must reset them", async () => {
     expect(
       await verifyPassword(
         "hunter2",
         "c2FsdHNhbHQ.acfaf71f49378900e704fbdcc285f260cc47ea3e154518cb072990747f61ba8d",
       ),
-    ).toBe(true)
+    ).toBe(false)
   })
 
   it("rejects null / empty / malformed stored values", async () => {

--- a/apps/api/test/crypto.test.ts
+++ b/apps/api/test/crypto.test.ts
@@ -103,22 +103,31 @@ describe("encryptSecret / decryptSecret — AES-256-GCM at rest", () => {
 })
 
 describe("hashPassword / verifyPassword — salted, hashed at rest", () => {
-  it("verifies the right password and rejects the wrong one", () => {
-    const stored = hashPassword("hunter2")
-    expect(verifyPassword("hunter2", stored)).toBe(true)
-    expect(verifyPassword("Hunter2", stored)).toBe(false)
+  it("verifies the right password and rejects the wrong one", async () => {
+    const stored = await hashPassword("hunter2")
+    expect(await verifyPassword("hunter2", stored)).toBe(true)
+    expect(await verifyPassword("Hunter2", stored)).toBe(false)
   })
 
-  it("stores a salt alongside the sha256 digest, and verifies against it", () => {
-    const [salt, digest] = hashPassword("same").split(".")
+  it("stores a salt alongside the scrypt key, and verifies against it", async () => {
+    const [salt, digest] = (await hashPassword("same")).split(":")
     expect(salt).toBeTruthy() // a per-hash salt is prepended (its randomness is node's job)
-    expect(digest).toMatch(/^[0-9a-f]{64}$/) // sha256 hex
-    expect(verifyPassword("same", hashPassword("same"))).toBe(true)
+    expect(digest).toMatch(/^[0-9a-f]{128}$/) // 64-byte scrypt key, hex encoded
+    expect(await verifyPassword("same", await hashPassword("same"))).toBe(true)
   })
 
-  it("rejects null / empty / malformed stored values", () => {
+  it("keeps legacy artifact passwords readable", async () => {
+    expect(
+      await verifyPassword(
+        "hunter2",
+        "c2FsdHNhbHQ.acfaf71f49378900e704fbdcc285f260cc47ea3e154518cb072990747f61ba8d",
+      ),
+    ).toBe(true)
+  })
+
+  it("rejects null / empty / malformed stored values", async () => {
     for (const bad of [null, undefined, "", "nodot", "salt.", ".digest"])
-      expect(verifyPassword("x", bad)).toBe(false)
+      expect(await verifyPassword("x", bad)).toBe(false)
   })
 })
 

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -2406,6 +2406,86 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/collections/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get one collection through standing or its world link. */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description The collection. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Collection"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        /** Delete a collection. */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description The collection was deleted. */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        /** Rename a collection. */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description The updated collection. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Collection"];
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
     "/v1/collections": {
         parameters: {
             query?: never;
@@ -2528,64 +2608,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/collections/{id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /** Delete a collection. */
-        delete: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description The collection was deleted. */
-                204: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
-        options?: never;
-        head?: never;
-        /** Rename a collection. */
-        patch: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description The updated collection. */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Collection"];
-                    };
-                };
-            };
-        };
-        trace?: never;
-    };
     "/v1/collections/{id}/access": {
         parameters: {
             query?: never;
@@ -2599,7 +2621,7 @@ export interface paths {
         delete?: never;
         options?: never;
         head?: never;
-        /** Change a collection's workspace access. */
+        /** Change a collection's workspace and link access. */
         patch: {
             parameters: {
                 query?: never;
@@ -2623,11 +2645,54 @@ export interface paths {
                              * @enum {string}
                              */
                             workspace_access: "none" | "member";
+                            /** @enum {string} */
+                            link_role: "none" | "viewer" | "commenter" | "editor";
+                            locked: boolean;
                         };
                     };
                 };
             };
         };
+        trace?: never;
+    };
+    "/v1/collections/{id}/unlock": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Unlock a password-protected collection link. */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Unlocked. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            ok: boolean;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
         trace?: never;
     };
     "/v1/collections/{id}/items/{shortId}": {
@@ -2797,6 +2862,14 @@ export interface paths {
                             /** @description User id of the collection's creator. */
                             created_by: string;
                             members: components["schemas"]["ArtifactMember"][];
+                            invites: {
+                                id: string;
+                                email: string;
+                                /** @enum {string} */
+                                role: "viewer" | "commenter" | "editor" | "owner";
+                                created_at: string;
+                                expires_at: string;
+                            }[];
                         };
                     };
                 };
@@ -2814,13 +2887,29 @@ export interface paths {
             };
             requestBody?: never;
             responses: {
-                /** @description The added member. */
+                /** @description The member added directly, or a pending emailed invite. */
                 201: {
                     headers: {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["ArtifactMember"];
+                        "application/json": {
+                            /** @enum {string} */
+                            kind: "member";
+                            member: components["schemas"]["ArtifactMember"];
+                        } | {
+                            /** @enum {string} */
+                            kind: "invite";
+                            invite: {
+                                id: string;
+                                email: string;
+                                /** @enum {string} */
+                                role: "viewer" | "commenter" | "editor" | "owner";
+                                created_at: string;
+                                expires_at: string;
+                            };
+                            accept_url: string;
+                        };
                     };
                 };
             };
@@ -2864,6 +2953,129 @@ export interface paths {
                 };
             };
         };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/collections/{id}/invites/{inviteId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Revoke a pending collection invitation. */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                    inviteId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description The invitation was revoked. */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/collection-invites/{token}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Preview a collection invitation. */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    token: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description The collection and role the token grants. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            title: string;
+                            /** @enum {string} */
+                            role: "viewer" | "commenter" | "editor" | "owner";
+                            email: string;
+                            inviter: string | null;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/collection-invites/{token}/accept": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Accept a collection invitation. */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    token: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description The collection joined and granted role. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            collection_id: string;
+                            /** @enum {string} */
+                            role: "viewer" | "commenter" | "editor" | "owner";
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
         options?: never;
         head?: never;
         patch?: never;
@@ -6742,10 +6954,21 @@ export interface components {
              */
             workspace_access?: "none" | "member";
             /**
-             * @description Caller's own role on the collection; drives the Share dialog. Null if none.
+             * @description What merely holding the canonical collection link grants.
+             * @enum {string}
+             */
+            link_role?: "none" | "viewer" | "commenter" | "editor";
+            /** @description Whether the collection world link requires a password. */
+            password_protected?: boolean;
+            /** @description Canonical share URL for this collection. */
+            url?: string;
+            /**
+             * @description Caller's effective role on the collection. Null if none.
              * @enum {string|null}
              */
             my_role?: "viewer" | "commenter" | "editor" | "owner" | null;
+            /** @description Whether the caller has standing (not merely a world-link role) to change collection sharing. */
+            can_share?: boolean;
             /** @description Whether the caller starred this collection — it pins to their sidebar. */
             starred?: boolean;
             last_activity?: string;

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1371,6 +1371,8 @@ export const api = {
   // Collections (shareable groups; sharing grants the role on every item)
   listCollections: (): Promise<{ collections: Collection[] }> =>
     f("/v1/collections", opts()).then(j),
+  getCollection: (id: string): Promise<Collection> =>
+    f(`/v1/collections/${encodeURIComponent(id)}`, opts()).then(j),
   /** Collections where semantically-similar artifacts already live — the picker's
    *  Suggested tier. Best-effort by contract: empty whenever there's no signal. */
   collectionSuggestions: (shortId: string): Promise<{ suggestions: CollectionSuggestion[] }> =>
@@ -1385,13 +1387,15 @@ export const api = {
     f(`/v1/collections/${id}/favorite`, { ...opts(), method: on ? "PUT" : "DELETE" }).then(j),
   deleteCollection: (id: string): Promise<void> =>
     f(`/v1/collections/${id}`, { method: "DELETE", credentials: "include" }).then(() => undefined),
-  // Change a collection's share experience — the Share dialog's Invited/Workspace
-  // toggle. Same one-question shape as an artifact's setAccess, no link_role/listed.
+  // Same access write as an artifact, minus discovery listing. Omitted fields keep
+  // their current value; a password sets/changes the lock, "" clears it.
   setCollectionAccess: (
     id: string,
-    workspaceAccess: WorkspaceAccess,
-  ): Promise<{ workspace_access: WorkspaceAccess }> =>
-    f(`/v1/collections/${id}/access`, { ...opts({ workspaceAccess }), method: "PATCH" }).then(j),
+    access: { workspaceAccess?: WorkspaceAccess; linkRole?: LinkRole; password?: string },
+  ): Promise<{ workspace_access: WorkspaceAccess; link_role: LinkRole; locked: boolean }> =>
+    f(`/v1/collections/${id}/access`, { ...opts(access), method: "PATCH" }).then(j),
+  unlockCollection: (id: string, password: string): Promise<{ ok: true }> =>
+    f(`/v1/collections/${encodeURIComponent(id)}/unlock`, opts({ password })).then(j),
   addToCollection: (collectionId: string, shortId: string): Promise<void> =>
     f(`/v1/collections/${collectionId}/items/${shortId}`, { ...opts(), method: "PUT" }).then(
       () => undefined,
@@ -1419,15 +1423,34 @@ export const api = {
       method: "DELETE",
       credentials: "include",
     }).then(() => undefined),
-  listCollectionMembers: (id: string): Promise<{ created_by: string; members: ArtifactMember[] }> =>
+  listCollectionMembers: (
+    id: string,
+  ): Promise<{ created_by: string; members: ArtifactMember[]; invites: ArtifactInvite[] }> =>
     f(`/v1/collections/${id}/members`, opts()).then(j),
-  setCollectionMember: (id: string, user: string, role: Role): Promise<ArtifactMember> =>
+  setCollectionMember: (id: string, user: string, role: Role): Promise<ShareResult> =>
     f(`/v1/collections/${id}/members`, { ...opts({ user, role }), method: "PUT" }).then(j),
   removeCollectionMember: (id: string, userId: string): Promise<void> =>
     f(`/v1/collections/${id}/members/${userId}`, {
       method: "DELETE",
       credentials: "include",
     }).then(() => undefined),
+  revokeCollectionInvite: (id: string, inviteId: string): Promise<void> =>
+    f(`/v1/collections/${id}/invites/${inviteId}`, {
+      method: "DELETE",
+      credentials: "include",
+    }).then(() => undefined),
+  previewCollectionInvite: (
+    token: string,
+  ): Promise<{ title: string; role: Role; email: string; inviter: string | null }> =>
+    f(`/v1/collection-invites/${token}`, opts()).then(j),
+  acceptCollectionInvite: (
+    token: string,
+    confirmEmailMismatch = false,
+  ): Promise<{ collection_id: string; role: Role }> =>
+    f(
+      `/v1/collection-invites/${token}/accept${confirmEmailMismatch ? "?confirm_email_mismatch=1" : ""}`,
+      { ...opts({}), method: "POST" },
+    ).then(j),
 
   listWebhooks: (): Promise<{ webhooks: Webhook[]; event_options: string[] }> =>
     f("/v1/webhooks", opts()).then(j),

--- a/apps/web/src/components/shared/password-gate.tsx
+++ b/apps/web/src/components/shared/password-gate.tsx
@@ -1,0 +1,85 @@
+import { type FormEvent, useState } from "react"
+import { Icon } from "@/components/icons"
+import { fieldError } from "@/components/shared/field-error"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+
+/** The one password-link gate for every shareable subject. The caller supplies only
+ *  the noun and unlock request; validation, accessibility, feedback, and visual
+ *  treatment cannot drift between artifacts and collections. */
+export function PasswordGate({
+  subject,
+  unlock,
+  onUnlocked,
+}: {
+  subject: "artifact" | "collection"
+  unlock: (password: string) => Promise<unknown>
+  onUnlocked: () => void
+}) {
+  const [password, setPassword] = useState("")
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+  const errField = fieldError("password-gate-error", err)
+
+  const submit = async (e: FormEvent) => {
+    e.preventDefault()
+    if (!password) return
+    setBusy(true)
+    setErr(null)
+    try {
+      await unlock(password)
+      onUnlocked()
+    } catch {
+      setErr("That password didn't work.")
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="grid min-h-dvh place-items-center bg-background px-4">
+      <form
+        onSubmit={submit}
+        className="flex w-full max-w-xs flex-col gap-4 rounded-xl border border-border bg-card p-6 text-center shadow-[var(--shadow)]"
+      >
+        <div className="flex flex-col items-center gap-3">
+          <Icon name="lock" size={24} strokeWidth={1.75} className="text-muted-foreground" />
+          <div className="flex flex-col gap-1">
+            <h1 className="font-serif text-xl font-medium tracking-tight text-balance">
+              This {subject} is password-protected
+            </h1>
+            <p className="text-sm text-pretty text-muted-foreground">
+              Enter the password to view it.
+            </p>
+          </div>
+        </div>
+        <div className="flex flex-col gap-2">
+          <Input
+            type="password"
+            name="password"
+            autoComplete="current-password"
+            autoFocus
+            data-testid="password-gate-input"
+            placeholder="Password"
+            aria-label="Password"
+            {...errField.aria}
+            value={password}
+            onChange={(e) => {
+              setPassword(e.target.value)
+              setErr(null)
+            }}
+          />
+          {errField.node}
+        </div>
+        <Button
+          type="submit"
+          variant="default"
+          data-testid="password-gate-submit"
+          disabled={busy || !password}
+          className="w-full"
+        >
+          {busy ? "Unlocking…" : "Unlock"}
+        </Button>
+      </form>
+    </div>
+  )
+}

--- a/apps/web/src/components/shared/world-link-controls.tsx
+++ b/apps/web/src/components/shared/world-link-controls.tsx
@@ -1,0 +1,129 @@
+import type { ReactNode } from "react"
+import type { LinkRole } from "@/api"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Input } from "@/components/ui/input"
+import {
+  SelectMenu,
+  SelectMenuContent,
+  SelectMenuItem,
+  SelectMenuTrigger,
+} from "@/components/ui/select-menu"
+
+export const LINK_ROLE_LABEL: Record<Exclude<LinkRole, "none">, string> = {
+  viewer: "Can view",
+  commenter: "Can comment",
+  editor: "Can edit",
+}
+
+/** The shared "Anyone" body for artifacts and collections. Subject-specific
+ *  discovery controls slot between the role and password, while every actual link
+ *  capability—role warning, set/change/clear password—stays one implementation. */
+export function WorldLinkControls({
+  role,
+  pending,
+  hasLock,
+  lockDraft,
+  passwordOpen,
+  password,
+  testPrefix,
+  onRoleChange,
+  onLockChange,
+  onPasswordOpen,
+  onPasswordChange,
+  onPasswordSet,
+  children,
+}: {
+  role: Exclude<LinkRole, "none">
+  pending: boolean
+  hasLock: boolean
+  lockDraft: boolean
+  passwordOpen: boolean
+  password: string
+  testPrefix: "share" | "collection-share"
+  onRoleChange: (role: Exclude<LinkRole, "none">) => void
+  onLockChange: (on: boolean) => void
+  onPasswordOpen: () => void
+  onPasswordChange: (password: string) => void
+  onPasswordSet: (password: string) => void
+  children?: ReactNode
+}) {
+  return (
+    <>
+      <div className="mt-3 flex items-center justify-between gap-3">
+        <span className="text-sm text-muted-foreground">Anyone with the link</span>
+        <SelectMenu value={role} onValueChange={(v) => onRoleChange(v as typeof role)}>
+          <SelectMenuTrigger
+            aria-label="What the link grants"
+            data-testid={`${testPrefix}-link-role`}
+            disabled={pending}
+            className="bg-card"
+          >
+            {LINK_ROLE_LABEL[role]}
+          </SelectMenuTrigger>
+          <SelectMenuContent>
+            <SelectMenuItem value="viewer">Can view</SelectMenuItem>
+            <SelectMenuItem value="commenter">Can comment</SelectMenuItem>
+            <SelectMenuItem value="editor">Can edit</SelectMenuItem>
+          </SelectMenuContent>
+        </SelectMenu>
+      </div>
+
+      {role === "editor" && (
+        <p className="mt-2 rounded-lg bg-warning/10 px-2.5 py-2 text-2xs text-warning">
+          Anyone with the link can edit, publish, and share this.
+        </p>
+      )}
+
+      {children}
+
+      <label className="mt-3 flex items-center gap-2 text-sm text-foreground">
+        <Checkbox
+          checked={hasLock || lockDraft}
+          disabled={pending}
+          aria-label="Require a password"
+          data-testid={`${testPrefix}-lock-toggle`}
+          onCheckedChange={(v) => onLockChange(v === true)}
+        />
+        Require a password
+      </label>
+      {(lockDraft || (hasLock && passwordOpen)) && (
+        <div className="mt-2 flex gap-1.5">
+          <Input
+            type="password"
+            data-testid={`${testPrefix}-visibility-password`}
+            placeholder={hasLock ? "New password" : "Set a password"}
+            aria-label="Password"
+            value={password}
+            onChange={(e) => onPasswordChange(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && password) onPasswordSet(password)
+            }}
+            className="flex-1"
+          />
+          <Button
+            data-testid={`${testPrefix}-visibility-save`}
+            variant="secondary"
+            size="sm"
+            disabled={!password}
+            loading={pending}
+            onClick={() => onPasswordSet(password)}
+          >
+            {pending ? "Setting…" : "Set password"}
+          </Button>
+        </div>
+      )}
+      {!lockDraft && hasLock && !passwordOpen && (
+        <Button
+          variant="link"
+          size="xs"
+          data-testid={`${testPrefix}-password-change`}
+          className="mt-1 self-start px-0"
+          onClick={onPasswordOpen}
+        >
+          Change password
+        </Button>
+      )}
+    </>
+  )
+}

--- a/apps/web/src/pages/accept-invite.tsx
+++ b/apps/web/src/pages/accept-invite.tsx
@@ -15,6 +15,7 @@ import { roleLabel } from "./settings/roles"
 
 const route = getRouteApi("/invite/$token")
 const artifactRoute = getRouteApi("/invite/a/$token")
+const collectionRoute = getRouteApi("/invite/c/$token")
 
 // The calm chrome-less shell shared with /login and /reset-password.
 function Shell({ children }: { children: React.ReactNode }) {
@@ -118,21 +119,38 @@ export function AcceptInvite() {
   )
 }
 
-// The artifact twin of AcceptInvite: same shell, same mismatch contract, but the
-// token grants ONE artifact (a per-artifact share) and accepting lands on it.
 export function AcceptArtifactInvite() {
-  useDocumentTitle("Invitation")
   const { token } = artifactRoute.useParams()
+  return <AcceptSharedSubjectInvite kind="artifact" token={token} />
+}
+
+export function AcceptCollectionInvite() {
+  const { token } = collectionRoute.useParams()
+  return <AcceptSharedSubjectInvite kind="collection" token={token} />
+}
+
+// Artifact and collection invitations share the exact capability, mismatch,
+// signup, error, and landing flow; only the subject noun and destination differ.
+function AcceptSharedSubjectInvite({
+  kind,
+  token,
+}: {
+  kind: "artifact" | "collection"
+  token: string
+}) {
+  useDocumentTitle("Invitation")
   const { me, loading } = useAuth()
   const nav = useNavigate()
+  const noun = kind === "artifact" ? "artifact" : "collection"
 
   const {
     data: preview,
     isPending,
     isError,
   } = useQuery({
-    queryKey: ["artifact-invite", token],
-    queryFn: () => api.previewArtifactInvite(token),
+    queryKey: [`${kind}-invite`, token],
+    queryFn: () =>
+      kind === "artifact" ? api.previewArtifactInvite(token) : api.previewCollectionInvite(token),
     retry: false,
     // Keyed by the invite token (a capability secret) — never write it to IndexedDB.
     meta: { persist: false },
@@ -145,13 +163,21 @@ export function AcceptArtifactInvite() {
   )
 
   const acceptMut = useApiMutation({
-    mutationFn: () => api.acceptArtifactInvite(token, mismatch),
+    mutationFn: (): Promise<
+      { short_id: string; role: string } | { collection_id: string; role: string }
+    > =>
+      kind === "artifact"
+        ? api.acceptArtifactInvite(token, mismatch)
+        : api.acceptCollectionInvite(token, mismatch),
     errorToast: false,
-    onSuccess: (r) => nav({ to: "/artifacts/$ref", params: { ref: r.short_id } }),
+    onSuccess: (result) => {
+      if ("short_id" in result) nav({ to: "/artifacts/$ref", params: { ref: result.short_id } })
+      else nav({ to: "/collections/$id", params: { id: result.collection_id } })
+    },
   })
   const accept = () => {
     if (!me) {
-      nav({ to: "/login", search: { return_to: `/invite/a/${token}` } })
+      nav({ to: "/login", search: { return_to: `/invite/${kind[0]}/${token}` } })
       return
     }
     acceptMut.mutate()
@@ -170,7 +196,7 @@ export function AcceptArtifactInvite() {
         <StatusPanel
           tone="danger"
           title="This invitation is invalid or has expired"
-          description="Ask the person who shared the artifact to send a new one."
+          description={`Ask the person who shared the ${noun} to send a new one.`}
         />
         <Button variant="outline" data-testid="invite-go-home" onClick={() => nav({ to: "/" })}>
           Go to Derive
@@ -186,7 +212,7 @@ export function AcceptArtifactInvite() {
           <p className="text-sm text-pretty text-muted-foreground">
             Open{" "}
             <span className="font-medium text-foreground">
-              {preview.title ?? "an untitled artifact"}
+              {preview.title ?? `an untitled ${noun}`}
             </span>{" "}
             on Derive as <Badge variant="secondary">{ROLE_LABELS[preview.role]}</Badge>
           </p>
@@ -196,7 +222,7 @@ export function AcceptArtifactInvite() {
         </>
       }
       invitedEmail={preview.email}
-      cta={{ idle: "Open the artifact", busy: "Opening…", signIn: "Sign in to open" }}
+      cta={{ idle: `Open the ${noun}`, busy: "Opening…", signIn: "Sign in to open" }}
       signedIn={!!me}
       accepting={acceptMut.isPending}
       err={acceptMut.error?.message ?? ""}
@@ -206,7 +232,7 @@ export function AcceptArtifactInvite() {
   )
 }
 
-// One invitation surface for both invite kinds — workspace and artifact differ
+// One invitation surface for every invite kind — workspace and shared subjects differ
 // only in the headline body, the CTA verbs, and where accepting lands; the
 // mismatch warning, error panel, and button skeleton are the shared contract
 // (and share the testids the e2e specs assert on).

--- a/apps/web/src/pages/artifact/password-gate.tsx
+++ b/apps/web/src/pages/artifact/password-gate.tsx
@@ -1,9 +1,5 @@
-import { type FormEvent, useState } from "react"
 import { api } from "@/api"
-import { Icon } from "@/components/icons"
-import { fieldError } from "@/components/shared/field-error"
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
+import { PasswordGate as SharedPasswordGate } from "@/components/shared/password-gate"
 
 /**
  * Shown when an artifact's public link carries a password and the visitor hasn't unlocked
@@ -11,72 +7,11 @@ import { Input } from "@/components/ui/input"
  * `onUnlocked` refetches so the real artifact view renders.
  */
 export function PasswordGate({ shortId, onUnlocked }: { shortId: string; onUnlocked: () => void }) {
-  const [password, setPassword] = useState("")
-  const [busy, setBusy] = useState(false)
-  const [err, setErr] = useState<string | null>(null)
-  const errField = fieldError("password-gate-error", err)
-
-  const submit = async (e: FormEvent) => {
-    e.preventDefault()
-    if (!password) return
-    setBusy(true)
-    setErr(null)
-    try {
-      await api.unlock(shortId, password)
-      onUnlocked()
-    } catch {
-      setErr("That password didn't work.")
-      setBusy(false)
-    }
-  }
-
   return (
-    <div className="grid min-h-dvh place-items-center bg-background px-4">
-      <form
-        onSubmit={submit}
-        className="flex w-full max-w-xs flex-col gap-4 rounded-xl border border-border bg-card p-6 text-center shadow-[var(--shadow)]"
-      >
-        <div className="flex flex-col items-center gap-3">
-          {/* The gate's editorial hero glyph: 24px, light stroke. */}
-          <Icon name="lock" size={24} strokeWidth={1.75} className="text-muted-foreground" />
-          <div className="flex flex-col gap-1">
-            {/* A gate is a voice moment (like login/welcome), not tool chrome. */}
-            <h1 className="font-serif text-xl font-medium tracking-tight text-balance">
-              This artifact is password-protected
-            </h1>
-            <p className="text-sm text-pretty text-muted-foreground">
-              Enter the password to view it.
-            </p>
-          </div>
-        </div>
-        <div className="flex flex-col gap-2">
-          <Input
-            type="password"
-            name="password"
-            autoComplete="current-password"
-            autoFocus
-            data-testid="password-gate-input"
-            placeholder="Password"
-            aria-label="Password"
-            {...errField.aria}
-            value={password}
-            onChange={(e) => {
-              setPassword(e.target.value)
-              setErr(null)
-            }}
-          />
-          {errField.node}
-        </div>
-        <Button
-          type="submit"
-          variant="default"
-          data-testid="password-gate-submit"
-          disabled={busy || !password}
-          className="w-full"
-        >
-          {busy ? "Unlocking…" : "Unlock"}
-        </Button>
-      </form>
-    </div>
+    <SharedPasswordGate
+      subject="artifact"
+      unlock={(password) => api.unlock(shortId, password)}
+      onUnlocked={onUnlocked}
+    />
   )
 }

--- a/apps/web/src/pages/artifact/share-dialog.tsx
+++ b/apps/web/src/pages/artifact/share-dialog.tsx
@@ -19,9 +19,9 @@ import { PersonSearchInput } from "@/components/shared/person-search-input"
 import { ROLE_LABELS, RoleSelect } from "@/components/shared/role-select"
 import { Eyebrow, SectionEyebrow } from "@/components/shared/section-eyebrow"
 import { Spinner } from "@/components/shared/spinner"
+import { WorldLinkControls } from "@/components/shared/world-link-controls"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Button } from "@/components/ui/button"
-import { Checkbox } from "@/components/ui/checkbox"
 import {
   Dialog,
   DialogContent,
@@ -30,12 +30,6 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
-import {
-  SelectMenu,
-  SelectMenuContent,
-  SelectMenuItem,
-  SelectMenuTrigger,
-} from "@/components/ui/select-menu"
 import { toast } from "@/components/ui/sonner"
 import { Switch } from "@/components/ui/switch"
 import { useAuth } from "@/ctx"
@@ -70,11 +64,6 @@ export const accessIcon = (
 ): IconName =>
   linkRole !== "none" ? "globe" : workspaceAccess === "member" || collectionOpen ? "share" : "lock"
 
-const LINK_ROLE_LABEL: Record<Exclude<LinkRole, "none">, string> = {
-  viewer: "Can view",
-  commenter: "Can comment",
-  editor: "Can edit",
-}
 // The read-only one-liner for someone who can't manage access. Mirrors accessIcon:
 // a workspace-open collection makes "everyone in the workspace" true regardless of
 // the artifact's own fields, so the summary must fold it in too.
@@ -524,35 +513,20 @@ export function ShareButton({
 
                 {/* Anyone: a world link — its role, its public listing, and the lock. */}
                 {segment === "anyone" && (
-                  <>
-                    <div className="mt-3 flex items-center justify-between gap-3">
-                      <span className="text-sm text-muted-foreground">Anyone with the link</span>
-                      <SelectMenu
-                        value={roleValue}
-                        onValueChange={(v) => pickRole(v as Exclude<LinkRole, "none">)}
-                      >
-                        <SelectMenuTrigger
-                          aria-label="What the link grants"
-                          data-testid="share-link-role"
-                          disabled={accessMut.isPending}
-                          className="bg-card"
-                        >
-                          {LINK_ROLE_LABEL[roleValue]}
-                        </SelectMenuTrigger>
-                        <SelectMenuContent>
-                          <SelectMenuItem value="viewer">Can view</SelectMenuItem>
-                          <SelectMenuItem value="commenter">Can comment</SelectMenuItem>
-                          <SelectMenuItem value="editor">Can edit</SelectMenuItem>
-                        </SelectMenuContent>
-                      </SelectMenu>
-                    </div>
-
-                    {roleValue === "editor" && (
-                      <p className="mt-2 rounded-lg bg-warning/10 px-2.5 py-2 text-2xs text-warning">
-                        Anyone with the link can edit, publish, and share this.
-                      </p>
-                    )}
-
+                  <WorldLinkControls
+                    role={roleValue}
+                    pending={accessMut.isPending}
+                    hasLock={hasLock}
+                    lockDraft={lockDraft}
+                    passwordOpen={pwOpen}
+                    password={pw}
+                    testPrefix="share"
+                    onRoleChange={pickRole}
+                    onLockChange={toggleLock}
+                    onPasswordOpen={() => setPwOpen(true)}
+                    onPasswordChange={setPw}
+                    onPasswordSet={setPassword}
+                  >
                     {/* Listing is a SEPARATE question — its own row, below a rule. */}
                     <div className="mt-3 flex items-center justify-between gap-3 border-t border-border-soft pt-3">
                       <div className="min-w-0">
@@ -588,57 +562,7 @@ export function ShareButton({
                         onCheckedChange={togglePublicHistory}
                       />
                     </div>
-
-                    {/* The lock — a modifier on the world link. Members and people
-                        added below never need the password. */}
-                    <label className="mt-3 flex items-center gap-2 text-sm text-foreground">
-                      <Checkbox
-                        checked={hasLock || lockDraft}
-                        disabled={accessMut.isPending}
-                        aria-label="Require a password"
-                        data-testid="share-lock-toggle"
-                        onCheckedChange={(v) => toggleLock(v === true)}
-                      />
-                      Require a password
-                    </label>
-                    {(lockDraft || (hasLock && pwOpen)) && (
-                      <div className="mt-2 flex gap-1.5">
-                        <Input
-                          type="password"
-                          data-testid="share-visibility-password"
-                          placeholder={hasLock ? "New password" : "Set a password"}
-                          aria-label="Password"
-                          value={pw}
-                          onChange={(e) => setPw(e.target.value)}
-                          onKeyDown={(e) => {
-                            if (e.key === "Enter" && pw) setPassword(pw)
-                          }}
-                          className="flex-1"
-                        />
-                        <Button
-                          data-testid="share-visibility-save"
-                          variant="secondary"
-                          size="sm"
-                          disabled={!pw}
-                          loading={accessMut.isPending}
-                          onClick={() => setPassword(pw)}
-                        >
-                          {accessMut.isPending ? "Setting…" : "Set password"}
-                        </Button>
-                      </div>
-                    )}
-                    {!lockDraft && hasLock && !pwOpen && (
-                      <Button
-                        variant="link"
-                        size="xs"
-                        data-testid="share-password-change"
-                        className="mt-1 self-start px-0"
-                        onClick={() => setPwOpen(true)}
-                      >
-                        Change password
-                      </Button>
-                    )}
-                  </>
+                  </WorldLinkControls>
                 )}
 
                 {/* First-need on-ramp: the word "workspace" earns its first

--- a/apps/web/src/pages/brandprint/use-brandprint-import.ts
+++ b/apps/web/src/pages/brandprint/use-brandprint-import.ts
@@ -92,7 +92,7 @@ export function useBrandprintImport(
         // Conventions are for the whole team: open the collection to the workspace so
         // members can read the docs (collection access propagates to its contents).
         // Best-effort — MCP delivery reads under the workspace grant either way.
-        await api.setCollectionAccess(target, "member").catch(() => {})
+        await api.setCollectionAccess(target, { workspaceAccess: "member" }).catch(() => {})
       }
       // Seed the brand-profile placeholder on the first run that lacks one, best-effort
       // — losing it costs the hand-off beat, not the docs (a later run heals it).

--- a/apps/web/src/pages/library/artifact-card.tsx
+++ b/apps/web/src/pages/library/artifact-card.tsx
@@ -41,7 +41,7 @@ export function ArtifactCard({
 }: {
   artifact: Artifact
   onOpen: () => void
-  onToggleFavorite: () => void
+  onToggleFavorite?: () => void
   // Quick action in the ⋯ menu — organize without opening the artifact.
   // Collections apply to any signed-in viewer (you're organizing your
   // collections, not mutating the artifact).
@@ -188,29 +188,31 @@ export function ArtifactCard({
               </DropdownMenuContent>
             </DropdownMenu>
           )}
-          <Button
-            size="icon-sm"
-            variant="outline"
-            data-testid={`artifact-card-favorite-${a.short_id}`}
-            aria-label="Toggle favorite"
-            aria-pressed={a.favorite}
-            onClick={(e) => {
-              e.stopPropagation()
-              onToggleFavorite()
-            }}
-            className={cn("relative border-border-soft bg-card", reveal(!!a.favorite))}
-          >
-            <Icon
-              name="star"
-              size={16}
-              weight={a.favorite ? "fill" : "regular"}
-              className={a.favorite ? "text-primary" : "text-muted-foreground"}
-            />
-            <span
-              aria-hidden
-              className="absolute top-1/2 left-1/2 size-[max(100%,3rem)] -translate-1/2 pointer-fine:hidden"
-            />
-          </Button>
+          {onToggleFavorite && (
+            <Button
+              size="icon-sm"
+              variant="outline"
+              data-testid={`artifact-card-favorite-${a.short_id}`}
+              aria-label="Toggle favorite"
+              aria-pressed={a.favorite}
+              onClick={(e) => {
+                e.stopPropagation()
+                onToggleFavorite()
+              }}
+              className={cn("relative border-border-soft bg-card", reveal(!!a.favorite))}
+            >
+              <Icon
+                name="star"
+                size={16}
+                weight={a.favorite ? "fill" : "regular"}
+                className={a.favorite ? "text-primary" : "text-muted-foreground"}
+              />
+              <span
+                aria-hidden
+                className="absolute top-1/2 left-1/2 size-[max(100%,3rem)] -translate-1/2 pointer-fine:hidden"
+              />
+            </Button>
+          )}
         </div>
       </div>
 

--- a/apps/web/src/pages/library/public-collection.tsx
+++ b/apps/web/src/pages/library/public-collection.tsx
@@ -1,0 +1,121 @@
+import { useQuery } from "@tanstack/react-query"
+import { useNavigate, useParams } from "@tanstack/react-router"
+import { useState } from "react"
+import { ApiError, api } from "@/api"
+import { Icon } from "@/components/icons"
+import { EmptyState } from "@/components/shared/empty-state"
+import { PasswordGate } from "@/components/shared/password-gate"
+import { Spinner } from "@/components/shared/spinner"
+import { Button } from "@/components/ui/button"
+import { useDocumentTitle } from "@/lib/use-document-title"
+import { ArtifactCard } from "./artifact-card"
+import { ShareCollectionDialog } from "./share-collection-dialog"
+
+/** The canonical collection link. It is intentionally a thin projection over the
+ *  same collection record, artifact-list endpoint, cards, share dialog, and password
+ *  gate used elsewhere—no public-only collection model to drift. */
+export function PublicCollection() {
+  const { id } = useParams({ from: "/collections/$id" })
+  const nav = useNavigate()
+  const [sharing, setSharing] = useState(false)
+  const collection = useQuery({
+    queryKey: ["collection", id],
+    queryFn: () => api.getCollection(id),
+    retry: false,
+  })
+  const locked = collection.error instanceof ApiError && collection.error.status === 401
+  const artifacts = useQuery({
+    queryKey: ["artifacts", "collection-link", id],
+    queryFn: () => api.listArtifacts({ collection: id, limit: 100 }).then((r) => r.artifacts),
+    enabled: !!collection.data,
+  })
+  useDocumentTitle(collection.data?.title ?? null)
+
+  if (locked)
+    return (
+      <PasswordGate
+        subject="collection"
+        unlock={(password) => api.unlockCollection(id, password)}
+        onUnlocked={() => collection.refetch()}
+      />
+    )
+  if (collection.isError)
+    return (
+      <div className="grid min-h-dvh place-items-center bg-background px-4">
+        <EmptyState icon={<Icon name="collection" />} title="Collection not found">
+          This link is unavailable or you don't have access.
+        </EmptyState>
+      </div>
+    )
+  if (!collection.data)
+    return (
+      <div className="grid min-h-dvh place-items-center bg-background">
+        <Spinner />
+      </div>
+    )
+
+  const col = collection.data
+  // Effective role may come solely from an editor world link. That can edit
+  // contents, but it cannot bootstrap re-sharing; the API's standing decision
+  // is authoritative for whether this control exists.
+  const canShare = col.can_share === true
+  return (
+    <main className="min-h-dvh bg-background">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-5 py-8 sm:px-8 sm:py-12">
+        <header className="flex flex-wrap items-end gap-4 border-b border-border-soft pb-6">
+          <div className="min-w-0 flex-1">
+            <div className="mb-2 flex items-center gap-2 text-sm text-muted-foreground">
+              <Icon name="collection" /> Collection
+            </div>
+            <h1 className="font-serif text-3xl font-medium tracking-tight text-foreground">
+              {col.title}
+            </h1>
+            <p className="mt-2 text-sm text-muted-foreground">
+              {col.count} {col.count === 1 ? "artifact" : "artifacts"}
+            </p>
+          </div>
+          {canShare && (
+            <Button
+              data-testid="collection-public-share"
+              size="sm"
+              onClick={() => setSharing(true)}
+            >
+              <Icon name="share" /> Share
+            </Button>
+          )}
+        </header>
+
+        {artifacts.isPending ? (
+          <div className="grid min-h-48 place-items-center">
+            <Spinner />
+          </div>
+        ) : artifacts.data?.length ? (
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {artifacts.data.map((artifact) => (
+              <ArtifactCard
+                key={artifact.short_id}
+                artifact={artifact}
+                onOpen={() => nav({ to: "/artifacts/$ref", params: { ref: artifact.short_id } })}
+              />
+            ))}
+          </div>
+        ) : (
+          <EmptyState icon={<Icon name="collection" />} title="This collection is empty">
+            Artifacts added here will appear through this same link.
+          </EmptyState>
+        )}
+      </div>
+
+      {sharing && (
+        <ShareCollectionDialog
+          collection={col}
+          onChanged={() => {
+            collection.refetch()
+            artifacts.refetch()
+          }}
+          onClose={() => setSharing(false)}
+        />
+      )}
+    </main>
+  )
+}

--- a/apps/web/src/pages/library/share-collection-dialog.tsx
+++ b/apps/web/src/pages/library/share-collection-dialog.tsx
@@ -1,5 +1,13 @@
 import { useEffect, useRef, useState } from "react"
-import { type ArtifactMember, api, type Collection, type Role, type WorkspaceAccess } from "@/api"
+import {
+  type ArtifactInvite,
+  type ArtifactMember,
+  api,
+  type Collection,
+  type LinkRole,
+  type Role,
+  type WorkspaceAccess,
+} from "@/api"
 import { Icon, type IconName } from "@/components/icons"
 import { AccessSegmentToggle } from "@/components/shared/access-segment-toggle"
 import { EmptyState } from "@/components/shared/empty-state"
@@ -7,6 +15,7 @@ import { PersonSearchInput } from "@/components/shared/person-search-input"
 import { ROLE_LABELS, RoleSelect } from "@/components/shared/role-select"
 import { SectionEyebrow } from "@/components/shared/section-eyebrow"
 import { Spinner } from "@/components/shared/spinner"
+import { WorldLinkControls } from "@/components/shared/world-link-controls"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -15,16 +24,19 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
+import { toast } from "@/components/ui/sonner"
+import { useCopy } from "@/lib/clipboard"
 import { useApiMutation } from "@/lib/use-api-mutation"
 
 // Same share experience as an artifact (docs/access-model.md), minus the
 // Anyone segment — a collection isn't individually link-servable content, it's a
 // grouping of other artifacts, each with its own access. So just the one
 // question: invite-only, or does the workspace reach it at each member's seat?
-type Segment = "invite" | "workspace"
+type Segment = "invite" | "workspace" | "anyone"
 const SEGMENTS: { value: Segment; label: string; icon: IconName }[] = [
   { value: "invite", label: "Invited", icon: "lock" },
   { value: "workspace", label: "Workspace", icon: "workspace" },
+  { value: "anyone", label: "Anyone", icon: "globe" },
 ]
 
 // Share a collection: who can open it at all (Invited vs Workspace, applies
@@ -38,7 +50,8 @@ export function ShareCollectionDialog({
   /** Narrowed to the fields this dialog reads, so both callers fit: the library
    *  passes a full Collection; the artifact share dialog passes a CollectionGrant
    *  (its disclosure row's Manage action — see share-dialog.tsx). */
-  collection: Pick<Collection, "id" | "title" | "created_by" | "workspace_access" | "my_role">
+  collection: Pick<Collection, "id" | "title" | "created_by" | "workspace_access" | "my_role"> &
+    Partial<Pick<Collection, "link_role" | "password_protected" | "url">>
   onClose: () => void
   /** Fired each time a write LANDS (access flip, member add/remove/re-role) — the
    *  artifact share dialog refetches its disclosure rows from here, never from
@@ -46,6 +59,7 @@ export function ShareCollectionDialog({
   onChanged?: () => void
 }) {
   const [members, setMembers] = useState<ArtifactMember[]>([])
+  const [invites, setInvites] = useState<ArtifactInvite[]>([])
   const [email, setEmail] = useState("")
   const [role, setRole] = useState<Role>("editor")
   // A ref, not just the mutation's async `isPending`: a burst of synchronous native
@@ -54,6 +68,12 @@ export function ShareCollectionDialog({
   // first mutate re-renders. The ref flips synchronously, so only the first gets through.
   const adding = useRef(false)
   const [wsAccess, setWsAccess] = useState<WorkspaceAccess>(collection.workspace_access ?? "member")
+  const [linkRole, setLinkRole] = useState<LinkRole>(collection.link_role ?? "none")
+  const [hasLock, setHasLock] = useState(!!collection.password_protected)
+  const [lockDraft, setLockDraft] = useState(false)
+  const [passwordOpen, setPasswordOpen] = useState(false)
+  const [password, setPassword] = useState("")
+  const { copied, copy } = useCopy()
   // Re-seed when the caller hands us a different snapshot of the SAME dialog's
   // subject — the artifact share dialog's grant refreshes after a write, and a
   // stale seed here would re-create the exact lie this feature exists to fix.
@@ -61,45 +81,93 @@ export function ShareCollectionDialog({
     setWsAccess(collection.workspace_access ?? "member")
   }, [collection.workspace_access])
 
-  // Unlike an artifact (editors can share — GDocs model), a collection's access
-  // and membership routes are owner-only on the backend (same bar as delete —
-  // pre-dates this dialog, see collections.ts's canManageCollection(..., "manage")
-  // calls). Match that here: an editor would otherwise see live-looking controls
-  // that 403 on every action.
-  const canManage = collection.my_role === "owner"
+  // Same GDocs-style sharing bar as an artifact: owners and editors can share.
+  const canManage = collection.my_role === "owner" || collection.my_role === "editor"
 
   const load = () => {
     api
       .listCollectionMembers(collection.id)
-      .then((r) => setMembers(r.members))
+      .then((r) => {
+        setMembers(r.members)
+        setInvites(r.invites)
+      })
+      .catch(() => toast.error("Couldn't load who has access"))
+  }
+  const loadAccess = () => {
+    api
+      .getCollection(collection.id)
+      .then((fresh) => {
+        setWsAccess(fresh.workspace_access ?? "member")
+        setLinkRole(fresh.link_role ?? "none")
+        setHasLock(!!fresh.password_protected)
+      })
       .catch(() => {})
   }
   // biome-ignore lint/correctness/useExhaustiveDependencies: re-fetch members when the shared collection changes; load reads collection.id.
   useEffect(() => {
     load()
+    loadAccess()
   }, [collection.id])
 
   // Access applies immediately (a Save button between a toggle and its effect is friction
   // with no safety benefit). Optimistic via setWsAccess; the primitive rolls it back +
   // toasts on failure. Membership add/remove/re-role reconcile the roster on success.
+  type AccessDraft = { workspaceAccess: WorkspaceAccess; linkRole: LinkRole; password?: string }
   const accessMut = useApiMutation({
-    mutationFn: (next: WorkspaceAccess) => api.setCollectionAccess(collection.id, next),
+    mutationFn: (next: AccessDraft) => api.setCollectionAccess(collection.id, next),
     optimistic: (next) => {
-      const prev = wsAccess
-      setWsAccess(next)
-      return () => setWsAccess(prev)
+      const prev = { wsAccess, linkRole, hasLock, lockDraft }
+      setWsAccess(next.workspaceAccess)
+      setLinkRole(next.linkRole)
+      if (next.linkRole === "none") {
+        setHasLock(false)
+        setLockDraft(false)
+      }
+      return () => {
+        setWsAccess(prev.wsAccess)
+        setLinkRole(prev.linkRole)
+        setHasLock(prev.hasLock)
+        setLockDraft(prev.lockDraft)
+      }
     },
     onSuccess: (r) => {
       setWsAccess(r.workspace_access)
+      setLinkRole(r.link_role)
+      setHasLock(r.locked)
+      setLockDraft(false)
+      setPasswordOpen(false)
+      setPassword("")
       onChanged?.()
     },
   })
-  const applyAccess = (next: WorkspaceAccess) => accessMut.mutate(next)
+  const applyAccess = (next: AccessDraft) => accessMut.mutate(next)
+  const segment: Segment =
+    linkRole !== "none" ? "anyone" : wsAccess === "member" ? "workspace" : "invite"
+  const linkRoleValue: Exclude<LinkRole, "none"> = linkRole === "none" ? "viewer" : linkRole
+  const pickSegment = (next: Segment) => {
+    if (next === "invite") return applyAccess({ workspaceAccess: "none", linkRole: "none" })
+    if (next === "workspace") return applyAccess({ workspaceAccess: "member", linkRole: "none" })
+    return applyAccess({ workspaceAccess: "member", linkRole: linkRoleValue })
+  }
+  const currentWithPassword = (nextPassword: string): AccessDraft => ({
+    workspaceAccess: wsAccess,
+    linkRole,
+    password: nextPassword,
+  })
+  const toggleLock = (on: boolean) => {
+    if (on) setLockDraft(true)
+    else if (hasLock) applyAccess(currentWithPassword(""))
+    else setLockDraft(false)
+  }
+  const shareUrl =
+    collection.url ??
+    `${typeof window === "undefined" ? "" : window.location.origin}/collections/${collection.id}`
 
   const addMut = useApiMutation({
     mutationFn: (addr: string) => api.setCollectionMember(collection.id, addr, role),
-    onSuccess: () => {
+    onSuccess: (res) => {
       setEmail("")
+      if (res.kind === "invite") toast(`Invite sent to ${res.invite.email}.`)
       load()
       onChanged?.()
     },
@@ -125,6 +193,12 @@ export function ShareCollectionDialog({
     },
   })
   const remove = (m: ArtifactMember) => removeMut.mutate(m)
+
+  const revokeInviteMut = useApiMutation({
+    mutationFn: (inviteId: string) => api.revokeCollectionInvite(collection.id, inviteId),
+    success: "Invite revoked",
+    onSuccess: () => load(),
+  })
 
   // Re-role in place — setCollectionMember upserts, so it's the Add call keyed by handle.
   const changeMut = useApiMutation({
@@ -166,20 +240,37 @@ export function ShareCollectionDialog({
               <div className="mt-2 flex flex-col">
                 <AccessSegmentToggle
                   segments={SEGMENTS}
-                  value={wsAccess === "member" ? "workspace" : "invite"}
-                  onChange={(v) => applyAccess(v === "workspace" ? "member" : "none")}
+                  value={segment}
+                  onChange={pickSegment}
                   disabled={accessMut.isPending}
                   testId="collection-share-access"
                 />
-                {wsAccess === "none" ? (
+                {segment === "invite" ? (
                   <p className="mt-3 text-sm text-muted-foreground">
                     Only the people you add below can open this.
                   </p>
-                ) : (
+                ) : segment === "workspace" ? (
                   <p className="mt-3 text-sm text-muted-foreground">
                     Everyone in the workspace opens this at their role — admins manage, editors
                     edit, commenters comment.
                   </p>
+                ) : (
+                  <WorldLinkControls
+                    role={linkRoleValue}
+                    pending={accessMut.isPending}
+                    hasLock={hasLock}
+                    lockDraft={lockDraft}
+                    passwordOpen={passwordOpen}
+                    password={password}
+                    testPrefix="collection-share"
+                    onRoleChange={(next) =>
+                      applyAccess({ workspaceAccess: wsAccess, linkRole: next })
+                    }
+                    onLockChange={toggleLock}
+                    onPasswordOpen={() => setPasswordOpen(true)}
+                    onPasswordChange={setPassword}
+                    onPasswordSet={(next) => applyAccess(currentWithPassword(next))}
+                  />
                 )}
               </div>
             ) : (
@@ -275,7 +366,47 @@ export function ShareCollectionDialog({
                 })}
               </div>
             )}
+            {invites.length > 0 && (
+              <div className="mt-2 flex flex-col gap-1.5">
+                {invites.map((invite) => (
+                  <div key={invite.id} className="flex items-center gap-2">
+                    <Icon name="mail" className="text-muted-foreground" />
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-sm font-medium text-foreground">
+                        {invite.email}
+                      </div>
+                      <div className="truncate text-xs text-muted-foreground">
+                        Invited · joins as {ROLE_LABELS[invite.role]} once they accept
+                      </div>
+                    </div>
+                    {canManage && (
+                      <Button
+                        data-testid={`collection-share-invite-revoke-${invite.id}`}
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => revokeInviteMut.mutate(invite.id)}
+                        aria-label={`Revoke the invite to ${invite.email}`}
+                      >
+                        <Icon name="close" />
+                      </Button>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
+        </div>
+
+        <div className="border-t border-border pt-4">
+          <Button
+            data-testid="collection-share-url-copy"
+            variant="outline"
+            size="sm"
+            onClick={() => copy(shareUrl)}
+          >
+            <Icon name={copied ? "check" : "link"} />
+            {copied ? "Copied" : "Copy link"}
+          </Button>
         </div>
       </DialogContent>
     </Dialog>

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -33,8 +33,10 @@ import { Route as SettingsSectionRouteImport } from './routes/settings.$section'
 import { Route as InviteTokenRouteImport } from './routes/invite.$token'
 import { Route as ContextsNewRouteImport } from './routes/contexts.new'
 import { Route as ContextsIdRouteImport } from './routes/contexts.$id'
+import { Route as CollectionsIdRouteImport } from './routes/collections.$id'
 import { Route as ClaimTokenRouteImport } from './routes/claim.$token'
 import { Route as ArtifactsRefRouteImport } from './routes/artifacts.$ref'
+import { Route as InviteCTokenRouteImport } from './routes/invite.c.$token'
 import { Route as InviteATokenRouteImport } from './routes/invite.a.$token'
 
 const WelcomeRoute = WelcomeRouteImport.update({
@@ -157,6 +159,11 @@ const ContextsIdRoute = ContextsIdRouteImport.update({
   path: '/contexts/$id',
   getParentRoute: () => rootRouteImport,
 } as any)
+const CollectionsIdRoute = CollectionsIdRouteImport.update({
+  id: '/collections/$id',
+  path: '/collections/$id',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ClaimTokenRoute = ClaimTokenRouteImport.update({
   id: '/claim/$token',
   path: '/claim/$token',
@@ -165,6 +172,11 @@ const ClaimTokenRoute = ClaimTokenRouteImport.update({
 const ArtifactsRefRoute = ArtifactsRefRouteImport.update({
   id: '/artifacts/$ref',
   path: '/artifacts/$ref',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const InviteCTokenRoute = InviteCTokenRouteImport.update({
+  id: '/invite/c/$token',
+  path: '/invite/c/$token',
   getParentRoute: () => rootRouteImport,
 } as any)
 const InviteATokenRoute = InviteATokenRouteImport.update({
@@ -193,6 +205,7 @@ export interface FileRoutesByFullPath {
   '/welcome': typeof WelcomeRoute
   '/artifacts/$ref': typeof ArtifactsRefRoute
   '/claim/$token': typeof ClaimTokenRoute
+  '/collections/$id': typeof CollectionsIdRoute
   '/contexts/$id': typeof ContextsIdRoute
   '/contexts/new': typeof ContextsNewRoute
   '/invite/$token': typeof InviteTokenRoute
@@ -201,6 +214,7 @@ export interface FileRoutesByFullPath {
   '/contexts/': typeof ContextsIndexRoute
   '/settings/': typeof SettingsIndexRoute
   '/invite/a/$token': typeof InviteATokenRoute
+  '/invite/c/$token': typeof InviteCTokenRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -221,6 +235,7 @@ export interface FileRoutesByTo {
   '/welcome': typeof WelcomeRoute
   '/artifacts/$ref': typeof ArtifactsRefRoute
   '/claim/$token': typeof ClaimTokenRoute
+  '/collections/$id': typeof CollectionsIdRoute
   '/contexts/$id': typeof ContextsIdRoute
   '/contexts/new': typeof ContextsNewRoute
   '/invite/$token': typeof InviteTokenRoute
@@ -229,6 +244,7 @@ export interface FileRoutesByTo {
   '/contexts': typeof ContextsIndexRoute
   '/settings': typeof SettingsIndexRoute
   '/invite/a/$token': typeof InviteATokenRoute
+  '/invite/c/$token': typeof InviteCTokenRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -251,6 +267,7 @@ export interface FileRoutesById {
   '/welcome': typeof WelcomeRoute
   '/artifacts/$ref': typeof ArtifactsRefRoute
   '/claim/$token': typeof ClaimTokenRoute
+  '/collections/$id': typeof CollectionsIdRoute
   '/contexts/$id': typeof ContextsIdRoute
   '/contexts/new': typeof ContextsNewRoute
   '/invite/$token': typeof InviteTokenRoute
@@ -259,6 +276,7 @@ export interface FileRoutesById {
   '/contexts/': typeof ContextsIndexRoute
   '/settings/': typeof SettingsIndexRoute
   '/invite/a/$token': typeof InviteATokenRoute
+  '/invite/c/$token': typeof InviteCTokenRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -282,6 +300,7 @@ export interface FileRouteTypes {
     | '/welcome'
     | '/artifacts/$ref'
     | '/claim/$token'
+    | '/collections/$id'
     | '/contexts/$id'
     | '/contexts/new'
     | '/invite/$token'
@@ -290,6 +309,7 @@ export interface FileRouteTypes {
     | '/contexts/'
     | '/settings/'
     | '/invite/a/$token'
+    | '/invite/c/$token'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -310,6 +330,7 @@ export interface FileRouteTypes {
     | '/welcome'
     | '/artifacts/$ref'
     | '/claim/$token'
+    | '/collections/$id'
     | '/contexts/$id'
     | '/contexts/new'
     | '/invite/$token'
@@ -318,6 +339,7 @@ export interface FileRouteTypes {
     | '/contexts'
     | '/settings'
     | '/invite/a/$token'
+    | '/invite/c/$token'
   id:
     | '__root__'
     | '/'
@@ -339,6 +361,7 @@ export interface FileRouteTypes {
     | '/welcome'
     | '/artifacts/$ref'
     | '/claim/$token'
+    | '/collections/$id'
     | '/contexts/$id'
     | '/contexts/new'
     | '/invite/$token'
@@ -347,6 +370,7 @@ export interface FileRouteTypes {
     | '/contexts/'
     | '/settings/'
     | '/invite/a/$token'
+    | '/invite/c/$token'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -369,12 +393,14 @@ export interface RootRouteChildren {
   WelcomeRoute: typeof WelcomeRoute
   ArtifactsRefRoute: typeof ArtifactsRefRoute
   ClaimTokenRoute: typeof ClaimTokenRoute
+  CollectionsIdRoute: typeof CollectionsIdRoute
   ContextsIdRoute: typeof ContextsIdRoute
   ContextsNewRoute: typeof ContextsNewRoute
   InviteTokenRoute: typeof InviteTokenRoute
   UsersHandleRoute: typeof UsersHandleRoute
   ContextsIndexRoute: typeof ContextsIndexRoute
   InviteATokenRoute: typeof InviteATokenRoute
+  InviteCTokenRoute: typeof InviteCTokenRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -547,6 +573,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ContextsIdRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/collections/$id': {
+      id: '/collections/$id'
+      path: '/collections/$id'
+      fullPath: '/collections/$id'
+      preLoaderRoute: typeof CollectionsIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/claim/$token': {
       id: '/claim/$token'
       path: '/claim/$token'
@@ -559,6 +592,13 @@ declare module '@tanstack/react-router' {
       path: '/artifacts/$ref'
       fullPath: '/artifacts/$ref'
       preLoaderRoute: typeof ArtifactsRefRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/invite/c/$token': {
+      id: '/invite/c/$token'
+      path: '/invite/c/$token'
+      fullPath: '/invite/c/$token'
+      preLoaderRoute: typeof InviteCTokenRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/invite/a/$token': {
@@ -605,12 +645,14 @@ const rootRouteChildren: RootRouteChildren = {
   WelcomeRoute: WelcomeRoute,
   ArtifactsRefRoute: ArtifactsRefRoute,
   ClaimTokenRoute: ClaimTokenRoute,
+  CollectionsIdRoute: CollectionsIdRoute,
   ContextsIdRoute: ContextsIdRoute,
   ContextsNewRoute: ContextsNewRoute,
   InviteTokenRoute: InviteTokenRoute,
   UsersHandleRoute: UsersHandleRoute,
   ContextsIndexRoute: ContextsIndexRoute,
   InviteATokenRoute: InviteATokenRoute,
+  InviteCTokenRoute: InviteCTokenRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/web/src/routes/collections.$id.tsx
+++ b/apps/web/src/routes/collections.$id.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { PublicCollection } from "../pages/library/public-collection"
+
+export const Route = createFileRoute("/collections/$id")({
+  component: PublicCollection,
+})

--- a/apps/web/src/routes/invite.c.$token.tsx
+++ b/apps/web/src/routes/invite.c.$token.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { AcceptCollectionInvite } from "@/pages/accept-invite"
+
+export const Route = createFileRoute("/invite/c/$token")({
+  component: AcceptCollectionInvite,
+})

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -289,6 +289,21 @@ CREATE TABLE IF NOT EXISTS artifact_invite (
 
 CREATE INDEX IF NOT EXISTS artifact_invite_artifact_email ON artifact_invite (artifact_id, email);
 
+CREATE TABLE IF NOT EXISTS collection_invite (
+  id TEXT PRIMARY KEY,
+  collection_id TEXT NOT NULL,
+  email TEXT NOT NULL,
+  role TEXT NOT NULL DEFAULT 'commenter',
+  token TEXT NOT NULL,
+  invited_by TEXT,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  expires_at TEXT NOT NULL,
+  accepted_at TEXT,
+  UNIQUE (token)
+);
+
+CREATE INDEX IF NOT EXISTS collection_invite_collection_email ON collection_invite (collection_id, email);
+
 CREATE TABLE IF NOT EXISTS beta_signup (
   id TEXT PRIMARY KEY,
   email TEXT NOT NULL,
@@ -356,6 +371,8 @@ CREATE TABLE IF NOT EXISTS collection (
   created_by TEXT NOT NULL,
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
   workspace_access TEXT NOT NULL DEFAULT 'member',
+  link_role TEXT NOT NULL DEFAULT 'none',
+  password_hash TEXT,
   folder_id TEXT
 );
 

--- a/docs/access-model.md
+++ b/docs/access-model.md
@@ -67,7 +67,7 @@ Consequences that fall out for free:
 - The **role dropdown only appears for "Anyone"** in the UI — Workspace uses seats,
   so it has no role, just a listing switch.
 
-### Collections propagate like a workspace-open artifact
+### Collections use the same sharing primitive
 
 A collection's role reaches its **contents** by the same explicit-or-seat rule an
 artifact uses, so "who can open the collection" and "who can open what's inside"
@@ -81,15 +81,24 @@ never diverge:
   dialog's promise, "Everyone in the workspace opens this at their role." An
   **invite-only** collection (`workspace_access = none`) grants nothing from a mere
   seat; only its explicit members reach it.
+- A collection **world link** (`link_role`) is also additive on every artifact it
+  contains. The canonical `/collections/:id` page lists the collection through
+  that grant, and direct artifact URLs inherit it. Anonymous holders remain
+  clamped to viewer exactly as they are on artifact links.
+- `password_hash` locks that collection link as one unit. One collection unlock
+  cookie opens the collection page and every contained artifact; standing access
+  from a seat or explicit share never depends on the password.
 
 `collectionRolesForArtifact` (both stores) folds both sources into an artifact's
 effective role, and `collectionRole` gates collection visibility on the same rule —
 so a raw `COUNT(collection_item)` is always truthful for anyone who can see the
 collection (no "· 1 but empty"). The **creator** (`created_by`) is permanently
 owner while that collection's workspace is active and can never be demoted or
-removed; workspace admins may otherwise manage membership. Collections omit
-`listed`/`link_role` (a collection isn't individually link-servable — it's a
-grouping of artifacts, each with its own link).
+removed; workspace admins may otherwise manage membership. Collections deliberately
+omit only `listed`: they are reachable at a canonical link but are not independently
+directory-listed. Their Share dialog reuses the same Invited / Workspace / Anyone
+controls, link-role selector, password controls, people roles, pending email
+invitations, and copy-link action as an artifact.
 
 ## Listing preconditions (the only invariants)
 

--- a/packages/core/src/permissions.ts
+++ b/packages/core/src/permissions.ts
@@ -67,6 +67,9 @@ export interface Actor {
   locked?: boolean
   /** The caller has entered the correct password for a locked artifact. */
   unlocked?: boolean
+  /** An already-authorized world-link grant inherited from a container. Its own
+   *  password gate has been resolved while assembling this Actor. */
+  inheritedLinkRole?: Exclude<LinkRole, "none"> | null
 }
 
 /**
@@ -74,7 +77,7 @@ export interface Actor {
  * (docs/access-model.md). null means no access at all. The single source of
  * truth for the access matrix; SECURITY.md documents the same for humans.
  *
- *   access = max( explicit share , workspace seat , world link )
+ *   access = max( explicit share , workspace seat , world link , inherited link )
  *
  * EXPLICIT (`artifactRole`) — an already-scoped per-artifact or collection grant.
  * Portable collaborator shares always count; request adapters omit workspace-bound
@@ -123,7 +126,12 @@ export function effectiveRole(
         : actor.kind === "user"
           ? linkRole
           : "viewer"
-  return maxRole(explicit, seat, world)
+  const inheritedWorld: Role | null = actor.inheritedLinkRole
+    ? actor.kind === "user"
+      ? actor.inheritedLinkRole
+      : "viewer"
+    : null
+  return maxRole(explicit, seat, world, inheritedWorld)
 }
 
 /** The one authorization gate. */

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -1025,7 +1025,12 @@ export interface CollectionStore {
   getCollections(ids: string[]): Promise<CollectionRecord[]>
   updateCollection(id: string, fields: { title?: string }): Promise<CollectionRecord | null>
   /** Change a collection's share experience (see CollectionRecord.workspace_access). */
-  setCollectionAccess(id: string, workspaceAccess: WorkspaceAccess): Promise<void>
+  setCollectionAccess(
+    id: string,
+    workspaceAccess: WorkspaceAccess,
+    linkRole?: LinkRole,
+    passwordHash?: string | null,
+  ): Promise<void>
   /** Remove a collection and its items + member rows. */
   deleteCollection(id: string): Promise<void>
   /** Collections with their item counts, newest first; scoped to a workspace when orgId is given. */
@@ -1043,6 +1048,9 @@ export interface CollectionStore {
   collectionArtifactIds(collectionId: string): Promise<string[]>
   /** Collection ids containing an artifact (for the artifact's "add to" UI). */
   collectionIdsForArtifact(artifactId: string): Promise<string[]>
+  /** Collections containing an artifact, in one join. Authorization uses their
+   *  already-gated world links as inherited grants on the artifact. */
+  collectionsForArtifact(artifactId: string): Promise<CollectionRecord[]>
   addCollectionItem(collectionId: string, artifactId: string): Promise<void>
   removeCollectionItem(collectionId: string, artifactId: string): Promise<void>
   getCollectionMember(collectionId: string, userId: string): Promise<CollectionMemberRecord | null>
@@ -2017,6 +2025,14 @@ export interface AgentStore {
   deleteArtifactInvite(id: string, artifactId: string): Promise<void>
   /** Atomically spend a still-live invite. Exactly one concurrent caller wins. */
   consumeArtifactInvite(id: string, now: string): Promise<boolean>
+
+  // ---- Collection invitations (share-by-email → accept) -------------------
+  createCollectionInvite(i: NewCollectionInvite): Promise<CollectionInviteRecord>
+  getCollectionInviteByToken(tokenHash: string): Promise<CollectionInviteRecord | null>
+  listPendingCollectionInvites(collectionId: string): Promise<CollectionInviteRecord[]>
+  deletePendingCollectionInvitesFor(collectionId: string, email: string): Promise<void>
+  deleteCollectionInvite(id: string, collectionId: string): Promise<void>
+  consumeCollectionInvite(id: string, now: string): Promise<boolean>
   // ---- Beta signups (the marketing site's request-access form) ------------
   /** Record a beta signup (idempotent per email). Returns true when the email is
    *  new, false when it was already on the list — the caller resends the access
@@ -2709,6 +2725,29 @@ export interface NewArtifactInvite {
   expires_at: string
 }
 
+/** Collection counterpart to ArtifactInviteRecord. Separate storage preserves
+ *  each subject's foreign-key lifecycle; the API/UI share the invite behavior. */
+export interface CollectionInviteRecord {
+  id: string
+  collection_id: string
+  email: string
+  role: Role
+  token: string
+  invited_by: string | null
+  created_at: string
+  expires_at: string
+  accepted_at: string | null
+}
+export interface NewCollectionInvite {
+  id: string
+  collection_id: string
+  email: string
+  role: Role
+  token: string
+  invited_by?: string | null
+  expires_at: string
+}
+
 /**
  * A candidate version awaiting review. It holds content exactly like a version
  * (blob_key + content_type, file or bundle manifest) but is NOT current until a
@@ -3075,6 +3114,10 @@ export interface CollectionRecord {
    *  link-servable content). `member` = every workspace member reaches it at
    *  their seat role; `none` = invite-only (collectionMember rows only). */
   workspace_access: WorkspaceAccess
+  /** What merely holding the canonical collection URL grants. */
+  link_role: LinkRole
+  /** Salted hash that gates only the collection's world-link grant. */
+  password_hash: string | null
   /** The org-shared folder this collection is filed under (null = ungrouped). Pure
    *  organization — never consulted by any auth path. See FolderRecord. */
   folder_id: string | null
@@ -3087,6 +3130,8 @@ export interface NewCollection {
   /** Omitted falls to the store's column default (`member`, unlike an artifact's
    *  fail-closed `none` — see CollectionRecord.workspace_access). */
   workspace_access?: WorkspaceAccess
+  link_role?: LinkRole
+  password_hash?: string | null
 }
 
 /** A folder that organizes ONE collection's artifacts (Collection → Folder → artifacts).

--- a/packages/core/test/permissions.test.ts
+++ b/packages/core/test/permissions.test.ts
@@ -49,6 +49,13 @@ describe("effectiveRole resolution", () => {
     expect(effectiveRole(user({}), "member")).toBe(null) // no seat
     expect(effectiveRole(user({ locked: true }), "none", "viewer")).toBe(null)
   })
+  it("folds an inherited collection link into the same additive role ladder", () => {
+    expect(effectiveRole(user({ inheritedLinkRole: "commenter" }), "none")).toBe("commenter")
+    expect(
+      effectiveRole(user({ artifactRole: "viewer", inheritedLinkRole: "editor" }), "none"),
+    ).toBe("editor")
+    expect(effectiveRole({ kind: "anon", inheritedLinkRole: "editor" }, "none")).toBe("viewer")
+  })
   it("a static token is owner; an anonymous caller is always read-only, never above viewer", () => {
     expect(effectiveRole({ kind: "token" }, "member")).toBe("owner")
     // No "open"/trusted-anonymous path exists: anon never gets a writing role, even

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -373,6 +373,25 @@ export const artifactInvite = pgTable(
   ],
 )
 
+export const collectionInvite = pgTable(
+  "collection_invite",
+  {
+    id: text("id").primaryKey(),
+    collection_id: text("collection_id").notNull(),
+    email: text("email").notNull(),
+    role: text("role").$type<Role>().notNull().default("commenter"),
+    token: text("token").notNull(),
+    invited_by: text("invited_by"),
+    created_at: text("created_at").notNull().$defaultFn(isoNow),
+    expires_at: text("expires_at").notNull(),
+    accepted_at: text("accepted_at"),
+  },
+  (t) => [
+    uniqueIndex("collection_invite_token").on(t.token),
+    index("collection_invite_collection_email").on(t.collection_id, t.email),
+  ],
+)
+
 // A beta signup from the marketing site (see schema.ts for the full note).
 export const betaSignup = pgTable(
   "beta_signup",
@@ -486,6 +505,8 @@ export const collection = pgTable("collection", {
   // See the sqlite dialect's schema.ts for the full comment. Defaults to `member`
   // (not artifact's fail-closed `none`) to match collections' existing behavior.
   workspace_access: text("workspace_access").$type<WorkspaceAccess>().notNull().default("member"),
+  link_role: text("link_role").$type<LinkRole>().notNull().default("none"),
+  password_hash: text("password_hash"),
   // See schema.ts for the full comment: the org-shared folder this collection is filed
   // under (null = ungrouped). Plain nullable pointer, NOT a FK — folders grant no access.
   folder_id: text("folder_id"),
@@ -974,6 +995,7 @@ const TABLES = [
   connection,
   invitation,
   artifactInvite,
+  collectionInvite,
   betaSignup,
   signupAttribution,
   instanceOperator,

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -10,6 +10,7 @@ import type {
   AuditLogRecord,
   AutomationRecord,
   BootstrapRead,
+  CollectionInviteRecord,
   CollectionMemberRecord,
   CollectionPreview,
   CollectionRecord,
@@ -55,6 +56,7 @@ import type {
   NewAuditLog,
   NewAutomation,
   NewCollection,
+  NewCollectionInvite,
   NewCollectionMember,
   NewComment,
   NewConnection,
@@ -172,6 +174,7 @@ import {
   betaSignup,
   collection,
   collectionFavorite,
+  collectionInvite,
   collectionItem,
   collectionMember,
   comment,
@@ -2936,14 +2939,24 @@ export class PgMetaStore implements MetaStore {
       .returning()
     return rows[0] ?? null
   }
-  async setCollectionAccess(id: string, workspaceAccess: WorkspaceAccess): Promise<void> {
+  async setCollectionAccess(
+    id: string,
+    workspaceAccess: WorkspaceAccess,
+    linkRole?: LinkRole,
+    passwordHash?: string | null,
+  ): Promise<void> {
     await this.db
       .update(collection)
-      .set({ workspace_access: workspaceAccess })
+      .set({
+        workspace_access: workspaceAccess,
+        ...(linkRole !== undefined ? { link_role: linkRole } : {}),
+        ...(passwordHash !== undefined ? { password_hash: passwordHash } : {}),
+      })
       .where(eq(collection.id, id))
   }
   async deleteCollection(id: string): Promise<void> {
     await this.db.transaction(async (tx) => {
+      await tx.delete(collectionInvite).where(eq(collectionInvite.collection_id, id))
       await tx.delete(collectionItem).where(eq(collectionItem.collection_id, id))
       await tx.delete(collectionMember).where(eq(collectionMember.collection_id, id))
       await tx.delete(folder).where(eq(folder.collection_id, id))
@@ -3068,6 +3081,14 @@ export class PgMetaStore implements MetaStore {
       .from(collectionItem)
       .where(eq(collectionItem.artifact_id, artifactId))
     return rows.map((r) => r.id)
+  }
+  async collectionsForArtifact(artifactId: string): Promise<CollectionRecord[]> {
+    const rows = await this.db
+      .select({ collection })
+      .from(collectionItem)
+      .innerJoin(collection, eq(collection.id, collectionItem.collection_id))
+      .where(eq(collectionItem.artifact_id, artifactId))
+    return rows.map((r) => r.collection)
   }
   async addCollectionItem(collectionId: string, artifactId: string): Promise<void> {
     await this.db
@@ -5369,6 +5390,57 @@ export class PgMetaStore implements MetaStore {
       .returning({ id: artifactInvite.id })
     return rows.length > 0
   }
+  // ---- Collection invitations ---------------------------------------------
+  async createCollectionInvite(i: NewCollectionInvite): Promise<CollectionInviteRecord> {
+    const rows = await this.db.insert(collectionInvite).values(i).returning()
+    return one(rows) as CollectionInviteRecord
+  }
+  async getCollectionInviteByToken(tokenHash: string): Promise<CollectionInviteRecord | null> {
+    const rows = await this.db
+      .select()
+      .from(collectionInvite)
+      .where(eq(collectionInvite.token, tokenHash))
+    return (rows[0] as CollectionInviteRecord | undefined) ?? null
+  }
+  listPendingCollectionInvites(collectionId: string): Promise<CollectionInviteRecord[]> {
+    return this.db
+      .select()
+      .from(collectionInvite)
+      .where(
+        and(eq(collectionInvite.collection_id, collectionId), isNull(collectionInvite.accepted_at)),
+      )
+      .orderBy(desc(collectionInvite.created_at)) as Promise<CollectionInviteRecord[]>
+  }
+  async deletePendingCollectionInvitesFor(collectionId: string, email: string): Promise<void> {
+    await this.db
+      .delete(collectionInvite)
+      .where(
+        and(
+          eq(collectionInvite.collection_id, collectionId),
+          eq(collectionInvite.email, email),
+          isNull(collectionInvite.accepted_at),
+        ),
+      )
+  }
+  async deleteCollectionInvite(id: string, collectionId: string): Promise<void> {
+    await this.db
+      .delete(collectionInvite)
+      .where(and(eq(collectionInvite.id, id), eq(collectionInvite.collection_id, collectionId)))
+  }
+  async consumeCollectionInvite(id: string, now: string): Promise<boolean> {
+    const rows = await this.db
+      .update(collectionInvite)
+      .set({ accepted_at: now })
+      .where(
+        and(
+          eq(collectionInvite.id, id),
+          isNull(collectionInvite.accepted_at),
+          gt(collectionInvite.expires_at, now),
+        ),
+      )
+      .returning({ id: collectionInvite.id })
+    return rows.length > 0
+  }
   // ---- Account deletion cascade (see MetaStore.deleteUserData) ------------
   async deleteUserData(userId: string): Promise<void> {
     await this.db.delete(instanceOperator).where(eq(instanceOperator.user_id, userId))
@@ -5394,6 +5466,10 @@ export class PgMetaStore implements MetaStore {
       .update(artifactInvite)
       .set({ invited_by: null })
       .where(eq(artifactInvite.invited_by, userId))
+    await this.db
+      .update(collectionInvite)
+      .set({ invited_by: null })
+      .where(eq(collectionInvite.invited_by, userId))
     await this.db.delete(workspace).where(eq(workspace.id, `ws_p_${userId}`))
   }
   listPendingAgentMentions(agentId: string, limit: number): Promise<AgentMentionRecord[]> {

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -7,6 +7,7 @@ import type {
   AssetRecord,
   AuditLogRecord,
   AutomationRecord,
+  CollectionInviteRecord,
   CollectionMemberRecord,
   CollectionPreview,
   CollectionRecord,
@@ -45,6 +46,7 @@ import type {
   NewAuditLog,
   NewAutomation,
   NewCollection,
+  NewCollectionInvite,
   NewCollectionMember,
   NewComment,
   NewConnection,
@@ -159,6 +161,7 @@ import {
   betaSignup,
   collection,
   collectionFavorite,
+  collectionInvite,
   collectionItem,
   collectionMember,
   comment,
@@ -2276,15 +2279,22 @@ export function makeRepos(db: SqliteDb) {
   const setCollectionAccess = async (
     id: string,
     workspaceAccess: WorkspaceAccess,
+    linkRole?: LinkRole,
+    passwordHash?: string | null,
   ): Promise<void> => {
     await db
       .update(collection)
-      .set({ workspace_access: workspaceAccess })
+      .set({
+        workspace_access: workspaceAccess,
+        ...(linkRole !== undefined ? { link_role: linkRole } : {}),
+        ...(passwordHash !== undefined ? { password_hash: passwordHash } : {}),
+      })
       .where(eq(collection.id, id))
       .run()
   }
   // Sequential cascade (used by D1). better-sqlite3 overrides with a transaction.
   const deleteCollection = async (id: string): Promise<void> => {
+    await db.delete(collectionInvite).where(eq(collectionInvite.collection_id, id)).run()
     await db.delete(collectionItem).where(eq(collectionItem.collection_id, id)).run()
     await db.delete(collectionMember).where(eq(collectionMember.collection_id, id)).run()
     await db.delete(folder).where(eq(folder.collection_id, id)).run()
@@ -2387,6 +2397,15 @@ export function makeRepos(db: SqliteDb) {
         .where(eq(collectionItem.artifact_id, artifactId))
         .all()
     ).map((r) => r.id)
+  const collectionsForArtifact = async (artifactId: string): Promise<CollectionRecord[]> => {
+    const rows = await db
+      .select({ collection })
+      .from(collectionItem)
+      .innerJoin(collection, eq(collection.id, collectionItem.collection_id))
+      .where(eq(collectionItem.artifact_id, artifactId))
+      .all()
+    return rows.map((r) => r.collection as CollectionRecord)
+  }
   const addCollectionItem = async (collectionId: string, artifactId: string): Promise<void> => {
     await db
       .insert(collectionItem)
@@ -4393,6 +4412,62 @@ export function makeRepos(db: SqliteDb) {
     return row !== undefined
   }
 
+  // ---- Collection invitations ---------------------------------------------
+  const createCollectionInvite = async (i: NewCollectionInvite): Promise<CollectionInviteRecord> =>
+    (await db.insert(collectionInvite).values(i).returning().get()) as CollectionInviteRecord
+  const getCollectionInviteByToken = async (
+    tokenHash: string,
+  ): Promise<CollectionInviteRecord | null> =>
+    (await db.select().from(collectionInvite).where(eq(collectionInvite.token, tokenHash)).get()) ??
+    null
+  const listPendingCollectionInvites = async (
+    collectionId: string,
+  ): Promise<CollectionInviteRecord[]> =>
+    db
+      .select()
+      .from(collectionInvite)
+      .where(
+        and(eq(collectionInvite.collection_id, collectionId), isNull(collectionInvite.accepted_at)),
+      )
+      .orderBy(desc(collectionInvite.created_at))
+      .all()
+  const deletePendingCollectionInvitesFor = async (
+    collectionId: string,
+    email: string,
+  ): Promise<void> => {
+    await db
+      .delete(collectionInvite)
+      .where(
+        and(
+          eq(collectionInvite.collection_id, collectionId),
+          eq(collectionInvite.email, email),
+          isNull(collectionInvite.accepted_at),
+        ),
+      )
+      .run()
+  }
+  const deleteCollectionInvite = async (id: string, collectionId: string): Promise<void> => {
+    await db
+      .delete(collectionInvite)
+      .where(and(eq(collectionInvite.id, id), eq(collectionInvite.collection_id, collectionId)))
+      .run()
+  }
+  const consumeCollectionInvite = async (id: string, now: string): Promise<boolean> => {
+    const row = await db
+      .update(collectionInvite)
+      .set({ accepted_at: now })
+      .where(
+        and(
+          eq(collectionInvite.id, id),
+          isNull(collectionInvite.accepted_at),
+          gt(collectionInvite.expires_at, now),
+        ),
+      )
+      .returning({ id: collectionInvite.id })
+      .get()
+    return row !== undefined
+  }
+
   // ---- Account deletion cascade (see MetaStore.deleteUserData) ------------
   const deleteUserData = async (userId: string): Promise<void> => {
     // The user's own association rows go entirely.
@@ -4422,6 +4497,11 @@ export function makeRepos(db: SqliteDb) {
       .update(artifactInvite)
       .set({ invited_by: null })
       .where(eq(artifactInvite.invited_by, userId))
+      .run()
+    await db
+      .update(collectionInvite)
+      .set({ invited_by: null })
+      .where(eq(collectionInvite.invited_by, userId))
       .run()
     // Drop the personal workspace row (removes the "<name>'s Workspace" label).
     await db
@@ -4750,6 +4830,7 @@ export function makeRepos(db: SqliteDb) {
     collectionItemFolders,
     collectionArtifactIds,
     collectionIdsForArtifact,
+    collectionsForArtifact,
     addCollectionItem,
     removeCollectionItem,
     getCollectionMember,
@@ -4927,6 +5008,12 @@ export function makeRepos(db: SqliteDb) {
     deletePendingArtifactInvitesFor,
     deleteArtifactInvite,
     consumeArtifactInvite,
+    createCollectionInvite,
+    getCollectionInviteByToken,
+    listPendingCollectionInvites,
+    deletePendingCollectionInvitesFor,
+    deleteCollectionInvite,
+    consumeCollectionInvite,
     deleteUserData,
     createReport,
     getReport,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -453,6 +453,25 @@ export const artifactInvite = sqliteTable(
   ],
 )
 
+export const collectionInvite = sqliteTable(
+  "collection_invite",
+  {
+    id: text("id").primaryKey(),
+    collection_id: text("collection_id").notNull(),
+    email: text("email").notNull(),
+    role: text("role").$type<Role>().notNull().default("commenter"),
+    token: text("token").notNull(),
+    invited_by: text("invited_by"),
+    created_at: text("created_at").notNull().default(now),
+    expires_at: text("expires_at").notNull(),
+    accepted_at: text("accepted_at"),
+  },
+  (t) => [
+    uniqueIndex("collection_invite_token").on(t.token),
+    index("collection_invite_collection_email").on(t.collection_id, t.email),
+  ],
+)
+
 // A beta signup from the marketing site's request-access form: just the email and
 // when it arrived. The access email (with the create-account link) is sent on
 // signup; this row is the audience list — who asked, and in what order.
@@ -592,6 +611,10 @@ export const collection = sqliteTable("collection", {
   // already folds in the caller's seat unconditionally, so an ADD COLUMN migration
   // defaulting every existing row to `member` changes nothing for anyone.
   workspace_access: text("workspace_access").$type<WorkspaceAccess>().notNull().default("member"),
+  // The canonical collection URL can grant a role which propagates to every item.
+  // Existing collections stay closed to the world through the additive `none` default.
+  link_role: text("link_role").$type<LinkRole>().notNull().default("none"),
+  password_hash: text("password_hash"),
   // The org-shared folder this collection is filed under (null = ungrouped). A plain
   // pointer, NOT a FK — folders are pure organization and grant no access, and a
   // constraint-free nullable column keeps the ADD COLUMN migration trivially additive
@@ -1198,6 +1221,7 @@ const TABLES = [
   connection,
   invitation,
   artifactInvite,
+  collectionInvite,
   betaSignup,
   signupAttribution,
   instanceOperator,


### PR DESCRIPTION
## What changed

- gives collections the same Invited / Workspace / Anyone sharing model as artifacts
- adds canonical collection links, role-based world-link access, and optional password protection
- adds collection member management and pending email invitations
- reuses shared password-gate and world-link controls across artifacts and collections
- propagates collection standing and link grants to contained artifacts while preserving active-workspace ownership boundaries

## Why

Collections previously had a narrower sharing surface than regular artifacts. This makes their sharing behavior consistent while centralizing common UI and authorization primitives.

## Validation

- `pnpm verify`
- local browser dogfood: owner controls, password gate/unlock, anonymous public collection, and signed-in editor link without re-sharing rights

## Review walkthrough

https://derive.to/artifacts/collection-sharing-in-derive-implementation-walk-m75kdukr

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789250513&installation_model_id=428097&pr_number=712&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F712&signature=366a2bb41fb25fafd6b90e6b6e9e7a6bfab07fad1dc4672e034e89943b4cee50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->