### PR TITLE
Improve docs navigation and agent access

### DIFF
--- a/apps/docs/scripts/check-built.mjs
+++ b/apps/docs/scripts/check-built.mjs
@@ -39,7 +39,25 @@ for (const path of required) if (!existsSync(join(DIST, path))) fail(`missing bu
 
 for (const page of docsPages) {
   const path = page.slug === "index" ? "index.html" : `${page.slug}/index.html`
-  if (!existsSync(join(DIST, path))) fail(`manifest page did not build: ${path}`)
+  const htmlFile = join(DIST, path)
+  if (!existsSync(htmlFile)) fail(`manifest page did not build: ${path}`)
+  else {
+    const html = readFileSync(htmlFile, "utf8")
+    if (!html.includes(`type="text/markdown" href="/${page.slug}.md"`))
+      fail(`${path} does not advertise its Markdown representation`)
+    if (page.slug !== "index" && !html.includes(`data-copy-url="/${page.slug}.md"`))
+      fail(`${path} does not expose its Markdown copy action`)
+  }
+  const markdownPath = `${page.slug}.md`
+  const markdownFile = join(DIST, markdownPath)
+  if (!existsSync(markdownFile)) fail(`manifest Markdown page did not build: ${markdownPath}`)
+  else {
+    const markdown = readFileSync(markdownFile, "utf8")
+    if (!markdown.includes(`\n# ${page.title}\n`))
+      fail(`${markdownPath} does not preserve its canonical page title`)
+    if (!markdown.includes("Generated from the canonical repository source"))
+      fail(`${markdownPath} is not marked as generated`)
+  }
 }
 
 const htmlFiles = filesUnder(DIST).filter((path) => extname(path) === ".html")
@@ -50,8 +68,15 @@ for (const path of htmlFiles) {
     fail(`${label} has no docs.derive.to canonical URL`)
   if (label === "404.html" && !/name="robots" content="noindex/.test(html))
     fail("404.html must be noindex")
-  if (/href="\/[^"]+\.md(?:#|\?|")/.test(html))
-    fail(`${label} contains an internal source Markdown link`)
+  const expectedMarkdownHref =
+    label === "index.html"
+      ? "/index.md"
+      : label.endsWith("/index.html")
+        ? `/${label.slice(0, -"/index.html".length)}.md`
+        : undefined
+  for (const match of html.matchAll(/href="(\/[^"]+\.md)(?:#|\?|")/g))
+    if (match[1] !== expectedMarkdownHref)
+      fail(`${label} contains an unexpected internal Markdown link ${match[1]}`)
   if (/<p\b[^>]*>\s*<p\b/i.test(html)) fail(`${label} contains nested paragraph markup`)
 
   for (const match of html.matchAll(/href="([^"]+)"/g)) {

--- a/apps/docs/scripts/sync-content.mjs
+++ b/apps/docs/scripts/sync-content.mjs
@@ -88,7 +88,7 @@ const lastUpdated = (source) => {
 
 const yamlString = (value) => JSON.stringify(value)
 
-const renderPage = (page) => {
+const pageSource = (page) => {
   const source = resolve(REPO_ROOT, page.source)
   if (!withinRepo(source) || !existsSync(source))
     throw new Error(`missing docs source: ${page.source}`)
@@ -97,6 +97,11 @@ const renderPage = (page) => {
   body = rewriteLinks(body, source)
     .replace(/^```caddyfile$/gm, "```text")
     .trim()
+  return { body, source }
+}
+
+const renderPage = (page) => {
+  const { body, source } = pageSource(page)
   const updated = lastUpdated(source)
   const frontmatter = [
     "---",
@@ -109,6 +114,24 @@ const renderPage = (page) => {
   ].join("\n")
   const marker = extname(page.source) === ".mdx" ? GENERATED_MDX_MARKER : GENERATED_MARKER
   return `${frontmatter}\n\n${marker}\n\n${body}\n`
+}
+
+const renderMarkdownPage = (page) => {
+  if (page.slug === "index") {
+    const sections = docsSections.flatMap((section) => [
+      `## ${section.label}`,
+      "",
+      ...section.pages.map(
+        (entry) => `- [${entry.title}](/${entry.slug}.md) — ${entry.description}`,
+      ),
+      "",
+    ])
+    return [GENERATED_MARKER, "", `# ${page.title}`, "", page.description, "", ...sections].join(
+      "\n",
+    )
+  }
+  const { body } = pageSource(page)
+  return [GENERATED_MARKER, "", `# ${page.title}`, "", page.description, "", body, ""].join("\n")
 }
 
 const generatedFiles = (directory) => {
@@ -149,6 +172,17 @@ for (const page of docsPages) {
   writeFileSync(output, renderPage(page))
 }
 
+// Every documentation URL has a neighboring Markdown representation for agents,
+// search tools, and readers who prefer the source. Keep these static so the
+// capability adds no runtime service or client dependency.
+const expectedMarkdown = new Set()
+for (const page of docsPages) {
+  const output = join(PUBLIC_ROOT, `${page.slug}.md`)
+  expectedMarkdown.add(output)
+  mkdirSync(dirname(output), { recursive: true })
+  writeFileSync(output, renderMarkdownPage(page))
+}
+
 // Remove only files carrying our ownership marker. An unexpected hand-authored
 // file fails closed instead of being deleted by a generator.
 for (const path of generatedFiles(CONTENT_ROOT)) {
@@ -159,6 +193,12 @@ for (const path of generatedFiles(CONTENT_ROOT)) {
       `unexpected non-generated file in generated docs tree: ${relative(APP_ROOT, path)}`,
     )
   unlinkSync(path)
+}
+
+for (const path of generatedFiles(PUBLIC_ROOT)) {
+  if (extname(path) !== ".md" || expectedMarkdown.has(path)) continue
+  const content = readFileSync(path, "utf8")
+  if (content.includes(GENERATED_MARKER)) unlinkSync(path)
 }
 
 mkdirSync(GENERATED_ROOT, { recursive: true })
@@ -220,7 +260,7 @@ const indexLines = [
   "## Pages",
   "",
   ...docsPages.map(
-    (page) => `- [${page.title}](https://docs.derive.to${webPath(page)}) — ${page.description}`,
+    (page) => `- [${page.title}](https://docs.derive.to/${page.slug}.md) — ${page.description}`,
   ),
   "",
 ]

--- a/apps/docs/src/components/Search.astro
+++ b/apps/docs/src/components/Search.astro
@@ -10,6 +10,10 @@
         id="docs-search-input"
         name="query"
         type="search"
+        role="combobox"
+        aria-autocomplete="list"
+        aria-controls="docs-search-results"
+        aria-expanded="false"
         placeholder="Search documentation…"
         autocomplete="off"
         spellcheck="false"
@@ -19,8 +23,8 @@
     <div class="search-status" id="search-status" aria-live="polite">
       Search for guides, concepts, commands, or configuration.
     </div>
-    <ol class="search-results" id="search-results"></ol>
-    <footer class="search-footer">
+    <div class="search-results" id="docs-search-results" role="listbox"></div>
+    <footer class="search-footer" aria-hidden="true">
       <span><kbd>↑</kbd><kbd>↓</kbd> navigate</span>
       <span><kbd>↵</kbd> open</span>
     </footer>
@@ -36,12 +40,12 @@
 <script>
   const dialog = document.querySelector<HTMLDialogElement>("#docs-search")
   const input = document.querySelector<HTMLInputElement>("#docs-search-input")
-  const results = document.querySelector<HTMLOListElement>("#search-results")
+  const results = document.querySelector<HTMLElement>("#docs-search-results")
   const status = document.querySelector<HTMLElement>("#search-status")
   interface PagefindResultData {
     url: string
     excerpt: string
-    meta: { title?: string }
+    meta: { title?: string; section?: string }
   }
   interface PagefindModule {
     init: () => Promise<void>
@@ -53,6 +57,7 @@
   let resultLinks: HTMLAnchorElement[] = []
   let selectedIndex = -1
   let queryVersion = 0
+  let searchTimer: number | undefined
 
   const plainText = (value: string) => {
     const element = document.createElement("span")
@@ -66,8 +71,10 @@
     for (const [linkIndex, link] of resultLinks.entries()) {
       const selected = linkIndex === selectedIndex
       link.toggleAttribute("data-selected", selected)
+      link.setAttribute("aria-selected", String(selected))
       if (selected) link.scrollIntoView({ block: "nearest" })
     }
+    input?.setAttribute("aria-activedescendant", resultLinks[selectedIndex]?.id ?? "")
   }
 
   const renderSearch = async () => {
@@ -77,6 +84,7 @@
     results.replaceChildren()
     resultLinks = []
     selectedIndex = -1
+    input.removeAttribute("aria-activedescendant")
     if (!query) {
       status.textContent = "Search for guides, concepts, commands, or configuration."
       return
@@ -104,19 +112,26 @@
         : `No results for “${query}”`
 
       for (const entry of entries) {
-        const item = document.createElement("li")
         const link = document.createElement("a")
+        const section = document.createElement("span")
         const title = document.createElement("strong")
         const excerpt = document.createElement("span")
         const arrow = document.createElement("span")
+        const resultId = `docs-search-result-${resultLinks.length}`
         link.href = entry.url
+        link.id = resultId
+        link.setAttribute("role", "option")
+        link.setAttribute("aria-selected", "false")
+        section.className = "search-result-section"
+        section.textContent = entry.meta.section || "Documentation"
         title.textContent = entry.meta.title || "Untitled page"
         excerpt.textContent = plainText(entry.excerpt)
-        arrow.textContent = "↗"
+        excerpt.className = "search-result-excerpt"
+        arrow.className = "search-result-arrow"
+        arrow.textContent = "→"
         arrow.setAttribute("aria-hidden", "true")
-        link.append(title, excerpt, arrow)
-        item.append(link)
-        results.append(item)
+        link.append(section, title, excerpt, arrow)
+        results.append(link)
         resultLinks.push(link)
       }
       if (resultLinks.length) selectResult(0)
@@ -129,6 +144,7 @@
   const openSearch = () => {
     if (!dialog || !input) return
     if (!dialog.open) dialog.showModal()
+    input.setAttribute("aria-expanded", "true")
     window.setTimeout(() => input.focus(), 0)
   }
 
@@ -138,7 +154,11 @@
     trigger.addEventListener("click", openSearch)
   })
   document.querySelector<HTMLElement>("[data-search-close]")?.addEventListener("click", closeSearch)
-  input?.addEventListener("input", renderSearch)
+  input?.addEventListener("input", () => {
+    queryVersion += 1
+    window.clearTimeout(searchTimer)
+    searchTimer = window.setTimeout(renderSearch, 120)
+  })
   input?.addEventListener("keydown", (event) => {
     if (event.key === "ArrowDown") {
       event.preventDefault()
@@ -148,9 +168,14 @@
       selectResult(selectedIndex - 1)
     } else if (event.key === "Enter" && selectedIndex >= 0) {
       event.preventDefault()
-      resultLinks[selectedIndex]?.click()
+      const selected = resultLinks[selectedIndex]
+      if (!selected) return
+      if (event.shiftKey || event.metaKey || event.ctrlKey)
+        window.open(selected.href, "_blank", "noopener")
+      else selected.click()
     }
   })
+  dialog?.addEventListener("close", () => input?.setAttribute("aria-expanded", "false"))
   dialog?.addEventListener("click", (event) => {
     if (event.target === dialog) closeSearch()
   })

--- a/apps/docs/src/components/TableOfContents.astro
+++ b/apps/docs/src/components/TableOfContents.astro
@@ -3,25 +3,65 @@ import type { MarkdownHeading } from "astro"
 
 interface Props {
   headings: MarkdownHeading[]
+  markdownUrl: string
+  mobile?: boolean
 }
 
-const { headings } = Astro.props
+const { headings, markdownUrl, mobile = false } = Astro.props
 const visibleHeadings = headings.filter(({ depth }) => depth === 2 || depth === 3)
 ---
 
-{visibleHeadings.length > 0 && (
-  <nav class="table-of-contents" aria-label="On this page" data-pagefind-ignore>
-    <h2>On this page</h2>
-    <ul role="list">
-      {visibleHeadings.map((heading) => (
-        <li class:list={{ nested: heading.depth === 3 }}>
-          <a href={`#${heading.slug}`} data-toc-link={heading.slug}>{heading.text}</a>
-        </li>
-      ))}
-    </ul>
-    <div class="toc-rule" aria-hidden="true"></div>
-    <a class="toc-feedback" href="https://github.com/derive-to/derive/issues/new/choose">
-      Documentation feedback <span aria-hidden="true">↗</span>
-    </a>
-  </nav>
-)}
+<div
+  class:list={["table-of-contents", { "table-of-contents-mobile": mobile }]}
+  data-pagefind-ignore
+>
+  {mobile ? (
+    <div class="mobile-page-tools">
+      {visibleHeadings.length > 0 && (
+        <details>
+          <summary>
+            <span>On this page</span>
+            <span aria-hidden="true">⌄</span>
+          </summary>
+          <nav aria-label="On this page">
+            <ul role="list">
+              {visibleHeadings.map((heading) => (
+                <li class:list={{ nested: heading.depth === 3 }}>
+                  <a href={`#${heading.slug}`} data-toc-link={heading.slug}>{heading.text}</a>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        </details>
+      )}
+      <button type="button" data-copy-page data-copy-url={markdownUrl} aria-live="polite">
+        Copy page
+      </button>
+    </div>
+  ) : (
+    <>
+      {visibleHeadings.length > 0 && (
+        <nav aria-label="On this page">
+          <h2>On this page</h2>
+          <ul role="list">
+            {visibleHeadings.map((heading) => (
+              <li class:list={{ nested: heading.depth === 3 }}>
+                <a href={`#${heading.slug}`} data-toc-link={heading.slug}>{heading.text}</a>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      )}
+      <div class="toc-rule" aria-hidden="true"></div>
+      <div class="toc-actions">
+        <button type="button" data-copy-page data-copy-url={markdownUrl} aria-live="polite">
+          Copy page as Markdown
+        </button>
+        <a href={markdownUrl}>View Markdown <span aria-hidden="true">↗</span></a>
+        <a href="https://github.com/derive-to/derive/issues/new/choose">
+          Documentation feedback <span aria-hidden="true">↗</span>
+        </a>
+      </div>
+    </>
+  )}
+</div>

--- a/apps/docs/src/layouts/DocsLayout.astro
+++ b/apps/docs/src/layouts/DocsLayout.astro
@@ -28,6 +28,7 @@ const {
 } = Astro.props
 const isHome = slug === "index"
 const pagePath = isHome ? "/" : `/${slug}/`
+const markdownPath = `/${slug}.md`
 const canonical = new URL(pagePath, Astro.site)
 const pageTitle = isHome
   ? "Derive Docs — Turn agent output into approved work"
@@ -72,6 +73,9 @@ const updatedLabel = lastUpdated
     {noindex && <meta name="robots" content="noindex, nofollow" />}
     <link rel="canonical" href={canonical} />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    {!noindex && (
+      <link rel="alternate" type="text/markdown" href={markdownPath} title={`${title} as Markdown`} />
+    )}
     <link rel="alternate" type="text/plain" href="/llms.txt" title="LLM index" />
     <meta property="og:type" content="website" />
     <meta property="og:title" content={pageTitle} />
@@ -108,11 +112,12 @@ const updatedLabel = lastUpdated
               <nav class="article-breadcrumbs" aria-label="Breadcrumb">
                 <a href="/">Docs</a>
                 <span aria-hidden="true">/</span>
-                <span>{activeSection?.label ?? "Documentation"}</span>
+                <span data-pagefind-meta="section">{activeSection?.label ?? "Documentation"}</span>
               </nav>
-              <h1>{title}</h1>
+              <h1 data-pagefind-meta="title">{title}</h1>
               <p>{description}</p>
             </header>
+            {!noindex && <TableOfContents headings={headings} markdownUrl={markdownPath} mobile />}
             <div class="docs-content">
               <slot />
             </div>
@@ -142,9 +147,9 @@ const updatedLabel = lastUpdated
         )}
       </main>
 
-      {!isHome && (
+      {!isHome && !noindex && (
         <aside class="toc-column">
-          <TableOfContents headings={headings} />
+          <TableOfContents headings={headings} markdownUrl={markdownPath} />
         </aside>
       )}
     </div>
@@ -202,12 +207,38 @@ const updatedLabel = lastUpdated
         wrapper.append(button)
       }
 
-      const tocLinks = new Map(
-        Array.from(document.querySelectorAll<HTMLAnchorElement>("[data-toc-link]"))
-          .map((link) => [link.dataset.tocLink, link]),
+      for (const button of document.querySelectorAll<HTMLButtonElement>("[data-copy-page]")) {
+        const initialLabel = button.textContent ?? "Copy page"
+        button.addEventListener("click", async () => {
+          const url = button.dataset.copyUrl
+          if (!url) return
+          try {
+            const response = await fetch(url)
+            if (!response.ok) throw new Error("Markdown unavailable")
+            await navigator.clipboard.writeText(await response.text())
+            button.textContent = "Copied"
+          } catch {
+            button.textContent = "Copy failed"
+          }
+          window.setTimeout(() => { button.textContent = initialLabel }, 1600)
+        })
+      }
+
+      for (const heading of document.querySelectorAll<HTMLElement>(".docs-content :is(h2, h3)")) {
+        if (!heading.id) continue
+        const anchor = document.createElement("a")
+        anchor.className = "heading-anchor"
+        anchor.href = `#${heading.id}`
+        anchor.textContent = "#"
+        anchor.setAttribute("aria-label", `Link to ${heading.textContent ?? "section"}`)
+        heading.append(anchor)
+      }
+
+      const tocLinks = Array.from(
+        document.querySelectorAll<HTMLAnchorElement>("[data-toc-link]"),
       )
       const observedHeadings = Array.from(document.querySelectorAll<HTMLElement>(".docs-content :is(h2, h3)"))
-      if (tocLinks.size && observedHeadings.length) {
+      if (tocLinks.length && observedHeadings.length) {
         const visible = new Set<string>()
         const observer = new IntersectionObserver((entries) => {
           for (const entry of entries) {
@@ -215,7 +246,11 @@ const updatedLabel = lastUpdated
             else visible.delete(entry.target.id)
           }
           const active = observedHeadings.find((heading) => visible.has(heading.id))?.id
-          for (const [id, link] of tocLinks) link.toggleAttribute("aria-current", id === active)
+            ?? [...observedHeadings].reverse()
+              .find((heading) => heading.getBoundingClientRect().top <= 112)?.id
+            ?? observedHeadings[0]?.id
+          for (const link of tocLinks)
+            link.toggleAttribute("aria-current", link.dataset.tocLink === active)
         }, { rootMargin: "-96px 0px -70%" })
         observedHeadings.forEach((heading) => observer.observe(heading))
       }

--- a/apps/docs/src/styles/docs.css
+++ b/apps/docs/src/styles/docs.css
@@ -103,6 +103,7 @@ button {
 a:focus-visible,
 button:focus-visible,
 input:focus-visible,
+summary:focus-visible,
 [tabindex="0"]:focus-visible {
   outline: 2px solid var(--ink);
   outline-offset: 3px;
@@ -276,12 +277,17 @@ input:focus-visible,
   padding: 0 0.8rem;
   align-items: center;
   gap: 0.4rem;
-  border: 1px solid var(--ink);
+  border: 1px solid var(--line);
   border-radius: 0.375rem;
-  background: var(--ink);
-  color: var(--canvas);
+  background: transparent;
+  color: var(--ink);
   font-size: 0.8125rem;
   font-weight: 560;
+}
+
+.open-derive:hover {
+  border-color: var(--ink-faint);
+  background: var(--surface-muted);
 }
 
 .mobile-navigation-trigger {
@@ -476,6 +482,20 @@ input:focus-visible,
 .docs-content h4 {
   margin: 1.75rem 0 0.6rem;
   font-size: 1rem;
+}
+
+.docs-content :is(h2, h3) .heading-anchor {
+  display: inline-flex;
+  margin-left: 0.5rem;
+  color: var(--ink-faint);
+  font-weight: 450;
+  opacity: 0;
+  text-decoration: none;
+}
+
+.docs-content :is(h2, h3):hover .heading-anchor,
+.heading-anchor:focus-visible {
+  opacity: 1;
 }
 
 .docs-content p,
@@ -693,8 +713,30 @@ input:focus-visible,
   border-top: 1px solid var(--line-soft);
 }
 
-.table-of-contents .toc-feedback {
+.toc-actions {
+  display: grid;
+  gap: 0.1rem;
+}
+
+.toc-actions button,
+.toc-actions a {
+  width: 100%;
+  padding: 0.35rem 0;
+  border: 0;
+  background: transparent;
+  color: var(--ink-faint);
   font-size: 0.75rem;
+  line-height: 1.5;
+  text-align: left;
+}
+
+.toc-actions button:hover,
+.toc-actions a:hover {
+  color: var(--ink);
+}
+
+.table-of-contents-mobile {
+  display: none;
 }
 
 /* Buttons and links */
@@ -1161,9 +1203,11 @@ input:focus-visible,
 .search-results a {
   position: relative;
   display: flex;
-  padding: 0.75rem 2.4rem 0.75rem 0.75rem;
+  min-height: 5.25rem;
+  padding: 0.7rem 2.4rem 0.8rem 0.75rem;
   flex-direction: column;
-  gap: 0.2rem;
+  justify-content: center;
+  gap: 0.12rem;
   border-radius: 0.35rem;
 }
 
@@ -1173,11 +1217,17 @@ input:focus-visible,
 }
 
 .search-results strong {
-  font-size: 0.875rem;
+  font-size: 0.9375rem;
   font-weight: 580;
 }
 
-.search-results a > span:first-of-type {
+.search-result-section {
+  color: var(--ink-faint);
+  font-size: 0.6875rem;
+  line-height: 1.4;
+}
+
+.search-result-excerpt {
   overflow: hidden;
   color: var(--ink-soft);
   font-size: 0.8125rem;
@@ -1185,7 +1235,7 @@ input:focus-visible,
   white-space: nowrap;
 }
 
-.search-results a > span:last-of-type {
+.search-result-arrow {
   position: absolute;
   top: 50%;
   right: 0.9rem;
@@ -1307,6 +1357,82 @@ input:focus-visible,
   .toc-column {
     display: none;
   }
+
+  .table-of-contents-mobile {
+    position: static;
+    display: block;
+    max-height: none;
+    margin-top: 1.25rem;
+    overflow: visible;
+    border-top: 1px solid var(--line);
+    border-bottom: 1px solid var(--line);
+  }
+
+  .mobile-page-tools {
+    display: flex;
+    align-items: flex-start;
+  }
+
+  .mobile-page-tools details {
+    min-width: 0;
+    flex: 1;
+  }
+
+  .mobile-page-tools summary,
+  .mobile-page-tools > button {
+    display: flex;
+    min-height: 3rem;
+    padding: 0.7rem 0.75rem;
+    align-items: center;
+    border: 0;
+    background: transparent;
+    color: var(--ink-soft);
+    font-size: 0.875rem;
+    line-height: 1.5;
+    list-style: none;
+  }
+
+  .mobile-page-tools summary {
+    justify-content: space-between;
+    cursor: pointer;
+  }
+
+  .mobile-page-tools summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .mobile-page-tools summary > span:last-child {
+    margin-left: 1rem;
+  }
+
+  .mobile-page-tools details[open] summary > span:last-child {
+    transform: rotate(180deg);
+  }
+
+  .mobile-page-tools > button {
+    flex: none;
+  }
+
+  .mobile-page-tools details + button {
+    border-left: 1px solid var(--line);
+  }
+
+  .mobile-page-tools :is(summary, button):hover {
+    color: var(--ink);
+  }
+
+  .mobile-page-tools nav {
+    padding: 0.2rem 0.75rem 1rem;
+  }
+
+  .mobile-page-tools nav a {
+    padding: 0.35rem 0;
+    font-size: 0.875rem;
+  }
+
+  .mobile-page-tools nav li.nested a {
+    padding-left: 0.85rem;
+  }
 }
 
 @media (max-width: 58rem) {
@@ -1384,7 +1510,8 @@ input:focus-visible,
 
   .docs-navigation-mobile .navigation-home,
   .docs-navigation-mobile .navigation-section a,
-  .search-results a > span:first-of-type {
+  .search-result-excerpt,
+  .mobile-page-tools nav a {
     font-size: 1rem;
   }
 

--- a/apps/web/e2e/public-quality/accessibility.spec.ts
+++ b/apps/web/e2e/public-quality/accessibility.spec.ts
@@ -87,7 +87,44 @@ test("marketing skip link moves focus to the primary content", async ({ page }) 
 test("docs search loads the local browser index", async ({ page }) => {
   await page.goto(`${docsOrigin}/`)
   await page.locator("[data-search-open]").first().click()
-  await page.locator("#docs-search-input").fill("self-host")
+  const search = page.getByRole("combobox", { name: "Search documentation" })
+  await expect(search).toHaveAttribute("aria-expanded", "true")
+  await search.fill("self-host")
   await expect(page.locator('.search-results a[href="/self-hosting/quickstart/"]')).toBeVisible()
+  await expect(page.locator(".search-result-section").first()).not.toBeEmpty()
+  await expect(page.getByRole("option").first()).toHaveAttribute("aria-selected", "true")
+  await expect(search).toHaveAttribute("aria-activedescendant", /docs-search-result-\d+/)
   await expect(page.locator("#search-status")).not.toContainText("could not load")
+
+  const { violations } = await new AxeBuilder({ page })
+    .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "wcag22aa"])
+    .analyze()
+  expect(violations).toEqual([])
+})
+
+test("docs pages expose and copy their canonical Markdown", async ({ context, page }, testInfo) => {
+  const markdown = await page.request.get(`${docsOrigin}/start/first-artifact.md`)
+  expect(markdown.ok()).toBe(true)
+  expect(markdown.headers()["content-type"]).toContain("text/markdown")
+  expect(await markdown.text()).toContain("# Publish your first artifact")
+
+  await context.grantPermissions(["clipboard-read", "clipboard-write"], { origin: docsOrigin })
+  await page.goto(`${docsOrigin}/start/first-artifact/`)
+  await expect(page.locator('link[rel="alternate"][type="text/markdown"]')).toHaveAttribute(
+    "href",
+    "/start/first-artifact.md",
+  )
+
+  const copy = page.locator("[data-copy-page]:visible").first()
+  await copy.click()
+  await expect(copy).toHaveText("Copied")
+  expect(await page.evaluate(() => navigator.clipboard.readText())).toContain(
+    "# Publish your first artifact",
+  )
+
+  if (testInfo.project.name === "mobile") {
+    const outline = page.locator(".mobile-page-tools details")
+    await outline.getByText("On this page").click()
+    await expect(outline.getByRole("link", { name: "Make the artifact durable" })).toBeVisible()
+  }
 })

--- a/apps/web/e2e/public-quality/static-server.mjs
+++ b/apps/web/e2e/public-quality/static-server.mjs
@@ -15,6 +15,7 @@ const contentTypes = new Map([
   [".ico", "image/x-icon"],
   [".js", "text/javascript; charset=utf-8"],
   [".json", "application/json; charset=utf-8"],
+  [".md", "text/markdown; charset=utf-8"],
   [".png", "image/png"],
   [".svg", "image/svg+xml"],
   [".txt", "text/plain; charset=utf-8"],


### PR DESCRIPTION
## What & why

Refine the branded documentation experience around current task-oriented, accessible, and agent-readable documentation patterns while keeping the implementation small and dependency-free.

## Changes

- add responsive article wayfinding, deep-linked headings, and desktop/mobile page tools
- improve Pagefind result hierarchy, keyboard behavior, and combobox semantics
- emit canonical Markdown endpoints and expose copy/view Markdown actions
- add deterministic build contracts and public browser coverage for the new behavior

## Testing

- [x] `pnpm verify` passes (the exact CI `check` gate, including coverage ratchets)
- [x] Added/updated tests for the change
- [x] 30/30 public-quality Playwright tests pass
- [x] Manual light, dark, mobile, search, and Axe review completed

## Notes for reviewers

No new framework or runtime dependency. Visual and systems review: https://derive.to/artifacts/derive-docs-2026-design-and-systems-audit-w4xmev82

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/737"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789379583&installation_model_id=428097&pr_number=737&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F737&signature=896eef52eb9175ac79c38bb7f01fffffc326fef07354a8d3697ff58d77273238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->