### PR TITLE
Fix docs production marker verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -516,8 +516,8 @@ jobs:
             if [ -n "$asset" ]; then
               asset_headers=$(curl -fsSI --max-time 15 "https://docs.derive.to$asset" | tr -d '\r' || true)
             fi
-            if printf '%s' "$page" | grep -Fq \
-              "<meta name=\"derive-docs-build\" content=\"$GITHUB_SHA\"/>" \
+            if printf '%s' "$page" | grep -Eq \
+              "<meta name=\"derive-docs-build\" content=\"$GITHUB_SHA\"[[:space:]]*/?>" \
               && printf '%s' "$headers" | grep -Eiq '^content-security-policy:' \
               && printf '%s' "$headers" | grep -Eiq '^x-content-type-options: nosniff$' \
               && printf '%s' "$asset_headers" | grep -Eiq \


### PR DESCRIPTION
## Summary
- accept Astro's normal HTML meta serialization in the docs production marker probe
- retain compatibility with an optional XHTML-style closing slash

## Root cause
The docs Worker deployed the correct commit and passed every other production assertion, but Astro serializes void meta elements with a closing angle bracket rather than a self-closing slash.

## Verification
- pnpm verify
- live marker probe against https://docs.derive.to/

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/735"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789375257&installation_model_id=428097&pr_number=735&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F735&signature=3aff2d5b654af27c572cce1a1adf3c404132df08581b51c7b2dbc0b46a8416c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->