### PR TITLE
Fix expired artifact preview tokens

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -242,6 +242,10 @@
             "type": "string",
             "description": "Signed, short-lived token for fetching raw content; detail responses only."
           },
+          "raw_token_expires_at": {
+            "type": "string",
+            "description": "Expiry of raw_token as an ISO timestamp; detail responses only."
+          },
           "spa": {
             "type": "boolean",
             "description": "true when the bundle is a single-page app (all paths route to the entry)."

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -83,6 +83,7 @@ import {
   linkRoleOf,
   listedOf,
   MAX_UPLOAD_BYTES,
+  RAW_TOKEN_MAX_AGE_MS,
   RAW_TOKEN_WINDOW_MS,
   readJson,
   str,
@@ -1653,6 +1654,7 @@ export const artifactRoutes = (ctx: AppContext) => {
         ? await meta.getArtifactById(artifact.derived_from)
         : null
       const base = toJson(deps.baseUrl, artifact, versions)
+      const rawTokenIssuedAt = bucketedNow(RAW_TOKEN_WINDOW_MS)
       // `versions` stays at revision granularity (machines/agents); `sessions` is
       // the time-grouped view the UI shows by default. `my_role` tells the client
       // which actions to surface; `open_proposals` badges the review queue while
@@ -1739,11 +1741,11 @@ export const artifactRoutes = (ctx: AppContext) => {
         // a different URL every fetch, which silently defeated the cache — measured, an
         // open whose URL matched served in 13ms from cache; the next one re-downloaded
         // 15KB. Validity is unchanged (verifyState still enforces the same max age).
-        raw_token: signState(
-          { rid: artifact.id },
-          deps.encryptionKey ?? "",
-          bucketedNow(RAW_TOKEN_WINDOW_MS),
-        ),
+        raw_token: signState({ rid: artifact.id }, deps.encryptionKey ?? "", rawTokenIssuedAt),
+        // The detail record can outlive the capability in the browser query cache.
+        // Make the lifetime explicit so the viewer never pins an expired token while
+        // React Query refreshes the record in the background.
+        raw_token_expires_at: new Date(rawTokenIssuedAt + RAW_TOKEN_MAX_AGE_MS).toISOString(),
       })
     },
   )

--- a/apps/api/src/schemas.ts
+++ b/apps/api/src/schemas.ts
@@ -156,6 +156,10 @@ export const Artifact = z
       .string()
       .optional()
       .describe("Signed, short-lived token for fetching raw content; detail responses only."),
+    raw_token_expires_at: z
+      .string()
+      .optional()
+      .describe("Expiry of raw_token as an ISO timestamp; detail responses only."),
     spa: z
       .boolean()
       .optional()

--- a/apps/api/test/raw-token-cache.test.ts
+++ b/apps/api/test/raw-token-cache.test.ts
@@ -15,6 +15,10 @@ const tokenUrlFor = async (
 ) => {
   const rec = await (await app.request(`/v1/artifacts/${shortId}`, { headers })).json()
   expect(rec.raw_token, "the record should carry a raw token for the viewer").toBeTruthy()
+  expect(
+    Date.parse(rec.raw_token_expires_at),
+    "the record should say when its cached raw capability expires",
+  ).toBeGreaterThan(Date.now())
   return `/raw/${shortId}/v/${rec.current_version}/t/${rec.raw_token}/index.html`
 }
 

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -6529,6 +6529,8 @@ export interface components {
             org_id?: string;
             /** @description Signed, short-lived token for fetching raw content; detail responses only. */
             raw_token?: string;
+            /** @description Expiry of raw_token as an ISO timestamp; detail responses only. */
+            raw_token_expires_at?: string;
             /** @description true when the bundle is a single-page app (all paths route to the entry). */
             spa?: boolean;
             /** @description Latest version number; 0 before any content is published. */

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -328,6 +328,11 @@ export const artifactQuery = (shortId: string, client?: QueryClient) =>
   queryOptions({
     queryKey: ["artifact", shortId] as const,
     queryFn: () => api.getArtifact(shortId),
+    // Detail responses contain a short-lived raw-content capability. Persisting the
+    // whole record for 24 hours made an expired token the first value rendered after
+    // boot; the background refresh arrived too late because the iframe had pinned it.
+    // List rows are persisted and still seed the instant header paint below.
+    meta: { persist: false },
     placeholderData: client
       ? () => {
           for (const [, data] of client.getQueriesData<ArtifactListCache>({

--- a/apps/web/src/lib/raw-token.test.ts
+++ b/apps/web/src/lib/raw-token.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest"
+import { rawTokenNeedsRefresh } from "./raw-token"
+
+describe("rawTokenNeedsRefresh", () => {
+  const now = Date.parse("2026-08-15T12:00:00.000Z")
+
+  it("accepts a capability with useful life remaining", () => {
+    expect(rawTokenNeedsRefresh("2026-08-15T12:01:00.000Z", now - 60_000, now)).toBe(false)
+  })
+
+  it("refreshes an expired or nearly-expired capability before mounting the iframe", () => {
+    expect(rawTokenNeedsRefresh("2026-08-15T11:59:59.000Z", now, now)).toBe(true)
+    expect(rawTokenNeedsRefresh("2026-08-15T12:00:10.000Z", now, now)).toBe(true)
+  })
+
+  it("accepts a freshly fetched legacy detail but refreshes an old cached one", () => {
+    expect(rawTokenNeedsRefresh(undefined, now - 10_000, now)).toBe(false)
+    expect(rawTokenNeedsRefresh(undefined, now - 31_000, now)).toBe(true)
+  })
+})

--- a/apps/web/src/lib/raw-token.ts
+++ b/apps/web/src/lib/raw-token.ts
@@ -1,0 +1,21 @@
+// Leave enough life for the iframe navigation and a bundle's relative assets to start.
+// A capability closer to expiry is refreshed before any raw request is made.
+const RAW_TOKEN_REFRESH_MARGIN_MS = 15_000
+
+// Compatibility with a briefly mixed frontend/backend deploy: an older API does not
+// return raw_token_expires_at. A record fetched in the normal 30-second query freshness
+// window is safe (the server guarantees every newly minted token at least three minutes
+// of life); anything older is refreshed before use.
+const LEGACY_DETAIL_FRESH_MS = 30_000
+
+/** Whether a cached artifact detail's raw-content capability must be refreshed before
+ * mounting the sandboxed iframe. `fetchedAt` is React Query's dataUpdatedAt. */
+export const rawTokenNeedsRefresh = (
+  expiresAt: string | undefined,
+  fetchedAt: number,
+  now: number = Date.now(),
+): boolean => {
+  const expires = expiresAt ? Date.parse(expiresAt) : Number.NaN
+  if (Number.isFinite(expires)) return expires <= now + RAW_TOKEN_REFRESH_MARGIN_MS
+  return fetchedAt <= 0 || now - fetchedAt > LEGACY_DETAIL_FRESH_MS
+}

--- a/apps/web/src/lib/raw-url.test.ts
+++ b/apps/web/src/lib/raw-url.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { rawArtifactUrl } from "./queries"
+import { artifactQuery, rawArtifactUrl } from "./queries"
 
 // The regression this guards: the prefetch and the viewer frame each built the raw
 // URL themselves, and they built DIFFERENT ones. The frame loads a tokenized URL
@@ -23,5 +23,11 @@ describe("rawArtifactUrl", () => {
 
   it("distinguishes tokened from tokenless — the mismatch that caused the bug", () => {
     expect(rawArtifactUrl("abc123", 4, "tok")).not.toBe(rawArtifactUrl("abc123", 4))
+  })
+})
+
+describe("artifactQuery", () => {
+  it("does not persist the detail record because it contains a short-lived capability", () => {
+    expect(artifactQuery("abc123").meta).toEqual({ persist: false })
   })
 })

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -19,6 +19,7 @@ import {
   rawArtifactUrl,
   workspaceSettingsQuery,
 } from "@/lib/queries"
+import { rawTokenNeedsRefresh } from "@/lib/raw-token"
 import { ago } from "@/lib/time"
 import { snapshot, useApiMutation } from "@/lib/use-api-mutation"
 import { useDocumentTitle } from "@/lib/use-document-title"
@@ -139,10 +140,22 @@ export function Artifact() {
   const {
     data: art,
     isPlaceholderData: seeded,
+    isFetching: refreshingArtifact,
     isError: failed,
     error,
+    dataUpdatedAt: artifactFetchedAt,
     refetch,
   } = useQuery(artifactQuery(shortId, qc))
+
+  // A restored/in-memory detail can carry a raw capability that expired long before
+  // this click. Refresh it before the iframe gets a src; otherwise the first token is
+  // pinned for the render and the later background response cannot repair its 404.
+  const rawTokenStale =
+    !!art?.raw_token && rawTokenNeedsRefresh(art.raw_token_expires_at, artifactFetchedAt)
+  useEffect(() => {
+    if (!rawTokenStale || refreshingArtifact || failed) return
+    void refetch()
+  }, [rawTokenStale, refreshingArtifact, failed, refetch])
 
   // Deferred use-as-template: the public viewer's "Make your own" sends a signed-out
   // clicker through login with `?use=1`, and the copy fires here, right after auth.
@@ -715,6 +728,12 @@ export function Artifact() {
   // While inline editing, the shown version stays frozen at the mode-entry head so
   // a concurrent publish can't reload the frame and wipe typed-but-unsaved text.
   const shown = version ?? inlineEdit.frozenVersion ?? art.current_version
+  const pinnedForShown =
+    pinnedRawToken.current?.shortId === shortId && pinnedRawToken.current.version === shown
+  // A background failure may leave old metadata available, but an expired capability
+  // cannot render it. Surface the retry state instead of leaving Loading preview… forever.
+  if (failed && rawTokenStale && !pinnedForShown)
+    return <ArtifactLoadError onRetry={() => refetch()} onBack={() => nav({ to: "/" })} />
   // The public-history gate, client half: an anonymous @vN link on an artifact whose
   // owner kept history private is a 404, not a downgrade — the server already
   // refuses the old version's bytes (raw.ts), so render the same not-found the
@@ -739,6 +758,7 @@ export function Artifact() {
   // only ever reloads for a reason (a real version change), not a coincidental refetch.
   if (
     art.raw_token &&
+    !rawTokenStale &&
     (!pinnedRawToken.current ||
       pinnedRawToken.current.shortId !== shortId ||
       pinnedRawToken.current.version !== shown)
@@ -755,7 +775,8 @@ export function Artifact() {
   // rawArtifactUrl is SHARED with the prefetch (lib/queries) so the two can never build
   // different URLs again — when they did, hover prefetching warmed a response the frame
   // never requested.
-  const rawSrc = seeded ? null : rawArtifactUrl(shortId, shown, rawToken)
+  const rawSrc =
+    seeded || (rawTokenStale && !pinnedForShown) ? null : rawArtifactUrl(shortId, shown, rawToken)
   // Editors publish directly; commenters propose a candidate for review.
   const canPublish = art.my_role === "editor" || art.my_role === "owner"
   // md vs html drives syntax highlighting + how the live preview renders.


### PR DESCRIPTION
## Summary

- expose raw iframe capability expiry in artifact detail responses
- keep capability-bearing detail queries out of persisted browser cache
- refresh expired or near-expiry capabilities before mounting the preview iframe
- add regression coverage and regenerate the API contract and client types

## Root cause

Artifact detail records were persisted in the browser for 24 hours while their embedded raw iframe capabilities expire after five minutes. On SPA navigation, the page could immediately render and pin an expired capability before React Query's background refresh completed, leaving the iframe on a 404 until the page was reloaded.

## Impact

Opening a cached artifact now waits for a fresh capability instead of showing "not found." Fresh artifact opens remain immediate, and older API responses use a bounded freshness fallback.

## Validation

- `pnpm verify`
- focused API and web regression tests (13 tests)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/733"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789370063&installation_model_id=428097&pr_number=733&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F733&signature=2dc29445529004ebc6426f4aa64b941f4f2dc41f78879deacb5b6dec35532c98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->