### PR TITLE
Fix docs deployment command dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -472,7 +472,7 @@ jobs:
           set -euo pipefail
           deployed=false
           for attempt in 1 2 3; do
-            if pnpm --filter @derive/docs deploy; then
+            if pnpm --filter @derive/docs run deploy; then
               deployed=true
               break
             fi


### PR DESCRIPTION
Summary:
- Invoke the docs package deploy script explicitly with pnpm run.
- Avoid pnpm interpreting deploy as its built-in command.

Verification:
- pnpm verify
- Docs Worker dry run: 94 assets, no bindings.

Fixes the failed deploy-docs job from main CI run 31838341596.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/730"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789333688&installation_model_id=428097&pr_number=730&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F730&signature=f33c6e6614c432fcf0d97bfec4bcc93c05599df0258e6faa1c5ec3e49c348b24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->