### PR TITLE
feat(api): make artifact share URLs agent-readable

### DIFF
--- a/apps/api/src/lib/unfurl-info.ts
+++ b/apps/api/src/lib/unfurl-info.ts
@@ -48,6 +48,7 @@ export const unfurlInfoFor = async (
     // trip the counts do — no added query on the most-trafficked anonymous surface there is.
     summary: version?.summary ?? null,
     pageUrl: artifactUrl(baseUrl, artifact),
+    markdownUrl: `${artifactUrl(baseUrl, artifact)}.md`,
     imageUrl: `${baseUrl}/v1/og/${artifact.short_id}`,
     oembedUrl: `${baseUrl}/v1/oembed?url=${encodeURIComponent(artifactUrl(baseUrl, artifact))}`,
     embedUrl: `${baseUrl}/v1/embed/${ref}`,

--- a/apps/api/src/routes/embeds.ts
+++ b/apps/api/src/routes/embeds.ts
@@ -1,8 +1,10 @@
 import {
   type ArtifactRecord,
   candidateShortIds,
+  elideDataUris,
   escapeHtml,
   injectHead,
+  isBundleContentType,
   normalizeUsername,
   oembedResponse,
   ogCardSvg,
@@ -13,11 +15,14 @@ import {
   profileSummary,
   refFor,
   setRobotsMeta,
+  setTitle,
+  toMarkdown,
   type UnfurlInfo,
   unfurlMetaTags,
 } from "@derive/core"
 import { type Context, Hono } from "hono"
 import type { AppContext } from "../context"
+import { manifestOf } from "../lib/bundle"
 import { fail, toBody } from "../lib/http"
 import { SLACK_PREVIEW_ORIGIN, verifyOgToken } from "../lib/og-token"
 import { unfurlInfoFor } from "../lib/unfurl-info"
@@ -38,7 +43,7 @@ import { unfurlInfoFor } from "../lib/unfurl-info"
  * org/password artifacts never leak a title — they get a generic locked card.
  */
 export const embedRoutes = (ctx: AppContext) => {
-  const { meta, authorize, blobs, effectiveWhiteLabel } = ctx
+  const { meta, authorize, actorFor, blobs, effectiveWhiteLabel, sourceText } = ctx
   const baseUrl = ctx.deps.baseUrl
   const rawBase = ctx.deps.sandboxOrigin ?? baseUrl
   const app = new Hono()
@@ -294,36 +299,155 @@ export const embedRoutes = (ctx: AppContext) => {
   // the Worker reaches this handler instead of serving the raw static shell.
   const getShell = async (): Promise<string | null> =>
     ctx.deps.shell ?? (ctx.deps.shellFetch ? await ctx.deps.shellFetch() : null)
+
+  // A request that names text/markdown in Accept (with nonzero q) gets the markdown
+  // projection instead of the shell. Browsers never send it in a navigation; Claude-
+  // family agent fetchers send "text/markdown, text/html, */*" on every request.
+  // Order and q-weights beyond the q=0 refusal are deliberately not compared: naming
+  // the type at all is a signal only a markdown-capable client emits.
+  const acceptsMarkdown = (accept: string | undefined): boolean =>
+    !!accept?.split(",").some((part) => {
+      const [type, ...params] = part.trim().split(";")
+      if (type?.trim().toLowerCase() !== "text/markdown") return false
+      const q = params.map((p) => p.trim().toLowerCase()).find((p) => p.startsWith("q="))
+      return !q || Number.parseFloat(q.slice(2)) > 0
+    })
+
+  // The version exists but its stored bytes don't: a server-side 500, never to be
+  // dressed up as "private" — the content API draws the same line ("blob missing").
+  const GONE = Symbol("blob missing")
+
+  // The markdown projection of one version — the same rendering the content API's
+  // `?format=markdown` serves. `null` = no such version (a caller-side 404). A
+  // bundle converts by its ENTRY's own type — pickBundleEntry prefers
+  // SKILL.md/README.md over non-root HTML, so a skill's markdown entry must pass
+  // through verbatim, not through the HTML converter.
+  const markdownOf = async (
+    artifactId: string,
+    v: number,
+  ): Promise<string | null | typeof GONE> => {
+    const version = await meta.getVersion(artifactId, v)
+    if (!version) return null
+    if (!isBundleContentType(version.content_type)) {
+      const src = await sourceText(version)
+      if (src === null) return GONE
+      return elideDataUris(toMarkdown(src, version.content_type))
+    }
+    const manifest = await manifestOf(blobs, version)
+    const entry = manifest?.files[manifest.entry]
+    const bytes = entry ? await blobs.get(entry.key) : null
+    if (!entry || !bytes) return GONE
+    return elideDataUris(toMarkdown(new TextDecoder().decode(bytes), entry.type))
+  }
+
+  // The markdown surface's error body: one line, never the app shell (a markdown-
+  // preferring client can do nothing with 20KB of chrome) and never a title — the
+  // same no-leak rule the shell branch's generic 404 draws.
+  const markdownNotFound = (c: Context) => {
+    c.header("Vary", "Accept")
+    c.header("X-Robots-Tag", "noindex")
+    // Never let a shared cache pin this 404 heuristically and starve a member who
+    // could read the artifact a moment later.
+    c.header("Cache-Control", "no-store")
+    c.header("Content-Type", "text/markdown; charset=utf-8")
+    return c.body("Not found — or this artifact is private.\n", 404)
+  }
+
   if (ctx.deps.shell || ctx.deps.shellFetch)
     // Deliberately dynamic: readability, takedown state, status, and unfurl metadata
     // can differ by artifact and request. Signup attribution is carried explicitly by
     // CTA URLs, so this response no longer sets or depends on a tracking cookie.
     app.get("/artifacts/:ref", async (c) => {
-      const shell = await getShell()
-      if (!shell) return c.notFound()
-      const ref = c.req.param("ref")
+      const rawRef = c.req.param("ref")
+      // `/artifacts/<ref>.md` is the explicit markdown URL. Unambiguous: slugs and
+      // short ids come out of slugify/newShortId, which never emit a dot.
+      const mdSuffix = rawRef.endsWith(".md")
+      const ref = mdSuffix ? rawRef.slice(0, -".md".length) : rawRef
+      const wantsMd = mdSuffix || acceptsMarkdown(c.req.header("Accept"))
       const artifact = await readable(c, ref)
       // Missing, gated, and taken-down artifacts still hydrate the SPA so a human
       // gets its access/tombstone state, but carry a real 404 plus noindex so crawlers
       // do not treat the generic application shell as a page.
-      if (!artifact || artifact.removed_at)
+      if (!artifact || artifact.removed_at) {
+        if (wantsMd) return markdownNotFound(c)
+        const shell = await getShell()
+        if (!shell) return c.notFound()
+        // Two representations live at this URL now, 404s included.
+        c.header("Vary", "Accept")
         return c.html(setRobotsMeta(shell, "noindex,nofollow"), 404)
+      }
       // Canonicalise any non-canonical ref (bare id, stale name, legacy order) to
       // /artifacts/<name>-<shortId> so the browser/crawler holds the readable URL. 302 (not
       // 301) so a later rename re-canonicalises instead of being cached. Only ever for an
       // artifact the actor may read (readable() already authorised), so a gated title can't
-      // leak via the redirect. Preserves the @vN suffix and the query string.
+      // leak via the redirect. Preserves the @vN suffix, the .md suffix and the query string.
       const { version } = parseRef(ref)
       const canonical = version ? `${refFor(artifact)}@v${version}` : refFor(artifact)
       if (ref !== canonical)
-        return c.redirect(`/artifacts/${canonical}${new URL(c.req.url).search}`, 302)
+        return c.redirect(
+          `/artifacts/${canonical}${mdSuffix ? ".md" : ""}${new URL(c.req.url).search}`,
+          302,
+        )
       const indexable =
         artifact.listed === "public" &&
         artifact.link_role !== "none" &&
         !artifact.password_hash &&
         !artifact.expires_at
+      if (wantsMd) {
+        // The expiry fence (see serveArtifact in app.ts): authorize() doesn't know
+        // about expiry — only unclaimed drafts carry one, their world link stays
+        // viewer, and the sweep is the janitor. Without this an expired-but-unswept
+        // draft would serve its whole body here.
+        if (artifact.expires_at && artifact.expires_at <= new Date().toISOString())
+          return markdownNotFound(c)
+        const v = version ?? artifact.current_version
+        // The public-history gate (mirrors anonHistoryBlocked in routes/raw.ts):
+        // unless the owner opted the page into history, an anonymous caller reads
+        // only the CURRENT version — an old version's bytes are as hidden as the
+        // workbench that lists them.
+        if (
+          v !== artifact.current_version &&
+          !artifact.public_history &&
+          (await actorFor(c, artifact)).kind === "anon"
+        )
+          return markdownNotFound(c)
+        const md = await markdownOf(artifact.id, v)
+        if (md === null) return markdownNotFound(c)
+        if (md === GONE) return fail(c, 500, "blob missing")
+        c.header("Vary", "Accept")
+        // A live draft must never be CDN-cacheable (same rule as serveArtifact):
+        // its viewer link would earn a shared cache entry that outlives the sweep.
+        // And only the .md URL may cache SHARED: the negotiated response lives at
+        // the page URL, where nothing but Vary separates it from the HTML — and
+        // several major CDNs ignore Vary: Accept, which would hand this markdown
+        // to every browser behind them for 10 minutes.
+        const shared = mdSuffix ? "public, max-age=600" : "private, max-age=600"
+        c.header("Cache-Control", artifact.expires_at ? "no-store" : cacheFor(artifact, shared))
+        c.header("X-Content-Type-Options", "nosniff")
+        c.header("X-Derive-Version", String(v))
+        // The HTML page stays the canonical form of this document; the projection
+        // also self-noindexes when the page does (unlisted, password, expiring).
+        c.header("Link", `<${baseUrl}/artifacts/${refFor(artifact)}>; rel="canonical"`)
+        if (!indexable) c.header("X-Robots-Tag", "noindex")
+        c.header("Content-Type", "text/markdown; charset=utf-8")
+        return c.body(md)
+      }
+      const shell = await getShell()
+      if (!shell) return c.notFound()
       const governedShell = setRobotsMeta(shell, indexable ? "index,follow" : "noindex,nofollow")
-      return c.html(injectHead(governedShell, unfurlMetaTags(await infoFor(artifact))))
+      const info = await infoFor(artifact)
+      c.header("Vary", "Accept")
+      // Same cache line every infoFor sibling draws (see cacheFor): the injected
+      // meta and title are built for a caller who cleared readable(), so a gated
+      // artifact's shell must never land in a shared cache.
+      c.header(
+        "Cache-Control",
+        artifact.expires_at ? "no-store" : cacheFor(artifact, "public, max-age=600"),
+      )
+      c.header("Link", `<${info.markdownUrl}>; rel="alternate"; type="text/markdown"`)
+      return c.html(
+        injectHead(setTitle(governedShell, `${info.title} · Derive`), unfurlMetaTags(info)),
+      )
     })
   // Server-rendered profile URL: the SPA shell with profile OG/Twitter meta injected for
   // crawlers (which don't run JS). Humans get the SPA as usual (the meta is inert). Only

--- a/apps/api/test/embeds.test.ts
+++ b/apps/api/test/embeds.test.ts
@@ -1,6 +1,7 @@
 import { join } from "node:path"
-import { newId } from "@derive/core"
+import { newId, newShortId } from "@derive/core"
 import { FsBlobStore } from "@derive/storage/fs"
+import { zipSync } from "fflate"
 import { describe, expect, it } from "vitest"
 import { createApp } from "../src/app"
 import { anonApp, app, dir, makeAuthedApp, meta, type TestUser, upload } from "./helpers"
@@ -245,6 +246,229 @@ describe("unfurl + embed", () => {
     expect(html).not.toContain("og:title")
     expect(html).not.toContain("Private Page")
     expect(html).toContain('name="robots" content="noindex,nofollow"')
+  })
+})
+
+describe("agent-readable share URLs (.md + Accept: text/markdown)", () => {
+  // The Accept header Claude-family agent fetchers send on every request.
+  const AGENT_ACCEPT = "text/markdown, text/html, */*"
+  const BROWSER_ACCEPT =
+    "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8"
+  // Unlike the sibling embed apps, this one READS version blobs, so it must share
+  // the upload helper's blob directory — a throwaway dir would 404 every body.
+  const a = createApp({
+    meta,
+    blobs: new FsBlobStore(join(dir, "blobs")),
+    baseUrl: "http://derive.test",
+    token: "tok",
+    shell: SHELL,
+  })
+
+  it("serves an HTML artifact as markdown at the .md suffix, anonymously", async () => {
+    const short = await idOf(
+      await upload(
+        "news.html",
+        "<!doctype html><html><body><h1>Big News</h1><p>Body words.</p></body></html>",
+        { visibility: "public", title: "Big News" },
+      ),
+    )
+    const res = await a.request(`/artifacts/big-news-${short}.md`)
+    expect(res.status).toBe(200)
+    expect(res.headers.get("content-type")).toContain("text/markdown")
+    const md = await res.text()
+    expect(md).toContain("# Big News")
+    expect(md).toContain("Body words.")
+    expect(md).not.toContain("<h1")
+    // Listed-public is indexable: no noindex marker, and the HTML page stays canonical.
+    expect(res.headers.get("x-robots-tag")).toBeNull()
+    expect(res.headers.get("link")).toContain('rel="canonical"')
+  })
+
+  it("negotiates markdown on the page URL for a client that asks for it", async () => {
+    const short = await idOf(
+      await upload("n.html", "<!doctype html><html><body><h1>Negotiated</h1></body></html>", {
+        visibility: "public",
+        title: "Negotiated",
+      }),
+    )
+    const md = await a.request(`/artifacts/negotiated-${short}`, {
+      headers: { accept: AGENT_ACCEPT },
+    })
+    expect(md.status).toBe(200)
+    expect(md.headers.get("content-type")).toContain("text/markdown")
+    expect(await md.text()).toContain("# Negotiated")
+
+    const html = await a.request(`/artifacts/negotiated-${short}`, {
+      headers: { accept: BROWSER_ACCEPT },
+    })
+    expect(html.status).toBe(200)
+    expect(html.headers.get("content-type")).toContain("text/html")
+    expect(await html.text()).toContain("id=root")
+
+    // q=0 explicitly refuses markdown.
+    const refused = await a.request(`/artifacts/negotiated-${short}`, {
+      headers: { accept: "text/markdown;q=0, */*" },
+    })
+    expect(refused.headers.get("content-type")).toContain("text/html")
+
+    // Two representations at one URL: every branch must tell caches to key on Accept.
+    expect(md.headers.get("vary")).toContain("Accept")
+    expect(html.headers.get("vary")).toContain("Accept")
+  })
+
+  it("titles the shell and advertises the markdown alternate", async () => {
+    const short = await idOf(
+      await upload("t.html", "<!doctype html><html><body><h1>T</h1></body></html>", {
+        visibility: "public",
+        title: "Titled Page",
+      }),
+    )
+    const res = await a.request(`/artifacts/titled-page-${short}`)
+    expect(res.status).toBe(200)
+    const html = await res.text()
+    expect(html).toContain("<title>Titled Page · Derive</title>")
+    expect(html.match(/<title/g)).toHaveLength(1)
+    expect(html).toContain('rel="alternate" type="text/markdown"')
+    expect(html).toContain(`/artifacts/titled-page-${short}.md`)
+    expect(res.headers.get("link")).toContain('rel="alternate"')
+  })
+
+  it("redirects a non-canonical .md ref to the canonical .md", async () => {
+    const short = await idOf(
+      await upload("c.md", "# canon", { visibility: "public", title: "Canon Doc" }),
+    )
+    const res = await a.request(`/artifacts/${short}.md`)
+    expect(res.status).toBe(302)
+    expect(res.headers.get("location")).toBe(`/artifacts/canon-doc-${short}.md`)
+  })
+
+  it("passes a markdown artifact through as its source", async () => {
+    const source = "# Hello\n\nSome *notes*.\n"
+    const short = await idOf(
+      await upload("notes.md", source, { visibility: "public", title: "Hello" }),
+    )
+    const res = await a.request(`/artifacts/hello-${short}.md`)
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe(source)
+  })
+
+  it("serves a bundle's entry page as markdown", async () => {
+    const zip = zipSync({
+      "index.html": new TextEncoder().encode("<h1>Entry</h1><p>Site body.</p>"),
+    })
+    const short = await idOf(await upload("site.zip", zip, { visibility: "public", title: "Site" }))
+    const res = await a.request(`/artifacts/site-${short}.md`)
+    expect(res.status).toBe(200)
+    const md = await res.text()
+    expect(md).toContain("# Entry")
+    expect(md).toContain("Site body.")
+  })
+
+  it("passes a markdown-entry bundle (a skill) through verbatim", async () => {
+    // pickBundleEntry prefers SKILL.md over non-root HTML, so a skill's entry is
+    // markdown — running it through the HTML converter would strip its structure.
+    const source = "---\nname: my-skill\n---\n\n# My Skill\n\nUse when X.\n"
+    const zip = zipSync({
+      "SKILL.md": new TextEncoder().encode(source),
+      "assets/demo.html": new TextEncoder().encode("<h1>demo</h1>"),
+    })
+    const short = await idOf(
+      await upload("skill.zip", zip, { visibility: "public", title: "My Skill" }),
+    )
+    const res = await a.request(`/artifacts/my-skill-${short}.md`)
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe(source)
+  })
+
+  it("gates pinned versions at @vN.md behind the public-history rule", async () => {
+    const short = await idOf(
+      await upload("v.md", "# One", { visibility: "public", title: "Versioned" }),
+    )
+    await upload("v.md", "# Two", {}, short)
+    // The current version reads anonymously; history does NOT (mirrors /raw's
+    // anonHistoryBlocked — an old version's bytes are as hidden as the workbench).
+    expect(await (await a.request(`/artifacts/versioned-${short}.md`)).text()).toContain("# Two")
+    expect((await a.request(`/artifacts/versioned-${short}@v1.md`)).status).toBe(404)
+    // An authorised reader still gets the pinned version.
+    const authed = await a.request(`/artifacts/versioned-${short}@v1.md`, {
+      headers: { authorization: "Bearer tok" },
+    })
+    expect(authed.status).toBe(200)
+    expect(await authed.text()).toContain("# One")
+    // Opting the page into public history opens it to the world link too.
+    await app.request(`/v1/artifacts/${short}/access`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ publicHistory: true }),
+    })
+    const anon = await a.request(`/artifacts/versioned-${short}@v1.md`)
+    expect(anon.status).toBe(200)
+    expect(await anon.text()).toContain("# One")
+  })
+
+  it("leaks nothing through the markdown surface for a gated artifact", async () => {
+    const short = await idOf(
+      await upload("h.md", "# top secret", { visibility: "org", title: "Hush Doc" }),
+    )
+    const res = await a.request(`/artifacts/${short}.md`) // anonymous
+    expect(res.status).toBe(404)
+    const body = await res.text()
+    expect(body).not.toContain("secret")
+    expect(body).not.toContain("Hush")
+    expect(res.headers.get("x-robots-tag")).toContain("noindex")
+    // The negotiated form of the same request stays small too — no app shell.
+    const neg = await a.request(`/artifacts/${short}`, { headers: { accept: AGENT_ACCEPT } })
+    expect(neg.status).toBe(404)
+    expect(neg.headers.get("content-type")).toContain("text/markdown")
+    expect(await neg.text()).not.toContain("id=root")
+  })
+
+  it("refuses the body of an expired draft (the sweep may not have run yet)", async () => {
+    // authorize() knows nothing about expiry — an unclaimed draft keeps its viewer
+    // world link until the sweep deletes it, so the fence must live in the handler.
+    // The blob is REAL: with a dangling blob_key this 404s for the wrong reason
+    // (missing blob) and the test pins nothing.
+    const blobKey = await new FsBlobStore(join(dir, "blobs")).put(
+      new TextEncoder().encode("# stale body"),
+    )
+    const art = await meta.createArtifact({
+      id: newId("a"),
+      // A ref-resolvable short id (newId's underscore prefix never parses out of a ref).
+      short_id: newShortId(),
+      org_id: "default",
+      slug: "stale-draft",
+      title: "Stale Draft",
+      workspace_access: "none",
+      link_role: "viewer",
+      listed: "none",
+      kind: "file",
+      spa: 0,
+      expires_at: "2020-01-01T00:00:00.000Z",
+    })
+    await meta.addVersion(art.id, {
+      id: newId("v"),
+      blob_key: blobKey,
+      content_type: "text/markdown",
+      size_bytes: 12,
+      author: "t",
+      author_id: null,
+      message: null,
+    })
+    const res = await a.request(`/artifacts/stale-draft-${art.short_id}.md`)
+    expect(res.status).toBe(404)
+    expect(await res.text()).not.toContain("stale body")
+  })
+
+  it("serves link-shared but unlisted docs with a noindex marker", async () => {
+    // The modern access triple: anyone with the URL may view, but it is listed
+    // nowhere — readable to an agent holding the link, still noindex for crawlers.
+    const short = await idOf(
+      await upload("q.md", "# quiet", { link_role: "viewer", listed: "none", title: "Quiet Doc" }),
+    )
+    const res = await a.request(`/artifacts/quiet-doc-${short}.md`) // anonymous
+    expect(res.status).toBe(200)
+    expect(await res.text()).toContain("# quiet")
+    expect(res.headers.get("x-robots-tag")).toContain("noindex")
   })
 })
 

--- a/apps/api/test/slack-work-object.test.ts
+++ b/apps/api/test/slack-work-object.test.ts
@@ -32,6 +32,7 @@ const info: UnfurlInfo = {
   imageUrl: "https://derive.to/v1/og/abc123",
   oembedUrl: "x",
   embedUrl: "y",
+  markdownUrl: "z",
 }
 
 const status = (over: Partial<ArtifactStatus> = {}): ArtifactStatus => ({

--- a/apps/web/public/llms-full.txt
+++ b/apps/web/public/llms-full.txt
@@ -176,6 +176,21 @@ GET /v1/artifacts/:short_id/content?v=2
 
 Returns raw source. Headers include `X-Derive-Version` and `X-Derive-Kind`.
 
+### Read a share URL as markdown (no token needed)
+
+```
+GET /artifacts/<ref>.md
+GET /artifacts/<ref>@v2.md
+GET /artifacts/<ref>            with header  Accept: text/markdown
+```
+
+The share URL's markdown projection (HTML artifacts are converted; a bundle serves its
+entry page). Anonymous access works whenever the link itself is viewable (a
+password-locked link must be unlocked on the web page first); a pinned version other
+than the current one needs a signed-in reader unless the artifact enables public
+history. Without the suffix or header the URL serves the web app's HTML shell, whose
+content loads client-side.
+
 ### Version diff
 
 ```

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -31,6 +31,16 @@ The draft URL then redirects to the permanent home. The secret URL is the only
 access (view-by-link, unlisted, noindex): don't put secrets in a draft. Drafts can't
 be revised. Create a new one, or claim it before revising through MCP.
 
+## Reading a shared artifact URL (no token needed)
+
+Every `/artifacts/<ref>` share URL serves an agent-readable markdown projection of the
+document: request the URL with `Accept: text/markdown`, or append `.md` to it
+(`/artifacts/<ref>.md`, also `<ref>@vN.md` for a pinned version). Anonymous access works
+whenever the link itself is viewable (a password-locked link must be unlocked on the web
+page first); pinned versions other than the current one need a signed-in reader unless
+the artifact enables public history. Without the header or suffix the URL serves the web
+app's HTML shell, whose content loads client-side.
+
 ## Key API endpoints
 
 All requests use `Authorization: Bearer $DERIVE_TOKEN` (static agent token from Settings > Agents).

--- a/packages/core/src/unfurl.test.ts
+++ b/packages/core/src/unfurl.test.ts
@@ -10,6 +10,7 @@ import {
   profileMetaTags,
   profileSummary,
   setRobotsMeta,
+  setTitle,
   type UnfurlInfo,
   unfurlDescription,
   unfurlMetaTags,
@@ -24,6 +25,7 @@ const info: UnfurlInfo = {
   imageUrl: "http://derive.test/v1/og/abc12345",
   oembedUrl: "http://derive.test/v1/oembed?url=http%3A%2F%2Fderive.test%2Fa%2Fabc12345",
   embedUrl: "http://derive.test/v1/embed/abc12345",
+  markdownUrl: "http://derive.test/artifacts/my-report-abc12345.md",
 }
 
 describe("parseRef", () => {
@@ -65,8 +67,22 @@ describe("unfurlMetaTags", () => {
       '<link rel="canonical" href="http://derive.test/artifacts/my-report-abc12345">',
     )
     expect(html).toContain('type="application/json+oembed"')
+    expect(html).toContain(
+      '<link rel="alternate" type="text/markdown" href="http://derive.test/artifacts/my-report-abc12345.md">',
+    )
     // No unescaped angle brackets from the title leak into the markup.
     expect(html).not.toContain("My <Report>")
+  })
+})
+
+describe("setTitle", () => {
+  it("replaces the shell title with the page's own, escaped", () => {
+    expect(setTitle("<head><title>Derive</title></head>", 'A "B" <c>')).toBe(
+      "<head><title>A &quot;B&quot; &lt;c&gt;</title></head>",
+    )
+  })
+  it("injects a title when the shell has none", () => {
+    expect(setTitle("<head></head>", "x")).toBe("<head><title>x</title>\n</head>")
   })
 })
 

--- a/packages/core/src/unfurl.ts
+++ b/packages/core/src/unfurl.ts
@@ -26,6 +26,9 @@ export interface UnfurlInfo {
   oembedUrl: string
   /** Absolute embeddable-view URL (`/v1/embed/:ref`). */
   embedUrl: string
+  /** Absolute markdown-projection URL (`/artifacts/:ref.md`) — the agent-readable
+   *  form of the share URL, advertised as a `rel=alternate` link. */
+  markdownUrl: string
   /** A card-sized summary of this version's facts (`pass 48 · fail 0`), when it
    *  carries any. Leads the description: the numbers are what a reader scanning a shared
    *  link actually wants, and showing them is what rewards publishing a fact at all. */
@@ -94,7 +97,17 @@ export const unfurlMetaTags = (i: UnfurlInfo): string => {
     `<meta name="twitter:description" content="${d}">`,
     `<meta name="twitter:image" content="${img}">`,
     `<link rel="alternate" type="application/json+oembed" href="${oembed}" title="${t}">`,
+    `<link rel="alternate" type="text/markdown" href="${escapeHtml(i.markdownUrl)}">`,
   ].join("\n")
+}
+
+/** Replace the shell's generic `<title>` with the page's own (escaped); inject if absent. */
+export const setTitle = (shellHtml: string, title: string): string => {
+  const tag = `<title>${escapeHtml(title)}</title>`
+  // Non-greedy to the first close tag keeps the scan linear (see setRobotsMeta).
+  const m = shellHtml.match(/<title\b[^>]*>[\s\S]*?<\/title>/i)
+  if (!m || m.index === undefined) return injectHead(shellHtml, tag)
+  return shellHtml.slice(0, m.index) + tag + shellHtml.slice(m.index + m[0].length)
 }
 
 /** Insert head HTML just before `</head>` (case-insensitive); prepend if none. */


### PR DESCRIPTION
## Why

Artifact share URLs render client-side, so any fetcher that doesn't run the SPA gets the app shell with no document in it. Verified empirically: Claude's fetcher (which sends `Accept: text/markdown, text/html, */*` on every request) and ChatGPT's both fail to read a public artifact page. The markdown projection already exists on the content API, but nothing at the page URL points to it, and robots.txt disallows `/v1/`.

## What

`/artifacts/:ref` now serves the markdown projection when the request asks for it:

- **Content negotiation**: an `Accept` header naming `text/markdown` (nonzero q) gets `text/markdown` at the page URL. Browsers never send it in a navigation; unfurlers (Slack, Discord) and search crawlers don't either, so their behavior is unchanged.
- **`.md` suffix**: `/artifacts/<name>-<id>.md` (and `@vN.md`) is the explicit, cacheable markdown URL. Advertised from the HTML via `<link rel="alternate" type="text/markdown">`, a `Link` header, and llms.txt / llms-full.txt.
- **Real `<title>`** in the served shell (was a generic "Derive").

Access is the existing `readable()`/`authorize` gate, plus fences this surface has to draw itself:

- **Draft expiry**: `authorize()` is expiry-blind (the sweep is the janitor); an expired-but-unswept draft 404s here instead of serving its body, and live drafts are `no-store`.
- **Anonymous version history**: pinned `@vN` reads mirror `/raw`'s `public_history` rule rather than the content endpoint's looser one.
- **Cache discipline**: only the distinct `.md` URL caches shared; the negotiated form stays `private` because several major CDNs ignore `Vary: Accept`, which would otherwise let one agent request poison the page URL with markdown for every browser behind that cache. The markdown 404 is `no-store`; the HTML branch now draws `cacheFor`'s line like every other `infoFor` consumer.
- **Bundles convert by their entry's own type**: `pickBundleEntry` prefers `SKILL.md`/`README.md` over non-root HTML, so a skill's markdown entry passes through verbatim instead of being flattened by the HTML converter.
- Blob loss is a 500 ("blob missing"), matching the content API, never a "private"-shaped 404.

Deliberately **not** done here: a server-rendered readable body in the HTML itself (fixes fetchers that neither send the header nor discover the `.md` link; needs SPA hydration handling and design, so it's its own change), and any change to the content API's pre-existing behavior around expiry/history — this PR only keeps the new surface from inheriting it.

## Verified

- `pnpm verify` green (ci, typecheck, full coverage suite) locally; pre-push hook ran it again on push.
- 26 tests in `apps/api/test/embeds.test.ts` covering: `.md` suffix, negotiation (including `q=0` refusal and browser Accept), Vary on both representations, canonical redirect preserving `.md`, markdown/skill-bundle verbatim passthrough, HTML-bundle conversion, pinned-version gating (anon blocked → owner allowed → `publicHistory` opt-in allows anon), expired-draft fence, gated-artifact no-leak (suffix and negotiated), unlisted noindex, and title/alternate-link injection. New tests were watched failing before the implementation; the expiry fence was proven by disabling it and watching its test fail for the right reason.
- Three independent adversarial review passes (HTTP/routing, authz/leaks, line-by-line); every confirmed finding above was fixed and re-tested. Accepted with reasons: q-ordering beyond `q=0` is not weighed (documented in code), and the title may briefly revert to "Derive" during hydration until the artifact query resolves (same as today's behavior for humans).
- Worker routing verified by code walk: `run_worker_first` + the `/artifacts/` server prefix means `.md` URLs reach this handler on the edge exactly as in the Node tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789561298&installation_model_id=428097&pr_number=744&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F744&signature=548a4f0989321f37a57c953f321d347630d8e5f53c78e4250a9ce7fe1de8c5f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->