### PR TITLE
Fix schema upgrade ordering before indexes

### DIFF
--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -273,8 +273,6 @@ CREATE TABLE IF NOT EXISTS invitation (
   UNIQUE (token)
 );
 
-CREATE INDEX IF NOT EXISTS invitation_org_email ON invitation (org_id, email);
-
 CREATE TABLE IF NOT EXISTS artifact_invite (
   id TEXT PRIMARY KEY,
   artifact_id TEXT NOT NULL,
@@ -288,8 +286,6 @@ CREATE TABLE IF NOT EXISTS artifact_invite (
   UNIQUE (token)
 );
 
-CREATE INDEX IF NOT EXISTS artifact_invite_artifact_email ON artifact_invite (artifact_id, email);
-
 CREATE TABLE IF NOT EXISTS collection_invite (
   id TEXT PRIMARY KEY,
   collection_id TEXT NOT NULL,
@@ -302,8 +298,6 @@ CREATE TABLE IF NOT EXISTS collection_invite (
   accepted_at TEXT,
   UNIQUE (token)
 );
-
-CREATE INDEX IF NOT EXISTS collection_invite_collection_email ON collection_invite (collection_id, email);
 
 CREATE TABLE IF NOT EXISTS beta_signup (
   id TEXT PRIMARY KEY,
@@ -504,8 +498,6 @@ CREATE TABLE IF NOT EXISTS slack_user_link (
   UNIQUE (team_id, slack_user_id)
 );
 
-CREATE INDEX IF NOT EXISTS slack_user_link_user ON slack_user_link (team_id, user_id);
-
 CREATE TABLE IF NOT EXISTS slack_subscription (
   id TEXT PRIMARY KEY,
   org_id TEXT NOT NULL,
@@ -520,8 +512,6 @@ CREATE TABLE IF NOT EXISTS slack_subscription (
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
   UNIQUE (org_id, channel_id, scope_kind, scope_id)
 );
-
-CREATE INDEX IF NOT EXISTS slack_subscription_org ON slack_subscription (org_id, active);
 
 CREATE TABLE IF NOT EXISTS user_notification_pref (
   id TEXT PRIMARY KEY,
@@ -601,8 +591,6 @@ CREATE TABLE IF NOT EXISTS review_round (
   FOREIGN KEY (artifact_id) REFERENCES artifact(id)
 );
 
-CREATE INDEX IF NOT EXISTS review_round_artifact ON review_round (artifact_id, requested_for);
-
 CREATE TABLE IF NOT EXISTS context (
   id TEXT PRIMARY KEY,
   org_id TEXT NOT NULL,
@@ -648,10 +636,6 @@ CREATE TABLE IF NOT EXISTS context_session (
   FOREIGN KEY (context_id) REFERENCES context(id)
 );
 
-CREATE INDEX IF NOT EXISTS context_session_queue ON context_session (context_id, state, created_at);
-
-CREATE INDEX IF NOT EXISTS context_session_asker ON context_session (asker_id, created_at);
-
 CREATE TABLE IF NOT EXISTS session_message (
   id TEXT PRIMARY KEY,
   session_id TEXT NOT NULL,
@@ -662,8 +646,6 @@ CREATE TABLE IF NOT EXISTS session_message (
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
   FOREIGN KEY (session_id) REFERENCES context_session(id)
 );
-
-CREATE INDEX IF NOT EXISTS session_message_session ON session_message (session_id, created_at);
 
 CREATE TABLE IF NOT EXISTS report (
   id TEXT PRIMARY KEY,
@@ -697,8 +679,6 @@ CREATE TABLE IF NOT EXISTS asset (
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
 );
 
-CREATE INDEX IF NOT EXISTS asset_org ON asset (org_id);
-
 CREATE TABLE IF NOT EXISTS principal (
     id TEXT PRIMARY KEY,
     org_id TEXT NOT NULL,
@@ -715,6 +695,26 @@ CREATE TABLE IF NOT EXISTS view (
     viewer_kind TEXT NOT NULL DEFAULT 'anon',
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
   );
+
+CREATE INDEX IF NOT EXISTS invitation_org_email ON invitation (org_id, email);
+
+CREATE INDEX IF NOT EXISTS artifact_invite_artifact_email ON artifact_invite (artifact_id, email);
+
+CREATE INDEX IF NOT EXISTS collection_invite_collection_email ON collection_invite (collection_id, email);
+
+CREATE INDEX IF NOT EXISTS slack_user_link_user ON slack_user_link (team_id, user_id);
+
+CREATE INDEX IF NOT EXISTS slack_subscription_org ON slack_subscription (org_id, active);
+
+CREATE INDEX IF NOT EXISTS review_round_artifact ON review_round (artifact_id, requested_for);
+
+CREATE INDEX IF NOT EXISTS context_session_queue ON context_session (context_id, state, created_at);
+
+CREATE INDEX IF NOT EXISTS context_session_asker ON context_session (asker_id, created_at);
+
+CREATE INDEX IF NOT EXISTS session_message_session ON session_message (session_id, created_at);
+
+CREATE INDEX IF NOT EXISTS asset_org ON asset (org_id);
 
 CREATE INDEX IF NOT EXISTS artifact_org_created ON artifact (org_id, created_at, id);
 

--- a/packages/db/src/ddl.ts
+++ b/packages/db/src/ddl.ts
@@ -43,14 +43,21 @@ const renderDefault = (c: Any, o: DdlOptions): string | null =>
 export const isMigratable = (c: Any): boolean =>
   !c.primary && !isTimestampDefault(c) && (!c.notNull || literalDefault(c) !== null)
 
-/** Generate per-dialect boot DDL from the drizzle tables. Returns the table/index
- *  CREATEs and the idempotent ADD COLUMN migrations separately, since SQLite runs
- *  them through different boot paths (CREATE direct, ALTER in a try/catch). */
-export function generateDdl(
-  tables: Any[],
-  getConfig: (t: Any) => Any,
-  o: DdlOptions,
-): { creates: string[]; alters: string[] } {
+export interface DdlPlan {
+  /** Create the complete current table shape for a new database. */
+  createTables: string[]
+  /** Reconcile columns that can be added safely to an existing populated table. */
+  addColumns: string[]
+  /** Create non-unique secondary indexes after every table and migrated column exists. */
+  createIndexes: string[]
+}
+
+/** Generate dependency-ordered boot DDL from the drizzle tables.
+ *
+ * Keeping tables, additive column migrations, and indexes as distinct phases is
+ * load-bearing: CREATE TABLE IF NOT EXISTS does not update an existing table, and
+ * an index may reference a column that only the migration phase can add. */
+export function generateDdl(tables: Any[], getConfig: (t: Any) => Any, o: DdlOptions): DdlPlan {
   const tableName = (t: Any): string => getConfig(t).name
   const columnDef = (c: Any): string => {
     const p = [c.name, sqlType(c)]
@@ -85,21 +92,26 @@ export function generateDdl(
     return p.join(" ")
   }
 
-  const creates: string[] = []
-  const alters: string[] = []
+  const tableStatements: string[] = []
+  const columnStatements: string[] = []
+  const indexStatements: string[] = []
   for (const t of tables) {
     const cfg = getConfig(t)
-    creates.push(createTable(cfg))
+    tableStatements.push(createTable(cfg))
     for (const idx of cfg.indexes)
       if (!idx.config.unique)
-        creates.push(
+        indexStatements.push(
           `CREATE INDEX IF NOT EXISTS ${idx.config.name} ON ${cfg.name} (${idx.config.columns
             .map((x: Any) => x.name)
             .join(", ")})`,
         )
-    for (const c of cfg.columns) if (isMigratable(c)) alters.push(addColumn(cfg.name, c))
+    for (const c of cfg.columns) if (isMigratable(c)) columnStatements.push(addColumn(cfg.name, c))
   }
-  return { creates, alters }
+  return {
+    createTables: tableStatements,
+    addColumns: columnStatements,
+    createIndexes: indexStatements,
+  }
 }
 
 /** The not-yet-queried placeholder tables (no drizzle def), created up front so

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -1036,8 +1036,9 @@ const TABLES = [
   modelCredential,
 ]
 
-/** Build the Postgres boot DDL: generated table/index CREATEs + placeholder tables
- *  + perf indexes, then the idempotent ADD COLUMN IF NOT EXISTS migrations. Pure;
+/** Build the Postgres boot DDL: table CREATEs + placeholder tables, then the idempotent
+ *  ADD COLUMN IF NOT EXISTS reconciliation, and only then every index — an index may
+ *  reference a column the reconciliation just added on an existing database. Pure;
  *  exported for the conformance test. */
 // Full-text search index (workspace search substrate) — the Postgres twin of the SQLite
 // fts5 virtual table. A real table holding a precomputed `tsvector` per artifact, with a

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -1098,18 +1098,21 @@ BEGIN
 END $$`
 
 export const buildPgSchemaStatements = (): string[] => {
-  const { creates, alters } = generateDdl(TABLES, getTableConfig, {
+  const ddl = generateDdl(TABLES, getTableConfig, {
     ifNotExists: true,
     timestampDefault: PG_TIMESTAMP_DEFAULT,
   })
   return [
-    ...creates,
+    ...ddl.createTables,
     ...placeholderTables(PG_TIMESTAMP_DEFAULT),
+    // CREATE TABLE IF NOT EXISTS does not reconcile an existing table. Add every safe
+    // column before creating derived objects that may reference the current schema.
+    ...ddl.addColumns,
+    ...ddl.createIndexes,
     ...PERF_INDEXES,
     ...ARTIFACT_SEARCH_PG,
-    ...alters,
-    // After the alters: partial indexes reference columns the alters add on a populated DB
-    // (dedupe_key), and the PG boot has no per-statement try/catch, so ordering is load-bearing.
+    // Partial indexes follow the same dependency rule: their predicates reference columns
+    // that the additive phase may just have introduced on a populated database.
     CONTEXT_SESSION_DEDUPE_UNIQUE_PG,
     RUN_SCHEDULE_OCCURRENCE_UNIQUE_PG,
     // A session no longer requires a context (chat with a document). Postgres can say this

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1324,8 +1324,9 @@ const RUN_SCHEDULE_OCCURRENCE_UNIQUE =
   `AND scheduled_for IS NOT NULL`
 
 export const SCHEMA_STATEMENTS: string[] = [
-  ...ddl.creates,
+  ...ddl.createTables,
   ...placeholderTables(SQLITE_TIMESTAMP_DEFAULT),
+  ...ddl.createIndexes,
   ...PERF_INDEXES,
   ARTIFACT_SEARCH_FTS5,
   CONTEXT_SESSION_DEDUPE_UNIQUE,
@@ -1339,7 +1340,7 @@ export const SCHEMA_STATEMENTS: string[] = [
  * to a populated table (nullable or constant-default), so a new column can't be
  * forgotten here.
  */
-export const MIGRATION_STATEMENTS: string[] = ddl.alters
+export const MIGRATION_STATEMENTS: string[] = ddl.addColumns
 
 /**
  * NOT-NULL RELAXATIONS for existing databases.

--- a/packages/db/test/ddl-generated.test.ts
+++ b/packages/db/test/ddl-generated.test.ts
@@ -14,9 +14,25 @@ type AnyCol = any
 // fails plain `pnpm test`, not only the Docker-gated pg lane. The real-DB equivalence
 // is proven separately (pg-schema-conformance.test.ts + the sqlite conformance test).
 const dialects = {
-  sqlite: { schema: sqliteSchema, statements: [...SCHEMA_STATEMENTS, ...MIGRATION_STATEMENTS] },
+  sqlite: { schema: sqliteSchema, statements: [...MIGRATION_STATEMENTS, ...SCHEMA_STATEMENTS] },
   postgres: { schema: pgSchema, statements: buildPgSchemaStatements() },
 }
+
+describe("Postgres DDL dependency order", () => {
+  it("reconciles additive columns before creating indexes", () => {
+    const statements = buildPgSchemaStatements()
+    const columnPositions = statements
+      .map((statement, index) => (/^ALTER TABLE .* ADD COLUMN /.test(statement) ? index : -1))
+      .filter((index) => index >= 0)
+    const indexPositions = statements
+      .map((statement, index) => (/^CREATE (?:UNIQUE )?INDEX /.test(statement) ? index : -1))
+      .filter((index) => index >= 0)
+
+    expect(columnPositions.length).toBeGreaterThan(0)
+    expect(indexPositions.length).toBeGreaterThan(0)
+    expect(Math.max(...columnPositions)).toBeLessThan(Math.min(...indexPositions))
+  })
+})
 
 for (const [dialect, { schema, statements }] of Object.entries(dialects)) {
   describe(`${dialect}: DDL generated from the drizzle schema`, () => {

--- a/packages/db/test/pg-schema-conformance.test.ts
+++ b/packages/db/test/pg-schema-conformance.test.ts
@@ -25,7 +25,7 @@ if (PG_URL) {
     let client: PoolClient
 
     beforeAll(async () => {
-      pool = new Pool({ connectionString: PG_URL, max: 1 })
+      pool = new Pool({ connectionString: PG_URL, max: 2 })
       client = await pool.connect()
       await client.query(`CREATE SCHEMA ${ns}`)
       // Unqualified CREATE TABLEs land in this schema; the boot path is the same.
@@ -62,6 +62,44 @@ if (PG_URL) {
         expect(defined).toEqual(live)
       })
     }
+
+    it("upgrades a populated legacy schema before creating dependent indexes", async () => {
+      const legacyNs = `t_upgrade_${process.pid}_${uuid().replace(/-/g, "")}`
+      const legacy = await pool.connect()
+      try {
+        await legacy.query(`CREATE SCHEMA ${legacyNs}`)
+        await legacy.query(`SET search_path TO ${legacyNs}`)
+
+        const currentArtifactCreate = PG_SCHEMA_STATEMENTS.find((statement) =>
+          statement.startsWith("CREATE TABLE IF NOT EXISTS artifact ("),
+        )
+        if (!currentArtifactCreate) throw new Error("artifact CREATE statement is missing")
+        expect(currentArtifactCreate).toContain("\n  archived_at TEXT,")
+        const legacyArtifactCreate = currentArtifactCreate.replace("\n  archived_at TEXT,", "")
+        expect(legacyArtifactCreate).not.toContain("archived_at")
+        await legacy.query(legacyArtifactCreate)
+        await legacy.query(
+          `INSERT INTO artifact (id, short_id, kind) VALUES ('legacy-artifact', 'legacy', 'document')`,
+        )
+
+        for (const statement of PG_SCHEMA_STATEMENTS) await legacy.query(statement)
+        // Reapplying the complete plan is the deployment contract, not a special migration path.
+        for (const statement of PG_SCHEMA_STATEMENTS) await legacy.query(statement)
+
+        const column = await legacy.query<{ archived_at: string | null }>(
+          `SELECT archived_at FROM artifact WHERE id = 'legacy-artifact'`,
+        )
+        expect(column.rows).toEqual([{ archived_at: null }])
+        const index = await legacy.query<{ indexname: string }>(
+          `SELECT indexname FROM pg_indexes WHERE schemaname = $1 AND indexname = $2`,
+          [legacyNs, "artifact_org_archived_created"],
+        )
+        expect(index.rows).toEqual([{ indexname: "artifact_org_archived_created" }])
+      } finally {
+        await legacy.query(`DROP SCHEMA IF EXISTS ${legacyNs} CASCADE`)
+        legacy.release()
+      }
+    })
   })
 } else {
   // Keep the file non-empty for the default (no-Postgres) run.

--- a/packages/db/test/pg-schema-conformance.test.ts
+++ b/packages/db/test/pg-schema-conformance.test.ts
@@ -100,6 +100,55 @@ if (PG_URL) {
         legacy.release()
       }
     })
+
+    // The drop-everything variant of the legacy test above. The boot's own ADD COLUMN
+    // statements are the authoritative list of columns that can be absent on an existing
+    // database, so remove ALL of them (Postgres drops dependent indexes with a column)
+    // and require the replay to succeed and re-add each one. This exercises every
+    // index/column pair at once — not just archived_at — including statements a
+    // regex-based ordering check can't see (e.g. inside a DO block). Columns only:
+    // constraint parity on upgraded databases (inline UNIQUE/FK on a migratable
+    // column) is a known, separate gap this does not cover.
+    it("replays cleanly when every alter-added column is missing", async () => {
+      const droppedNs = `t_dropall_${process.pid}_${uuid().replace(/-/g, "")}`
+      const dropped = await pool.connect()
+      try {
+        await dropped.query(`CREATE SCHEMA ${droppedNs}`)
+        await dropped.query(`SET search_path TO ${droppedNs}`)
+        for (const statement of PG_SCHEMA_STATEMENTS) await dropped.query(statement)
+
+        const migratable = PG_SCHEMA_STATEMENTS.map((statement) =>
+          /^ALTER TABLE (\S+) ADD COLUMN IF NOT EXISTS (\S+) /.exec(statement),
+        ).filter((m): m is RegExpExecArray => m !== null)
+        expect(migratable.length).toBeGreaterThan(0)
+        for (const [, table, column] of migratable)
+          await dropped.query(`ALTER TABLE ${table} DROP COLUMN ${column}`)
+
+        for (const statement of PG_SCHEMA_STATEMENTS) {
+          try {
+            await dropped.query(statement)
+          } catch (e) {
+            throw new Error(
+              `boot statement failed against a pre-column DB:\n${statement}\n→ ${
+                (e as Error).message
+              }`,
+            )
+          }
+        }
+
+        for (const [, table, column] of migratable) {
+          const { rows } = await dropped.query(
+            `SELECT 1 FROM information_schema.columns
+             WHERE table_schema = $1 AND table_name = $2 AND column_name = $3`,
+            [droppedNs, table, column],
+          )
+          expect(rows.length, `${table}.${column} was not re-added by the boot`).toBe(1)
+        }
+      } finally {
+        await dropped.query(`DROP SCHEMA IF EXISTS ${droppedNs} CASCADE`)
+        dropped.release()
+      }
+    })
   })
 } else {
   // Keep the file non-empty for the default (no-Postgres) run.


### PR DESCRIPTION
## Summary

- model generated DDL as explicit table, additive-column, and index phases
- apply PostgreSQL column reconciliation before any dependent index creation
- add a structural ordering guard and a populated legacy-schema upgrade test
- regenerate the D1 schema with generated tables grouped before indexes

## Root cause

PR #736 added an index on `artifact.archived_at`. The PostgreSQL boot plan created indexes before running generated `ADD COLUMN` migrations, so an existing production table failed at index creation while fresh-schema tests remained green.

This change fixes the schema lifecycle rather than special-casing `archived_at`: every additive column migration now runs before any generated or hand-authored index can depend on it.

## Validation

- `pnpm verify`
- `pnpm test:pg`
- `pnpm --filter @derive/db test:d1`