### PR TITLE
Search artifacts by tags and collections

### DIFF
--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -173,9 +173,9 @@ export const artifactRoutes = (ctx: AppContext) => {
   const app = new OpenAPIHono<BlankEnv>()
 
   // Keyset-paginated (?sort=&cursor=&limit=N; the cursor is keyed on the active sort —
-  // see sortKeyOf), with optional server-side ?query= (title search), ?tag=, and
-  // ?favorite=true. Returns { artifacts, next_cursor }. tag/favorite resolve to an id
-  // set first.
+  // see sortKeyOf), with optional server-side ?query= (artifact title, tag, or
+  // collection-title search), ?tag=, and ?favorite=true. Returns { artifacts,
+  // next_cursor }. tag/favorite resolve to an id set first.
   app.openapi(
     createRoute({
       method: "get",
@@ -228,7 +228,7 @@ export const artifactRoutes = (ctx: AppContext) => {
       // keep the historical created-desc ordering when no ?sort= is given.
       const sort = parseSortMode(c.req.query("sort") ?? "created")
       // Cap the search term: it goes into a SQL LIKE, and an oversized value tripped
-      // an unhandled DB error (a long-q 500). No real title search needs > 200 chars.
+      // an unhandled DB error (a long-q 500). No real metadata search needs > 200 chars.
       const q = c.req.query("query")?.trim().slice(0, 200) || undefined
       const tag = c.req.query("tag")?.trim() || undefined
       const collectionId = requestedCollection
@@ -349,6 +349,9 @@ export const artifactRoutes = (ctx: AppContext) => {
         cursor,
         sort,
         q,
+        // Collection titles are searchable only when this caller can see that
+        // collection. Artifact titles/tags already ride the artifact visibility gate.
+        collectionSearchViewerId: isOperator ? undefined : memberKey,
         ids,
         collectionId,
         // `shared` and `following` both resolve to an id set that ALREADY encodes the

--- a/apps/api/test/artifacts.test.ts
+++ b/apps/api/test/artifacts.test.ts
@@ -369,13 +369,31 @@ describe("server-side search + cursor pagination", () => {
       body: JSON.stringify({ tags }),
     })
 
-  it("searches by title server-side, case-insensitive", async () => {
-    await upload("s1.md", "x", { title: "Quarterly ZZUNIQUE Report" })
+  it("searches artifact titles, tags, and collection titles server-side", async () => {
+    const titled = await (await upload("s1.md", "x", { title: "Quarterly ZZUNIQUE Report" })).json()
     await upload("s2.md", "x", { title: "Totally unrelated" })
     const r = await (await app.request("/v1/artifacts?query=zzunique")).json()
     const titles = r.artifacts.map((a: { title: string | null }) => a.title)
     expect(titles).toContain("Quarterly ZZUNIQUE Report")
-    expect(titles.every((t: string | null) => /zzunique/i.test(t ?? ""))).toBe(true)
+
+    await putTags(titled.short_id, ["Roadmap Signal"])
+    const byTag = await (await app.request("/v1/artifacts?query=roadmap")).json()
+    expect(byTag.artifacts.map((a: { short_id: string }) => a.short_id)).toContain(titled.short_id)
+
+    const collection = await meta.createCollection({
+      id: "col_search_materials",
+      org_id: "default",
+      title: "Customer Materials",
+      created_by: "owner",
+    })
+    const titledRecord = await meta.getByShortId(titled.short_id)
+    expect(titledRecord).not.toBeNull()
+    if (!titledRecord) throw new Error("published search fixture was not stored")
+    await meta.addCollectionItem(collection.id, titledRecord.id)
+    const byCollection = await (await app.request("/v1/artifacts?query=customer")).json()
+    expect(byCollection.artifacts.map((a: { short_id: string }) => a.short_id)).toContain(
+      titled.short_id,
+    )
   })
 
   it("paginates newest-first with a keyset cursor (no overlap)", async () => {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -754,6 +754,7 @@ export const api = {
   sendVerificationEmail: (email: string, callbackURL: string): Promise<unknown> =>
     f("/api/auth/send-verification-email", opts({ email, callbackURL })).then(authJson),
 
+  // `q` searches artifact titles, tags, and the titles of containing collections.
   listArtifacts: (
     params?: {
       q?: string

--- a/apps/web/src/components/chrome/command-palette.tsx
+++ b/apps/web/src/components/chrome/command-palette.tsx
@@ -146,7 +146,8 @@ export function CommandPalette() {
     setResults(fuzzyTitles(cachedArtifactRows(qc), query))
   }, [query, paletteOpen, qc])
 
-  // Debounced server search for artifacts while open (authoritative pass).
+  // Debounced server search for artifacts by title, tag, or containing collection
+  // (authoritative pass).
   useEffect(() => {
     if (!paletteOpen) return
     let alive = true

--- a/apps/web/src/pages/library/index.tsx
+++ b/apps/web/src/pages/library/index.tsx
@@ -431,8 +431,8 @@ function LibraryBody({ view }: { view: LibraryView }) {
       value={query}
       onValueChange={setQuery}
       onEnter={(v) => nav({ to: "/search", search: { q: v } })}
-      placeholder="Filter…"
-      aria-label="Filter artifacts by title, or press Enter to search all content"
+      placeholder="Search names, tags, or collections…"
+      aria-label="Search artifacts by name, tag, or collection; press Enter to search content"
       testId="library-search"
       hotkey
       onAsk={(v) => askFromField(v)}

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -190,8 +190,12 @@ export interface ListArtifactsOpts {
    *  `listArtifacts` honors this; `listUserWorks`/`countUserWorks` ignore it and always order
    *  created-desc. */
   sort?: SortMode
-  /** Case-insensitive title search. */
+  /** Case-insensitive metadata search across artifact titles, tags, and collection titles. */
   q?: string
+  /** Which user's accessible collections may contribute collection-title matches.
+   * `undefined` trusts the caller and searches every collection (operator/internal jobs);
+   * `null` searches no collection titles. Artifact-title and tag matching are unaffected. */
+  collectionSearchViewerId?: string | null
   /** Restrict to these artifact ids (tag / favorite filters resolve to ids). Empty ⇒ none. */
   ids?: string[]
   /** Scope to a collection by JOINing its membership rather than materializing every
@@ -742,7 +746,8 @@ export interface CommentStore {
 export interface ArtifactQueryStore {
   /**
    * Newest-first artifact page. `cursor` is keyset pagination on created_at
-   * (rows strictly older than it); `q` is a case-insensitive title search;
+   * (rows strictly older than it); `q` is a case-insensitive metadata search across
+   * artifact titles, tags, and collection titles visible to `collectionSearchViewerId`;
    * `ids` restricts to a set (tag / favorite filters resolve to ids) — an empty
    * `ids` array matches nothing.
    */

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -204,7 +204,7 @@ import {
 } from "./schema"
 
 /**
- * The WHERE conditions for the artifact list (title search, keyset cursor, id
+ * The WHERE conditions for the artifact list (metadata search, keyset cursor, id
  * restriction, workspace scope). The drizzle operators are dialect-agnostic and
  * only the `artifact` columns differ between SQLite/D1 and Postgres, so both
  * drivers build the same filter through this one helper — a new filter is added
@@ -244,7 +244,49 @@ export function artifactListConditions(
     conds.push(sql`(${art.listed} != 'none' OR ${isMember})`)
   }
   // A trusted caller (operator token / internal jobs, no viewerId) sees everything.
-  if (opts?.q) conds.push(like(sql`lower(${art.title})`, `%${opts.q.toLowerCase()}%`))
+  if (opts?.q) {
+    const pattern = `%${opts.q.toLowerCase()}%`
+    const collectionAccess =
+      opts.collectionSearchViewerId === undefined
+        ? sql`1 = 1`
+        : opts.collectionSearchViewerId === null
+          ? sql`1 = 0`
+          : sql`(
+              c.created_by = ${opts.collectionSearchViewerId}
+              OR EXISTS (
+                SELECT 1 FROM collection_member cm
+                WHERE cm.collection_id = c.id AND cm.user_id = ${opts.collectionSearchViewerId}
+              )
+              OR (
+                c.workspace_access = 'member'
+                AND EXISTS (
+                  SELECT 1 FROM membership m
+                  WHERE m.org_id = c.org_id AND m.user_id = ${opts.collectionSearchViewerId}
+                )
+              )
+            )`
+    // One metadata search contract for every artifact-list consumer: an artifact
+    // matches its own title, any of its tags, or the title of any collection that
+    // contains it. EXISTS avoids duplicate artifact rows when several tags/collections
+    // match and, unlike expanding matching relations into an id IN (...), stays safe
+    // for large workspaces under D1's bound-parameter limit. These table names are
+    // deliberately shared by the SQLite/D1 and Postgres schemas, just like the
+    // artifact_member visibility subquery above.
+    conds.push(sql`(
+      lower(${art.title}) LIKE ${pattern}
+      OR EXISTS (
+        SELECT 1 FROM artifact_tag at
+        WHERE at.artifact_id = ${art.id} AND lower(at.tag) LIKE ${pattern}
+      )
+      OR EXISTS (
+        SELECT 1 FROM collection_item ci
+        INNER JOIN collection c ON c.id = ci.collection_id
+        WHERE ci.artifact_id = ${art.id}
+          AND lower(c.title) LIKE ${pattern}
+          AND ${collectionAccess}
+      )
+    )`)
+  }
   if (opts?.cursor) {
     const { field, dir } = sortFields(opts.sort ?? "created")
     const col = artifactSortExpr(art, field)

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -445,11 +445,33 @@ export function runStoreContract(
       expect((await store.listWorkspaceFacts(ORG, { limit: 1 })).length).toBe(1)
     })
 
-    it("filters listArtifacts by title search and by id set (empty ⇒ none)", async () => {
+    it("filters listArtifacts by artifact title, tag, or collection title and by id set", async () => {
       const a = await store.createArtifact(newArtifact({ title: "Quarterly Report XYZ" }))
       expect((await store.listArtifacts({ q: "quarterly report xyz" })).map((x) => x.id)).toContain(
         a.id,
       )
+      await store.setArtifactTags(a.id, ["Finance Planning"])
+      expect((await store.listArtifacts({ q: "finance" })).map((x) => x.id)).toContain(a.id)
+
+      const col = await store.createCollection({
+        id: uuid(),
+        org_id: ORG,
+        title: "Board Materials",
+        created_by: "amy",
+      })
+      await store.addCollectionItem(col.id, a.id)
+      expect((await store.listArtifacts({ q: "board material" })).map((x) => x.id)).toContain(a.id)
+      expect(
+        (
+          await store.listArtifacts({ q: "board material", collectionSearchViewerId: "stranger" })
+        ).map((x) => x.id),
+      ).not.toContain(a.id)
+      expect(
+        (await store.listArtifacts({ q: "board material", collectionSearchViewerId: "amy" })).map(
+          (x) => x.id,
+        ),
+      ).toContain(a.id)
+
       expect((await store.listArtifacts({ ids: [a.id] })).map((x) => x.id)).toEqual([a.id])
       expect(await store.listArtifacts({ ids: [] })).toEqual([])
     })


### PR DESCRIPTION
## What changed

- expands artifact list search from title-only to artifact titles, tags, and containing collection titles
- makes the behavior available to both the global command palette and the library filter through their shared API path
- keeps collection-title matches visibility-aware, including invite-only collections
- updates library search copy so the supported metadata is discoverable

## Why

Searching for an artifact required knowing its exact title even when its tag or collection was the more memorable organizing concept. Both search surfaces already call the same artifact listing endpoint, so the metadata contract belongs at that shared boundary.

## Validation

- `pnpm run ci`
- `pnpm typecheck`
- `pnpm test`
- full pre-commit coverage gate
- focused SQLite store and artifact API coverage for title, tag, collection-title, and collection-visibility behavior

Preview dogfood evidence will be added after deployment is ready.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789271663&installation_model_id=428097&pr_number=715&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F715&signature=9319b9f9af14bb53d45588f2ab2bf098db2beb677dbcc3a7132317955a4737d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->