### PR TITLE
Regenerate deploy/d1-schema.sql for the boot-order reorder

### DIFF
--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -444,8 +444,6 @@ CREATE TABLE IF NOT EXISTS template_library_entry (
   FOREIGN KEY (library_id) REFERENCES template_library(id)
 );
 
-CREATE INDEX IF NOT EXISTS template_library_entry_library ON template_library_entry (library_id, created_at);
-
 CREATE TABLE IF NOT EXISTS repo_source (
   id TEXT PRIMARY KEY,
   org_id TEXT NOT NULL DEFAULT 'local',
@@ -737,6 +735,8 @@ CREATE INDEX IF NOT EXISTS invitation_org_email ON invitation (org_id, email);
 CREATE INDEX IF NOT EXISTS artifact_invite_artifact_email ON artifact_invite (artifact_id, email);
 
 CREATE INDEX IF NOT EXISTS collection_invite_collection_email ON collection_invite (collection_id, email);
+
+CREATE INDEX IF NOT EXISTS template_library_entry_library ON template_library_entry (library_id, created_at);
 
 CREATE INDEX IF NOT EXISTS slack_user_link_user ON slack_user_link (team_id, user_id);
 


### PR DESCRIPTION
## Summary

- regenerate `deploy/d1-schema.sql` from current `SCHEMA_STATEMENTS`

## Why

#740 (boot indexes ordered after column reconciliation) and #687 (template libraries) merged concurrently. #740's regenerated schema file was produced on a base that predates the template tables, so after both merges the committed file kept the `template_library_entry_library` index in the old interleaved position and the snapshot gate (`d1-schema.test.ts`) went red on main, skipping the deploy.

Two-line move, no semantic change: the D1 apply script partitions indexes at run time regardless of file order.

## Validation

- `pnpm --filter @derive/db gen:d1-schema` (the snapshot test, updating)
- `pnpm --filter @derive/db test` — 353 passed
- full `pnpm verify` via the pre-push hook

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/741"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789420743&installation_model_id=428097&pr_number=741&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F741&signature=e07a9d438ee0b70f0b2f7039b43f2b0c26dfbe6d47a165392ca8b41c4bb583f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->