### PR TITLE
Share one dialog across artifacts and collections

### DIFF
--- a/apps/web/src/components/shared/share-dialog-sections.tsx
+++ b/apps/web/src/components/shared/share-dialog-sections.tsx
@@ -14,7 +14,7 @@ import { getInitials } from "@/lib/initials"
 export type ShareSegment = "invite" | "workspace" | "anyone"
 type ShareTestPrefix = "share" | "collection-share"
 
-export const SHARE_SEGMENTS: { value: ShareSegment; label: string; icon: IconName }[] = [
+const SHARE_SEGMENTS: { value: ShareSegment; label: string; icon: IconName }[] = [
   { value: "invite", label: "Invited", icon: "lock" },
   { value: "workspace", label: "Workspace", icon: "workspace" },
   { value: "anyone", label: "Anyone", icon: "globe" },

--- a/apps/web/src/components/shared/share-dialog-sections.tsx
+++ b/apps/web/src/components/shared/share-dialog-sections.tsx
@@ -1,0 +1,334 @@
+import type { ReactNode } from "react"
+import type { ArtifactInvite, ArtifactMember, LinkRole, Role, WorkspaceAccess } from "@/api"
+import { Icon, type IconName } from "@/components/icons"
+import { AccessSegmentToggle } from "@/components/shared/access-segment-toggle"
+import { PersonSearchInput } from "@/components/shared/person-search-input"
+import { ROLE_LABELS, RoleSelect } from "@/components/shared/role-select"
+import { SectionEyebrow } from "@/components/shared/section-eyebrow"
+import { Spinner } from "@/components/shared/spinner"
+import { WorldLinkControls } from "@/components/shared/world-link-controls"
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import { Button } from "@/components/ui/button"
+import { getInitials } from "@/lib/initials"
+
+export type ShareSegment = "invite" | "workspace" | "anyone"
+type ShareTestPrefix = "share" | "collection-share"
+
+export const SHARE_SEGMENTS: { value: ShareSegment; label: string; icon: IconName }[] = [
+  { value: "invite", label: "Invited", icon: "lock" },
+  { value: "workspace", label: "Workspace", icon: "workspace" },
+  { value: "anyone", label: "Anyone", icon: "globe" },
+]
+
+export const accessIcon = (
+  linkRole: LinkRole,
+  workspaceAccess: WorkspaceAccess,
+  collectionOpen = false,
+): IconName =>
+  linkRole !== "none" ? "globe" : workspaceAccess === "member" || collectionOpen ? "share" : "lock"
+
+export const accessSummary = (
+  linkRole: LinkRole,
+  workspaceAccess: WorkspaceAccess,
+  collectionOpen = false,
+): string => {
+  if (linkRole !== "none") {
+    const what = linkRole === "viewer" ? "view" : linkRole === "editor" ? "edit" : "comment"
+    return `Anyone with the link can ${what}.`
+  }
+  if (workspaceAccess === "member" || collectionOpen)
+    return "Everyone in the workspace can open this."
+  return "Only invited people can open this."
+}
+
+export function ShareAccessSection({
+  canManage,
+  pending,
+  segment,
+  testPrefix,
+  inviteCopy,
+  workspaceCopy,
+  readOnlyIcon,
+  readOnlyCopy,
+  world,
+  workspaceChildren,
+  worldChildren,
+  children,
+  onSegmentChange,
+}: {
+  canManage: boolean
+  pending: boolean
+  segment: ShareSegment
+  testPrefix: ShareTestPrefix
+  inviteCopy: ReactNode
+  workspaceCopy: ReactNode
+  readOnlyIcon: IconName
+  readOnlyCopy: ReactNode
+  world: {
+    role: Exclude<LinkRole, "none">
+    hasLock: boolean
+    lockDraft: boolean
+    passwordOpen: boolean
+    password: string
+    onRoleChange: (role: Exclude<LinkRole, "none">) => void
+    onLockChange: (on: boolean) => void
+    onPasswordOpen: () => void
+    onPasswordChange: (password: string) => void
+    onPasswordSet: (password: string) => void
+  }
+  workspaceChildren?: ReactNode
+  worldChildren?: ReactNode
+  children?: ReactNode
+  onSegmentChange: (segment: ShareSegment) => void
+}) {
+  return (
+    <div>
+      <SectionEyebrow action={pending && <Spinner className="size-3" />}>
+        Who can open this
+      </SectionEyebrow>
+      {canManage ? (
+        <div className="mt-2 flex flex-col">
+          <AccessSegmentToggle
+            segments={SHARE_SEGMENTS}
+            value={segment}
+            onChange={onSegmentChange}
+            disabled={pending}
+            testId={`${testPrefix}-access`}
+          />
+          {segment === "invite" && (
+            <p className="mt-3 text-sm text-muted-foreground">{inviteCopy}</p>
+          )}
+          {segment === "workspace" && (
+            <>
+              <p className="mt-3 text-sm text-muted-foreground">{workspaceCopy}</p>
+              {workspaceChildren}
+            </>
+          )}
+          {segment === "anyone" && (
+            <WorldLinkControls
+              role={world.role}
+              pending={pending}
+              hasLock={world.hasLock}
+              lockDraft={world.lockDraft}
+              passwordOpen={world.passwordOpen}
+              password={world.password}
+              testPrefix={testPrefix}
+              onRoleChange={world.onRoleChange}
+              onLockChange={world.onLockChange}
+              onPasswordOpen={world.onPasswordOpen}
+              onPasswordChange={world.onPasswordChange}
+              onPasswordSet={world.onPasswordSet}
+            >
+              {worldChildren}
+            </WorldLinkControls>
+          )}
+          {children}
+        </div>
+      ) : (
+        <p className="mt-2 flex items-center gap-1.5 text-sm text-muted-foreground">
+          <Icon name={readOnlyIcon} />
+          {readOnlyCopy}
+        </p>
+      )}
+    </div>
+  )
+}
+
+export function SharePeopleSection({
+  members,
+  invites,
+  currentUserId,
+  canManage,
+  email,
+  role,
+  pending,
+  testPrefix,
+  memberIsFixed,
+  onEmailChange,
+  onRoleChange,
+  onAdd,
+  onMemberRoleChange,
+  onRemoveMember,
+  onRevokeInvite,
+}: {
+  members: ArtifactMember[]
+  invites: ArtifactInvite[]
+  currentUserId?: string
+  canManage: boolean
+  email: string
+  role: Role
+  pending: boolean
+  testPrefix: ShareTestPrefix
+  memberIsFixed: (member: ArtifactMember) => boolean
+  onEmailChange: (email: string) => void
+  onRoleChange: (role: Role) => void
+  onAdd: (event: React.FormEvent) => void
+  onMemberRoleChange: (member: ArtifactMember, role: Role) => void
+  onRemoveMember: (member: ArtifactMember) => void
+  onRevokeInvite: (inviteId: string) => void
+}) {
+  return (
+    <div>
+      <SectionEyebrow count={members.length || undefined}>People with access</SectionEyebrow>
+      {members.length === 0 ? (
+        <p
+          data-testid={`${testPrefix}-empty`}
+          className="px-2 py-2.5 text-sm text-muted-foreground"
+        >
+          {canManage ? "No one shared yet." : "No one else has been added."}
+        </p>
+      ) : (
+        <div className="-mx-2 mt-1 flex flex-col">
+          {members.map((member) => {
+            const label = member.name ?? (member.handle ? `@${member.handle}` : member.user_id)
+            return (
+              <div
+                key={member.user_id}
+                data-testid={`${testPrefix}-member-row-${member.user_id}`}
+                className="flex items-center gap-3 rounded-lg px-2 py-2 hover:bg-secondary"
+              >
+                <Avatar className="size-8 shrink-0">
+                  <AvatarFallback className="text-xs">
+                    {getInitials(member.name ?? member.handle ?? "?")}
+                  </AvatarFallback>
+                </Avatar>
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-sm font-medium text-foreground">
+                    {label}
+                    {member.user_id === currentUserId && (
+                      <span className="text-muted-foreground"> (you)</span>
+                    )}
+                  </div>
+                  {member.name && member.handle && (
+                    <div className="truncate font-mono text-2xs text-muted-foreground">
+                      @{member.handle}
+                    </div>
+                  )}
+                </div>
+                {canManage && !memberIsFixed(member) ? (
+                  <>
+                    <div
+                      data-testid={`${testPrefix}-member-role-${member.user_id}`}
+                      className="w-25 shrink-0"
+                    >
+                      <RoleSelect
+                        value={member.role}
+                        onChange={(next) => onMemberRoleChange(member, next)}
+                        aria-label={`Role for ${label}`}
+                        className="w-full"
+                      />
+                    </div>
+                    <Button
+                      data-testid={`${testPrefix}-member-remove-${member.user_id}`}
+                      variant="ghost"
+                      size="icon-sm"
+                      onClick={() => onRemoveMember(member)}
+                      aria-label={`Remove ${label}`}
+                    >
+                      <Icon name="close" />
+                    </Button>
+                  </>
+                ) : (
+                  <span
+                    data-testid={`${testPrefix}-member-role-${member.user_id}`}
+                    className="shrink-0 text-sm text-muted-foreground"
+                  >
+                    {ROLE_LABELS[member.role]}
+                  </span>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      {invites.length > 0 && (
+        <div className="-mx-2 mt-1 flex flex-col">
+          {invites.map((invite) => (
+            <div
+              key={invite.id}
+              data-testid={`${testPrefix}-invite-row-${invite.id}`}
+              className="flex items-center gap-3 rounded-lg px-2 py-2 hover:bg-secondary"
+            >
+              <span className="grid size-8 shrink-0 place-items-center rounded-lg bg-secondary">
+                <Icon name="mail" size={16} className="text-muted-foreground" />
+              </span>
+              <div className="min-w-0 flex-1">
+                <div className="truncate text-sm font-medium text-foreground">{invite.email}</div>
+                <div className="truncate text-xs text-muted-foreground">
+                  Invited · joins as {ROLE_LABELS[invite.role]} once they accept
+                </div>
+              </div>
+              {canManage && (
+                <Button
+                  data-testid={`${testPrefix}-invite-revoke-${invite.id}`}
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={() => onRevokeInvite(invite.id)}
+                  aria-label={`Revoke the invite to ${invite.email}`}
+                >
+                  <Icon name="close" />
+                </Button>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="mt-3 flex flex-col gap-2">
+        {canManage ? (
+          <form onSubmit={onAdd} className="flex items-center gap-1.5">
+            <PersonSearchInput
+              value={email}
+              onChange={onEmailChange}
+              placeholder="Add people by @username or email…"
+              testId={`${testPrefix}-email`}
+            />
+            <div data-testid={`${testPrefix}-role`} className="w-28 shrink-0">
+              <RoleSelect
+                value={role}
+                onChange={onRoleChange}
+                aria-label="Role for new member"
+                className="w-full"
+              />
+            </div>
+            <Button
+              data-testid={`${testPrefix}-add`}
+              variant="default"
+              size="sm"
+              type="submit"
+              loading={pending}
+            >
+              {pending ? "Adding…" : "Add"}
+            </Button>
+          </form>
+        ) : (
+          <div
+            data-testid={`${testPrefix}-viewonly`}
+            className="flex items-center gap-2 rounded-lg bg-secondary px-3 py-2 text-sm text-muted-foreground"
+          >
+            <Icon name="lock" />
+            View only · ask an owner or editor to change access.
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export function ShareCopyLinkButton({
+  copied,
+  testPrefix,
+  onCopy,
+}: {
+  copied: boolean
+  testPrefix: ShareTestPrefix
+  onCopy: () => void
+}) {
+  return (
+    <Button data-testid={`${testPrefix}-url-copy`} variant="outline" size="sm" onClick={onCopy}>
+      <Icon name={copied ? "check" : "link"} />
+      {copied ? "Copied" : "Copy link"}
+    </Button>
+  )
+}

--- a/apps/web/src/pages/artifact/share-dialog.test.ts
+++ b/apps/web/src/pages/artifact/share-dialog.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { accessIcon, accessSummary } from "./share-dialog"
+import { accessIcon, accessSummary } from "@/components/shared/share-dialog-sections"
 
 // The share dialog's pure access projections. The invariant under test: a
 // workspace-open collection makes an artifact workspace-reachable regardless of the

--- a/apps/web/src/pages/artifact/share-dialog.tsx
+++ b/apps/web/src/pages/artifact/share-dialog.tsx
@@ -13,14 +13,16 @@ import {
   type Role,
   type WorkspaceAccess,
 } from "@/api"
-import { Icon, type IconName } from "@/components/icons"
-import { AccessSegmentToggle } from "@/components/shared/access-segment-toggle"
-import { PersonSearchInput } from "@/components/shared/person-search-input"
-import { ROLE_LABELS, RoleSelect } from "@/components/shared/role-select"
+import { Icon } from "@/components/icons"
 import { Eyebrow, SectionEyebrow } from "@/components/shared/section-eyebrow"
-import { Spinner } from "@/components/shared/spinner"
-import { WorldLinkControls } from "@/components/shared/world-link-controls"
-import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import {
+  accessIcon,
+  accessSummary,
+  ShareAccessSection,
+  ShareCopyLinkButton,
+  SharePeopleSection,
+  type ShareSegment,
+} from "@/components/shared/share-dialog-sections"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -34,7 +36,6 @@ import { toast } from "@/components/ui/sonner"
 import { Switch } from "@/components/ui/switch"
 import { useAuth } from "@/ctx"
 import { copyText, useCopy } from "@/lib/clipboard"
-import { getInitials } from "@/lib/initials"
 import { artifactQuery, workspaceQuery } from "@/lib/queries"
 import { STORAGE_KEYS } from "@/lib/storage-keys"
 import { useApiMutation } from "@/lib/use-api-mutation"
@@ -45,41 +46,12 @@ import { ShareCollectionDialog } from "@/pages/library/share-collection-dialog"
 // is the WIDEST reach currently granted: a world link is "anyone"; workspace-seat
 // access is "workspace"; neither is "invite". The world link's role and each
 // segment's listing (does it show in a feed) are secondary switches beneath it.
-type Segment = "invite" | "workspace" | "anyone"
-const SEGMENTS: { value: Segment; label: string; icon: IconName }[] = [
-  { value: "invite", label: "Invited", icon: "lock" },
-  { value: "workspace", label: "Workspace", icon: "workspace" },
-  { value: "anyone", label: "Anyone", icon: "globe" },
-]
-
 // The state glyph the Share trigger carries so exposure is legible without opening
 // the dialog: a globe when the URL alone reads, the share glyph for the workspace,
 // a lock for invite-only. A workspace-open collection makes the artifact workspace-
 // reachable even when its own fields say Invited (see access-model.md) — the lock is
 // a promise ("nobody but the roster"), so it must account for that grant too.
-export const accessIcon = (
-  linkRole: LinkRole,
-  workspaceAccess: WorkspaceAccess,
-  collectionOpen = false,
-): IconName =>
-  linkRole !== "none" ? "globe" : workspaceAccess === "member" || collectionOpen ? "share" : "lock"
-
-// The read-only one-liner for someone who can't manage access. Mirrors accessIcon:
-// a workspace-open collection makes "everyone in the workspace" true regardless of
-// the artifact's own fields, so the summary must fold it in too.
-export const accessSummary = (
-  linkRole: LinkRole,
-  workspaceAccess: WorkspaceAccess,
-  collectionOpen = false,
-): string => {
-  if (linkRole !== "none") {
-    const what = linkRole === "viewer" ? "view" : linkRole === "editor" ? "edit" : "comment"
-    return `Anyone with the link can ${what}.`
-  }
-  if (workspaceAccess === "member" || collectionOpen)
-    return "Everyone in the workspace can open this."
-  return "Only invited people can open this."
-}
+export { accessIcon, accessSummary } from "@/components/shared/share-dialog-sections"
 
 // The access triple + an optional world-link password, applied atomically by setAccess.
 type AccessDraft = {
@@ -204,7 +176,7 @@ export function ShareButton({
   // listed) draft ──────────────────────────────────────────────────────────────
   // The segment is the WIDEST reach: a live world link is "anyone"; workspace-seat
   // access is "workspace"; neither is "invite".
-  const segment: Segment =
+  const segment: ShareSegment =
     lRole !== "none" ? "anyone" : wsAccess === "member" ? "workspace" : "invite"
   // The listing switch per segment — public directory for "anyone", the workspace
   // library for "workspace". Invited lists nowhere.
@@ -254,7 +226,7 @@ export function ShareButton({
   const applyAccess = (next: AccessDraft) => accessMut.mutate(next)
   // Picking a segment sets its fields at the safe default: a fresh segment starts
   // UNLISTED (the switch is how you opt into a feed), the world link at view.
-  const pickSegment = (seg: Segment) => {
+  const pickSegment = (seg: ShareSegment) => {
     if (seg === "invite")
       return void applyAccess({ workspaceAccess: "none", linkRole: "none", listed: "none" })
     if (seg === "workspace")
@@ -460,144 +432,114 @@ export function ShareButton({
         </DialogHeader>
 
         <div className="flex flex-col gap-6">
-          <div>
-            <SectionEyebrow action={accessMut.isPending && <Spinner className="size-3" />}>
-              Who can open this
-            </SectionEyebrow>
-            {canManage ? (
-              <div className="mt-2 flex flex-col">
-                {/* One primary choice — the widest reach. Each segment sets the
-                    (workspace_access, link_role, listed) triple — see pickSegment. */}
-                <AccessSegmentToggle
-                  segments={SEGMENTS}
-                  value={segment}
-                  onChange={pickSegment}
+          <ShareAccessSection
+            canManage={canManage}
+            pending={accessMut.isPending}
+            segment={segment}
+            testPrefix="share"
+            inviteCopy={
+              grants.length > 0
+                ? "Only the people you add below — plus everyone reached through its collections."
+                : "Only the people you add below can open this."
+            }
+            workspaceCopy="Everyone in the workspace opens this at their role — admins manage, editors edit, commenters comment."
+            readOnlyIcon={accessIcon(
+              linkRole ?? "none",
+              workspaceAccess ?? "member",
+              collectionOpen,
+            )}
+            readOnlyCopy={accessSummary(
+              linkRole ?? "none",
+              workspaceAccess ?? "member",
+              collectionOpen,
+            )}
+            onSegmentChange={pickSegment}
+            world={{
+              role: roleValue,
+              hasLock,
+              lockDraft,
+              passwordOpen: pwOpen,
+              password: pw,
+              onRoleChange: pickRole,
+              onLockChange: toggleLock,
+              onPasswordOpen: () => setPwOpen(true),
+              onPasswordChange: setPw,
+              onPasswordSet: setPassword,
+            }}
+            workspaceChildren={
+              <div className="mt-3 flex items-center justify-between gap-3 border-t border-border-soft pt-3">
+                <div className="min-w-0">
+                  <div className="text-sm text-foreground">Show in the workspace library</div>
+                  <div className="text-xs text-muted-foreground">
+                    Otherwise it's link-only — out of the team's feed.
+                  </div>
+                </div>
+                <Switch
+                  checked={isListed}
                   disabled={accessMut.isPending}
-                  testId="share-access"
+                  aria-label="Show in the workspace library"
+                  data-testid="share-listed"
+                  onCheckedChange={toggleListed}
                 />
-
-                {segment === "invite" && (
-                  <p className="mt-3 text-sm text-muted-foreground">
-                    {grants.length > 0
-                      ? // Invited must not read as a promise the collections below break.
-                        "Only the people you add below — plus everyone reached through its collections."
-                      : "Only the people you add below can open this."}
-                  </p>
-                )}
-
-                {/* Workspace: seats decide the role — no dropdown. Admins manage,
-                    editors edit, commenters comment. Just the library switch. */}
-                {segment === "workspace" && (
-                  <>
-                    <p className="mt-3 text-sm text-muted-foreground">
-                      Everyone in the workspace opens this at their role — admins manage, editors
-                      edit, commenters comment.
-                    </p>
-                    <div className="mt-3 flex items-center justify-between gap-3 border-t border-border-soft pt-3">
-                      <div className="min-w-0">
-                        <div className="text-sm text-foreground">Show in the workspace library</div>
-                        <div className="text-xs text-muted-foreground">
-                          Otherwise it's link-only — out of the team's feed.
-                        </div>
-                      </div>
-                      <Switch
-                        checked={isListed}
-                        disabled={accessMut.isPending}
-                        aria-label="Show in the workspace library"
-                        data-testid="share-listed"
-                        onCheckedChange={toggleListed}
-                      />
-                    </div>
-                  </>
-                )}
-
-                {/* Anyone: a world link — its role, its public listing, and the lock. */}
-                {segment === "anyone" && (
-                  <WorldLinkControls
-                    role={roleValue}
-                    pending={accessMut.isPending}
-                    hasLock={hasLock}
-                    lockDraft={lockDraft}
-                    passwordOpen={pwOpen}
-                    password={pw}
-                    testPrefix="share"
-                    onRoleChange={pickRole}
-                    onLockChange={toggleLock}
-                    onPasswordOpen={() => setPwOpen(true)}
-                    onPasswordChange={setPw}
-                    onPasswordSet={setPassword}
-                  >
-                    {/* Listing is a SEPARATE question — its own row, below a rule. */}
-                    <div className="mt-3 flex items-center justify-between gap-3 border-t border-border-soft pt-3">
-                      <div className="min-w-0">
-                        <div className="text-sm text-foreground">List in the public directory</div>
-                        <div className="text-xs text-muted-foreground">
-                          Otherwise the link works, but it stays undiscoverable.
-                        </div>
-                      </div>
-                      <Switch
-                        checked={isListed}
-                        disabled={accessMut.isPending}
-                        aria-label="List in the public directory"
-                        data-testid="share-listed"
-                        onCheckedChange={toggleListed}
-                      />
-                    </div>
-
-                    {/* Public history — a disclosure like the listing: whether the
-                        anonymous page shows every version (dropdown + old reads).
-                        Signed-in readers always see history; this governs anon only. */}
-                    <div className="mt-3 flex items-center justify-between gap-3">
-                      <div className="min-w-0">
-                        <div className="text-sm text-foreground">Show version history</div>
-                        <div className="text-xs text-muted-foreground">
-                          Anyone with the link can browse every version.
-                        </div>
-                      </div>
-                      <Switch
-                        checked={pubHist}
-                        disabled={accessMut.isPending}
-                        aria-label="Show version history on the public page"
-                        data-testid="share-public-history"
-                        onCheckedChange={togglePublicHistory}
-                      />
-                    </div>
-                  </WorldLinkControls>
-                )}
-
-                {/* First-need on-ramp: the word "workspace" earns its first
-                    appearance by answering "how do I show this to my team?". */}
-                {solo && (
-                  <p className="mt-3 text-sm text-muted-foreground">
-                    Working with a team?{" "}
-                    <Button
-                      variant="link"
-                      size="xs"
-                      data-testid="share-create-workspace"
-                      className="px-0"
-                      onClick={() =>
-                        nav({
-                          to: "/settings/$section",
-                          params: { section: "general" },
-                          search: { "new-workspace": "1" },
-                        })
-                      }
-                    >
-                      Create a workspace
-                    </Button>{" "}
-                    to share with them.
-                  </p>
-                )}
               </div>
-            ) : (
-              <p className="mt-2 flex items-center gap-1.5 text-sm text-muted-foreground">
-                <Icon
-                  name={accessIcon(linkRole ?? "none", workspaceAccess ?? "member", collectionOpen)}
-                />
-                {accessSummary(linkRole ?? "none", workspaceAccess ?? "member", collectionOpen)}
+            }
+            worldChildren={
+              <>
+                <div className="mt-3 flex items-center justify-between gap-3 border-t border-border-soft pt-3">
+                  <div className="min-w-0">
+                    <div className="text-sm text-foreground">List in the public directory</div>
+                    <div className="text-xs text-muted-foreground">
+                      Otherwise the link works, but it stays undiscoverable.
+                    </div>
+                  </div>
+                  <Switch
+                    checked={isListed}
+                    disabled={accessMut.isPending}
+                    aria-label="List in the public directory"
+                    data-testid="share-listed"
+                    onCheckedChange={toggleListed}
+                  />
+                </div>
+                <div className="mt-3 flex items-center justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="text-sm text-foreground">Show version history</div>
+                    <div className="text-xs text-muted-foreground">
+                      Anyone with the link can browse every version.
+                    </div>
+                  </div>
+                  <Switch
+                    checked={pubHist}
+                    disabled={accessMut.isPending}
+                    aria-label="Show version history on the public page"
+                    data-testid="share-public-history"
+                    onCheckedChange={togglePublicHistory}
+                  />
+                </div>
+              </>
+            }
+          >
+            {solo && (
+              <p className="mt-3 text-sm text-muted-foreground">
+                Working with a team?{" "}
+                <Button
+                  variant="link"
+                  size="xs"
+                  data-testid="share-create-workspace"
+                  className="px-0"
+                  onClick={() =>
+                    nav({
+                      to: "/settings/$section",
+                      params: { section: "general" },
+                      search: { "new-workspace": "1" },
+                    })
+                  }
+                >
+                  Create a workspace
+                </Button>{" "}
+                to share with them.
               </p>
             )}
-          </div>
+          </ShareAccessSection>
 
           {/* Disclosure, not control: each row is a collection whose sharing reaches
               this artifact — the one access source the fields above can't express
@@ -657,164 +599,32 @@ export function ShareButton({
             </div>
           )}
 
-          <div>
-            <SectionEyebrow count={members.length || undefined}>People with access</SectionEyebrow>
-            {members.length === 0 ? (
-              <p data-testid="share-empty" className="px-2 py-2.5 text-sm text-muted-foreground">
-                {canManage ? "No one shared yet." : "No one else has been added."}
-              </p>
-            ) : (
-              <div className="-mx-2 mt-1 flex flex-col">
-                {members.map((m) => (
-                  <div
-                    key={m.user_id}
-                    data-testid={`share-member-row-${m.user_id}`}
-                    className="flex items-center gap-3 rounded-lg px-2 py-2 hover:bg-secondary"
-                  >
-                    <Avatar className="size-8 shrink-0">
-                      <AvatarFallback className="text-xs">
-                        {getInitials(m.name ?? m.handle ?? "?")}
-                      </AvatarFallback>
-                    </Avatar>
-                    <div className="min-w-0 flex-1">
-                      <div className="truncate text-sm font-medium text-foreground">
-                        {m.name ?? (m.handle ? `@${m.handle}` : m.user_id)}
-                        {m.user_id === me?.id && (
-                          <span className="text-muted-foreground"> (you)</span>
-                        )}
-                      </div>
-                      {m.name && m.handle && (
-                        <div className="truncate font-mono text-2xs text-muted-foreground">
-                          @{m.handle}
-                        </div>
-                      )}
-                    </div>
-                    {/* The sole owner's row is fixed — the server refuses to downgrade
-                      or remove the last owner, so don't offer it. */}
-                    {canManage &&
-                    !(
-                      m.role === "owner" && members.filter((x) => x.role === "owner").length === 1
-                    ) ? (
-                      <>
-                        <div
-                          data-testid={`share-member-role-${m.user_id}`}
-                          className="w-25 shrink-0"
-                        >
-                          <RoleSelect
-                            value={m.role}
-                            onChange={(next) => change(m, next)}
-                            aria-label={`Role for ${m.name ?? (m.handle ? `@${m.handle}` : "member")}`}
-                            className="w-full"
-                          />
-                        </div>
-                        <Button
-                          data-testid={`share-member-remove-${m.user_id}`}
-                          variant="ghost"
-                          size="icon-sm"
-                          onClick={() => remove(m)}
-                          aria-label={`Remove ${m.name ?? (m.handle ? `@${m.handle}` : "member")}`}
-                        >
-                          <Icon name="close" />
-                        </Button>
-                      </>
-                    ) : (
-                      <span
-                        data-testid={`share-member-role-${m.user_id}`}
-                        className="shrink-0 text-sm text-muted-foreground"
-                      >
-                        {ROLE_LABELS[m.role]}
-                      </span>
-                    )}
-                  </div>
-                ))}
-              </div>
-            )}
-
-            {/* Pending emailed invites: not members yet — a quiet mail row with the
-                granted role and a revoke. Accepting turns the row into a member. */}
-            {invites.length > 0 && (
-              <div className="-mx-2 mt-1 flex flex-col">
-                {invites.map((i) => (
-                  <div
-                    key={i.id}
-                    data-testid={`share-invite-row-${i.id}`}
-                    className="flex items-center gap-3 rounded-lg px-2 py-2 hover:bg-secondary"
-                  >
-                    <span className="grid size-8 shrink-0 place-items-center rounded-lg bg-secondary">
-                      <Icon name="mail" size={16} className="text-muted-foreground" />
-                    </span>
-                    <div className="min-w-0 flex-1">
-                      <div className="truncate text-sm font-medium text-foreground">{i.email}</div>
-                      <div className="truncate text-xs text-muted-foreground">
-                        Invited · joins as {ROLE_LABELS[i.role]} once they accept
-                      </div>
-                    </div>
-                    {canManage && (
-                      <Button
-                        data-testid={`share-invite-revoke-${i.id}`}
-                        variant="ghost"
-                        size="icon-sm"
-                        onClick={() => revokeInviteMut.mutate(i.id)}
-                        aria-label={`Revoke the invite to ${i.email}`}
-                      >
-                        <Icon name="close" />
-                      </Button>
-                    )}
-                  </div>
-                ))}
-              </div>
-            )}
-
-            {/* Adding people is the natural next step after seeing who already has
-                access — the roster reads top-to-bottom as one flow: who's in, then
-                bring in more. */}
-            <div className="mt-3 flex flex-col gap-2">
-              {canManage ? (
-                <form onSubmit={add} className="flex items-center gap-1.5">
-                  <PersonSearchInput
-                    value={email}
-                    onChange={setEmail}
-                    placeholder="Add people by @username or email…"
-                    testId="share-email"
-                  />
-                  <div data-testid="share-role" className="w-28 shrink-0">
-                    <RoleSelect
-                      value={role}
-                      onChange={setRole}
-                      aria-label="Role for new member"
-                      className="w-full"
-                    />
-                  </div>
-                  <Button
-                    data-testid="share-add"
-                    variant="default"
-                    size="sm"
-                    type="submit"
-                    loading={addMut.isPending}
-                  >
-                    {addMut.isPending ? "Adding…" : "Add"}
-                  </Button>
-                </form>
-              ) : (
-                <div
-                  data-testid="share-viewonly"
-                  className="flex items-center gap-2 rounded-lg bg-secondary px-3 py-2 text-sm text-muted-foreground"
-                >
-                  <Icon name="lock" />
-                  View only · ask an owner or editor to change access.
-                </div>
-              )}
-            </div>
-          </div>
+          <SharePeopleSection
+            members={members}
+            invites={invites}
+            currentUserId={me?.id}
+            canManage={canManage}
+            email={email}
+            role={role}
+            pending={addMut.isPending}
+            testPrefix="share"
+            memberIsFixed={(member) =>
+              member.role === "owner" &&
+              members.filter((item) => item.role === "owner").length === 1
+            }
+            onEmailChange={setEmail}
+            onRoleChange={setRole}
+            onAdd={add}
+            onMemberRoleChange={change}
+            onRemoveMember={remove}
+            onRevokeInvite={(inviteId) => revokeInviteMut.mutate(inviteId)}
+          />
         </div>
 
         {/* Footer: the universal action on the left, distribution mechanics folded
             behind a quiet disclosure on the right. */}
         <div className="flex items-center justify-between border-t border-border pt-4">
-          <Button data-testid="share-url-copy" variant="outline" size="sm" onClick={copyLink}>
-            <Icon name={copiedLink ? "check" : "link"} />
-            {copiedLink ? "Copied" : "Copy link"}
-          </Button>
+          <ShareCopyLinkButton copied={copiedLink} testPrefix="share" onCopy={copyLink} />
           <Button
             data-testid="share-more-toggle"
             variant="ghost"

--- a/apps/web/src/pages/artifact/share-dialog.tsx
+++ b/apps/web/src/pages/artifact/share-dialog.tsx
@@ -51,8 +51,6 @@ import { ShareCollectionDialog } from "@/pages/library/share-collection-dialog"
 // a lock for invite-only. A workspace-open collection makes the artifact workspace-
 // reachable even when its own fields say Invited (see access-model.md) — the lock is
 // a promise ("nobody but the roster"), so it must account for that grant too.
-export { accessIcon, accessSummary } from "@/components/shared/share-dialog-sections"
-
 // The access triple + an optional world-link password, applied atomically by setAccess.
 type AccessDraft = {
   workspaceAccess: WorkspaceAccess
@@ -145,7 +143,7 @@ export function ShareButton({
   // this caller may see (the collection_access contract) — render verbatim.
   const grants = collectionAccess ?? []
   const collectionOpen = grants.some((g) => g.workspace_access === "member")
-  // The collection being managed in the stacked ShareCollectionDialog (null = closed).
+  // The collection controller mounted over this dialog when its disclosure row is managed.
   const [manageCol, setManageCol] = useState<CollectionGrant | null>(null)
 
   // The canonical share URL — the server-built artifact URL when the detail is
@@ -188,7 +186,7 @@ export function ShareButton({
   // its effect is friction with no safety benefit. The lock is the one exception:
   // checking the box reveals the input, and nothing applies until Set password.
   // Optimistic so the controls don't flash the old state; the primitive rolls back the
-  // draft AND toasts on failure (converged with ShareCollectionDialog — no more inline err).
+  // draft AND toasts on failure through the shared access surface.
   const accessMut = useApiMutation({
     mutationFn: (next: AccessDraft) => api.setAccess(shortId, next),
     optimistic: (next) => {
@@ -573,8 +571,8 @@ export function ShareButton({
                             `${g.member_count} collection ${g.member_count === 1 ? "member opens" : "members open"} this at their role`}
                       </div>
                     </div>
-                    {/* Collection sharing is owner-managed (matches ShareCollectionDialog's
-                        bar); everyone else gets attribution — who to ask. Muted at rest
+                    {/* Collection sharing is owner-managed; everyone else gets attribution —
+                        who to ask. Muted at rest
                         (this section is disclosure, not control — the row's content
                         carries the weight); hover re-inks. */}
                     {g.my_role === "owner" ? (

--- a/apps/web/src/pages/library/share-collection-dialog.tsx
+++ b/apps/web/src/pages/library/share-collection-dialog.tsx
@@ -8,15 +8,14 @@ import {
   type Role,
   type WorkspaceAccess,
 } from "@/api"
-import { Icon, type IconName } from "@/components/icons"
-import { AccessSegmentToggle } from "@/components/shared/access-segment-toggle"
-import { EmptyState } from "@/components/shared/empty-state"
-import { PersonSearchInput } from "@/components/shared/person-search-input"
-import { ROLE_LABELS, RoleSelect } from "@/components/shared/role-select"
-import { SectionEyebrow } from "@/components/shared/section-eyebrow"
-import { Spinner } from "@/components/shared/spinner"
-import { WorldLinkControls } from "@/components/shared/world-link-controls"
-import { Button } from "@/components/ui/button"
+import {
+  accessIcon,
+  accessSummary,
+  ShareAccessSection,
+  ShareCopyLinkButton,
+  SharePeopleSection,
+  type ShareSegment,
+} from "@/components/shared/share-dialog-sections"
 import {
   Dialog,
   DialogContent,
@@ -25,6 +24,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { toast } from "@/components/ui/sonner"
+import { useAuth } from "@/ctx"
 import { useCopy } from "@/lib/clipboard"
 import { useApiMutation } from "@/lib/use-api-mutation"
 
@@ -32,13 +32,6 @@ import { useApiMutation } from "@/lib/use-api-mutation"
 // Anyone segment — a collection isn't individually link-servable content, it's a
 // grouping of other artifacts, each with its own access. So just the one
 // question: invite-only, or does the workspace reach it at each member's seat?
-type Segment = "invite" | "workspace" | "anyone"
-const SEGMENTS: { value: Segment; label: string; icon: IconName }[] = [
-  { value: "invite", label: "Invited", icon: "lock" },
-  { value: "workspace", label: "Workspace", icon: "workspace" },
-  { value: "anyone", label: "Anyone", icon: "globe" },
-]
-
 // Share a collection: who can open it at all (Invited vs Workspace, applies
 // immediately, no Save — mirrors the artifact ShareDialog), plus the people
 // roster whose role applies to every artifact inside it.
@@ -58,6 +51,7 @@ export function ShareCollectionDialog({
    *  onClose, so an Escape mid-flight can't race the write. */
   onChanged?: () => void
 }) {
+  const { me } = useAuth()
   const [members, setMembers] = useState<ArtifactMember[]>([])
   const [invites, setInvites] = useState<ArtifactInvite[]>([])
   const [email, setEmail] = useState("")
@@ -141,10 +135,10 @@ export function ShareCollectionDialog({
     },
   })
   const applyAccess = (next: AccessDraft) => accessMut.mutate(next)
-  const segment: Segment =
+  const segment: ShareSegment =
     linkRole !== "none" ? "anyone" : wsAccess === "member" ? "workspace" : "invite"
   const linkRoleValue: Exclude<LinkRole, "none"> = linkRole === "none" ? "viewer" : linkRole
-  const pickSegment = (next: Segment) => {
+  const pickSegment = (next: ShareSegment) => {
     if (next === "invite") return applyAccess({ workspaceAccess: "none", linkRole: "none" })
     if (next === "workspace") return applyAccess({ workspaceAccess: "member", linkRole: "none" })
     return applyAccess({ workspaceAccess: "member", linkRole: linkRoleValue })
@@ -222,7 +216,7 @@ export function ShareCollectionDialog({
         if (!o) onClose()
       }}
     >
-      <DialogContent aria-describedby={undefined}>
+      <DialogContent className="sm:max-w-lg" aria-describedby={undefined}>
         <DialogHeader>
           <DialogTitle className="line-clamp-1 pr-6">Share “{collection.title}”</DialogTitle>
           <DialogDescription>
@@ -232,181 +226,55 @@ export function ShareCollectionDialog({
         </DialogHeader>
 
         <div className="flex flex-col gap-6">
-          <div>
-            <SectionEyebrow action={accessMut.isPending && <Spinner className="size-3" />}>
-              Who can open this
-            </SectionEyebrow>
-            {canManage ? (
-              <div className="mt-2 flex flex-col">
-                <AccessSegmentToggle
-                  segments={SEGMENTS}
-                  value={segment}
-                  onChange={pickSegment}
-                  disabled={accessMut.isPending}
-                  testId="collection-share-access"
-                />
-                {segment === "invite" ? (
-                  <p className="mt-3 text-sm text-muted-foreground">
-                    Only the people you add below can open this.
-                  </p>
-                ) : segment === "workspace" ? (
-                  <p className="mt-3 text-sm text-muted-foreground">
-                    Everyone in the workspace opens this at their role — admins manage, editors
-                    edit, commenters comment.
-                  </p>
-                ) : (
-                  <WorldLinkControls
-                    role={linkRoleValue}
-                    pending={accessMut.isPending}
-                    hasLock={hasLock}
-                    lockDraft={lockDraft}
-                    passwordOpen={passwordOpen}
-                    password={password}
-                    testPrefix="collection-share"
-                    onRoleChange={(next) =>
-                      applyAccess({ workspaceAccess: wsAccess, linkRole: next })
-                    }
-                    onLockChange={toggleLock}
-                    onPasswordOpen={() => setPasswordOpen(true)}
-                    onPasswordChange={setPassword}
-                    onPasswordSet={(next) => applyAccess(currentWithPassword(next))}
-                  />
-                )}
-              </div>
-            ) : (
-              <p className="mt-2 text-sm text-muted-foreground">
-                {wsAccess === "member"
-                  ? "Everyone in the workspace can open this."
-                  : "Only people added below can open this."}
-              </p>
-            )}
-          </div>
+          <ShareAccessSection
+            canManage={canManage}
+            pending={accessMut.isPending}
+            segment={segment}
+            testPrefix="collection-share"
+            inviteCopy="Only the people you add below can open this."
+            workspaceCopy="Everyone in the workspace opens this at their role — admins manage, editors edit, commenters comment."
+            readOnlyIcon={accessIcon(linkRole, wsAccess)}
+            readOnlyCopy={accessSummary(linkRole, wsAccess)}
+            onSegmentChange={pickSegment}
+            world={{
+              role: linkRoleValue,
+              hasLock,
+              lockDraft,
+              passwordOpen,
+              password,
+              onRoleChange: (next) => applyAccess({ workspaceAccess: wsAccess, linkRole: next }),
+              onLockChange: toggleLock,
+              onPasswordOpen: () => setPasswordOpen(true),
+              onPasswordChange: setPassword,
+              onPasswordSet: (next) => applyAccess(currentWithPassword(next)),
+            }}
+          />
 
-          <div>
-            <SectionEyebrow>People with access</SectionEyebrow>
-            {canManage && (
-              <form onSubmit={add} className="mt-2 flex gap-1.5">
-                <PersonSearchInput
-                  value={email}
-                  onChange={setEmail}
-                  placeholder="@username or email"
-                  testId="collection-share-email"
-                  className="min-w-0"
-                />
-                <RoleSelect
-                  value={role}
-                  onChange={setRole}
-                  data-testid="collection-share-role"
-                  className="w-28 shrink-0"
-                />
-                {/* Add is this dialog's one filled primary — sm to sit flush with
-                    the h-8 row chassis, matching ShareDialog's add row. */}
-                <Button
-                  variant="default"
-                  size="sm"
-                  type="submit"
-                  data-testid="collection-share-add"
-                  loading={addMut.isPending}
-                >
-                  {addMut.isPending ? "Adding…" : "Add"}
-                </Button>
-              </form>
-            )}
-
-            {members.length === 0 ? (
-              <EmptyState className="mt-2 p-6">No one shared yet.</EmptyState>
-            ) : (
-              <div className="mt-2 flex flex-col gap-1.5">
-                {members.map((m) => {
-                  const who = m.name ?? (m.handle ? `@${m.handle}` : "member")
-                  return (
-                    <div key={m.user_id} className="flex items-center gap-2">
-                      <div className="min-w-0 flex-1">
-                        <div className="truncate text-sm font-medium text-foreground">
-                          {m.name ?? (m.handle ? `@${m.handle}` : m.user_id)}
-                        </div>
-                        {m.name && m.handle && (
-                          <div className="truncate font-mono text-2xs text-muted-foreground">
-                            @{m.handle}
-                          </div>
-                        )}
-                      </div>
-                      {/* The creator's row is fixed — a collection's creator is
-                        permanently owner via created_by regardless of member rows
-                        (collectionRole checks it first), so their role can't be
-                        changed and removing the row wouldn't revoke access, just
-                        orphan the roster. Show it read-only even to a manager (the
-                        backend rejects demote/remove of the creator too). */}
-                      {canManage && m.user_id !== collection.created_by ? (
-                        <>
-                          <RoleSelect
-                            value={m.role}
-                            onChange={(next) => change(m, next)}
-                            data-testid={`collection-share-member-role-${m.user_id}`}
-                            aria-label={`Role for ${who}`}
-                            className="w-28 shrink-0"
-                          />
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            data-testid={`collection-share-remove-${m.user_id}`}
-                            onClick={() => remove(m)}
-                            aria-label={`Remove ${who}`}
-                          >
-                            <Icon name="close" />
-                          </Button>
-                        </>
-                      ) : (
-                        <span className="shrink-0 text-sm text-muted-foreground">
-                          {ROLE_LABELS[m.role]}
-                        </span>
-                      )}
-                    </div>
-                  )
-                })}
-              </div>
-            )}
-            {invites.length > 0 && (
-              <div className="mt-2 flex flex-col gap-1.5">
-                {invites.map((invite) => (
-                  <div key={invite.id} className="flex items-center gap-2">
-                    <Icon name="mail" className="text-muted-foreground" />
-                    <div className="min-w-0 flex-1">
-                      <div className="truncate text-sm font-medium text-foreground">
-                        {invite.email}
-                      </div>
-                      <div className="truncate text-xs text-muted-foreground">
-                        Invited · joins as {ROLE_LABELS[invite.role]} once they accept
-                      </div>
-                    </div>
-                    {canManage && (
-                      <Button
-                        data-testid={`collection-share-invite-revoke-${invite.id}`}
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => revokeInviteMut.mutate(invite.id)}
-                        aria-label={`Revoke the invite to ${invite.email}`}
-                      >
-                        <Icon name="close" />
-                      </Button>
-                    )}
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
+          <SharePeopleSection
+            members={members}
+            invites={invites}
+            currentUserId={me?.id}
+            canManage={canManage}
+            email={email}
+            role={role}
+            pending={addMut.isPending}
+            testPrefix="collection-share"
+            memberIsFixed={(member) => member.user_id === collection.created_by}
+            onEmailChange={setEmail}
+            onRoleChange={setRole}
+            onAdd={add}
+            onMemberRoleChange={change}
+            onRemoveMember={remove}
+            onRevokeInvite={(inviteId) => revokeInviteMut.mutate(inviteId)}
+          />
         </div>
 
-        <div className="border-t border-border pt-4">
-          <Button
-            data-testid="collection-share-url-copy"
-            variant="outline"
-            size="sm"
-            onClick={() => copy(shareUrl)}
-          >
-            <Icon name={copied ? "check" : "link"} />
-            {copied ? "Copied" : "Copy link"}
-          </Button>
+        <div className="flex items-center justify-between border-t border-border pt-4">
+          <ShareCopyLinkButton
+            copied={copied}
+            testPrefix="collection-share"
+            onCopy={() => copy(shareUrl)}
+          />
         </div>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## What changed

- extracts one shared access section for artifacts and collections
- extracts one shared people/invite roster and add-person row
- extracts the shared copy-link control
- keeps only resource-specific API adapters and collection cascade copy in each caller

## Root cause

#712 added collection sharing through a separate dialog implementation. It reused low-level controls, but not the regular artifact dialog surface, so opening Share from a collection still looked and behaved like the older collection dialog.

## User impact

Collection sharing now uses the same layout and interaction model as artifact sharing, including Invited / Workspace / Anyone, link roles, password protection, member roles, pending invites, view-only state, and copy link.

## Validation

- `pnpm verify`
- local production build
- browser dogfood from Collections → collection → Share
- verified Workspace roster and Anyone role/password controls

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789255297&installation_model_id=428097&pr_number=714&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F714&signature=e7308d5932aa420842138b03f46a20e92bfe69074cebfdc8033331ee84a13ac3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->