### PR TITLE
Fix CI pnpm bootstrap after codeload rate limits

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,8 +1,7 @@
 name: Setup toolchain
 description: >-
-  pnpm + Node 24, with an optional frozen install. Collapses the four-line
-  setup block repeated across every CI job into one step. Checkout must run
-  before this (it reads action.yml from the checked-out tree).
+  Node 24 + the repo-pinned pnpm, with an optional frozen install. Shared by
+  every CI job. Checkout must run first because this action lives in the repo.
 
 inputs:
   install:
@@ -12,14 +11,13 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: 24 # the engines floor (Node 24 LTS — the sole supported runtime)
-        # Only cache the pnpm store when we install — with install:false (the
-        # security job) there's no store to save, and setup-node's post-step
-        # errors on the missing path.
-        cache: ${{ inputs.install == 'true' && 'pnpm' || '' }}
+        package-manager-cache: false
+    - name: Enable the repo-pinned pnpm
+      shell: bash
+      run: corepack enable pnpm
     - if: inputs.install == 'true'
       shell: bash
       run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,48 +156,76 @@ jobs:
   # seconds they actually run, and skip to nothing otherwise.
   db:
     runs-on: ubicloud-standard-8
-    # paths-filter lists a PR's changed files via the GitHub API, which needs
-    # pull-requests:read (the workflow default is contents:read only).
-    permissions:
-      contents: read
-      pull-requests: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
-        id: filter
         with:
-          filters: |
-            web:
-              - 'apps/web/**'
-              - 'packages/**'
-              - 'pnpm-lock.yaml'
-              - 'package.json'
-            runner:
-              - 'packages/cli/**'
-              - 'pnpm-lock.yaml'
-              - 'deploy/runner.Dockerfile'
-              - 'deploy/runner.Dockerfile.dockerignore'
-              - 'deploy/runner-entrypoint.sh'
-            app_image:
-              - '.dockerignore'
-              - '.github/workflows/ci.yml'
-              - '.github/workflows/release-images.yml'
-              - 'QUICKSTART.md'
-              - 'apps/api/**'
-              - 'apps/web/**'
-              - 'packages/broker/**'
-              - 'packages/core/**'
-              - 'packages/db/**'
-              - 'packages/storage/**'
-              - 'package.json'
-              - 'pnpm-lock.yaml'
-              - 'pnpm-workspace.yaml'
-              - 'deploy/Dockerfile*'
-              - 'deploy/compose*.yml'
-              - 'deploy/selfhost.env.example'
-              - 'scripts/selfhost-smoke-client.mjs'
-              - 'scripts/test-published-selfhost-bundle.sh'
-              - 'scripts/test-selfhost-quickstart.sh'
+          # The local path filter compares the event's exact base and head.
+          fetch-depth: 0
+      - name: Find build-affecting changes
+        id: filter
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          web=false
+          runner=false
+          app_image=false
+          range=
+
+          case "$EVENT_NAME" in
+            pull_request)
+              if [ -n "$BASE_SHA" ] && [ -n "$HEAD_SHA" ]; then
+                range="${BASE_SHA}...${HEAD_SHA}"
+              fi
+              ;;
+            push)
+              if [ -n "$BEFORE_SHA" ] && [ -n "${BEFORE_SHA//0/}" ]; then
+                range="${BEFORE_SHA}..${HEAD_SHA}"
+              fi
+              ;;
+          esac
+
+          if [ -z "$range" ]; then
+            web=true
+            runner=true
+            app_image=true
+          else
+            : "${RUNNER_TEMP:?}"
+            changed_paths="$RUNNER_TEMP/derive-changed-paths"
+            git diff --name-only -z "$range" > "$changed_paths"
+            while IFS= read -r -d '' path; do
+              case "$path" in
+                apps/web/* | packages/* | pnpm-lock.yaml | package.json) web=true ;;
+              esac
+              case "$path" in
+                packages/cli/* | pnpm-lock.yaml | \
+                  deploy/runner.Dockerfile | deploy/runner.Dockerfile.dockerignore | \
+                  deploy/runner-entrypoint.sh)
+                  runner=true
+                  ;;
+              esac
+              case "$path" in
+                .dockerignore | .github/workflows/ci.yml | \
+                  .github/workflows/release-images.yml | QUICKSTART.md | \
+                  apps/api/* | apps/web/* | packages/broker/* | packages/core/* | \
+                  packages/db/* | packages/storage/* | package.json | pnpm-lock.yaml | \
+                  pnpm-workspace.yaml | deploy/Dockerfile* | deploy/compose*.yml | \
+                  deploy/selfhost.env.example | scripts/selfhost-smoke-client.mjs | \
+                  scripts/test-published-selfhost-bundle.sh | \
+                  scripts/test-selfhost-quickstart.sh)
+                  app_image=true
+                  ;;
+              esac
+            done < "$changed_paths"
+          fi
+
+          echo "web=$web" >> "$GITHUB_OUTPUT"
+          echo "runner=$runner" >> "$GITHUB_OUTPUT"
+          echo "app_image=$app_image" >> "$GITHUB_OUTPUT"
       - uses: ./.github/actions/setup
 
       # More workers than cores, deliberately. This lane is the critical path —


### PR DESCRIPTION
## What changed

- replace `pnpm/action-setup` with Corepack already shipped by the pinned Node 24 runtime
- resolve pnpm from the repository pinned `packageManager` value
- keep package-manager caching disabled so setup has no optional cache dependency
- replace `dorny/paths-filter` with a small local `git diff` step that preserves the existing build path groups
- keep the critical CI workflow limited to pinned official GitHub actions and repository-local setup

## Why

The production deployment failed before any project command ran because GitHub codeload returned HTTP 429 while the runner downloaded a third-party action archive. After removing the pnpm action, the same failure moved to the third-party path-filter action. Removing both archive downloads addresses the shared failure mode while preserving the same checks and build selection.

## Verification

- `pnpm verify`
- local shell syntax check for the path filter
- workflow pin guardrail
- local filter cases: action-only change skips optional images; manual dispatch builds all images

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/747"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789569343&installation_model_id=428097&pr_number=747&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F747&signature=301eedaa36f81f777fb16272706c06e43f556e748db47c6c05486ab854bfac64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->