### PR TITLE
Restore the editorial marketing landing page

### DIFF
--- a/apps/web/e2e/public-quality/accessibility.spec.ts
+++ b/apps/web/e2e/public-quality/accessibility.spec.ts
@@ -101,6 +101,24 @@ test("marketing mobile menu exposes the same primary navigation", async ({ page 
   await expect(menu.locator("summary")).toBeFocused()
 })
 
+test("marketing walkthrough lets readers inspect each artifact version", async ({ page }) => {
+  await page.goto(`${siteOrigin}/site/index.html`)
+
+  const walkthrough = page.locator("[data-home-demo]")
+  const firstVersion = page.locator('[data-demo-version="1"]')
+  await firstVersion.click()
+
+  await expect(walkthrough).toHaveAttribute("data-version", "1")
+  await expect(firstVersion).toHaveAttribute("aria-pressed", "true")
+  await expect(walkthrough.getByRole("heading", { name: "OSC-8 Synthesizer" })).toBeVisible()
+  await expect(walkthrough.getByText("No comments yet.")).toBeVisible()
+  expect(
+    await page.evaluate(
+      () => document.documentElement.scrollWidth === document.documentElement.clientWidth,
+    ),
+  ).toBe(true)
+})
+
 test("docs search loads the local browser index", async ({ page }) => {
   await page.goto(`${docsOrigin}/`)
   await page.locator("[data-search-open]").first().click()

--- a/apps/web/public/site/index.html
+++ b/apps/web/public/site/index.html
@@ -52,7 +52,7 @@
 }
 </script>
 </head>
-<body>
+<body class="home-page">
 <a class="skip-link" href="#main-content">Skip to content</a>
 <nav class="site-nav" data-site-nav aria-label="Main navigation">
   <div class="nav-inner site-wrap">
@@ -91,124 +91,222 @@
 </nav>
 
 <main id="main-content" tabindex="-1">
-  <header class="page-hero site-wrap">
-    <div class="page-hero-copy">
-      <p class="eyebrow">Workspace for agent-made work</p>
+  <header class="home-hero">
+    <div class="home-stage site-wrap">
+      <p class="eyebrow">A workspace for agent-made work</p>
       <h1>Keep the result, not just the session.</h1>
-      <p class="lede">Give plans, reports, pages, decks, and sites a lasting place to live. Your team can see the current work, comment on it, and keep updating the same link.</p>
-      <div class="hero-actions">
-        <form data-waitlist class="waitlist-form" data-derive-source="homepage_waitlist" action="/v1/beta/signup" method="post" novalidate>
-          <label class="sr-only" for="home-email">Work email</label>
-          <input id="home-email" name="email" type="email" autocomplete="email" placeholder="you@company.com" required>
-          <button class="button button-primary" type="submit">Get beta access</button>
-        </form>
-        <div class="waitlist-complete" data-waitlist-complete role="status" hidden>Check your inbox for the access link.</div>
-        <a class="text-link" href="https://derive.to/artifacts/example-launch-page-5cmep9l9">See a live artifact <span aria-hidden="true">→</span></a>
-        <p class="hero-note">Free during beta. No card required.</p>
+      <p class="home-hero-copy">Give agent-made plans, reports, pages, decks, and sites a lasting URL with version history and feedback.</p>
+      <div class="home-hero-actions">
+        <button class="button button-primary home-primary-action" type="button" data-copy-from="agent-prompt" data-copied-label="Copied. Paste it into your agent."><span data-copy-label>Copy setup prompt</span></button>
+        <a class="button home-secondary-action" href="https://derive.to/artifacts/example-launch-page-5cmep9l9">Open a live example <span aria-hidden="true">→</span></a>
       </div>
+      <p class="home-hero-note">Works with Claude Code, Codex, Cursor, and other compatible MCP clients.</p>
     </div>
 
-    <div class="product-window" aria-label="Derive workspace showing an active engineering brief and its comments">
-      <div class="product-bar">
-        <span class="status-dot" aria-hidden="true"></span>
-        <strong>Launch readiness brief</strong>
-        <span class="product-path">derive.to/acme/launch-readiness</span>
-        <span>v7 · current</span>
+    <figure class="home-demo site-wrap" data-home-demo data-version="3">
+      <figcaption class="home-figure-label"><span>Product walkthrough</span><span>One artifact changing over time</span></figcaption>
+      <div class="home-demo-frame">
+        <div class="home-demo-bar">
+          <span class="home-demo-path">derive.to/artifacts/osc8-launch</span>
+          <span data-demo-meta>HTML · v3</span>
+          <span class="home-demo-lock">Password protected</span>
+          <span class="home-demo-spacer"></span>
+          <span class="home-demo-presence" aria-label="Three people viewing"><span>M</span><span>A</span><span>C</span></span>
+          <span class="home-demo-badge" data-demo-badge>Current</span>
+        </div>
+        <div class="home-demo-body">
+          <article class="home-artifact" aria-label="OSC-8 launch page artifact">
+            <div class="home-artifact-nav"><strong>OSC-8</strong><span>Voices</span><span>Specs</span><span>Preorder</span></div>
+            <div class="home-artifact-hero">
+              <div class="home-artifact-copy">
+                <h2 data-demo-heading>Eight voices. Zero menus.</h2>
+                <p data-demo-summary>Every parameter is already on the surface. No pages, no shift keys, no manual. Battery for an afternoon.</p>
+                <span class="home-artifact-button" data-demo-cta>Preorder for €249</span>
+                <p class="home-artifact-price">Ships Monday. Thirty-day returns.</p>
+              </div>
+              <div class="home-artifact-figure">
+                <div class="home-artifact-placeholder">Product image</div>
+                <svg class="home-synth-drawing" viewBox="0 0 560 300" fill="none" aria-label="Technical line drawing of the OSC-8 synthesizer" role="img">
+                  <rect x="42" y="46" width="452" height="204" rx="16"/>
+                  <text x="66" y="78">OSC-8</text>
+                  <g class="home-synth-knobs"><circle cx="118" cy="112" r="17"/><circle cx="166" cy="112" r="17"/><circle cx="214" cy="112" r="17"/><circle cx="262" cy="112" r="17"/><circle cx="310" cy="112" r="17"/><circle cx="358" cy="112" r="17"/><circle cx="406" cy="112" r="17"/><circle cx="454" cy="112" r="17"/></g>
+                  <g class="home-synth-marks"><path d="M118 98v8"/><path d="M177 101l-6 6"/><path d="M203 103l6 5"/><path d="M262 98v8"/><path d="M321 103l-6 5"/><path d="M358 98v8"/><path d="M395 101l6 6"/><path d="M465 105l-7 4"/></g>
+                  <g class="home-synth-keys"><rect x="66" y="168" width="30" height="58" rx="3"/><rect x="100" y="168" width="30" height="58" rx="3"/><rect x="134" y="168" width="30" height="58" rx="3"/><rect x="168" y="168" width="30" height="58" rx="3"/><rect x="202" y="168" width="30" height="58" rx="3"/><rect x="236" y="168" width="30" height="58" rx="3"/><rect x="270" y="168" width="30" height="58" rx="3"/><rect x="304" y="168" width="30" height="58" rx="3"/><rect x="338" y="168" width="30" height="58" rx="3"/><rect x="372" y="168" width="30" height="58" rx="3"/><rect x="406" y="168" width="30" height="58" rx="3"/><rect x="440" y="168" width="30" height="58" rx="3"/></g>
+                  <path class="home-synth-measure" d="M42 278H494M42 272v12M494 272v12"/>
+                  <text class="home-synth-measure-label" x="248" y="296">240 MM</text>
+                </svg>
+                <div class="home-artifact-figure-note"><span>Fig. 1</span><span>Production unit 0043</span></div>
+              </div>
+            </div>
+            <dl class="home-demo-stats">
+              <div><dt>8</dt><dd>Voices</dd></div>
+              <div><dt>22 h</dt><dd>Measured battery</dd></div>
+              <div><dt>1.8 ms</dt><dd>Key to sound</dd></div>
+              <div><dt>380 g</dt><dd>With battery</dd></div>
+            </dl>
+          </article>
+          <aside class="home-demo-comments" aria-label="Artifact comments">
+            <div class="home-comments-title"><span>Comments</span><span data-demo-comment-count>3</span></div>
+            <p class="home-comments-empty">No comments yet.</p>
+            <div class="home-demo-comment home-comment-v2">
+              <div class="home-comment-who"><span>M</span>Maeva</div>
+              <blockquote>Draw the product instead of leaving a placeholder.</blockquote>
+              <p>No glamour shot exists yet. Use the real dimensions and materials.</p>
+              <span class="home-comment-state">Addressed in v2</span>
+            </div>
+            <div class="home-demo-comment home-comment-v2">
+              <div class="home-comment-who"><span>M</span>Maeva</div>
+              <blockquote>“OSC-8 Synthesizer”</blockquote>
+              <p>This could describe any store template. Make the product the loudest thing on the page.</p>
+              <span class="home-comment-state">Addressed in v2</span>
+            </div>
+            <div class="home-demo-comment home-comment-v3">
+              <div class="home-comment-who"><span>A</span>Anya</div>
+              <blockquote>“€249”</blockquote>
+              <p>Anchor the price with facts, not adjectives.</p>
+              <span class="home-comment-state">Addressed in v3</span>
+            </div>
+          </aside>
+        </div>
       </div>
-      <div class="product-grid">
-        <aside class="product-rail" aria-label="Recent artifacts">
-          <div class="rail-title"><span>Active work</span><span>6</span></div>
-          <div class="rail-list">
-            <div class="rail-item is-active"><strong>Launch readiness brief</strong><span>updated 4m ago</span></div>
-            <div class="rail-item"><strong>API migration plan</strong><span>2 open comments</span></div>
-            <div class="rail-item"><strong>On-call handoff</strong><span>updated yesterday</span></div>
-            <div class="rail-item"><strong>Billing rollout</strong><span>v3 · shared</span></div>
-          </div>
-        </aside>
-        <article class="artifact-sheet">
-          <div class="artifact-meta"><span>Engineering</span><span>Updated by Codex</span></div>
-          <h2>Launch readiness</h2>
-          <p>The API migration is ready for a staged rollout. The remaining work is narrow and owned.</p>
-          <dl class="artifact-rows">
-            <div class="artifact-row"><dt>Status</dt><dd>Ready for the first 10% of traffic</dd></div>
-            <div class="artifact-row"><dt>Open work</dt><dd>Add the rollback alert and confirm the support handoff</dd></div>
-            <div class="artifact-row"><dt>Changed</dt><dd>Load-test results and the rollback threshold were added in v7</dd></div>
-            <div class="artifact-row"><dt>Next update</dt><dd>After the first production sample</dd></div>
-          </dl>
-        </article>
-        <aside class="product-comments" aria-label="Artifact comments">
-          <div class="comments-title"><span>Comments</span><span>2 open</span></div>
-          <div class="comment-card">
-            <div class="comment-person"><span class="comment-avatar">MK</span>Maeve</div>
-            <p>Can we put the rollback threshold next to the rollout step?</p>
-            <span class="comment-state">Addressed in v7</span>
-          </div>
-          <div class="comment-card">
-            <div class="comment-person"><span class="comment-avatar">AL</span>Alex</div>
-            <p>The support owner still needs a name before this goes out.</p>
-            <span class="comment-state">Open</span>
-          </div>
-        </aside>
+      <div class="home-version-control" aria-label="Artifact versions">
+        <div class="home-version-tabs">
+          <button type="button" data-demo-version="1" aria-pressed="false"><span>v1</span><small>First draft</small></button>
+          <button type="button" data-demo-version="2" aria-pressed="false"><span>v2</span><small>Clearer direction</small></button>
+          <button type="button" data-demo-version="3" aria-pressed="true"><span>v3</span><small>Current</small></button>
+        </div>
+        <p class="home-version-summary"><span data-demo-version-label>v3</span><span data-demo-version-message>Measured specs added after review</span></p>
       </div>
-    </div>
-
-    <dl class="proof-list">
-      <div><dt>One lasting URL</dt><dd>The link opens the current work, not a stale export.</dd></div>
-      <div><dt>Every version kept</dt><dd>See what changed and restore an earlier version.</dd></div>
-      <div><dt>Feedback in context</dt><dd>Comments stay with the version and text they refer to.</dd></div>
-    </dl>
+    </figure>
   </header>
 
-  <section class="marketing-section site-wrap">
-    <div class="section-heading">
-      <p class="eyebrow">How teams use it</p>
-      <div>
-        <h2>Make active work easy to find and follow</h2>
-        <p>Derive keeps the output of people and agents in one workspace. There is no required process. Publish, review, comment, and iterate in the way that fits the work.</p>
+  <section class="home-chapter site-wrap" aria-labelledby="publish-heading">
+    <h2 id="publish-heading">Publish</h2>
+    <div class="home-chapter-body">
+      <div class="home-chapter-copy">
+        <p class="home-chapter-lede">Give the work a home.</p>
+        <p>Publish a Markdown file, an HTML page, or a built site to a lasting URL. Styled HTML keeps its fonts, scripts, and images inside a sandboxed viewer. The link you shared last week still works.</p>
+        <p>Publish again to update the same URL. Each publish creates a version you can compare or restore.</p>
+      </div>
+      <div class="home-specimen" aria-label="Example publish command">
+        <div class="home-specimen-bar">derive publish</div>
+        <div class="home-code-lines"><span>$ derive publish launch/</span><span class="home-code-muted">→ 14 files · 1.2 MB · sandboxed</span><span class="home-code-success">✓ live at derive.to/artifacts/q3-launch-plan</span></div>
       </div>
     </div>
-    <dl class="feature-list">
-      <div><dt><span class="feature-kicker">Publish</span>Put the real work online</dt><dd>Publish Markdown, HTML, or a built site. Fonts, scripts, and images stay together in a sandboxed viewer.</dd></div>
-      <div><dt><span class="feature-kicker">Find</span>Open the current version</dt><dd>Search by name, tag, collection, or content. The workspace library shows what is active and who changed it.</dd></div>
-      <div><dt><span class="feature-kicker">Share</span>Send one link</dt><dd>Keep work private, share it by link, or protect it with a password. You can change or revoke access later.</dd></div>
-      <div><dt><span class="feature-kicker">Discuss</span>Comment on the work itself</dt><dd>Leave feedback on exact text, mention a person or agent, or edit directly. Commenting and editing require sign-in.</dd></div>
-      <div><dt><span class="feature-kicker">Update</span>Keep earlier versions intact</dt><dd>Publish again at the same URL. Compare versions, see what changed, and restore one when you need it.</dd></div>
-      <div><dt><span class="feature-kicker">Decide</span>Use formal review when it helps</dt><dd>Most work can move through comments and edits. Recorded approval is there for the work that needs a clear decision.</dd></div>
+  </section>
+
+  <section class="home-chapter site-wrap" aria-labelledby="find-heading">
+    <h2 id="find-heading">Find</h2>
+    <div class="home-chapter-body">
+      <div class="home-chapter-copy">
+        <p class="home-chapter-lede">Open the current work.</p>
+        <p>Every artifact appears in the workspace library. Search by name, tag, collection, or content instead of returning to the chat that produced it.</p>
+        <p>The same URL opens the current version and keeps earlier ones close by. You can see what changed and restore a version when you need it.</p>
+      </div>
+      <div class="home-specimen" aria-label="Recently updated artifacts">
+        <div class="home-specimen-bar">Library · Recently updated</div>
+        <dl class="home-library-list">
+          <div><dt>Q3 launch plan<small>Plans · updated today</small></dt><dd>v7</dd></div>
+          <div><dt>Customer import status<small>Reports · updated yesterday</small></dt><dd>v4</dd></div>
+          <div><dt>Database decision<small>Research · updated Monday</small></dt><dd>v2</dd></div>
+        </dl>
+      </div>
+    </div>
+  </section>
+
+  <section class="home-chapter site-wrap" aria-labelledby="share-heading">
+    <h2 id="share-heading">Share</h2>
+    <div class="home-chapter-body">
+      <div class="home-chapter-copy">
+        <p class="home-chapter-lede">Send a link, not an export.</p>
+        <p>Keep work inside your team, share it with anyone who has the link, or add a password for a client. The link opens the real page in a browser.</p>
+        <p>People can read without an account. Commenting and editing require sign-in. You can change or revoke access at any time.</p>
+      </div>
+      <div class="home-specimen" aria-label="Artifact sharing settings">
+        <div class="home-specimen-bar">Share · redesign-proposal</div>
+        <div class="home-share-link"><span>derive.to/artifacts/redesign-proposal</span><strong>Copy</strong></div>
+        <dl class="home-share-options">
+          <div><dt>Workspace<small>Everyone on your team</small></dt><dd>Editor</dd></div>
+          <div><dt>Anyone with the link<small>No account needed</small></dt><dd>Viewer</dd></div>
+          <div><dt>Password<small>For client access</small></dt><dd>On</dd></div>
+        </dl>
+      </div>
+    </div>
+  </section>
+
+  <section class="home-chapter site-wrap" aria-labelledby="discuss-heading">
+    <h2 id="discuss-heading">Discuss</h2>
+    <div class="home-chapter-body">
+      <div class="home-chapter-copy">
+        <p class="home-chapter-lede">Keep feedback next to the work.</p>
+        <p>Leave comments on exact text, mention a person or agent, or edit the artifact directly. Each version stays clear and recoverable, so everyone can see what changed.</p>
+        <p>Most work moves through comments and edits. Formal review is available when the work needs a recorded decision.</p>
+      </div>
+      <div class="home-specimen" aria-label="Artifact comment thread">
+        <div class="home-specimen-bar">Comments · q3-launch-plan</div>
+        <div class="home-thread">
+          <div><strong><span>A</span>Ada</strong><blockquote>“pilot cohort first”</blockquote><p>Which nine teams? Name them or nobody plans around it.</p></div>
+          <div><strong><span>C</span>agent · claude-code</strong><p>All nine are listed with owners in v3.</p><small>Resolved in v3</small></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="home-agent site-wrap" aria-labelledby="agent-heading">
+    <div class="home-agent-heading">
+      <p class="eyebrow">Connect your coding agent</p>
+      <h2 id="agent-heading">Give your agent a place to publish.</h2>
+      <p>Derive includes an MCP server for Claude Code, Codex, Cursor, and other compatible clients. Your agent can publish a page, read comments, and update the same artifact later.</p>
+    </div>
+    <div class="home-terminal" aria-label="Example Derive agent session">
+      <div class="home-terminal-bar"><span></span><span></span><span></span><strong>derive · agent session</strong></div>
+      <div class="home-terminal-lines"><span>$ claude mcp add derive https://derive.to/mcp</span><span class="home-code-success">✓ connected as @claude-code · role: editor</span><span></span><span>› publish “August growth report”</span><span class="home-code-muted">→ derive.to/artifacts/august-growth-report · v1 live</span><span></span><span>› catch_up</span><span class="home-code-muted">← 1 comment · Maeva on “+18% MoM”</span><span></span><span>› publish --addresses c_41x</span><span class="home-code-success">✓ v2 live · spike annotated · thread resolved</span></div>
+    </div>
+    <dl class="home-agent-tools">
+      <div><dt>publish</dt><dd>Save a revision</dd></div>
+      <div><dt>catch_up</dt><dd>Read new feedback</dd></div>
+      <div><dt>comment</dt><dd>Reply or resolve</dd></div>
+      <div><dt>read</dt><dd>Open any version</dd></div>
     </dl>
+    <div class="home-connect-actions">
+      <button class="button" type="button" data-copy-from="agent-prompt" data-copied-label="Copied. Paste it into your agent."><span data-copy-label>Copy setup prompt</span></button>
+      <a class="text-link" href="https://docs.derive.to/agents/connect/">Read the connection guide <span aria-hidden="true">→</span></a>
+    </div>
+    <div class="home-connect-list" aria-label="Ways to connect and publish">
+      <button type="button" data-copy="npx skills add derive-to/derive --skill derive" data-copied-label="Copied"><span>Install the Derive skill</span><code>npx skills add derive-to/derive --skill derive</code><strong data-copy-label>Copy</strong></button>
+      <button type="button" data-copy="claude mcp add --transport http derive https://derive.to/mcp" data-copied-label="Copied"><span>Connect over MCP</span><code>claude mcp add --transport http derive https://derive.to/mcp</code><strong data-copy-label>Copy</strong></button>
+      <button type="button" data-copy="curl -F file=@page.html https://derive.to/v1/drafts" data-copied-label="Copied"><span>Publish without an account</span><code>curl -F file=@page.html https://derive.to/v1/drafts</code><strong data-copy-label>Copy</strong></button>
+    </div>
+    <div id="agent-prompt" hidden>Set up Derive as the place where we keep, share, and improve our work. Install the skill with: npx skills add derive-to/derive --skill derive. Otherwise read https://derive.to/skill.md and connect to https://derive.to/mcp. Then publish one real plan, report, or designed page we have worked on recently. If I am not connected, use the anonymous draft flow and send me both the live URL and claim link.</div>
   </section>
 
-  <section class="marketing-section site-wrap">
-    <div class="agent-layout">
-      <div class="agent-copy">
-        <p class="eyebrow">Built for agents and people</p>
-        <h2>Your agent can come back to the work</h2>
-        <p>Connect Claude Code, Codex, Cursor, or another compatible MCP client. An agent can publish an artifact, read its comments, and update the same URL in a later session.</p>
-        <a class="text-link" href="https://docs.derive.to/start/connect-an-agent/">Connect an agent <span aria-hidden="true">→</span></a>
-      </div>
-      <div class="setup-panel" aria-label="Ways to connect and publish">
-        <div class="setup-title">Start from your tool</div>
-        <button class="setup-row" type="button" data-copy="npx skills add derive-to/derive --skill derive" data-copied-label="Copied"><strong>Skill</strong><code>npx skills add derive-to/derive --skill derive</code><span data-copy-label>Copy</span></button>
-        <button class="setup-row" type="button" data-copy="claude mcp add --transport http derive https://derive.to/mcp" data-copied-label="Copied"><strong>MCP</strong><code>claude mcp add --transport http derive https://derive.to/mcp</code><span data-copy-label>Copy</span></button>
-        <button class="setup-row" type="button" data-copy="curl -F file=@page.html https://derive.to/v1/drafts" data-copied-label="Copied"><strong>HTTP</strong><code>curl -F file=@page.html https://derive.to/v1/drafts</code><span data-copy-label>Copy</span></button>
-      </div>
+  <section class="home-price site-wrap" aria-labelledby="beta-heading">
+    <p class="eyebrow">Hosted or self-hosted</p>
+    <h2 id="beta-heading">Free during beta.</h2>
+    <p>All hosted features are included, and no card is required. Derive is Fair Source and self-hostable. Run it with SQLite and local disk, or use Postgres and S3 when you need them.</p>
+    <div class="home-price-links">
+      <a class="text-link" href="/pricing">Read the pricing plan <span aria-hidden="true">→</span></a>
+      <a class="text-link" href="https://docs.derive.to/self-hosting/quickstart/">Self-host Derive <span aria-hidden="true">→</span></a>
     </div>
   </section>
 
-  <section class="marketing-section access-section site-wrap">
-    <div class="access-panel">
-      <div>
-        <h2>Use the hosted beta or run it yourself</h2>
-        <p>The hosted product is free during beta. Derive is also Fair Source and self-hostable, with SQLite and local disk by default or Postgres and S3 at scale.</p>
-      </div>
-      <div>
-        <a class="button" href="https://docs.derive.to/self-hosting/quickstart/">Read the self-hosting guide</a>
-        <p class="access-alternative">Already have access? <a href="/login?src=nav_signin">Sign in to your workspace</a>.</p>
-      </div>
+  <section class="home-finale site-wrap" aria-labelledby="finale-heading">
+    <h2 id="finale-heading">Good work is derived.</h2>
+    <p>Publish one real piece of work, then keep improving it at the same link.</p>
+    <div class="home-finale-actions">
+      <form data-waitlist class="waitlist-form" data-derive-source="homepage_waitlist" action="/v1/beta/signup" method="post" novalidate>
+        <label class="sr-only" for="home-email">Work email</label>
+        <input id="home-email" name="email" type="email" autocomplete="email" placeholder="you@company.com" required>
+        <button class="button" type="submit">Get beta access</button>
+      </form>
+      <div class="waitlist-complete" data-waitlist-complete role="status" hidden>Check your inbox for the access link.</div>
     </div>
+    <p class="home-finale-note">Already have access? <a href="/login?src=nav_signin">Sign in to your workspace</a>.</p>
   </section>
 </main>
 
 <footer class="site-footer">
+  <div class="home-footer-watermark" aria-hidden="true">Derive</div>
   <div class="footer-inner site-wrap">
     <div class="footer-intro">
       <div class="footer-brand"><svg width="16" height="16" viewBox="0 0 18 18" fill="none" aria-hidden="true"><path d="M3 15V3h5.2a6 6 0 0 1 0 12H3Z" stroke="currentColor" stroke-width="1.6"/><path d="M11.5 15 15 3" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/></svg>Derive</div>

--- a/apps/web/public/site/site.css
+++ b/apps/web/public/site/site.css
@@ -413,422 +413,8 @@ strong {
   transform: translateX(2px);
 }
 
-.page-hero {
-  padding-top: 148px;
-}
-
-.page-hero-copy {
-  max-width: 760px;
-}
-
-.page-hero h1 {
-  max-width: 17ch;
-  margin-top: 18px;
-  font-size: clamp(42px, 6.5vw, 72px);
-  line-height: 1.01;
-}
-
-.page-hero .lede {
-  max-width: 62ch;
-  margin-top: 26px;
-  color: var(--muted-foreground);
-  font-size: clamp(17px, 2vw, 20px);
-  line-height: 1.55;
-}
-
-.hero-actions {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 12px 20px;
-  margin-top: 30px;
-}
-
-.hero-note {
-  width: 100%;
-  color: var(--muted-foreground);
-  font-size: 13px;
-}
-
-.product-window {
-  margin-top: 72px;
-  overflow: hidden;
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  background: var(--card);
-  box-shadow: var(--shadow);
-}
-
-.product-bar {
-  display: flex;
-  min-height: 48px;
-  align-items: center;
-  gap: 12px;
-  padding: 0 15px;
-  border-bottom: 1px solid var(--border-soft);
-  color: var(--muted-foreground);
-  font-size: 12px;
-}
-
-.product-bar strong {
-  overflow: hidden;
-  font-size: 13px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.product-path {
-  overflow: hidden;
-  margin-right: auto;
-  font-family: var(--font-mono);
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.status-dot {
-  width: 7px;
-  height: 7px;
-  flex: none;
-  border-radius: 50%;
-  background: var(--success);
-}
-
-.product-grid {
-  display: grid;
-  min-height: 510px;
-  grid-template-columns: 210px minmax(0, 1fr) 280px;
-}
-
-.product-rail,
-.product-comments {
-  padding: 18px;
-  background: color-mix(in srgb, var(--secondary) 36%, var(--background));
-}
-
-.product-rail {
-  border-right: 1px solid var(--border-soft);
-}
-
-.product-comments {
-  border-left: 1px solid var(--border-soft);
-}
-
-.rail-title,
-.comments-title {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  color: var(--muted-foreground);
-  font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.07em;
-  text-transform: uppercase;
-}
-
-.rail-list {
-  display: grid;
-  gap: 4px;
-  margin-top: 14px;
-}
-
-.rail-item {
-  padding: 10px;
-  border-radius: 5px;
-  color: var(--muted-foreground);
-  font-size: 12px;
-  line-height: 1.35;
-}
-
-.rail-item strong,
-.rail-item span {
-  display: block;
-}
-
-.rail-item span {
-  margin-top: 3px;
-  font-family: var(--font-mono);
-  font-size: 9px;
-  letter-spacing: 0.03em;
-}
-
-.rail-item.is-active {
-  border: 1px solid var(--border);
-  background: var(--card);
-  color: var(--foreground);
-  box-shadow: var(--shadow);
-}
-
-.artifact-sheet {
-  min-width: 0;
-  padding: 44px clamp(28px, 5vw, 64px);
-}
-
-.artifact-meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px 16px;
-  color: var(--muted-foreground);
-  font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-.artifact-sheet h2 {
-  max-width: 14ch;
-  margin-top: 24px;
-  font-size: clamp(30px, 4vw, 48px);
-  line-height: 1.02;
-}
-
-.artifact-sheet > p {
-  max-width: 52ch;
-  margin-top: 18px;
-  color: var(--muted-foreground);
-  font-size: 15px;
-}
-
-.artifact-rows {
-  display: grid;
-  gap: 0;
-  margin-top: 34px;
-  border-top: 1px solid var(--border-soft);
-}
-
-.artifact-row {
-  display: grid;
-  grid-template-columns: 108px 1fr;
-  gap: 18px;
-  padding: 14px 0;
-  border-bottom: 1px solid var(--border-soft);
-  font-size: 13px;
-}
-
-.artifact-row dt {
-  color: var(--muted-foreground);
-}
-
-.artifact-row dd {
-  color: var(--foreground);
-}
-
-.comment-card {
-  margin-top: 14px;
-  padding: 13px;
-  border: 1px solid var(--border);
-  border-radius: 7px;
-  background: var(--card);
-}
-
-.comment-person {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 12px;
-  font-weight: 550;
-}
-
-.comment-avatar {
-  display: inline-grid;
-  width: 20px;
-  height: 20px;
-  place-items: center;
-  border-radius: 50%;
-  background: var(--secondary);
-  color: var(--muted-foreground);
-  font-family: var(--font-mono);
-  font-size: 9px;
-}
-
-.comment-card p {
-  margin-top: 8px;
-  color: var(--muted-foreground);
-  font-size: 12px;
-  line-height: 1.5;
-}
-
-.comment-state {
-  display: block;
-  margin-top: 10px;
-  color: var(--success);
-  font-family: var(--font-mono);
-  font-size: 9px;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-}
-
-.proof-list {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  margin-top: 22px;
-  border-top: 1px solid var(--border);
-  border-bottom: 1px solid var(--border);
-}
-
-.proof-list > div {
-  padding: 22px 22px 24px 0;
-}
-
-.proof-list > div + div {
-  padding-left: 22px;
-  border-left: 1px solid var(--border-soft);
-}
-
-.proof-list dt {
-  font-size: 14px;
-  font-weight: 550;
-}
-
-.proof-list dd {
-  max-width: 32ch;
-  margin-top: 6px;
-  color: var(--muted-foreground);
-  font-size: 13px;
-}
-
 .marketing-section {
   padding-top: 144px;
-}
-
-.section-heading {
-  display: grid;
-  grid-template-columns: 180px minmax(0, 680px);
-  gap: 44px;
-}
-
-.section-heading h2 {
-  max-width: 18ch;
-  font-size: clamp(30px, 4vw, 44px);
-  line-height: 1.08;
-}
-
-.section-heading p {
-  max-width: 58ch;
-  margin-top: 18px;
-  color: var(--muted-foreground);
-  font-size: 16px;
-}
-
-.feature-list {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1px;
-  margin-top: 56px;
-  overflow: hidden;
-  border: 1px solid var(--border-soft);
-  border-radius: 8px;
-  background: var(--border-soft);
-}
-
-.feature-list > div {
-  min-height: 190px;
-  padding: 26px;
-  background: var(--background);
-}
-
-.feature-list dt {
-  font-size: 16px;
-  font-weight: 550;
-}
-
-.feature-list dd {
-  margin-top: 10px;
-  color: var(--muted-foreground);
-  font-size: 14px;
-  line-height: 1.65;
-}
-
-.feature-kicker {
-  display: block;
-  margin-bottom: 16px;
-  color: var(--muted-foreground);
-  font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.07em;
-  text-transform: uppercase;
-}
-
-.agent-layout {
-  display: grid;
-  grid-template-columns: minmax(0, 0.9fr) minmax(420px, 1.1fr);
-  gap: 72px;
-  align-items: center;
-}
-
-.agent-copy h2 {
-  max-width: 13ch;
-  margin-top: 18px;
-  font-size: clamp(30px, 4vw, 44px);
-  line-height: 1.08;
-}
-
-.agent-copy > p {
-  max-width: 52ch;
-  margin-top: 18px;
-  color: var(--muted-foreground);
-}
-
-.agent-copy .text-link {
-  margin-top: 24px;
-}
-
-.setup-panel {
-  overflow: hidden;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  background: var(--card);
-  box-shadow: var(--shadow);
-}
-
-.setup-title {
-  padding: 12px 16px;
-  border-bottom: 1px solid var(--border-soft);
-  color: var(--muted-foreground);
-  font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-}
-
-.setup-row {
-  display: grid;
-  width: 100%;
-  min-height: 56px;
-  grid-template-columns: 76px minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 14px;
-  padding: 10px 16px;
-  border-bottom: 1px solid var(--border-soft);
-  background: transparent;
-  text-align: left;
-}
-
-.setup-row:last-child {
-  border-bottom: 0;
-}
-
-.setup-row:hover {
-  background: var(--secondary);
-}
-
-.setup-row strong {
-  font-size: 12px;
-}
-
-.setup-row code {
-  overflow: hidden;
-  color: var(--muted-foreground);
-  font-family: var(--font-mono);
-  font-size: 11px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.setup-row span:last-child {
-  color: var(--muted-foreground);
-  font-family: var(--font-mono);
-  font-size: 9px;
-  letter-spacing: 0.05em;
 }
 
 .access-section {
@@ -916,6 +502,1228 @@ strong {
   text-underline-offset: 3px;
 }
 
+/* Home page: restores the original editorial landing-page rhythm. */
+.home-page {
+  --home-faint: var(--muted-foreground);
+  --home-wire: color-mix(in srgb, var(--foreground) 72%, transparent);
+  --home-wire-soft: color-mix(in srgb, var(--foreground) 25%, transparent);
+  --home-measure: color-mix(in srgb, var(--foreground) 18%, transparent);
+}
+
+.home-page::before {
+  background:
+    radial-gradient(circle at 50% -12%, color-mix(in srgb, var(--foreground) 6%, transparent), transparent 34rem),
+    linear-gradient(var(--background), var(--background));
+}
+
+.home-hero {
+  padding-top: 148px;
+}
+
+.home-stage {
+  text-align: center;
+}
+
+.home-stage .eyebrow {
+  margin-inline: auto;
+}
+
+.home-stage h1 {
+  max-width: 18ch;
+  margin: 24px auto 0;
+  font-size: clamp(48px, 7.4vw, 88px);
+  letter-spacing: -0.045em;
+}
+
+.home-hero-copy {
+  max-width: 48ch;
+  margin: 30px auto 0;
+  color: var(--muted-foreground);
+  font-size: clamp(17px, 1.7vw, 20px);
+}
+
+.home-hero-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  margin-top: 30px;
+}
+
+.home-primary-action {
+  min-height: 50px;
+  padding-inline: 22px;
+  font-size: 15px;
+}
+
+.home-secondary-action {
+  min-height: 42px;
+}
+
+.home-hero-note {
+  max-width: 56ch;
+  margin: 14px auto 0;
+  color: var(--muted-foreground);
+  font-size: 13px;
+}
+
+.home-demo {
+  margin-top: 80px;
+}
+
+.home-figure-label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 12px;
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.home-figure-label::after {
+  height: 1px;
+  flex: 1;
+  background: repeating-linear-gradient(
+    to right,
+    var(--border) 0,
+    var(--border) 4px,
+    transparent 4px,
+    transparent 8px
+  );
+  content: "";
+}
+
+.home-figure-label span:last-child {
+  color: var(--home-faint);
+}
+
+.home-demo-frame {
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: min(1vw, 12px);
+  background: var(--card);
+}
+
+.home-demo-bar {
+  display: flex;
+  min-height: 48px;
+  align-items: center;
+  gap: 12px;
+  padding: 0 16px;
+  border-bottom: 1px solid var(--border-soft);
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.home-demo-path {
+  overflow: hidden;
+  color: var(--foreground);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.home-demo-lock {
+  padding: 3px 8px;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  background: var(--secondary);
+}
+
+.home-demo-spacer {
+  flex: 1;
+}
+
+.home-demo-presence {
+  display: flex;
+  padding-left: 6px;
+}
+
+.home-demo-presence span {
+  display: inline-grid;
+  width: 22px;
+  height: 22px;
+  margin-left: -6px;
+  place-items: center;
+  border: 1px solid var(--card);
+  border-radius: 50%;
+  background: var(--secondary);
+  color: var(--muted-foreground);
+  font-size: 9px;
+}
+
+.home-demo-badge {
+  padding: 3px 8px;
+  border: 1px solid color-mix(in srgb, var(--success) 40%, transparent);
+  border-radius: 5px;
+  background: transparent;
+  color: var(--success);
+}
+
+.home-demo-body {
+  display: grid;
+  min-height: 500px;
+  grid-template-columns: minmax(0, 1fr) 300px;
+}
+
+.home-artifact {
+  min-width: 0;
+  padding: 34px 42px 30px;
+}
+
+.home-artifact-nav {
+  display: flex;
+  align-items: baseline;
+  gap: 18px;
+  color: var(--home-faint);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.home-artifact-nav strong {
+  color: var(--foreground);
+  letter-spacing: 0.15em;
+}
+
+.home-artifact-nav span:last-child {
+  margin-left: auto;
+  border-bottom: 1px solid var(--foreground);
+  color: var(--foreground);
+}
+
+.home-artifact-hero {
+  display: grid;
+  grid-template-columns: minmax(210px, 0.8fr) minmax(300px, 1.2fr);
+  gap: 40px;
+  align-items: start;
+  margin-top: 30px;
+}
+
+.home-artifact-copy {
+  min-width: 0;
+}
+
+.home-artifact-copy h2 {
+  max-width: 11ch;
+  font-size: clamp(30px, 3.6vw, 48px);
+}
+
+.home-artifact-copy > p {
+  max-width: 36ch;
+  margin-top: 16px;
+  color: var(--muted-foreground);
+  font-size: 14px;
+}
+
+.home-artifact-button {
+  display: inline-flex;
+  min-height: 36px;
+  align-items: center;
+  margin-top: 20px;
+  padding: 0 14px;
+  border-radius: 6px;
+  background: var(--foreground);
+  color: var(--background);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.home-artifact-copy .home-artifact-price {
+  margin-top: 10px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+
+.home-artifact-figure {
+  min-width: 0;
+}
+
+.home-artifact-placeholder {
+  display: none;
+  min-height: 245px;
+  place-items: center;
+  border: 1px dashed var(--home-wire-soft);
+  border-radius: min(1vw, 8px);
+  color: var(--home-faint);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.home-synth-drawing {
+  display: block;
+  width: 100%;
+  height: auto;
+  max-height: 260px;
+}
+
+.home-synth-drawing > rect,
+.home-synth-knobs,
+.home-synth-keys,
+.home-synth-measure {
+  stroke: var(--home-wire);
+  stroke-width: 1.4;
+}
+
+.home-synth-drawing > text {
+  fill: var(--muted-foreground);
+  font: 11px var(--font-mono);
+  letter-spacing: 3px;
+}
+
+.home-synth-marks {
+  stroke: var(--foreground);
+  stroke-width: 1.6;
+}
+
+.home-synth-keys rect:nth-child(even) {
+  fill: var(--secondary);
+}
+
+.home-synth-measure {
+  stroke: var(--home-measure);
+  stroke-width: 1;
+}
+
+.home-synth-drawing .home-synth-measure-label {
+  fill: var(--home-faint);
+  font-size: 9px;
+  letter-spacing: 2px;
+  text-anchor: middle;
+}
+
+.home-artifact-figure-note {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 8px;
+  color: var(--home-faint);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.home-demo-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  margin-top: 26px;
+  border-top: 1px solid var(--border-soft);
+}
+
+.home-demo-stats > div {
+  padding: 16px 14px 0 0;
+}
+
+.home-demo-stats > div + div {
+  padding-left: 14px;
+  border-left: 1px solid var(--border-soft);
+}
+
+.home-demo-stats dt {
+  font-size: 18px;
+  font-weight: 560;
+  font-variant-numeric: tabular-nums;
+}
+
+.home-demo-stats dd {
+  margin-top: 3px;
+  color: var(--home-faint);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.home-demo-comments {
+  padding: 20px 18px;
+  border-left: 1px solid var(--border-soft);
+  background: color-mix(in srgb, var(--secondary) 38%, var(--background));
+}
+
+.home-comments-title {
+  display: flex;
+  justify-content: space-between;
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.home-comments-empty {
+  display: none;
+  min-height: 380px;
+  place-items: center;
+  color: var(--muted-foreground);
+  font-size: 13px;
+}
+
+.home-demo-comment {
+  display: none;
+  margin-top: 12px;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--card);
+}
+
+.home-comment-who {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  font-weight: 550;
+}
+
+.home-comment-who span,
+.home-thread strong span {
+  display: inline-grid;
+  width: 20px;
+  height: 20px;
+  place-items: center;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  background: var(--secondary);
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 9px;
+}
+
+.home-demo-comment blockquote,
+.home-thread blockquote {
+  margin: 10px 0 0;
+  padding-left: 10px;
+  border-left: 2px solid var(--border);
+  color: var(--muted-foreground);
+  font-size: 12px;
+  font-style: italic;
+}
+
+.home-demo-comment p {
+  margin-top: 9px;
+  color: var(--foreground);
+  font-size: 13px;
+}
+
+.home-comment-state {
+  display: block;
+  margin-top: 10px;
+  color: var(--success);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.home-demo[data-version="1"] .home-artifact-placeholder,
+.home-demo[data-version="1"] .home-comments-empty {
+  display: grid;
+}
+
+.home-demo[data-version="1"] .home-synth-drawing,
+.home-demo[data-version="1"] .home-artifact-figure-note,
+.home-demo[data-version="1"] .home-demo-stats {
+  display: none;
+}
+
+.home-demo[data-version="2"] .home-comment-v2,
+.home-demo[data-version="3"] .home-comment-v2,
+.home-demo[data-version="3"] .home-comment-v3 {
+  display: block;
+}
+
+.home-demo[data-version="2"] .home-demo-stats {
+  display: none;
+}
+
+.home-version-control {
+  margin-top: 20px;
+}
+
+.home-version-tabs {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.home-version-tabs::before {
+  position: absolute;
+  top: 13px;
+  right: 0;
+  left: 0;
+  height: 1px;
+  background: var(--border);
+  content: "";
+}
+
+.home-version-tabs button {
+  position: relative;
+  display: grid;
+  gap: 7px;
+  justify-items: start;
+  padding: 0;
+  background: transparent;
+  color: var(--muted-foreground);
+  text-align: left;
+}
+
+.home-version-tabs button::before {
+  z-index: 1;
+  width: 9px;
+  height: 9px;
+  margin: 9px 0 0;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  background: var(--background);
+  content: "";
+}
+
+.home-version-tabs button:nth-child(2) {
+  justify-items: center;
+  text-align: center;
+}
+
+.home-version-tabs button:last-child {
+  justify-items: end;
+  text-align: right;
+}
+
+.home-version-tabs button[aria-pressed="true"] {
+  color: var(--foreground);
+}
+
+.home-version-tabs button[aria-pressed="true"]::before {
+  border-color: var(--foreground);
+  background: var(--foreground);
+}
+
+.home-version-tabs button span {
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.home-version-tabs button small {
+  font-size: 12px;
+  font-weight: 450;
+}
+
+.home-version-summary {
+  display: flex;
+  gap: 12px;
+  margin-top: 16px;
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.home-version-summary span:first-child {
+  color: var(--foreground);
+}
+
+.home-chapter {
+  padding-top: 184px;
+}
+
+.home-chapter > h2 {
+  font-size: clamp(52px, 7.5vw, 92px);
+  letter-spacing: -0.045em;
+}
+
+.home-chapter-body {
+  display: grid;
+  grid-template-columns: minmax(0, 11fr) minmax(360px, 9fr);
+  gap: 64px;
+  align-items: start;
+  margin-top: 34px;
+}
+
+.home-chapter-copy {
+  max-width: 60ch;
+}
+
+.home-chapter-copy p {
+  color: var(--muted-foreground);
+  font-size: 16px;
+}
+
+.home-chapter-copy .home-chapter-lede {
+  color: var(--foreground);
+  font-size: 21px;
+}
+
+.home-chapter-copy p + p {
+  margin-top: 18px;
+}
+
+.home-specimen {
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: min(1vw, 10px);
+  background: var(--card);
+}
+
+.home-specimen-bar {
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border-soft);
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.05em;
+}
+
+.home-code-lines,
+.home-terminal-lines {
+  display: grid;
+  padding: 16px 18px;
+  color: var(--foreground);
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.home-code-muted {
+  color: var(--muted-foreground);
+}
+
+.home-code-success {
+  color: var(--success);
+}
+
+.home-library-list,
+.home-share-options {
+  padding: 8px 18px;
+}
+
+.home-library-list > div,
+.home-share-options > div {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  padding: 12px 2px;
+  border-top: 1px solid var(--border-soft);
+}
+
+.home-library-list > div:first-child,
+.home-share-options > div:first-child {
+  border-top: 0;
+}
+
+.home-library-list dt,
+.home-share-options dt {
+  flex: 1;
+  font-size: 13px;
+  font-weight: 550;
+}
+
+.home-library-list small,
+.home-share-options small {
+  display: block;
+  margin-top: 2px;
+  color: var(--home-faint);
+  font-size: 11px;
+  font-weight: 450;
+}
+
+.home-library-list dd,
+.home-share-options dd {
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.home-share-link {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 12px;
+  margin: 16px 18px 6px;
+  padding: 9px 11px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--background);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.home-share-link span {
+  overflow: hidden;
+  flex: 1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.home-share-link strong {
+  color: var(--muted-foreground);
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.home-thread {
+  display: grid;
+  gap: 16px;
+  padding: 16px 18px;
+}
+
+.home-thread > div + div {
+  padding-top: 16px;
+  border-top: 1px solid var(--border-soft);
+}
+
+.home-thread strong {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+}
+
+.home-thread p {
+  margin-top: 8px;
+  font-size: 13px;
+}
+
+.home-thread small {
+  display: block;
+  margin-top: 8px;
+  color: var(--success);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.home-agent {
+  padding-top: 184px;
+}
+
+.home-agent-heading h2 {
+  max-width: 18ch;
+  margin-top: 16px;
+  font-size: clamp(38px, 5vw, 56px);
+}
+
+.home-agent-heading > p:last-child {
+  max-width: 54ch;
+  margin-top: 20px;
+  color: var(--muted-foreground);
+  font-size: 17px;
+}
+
+.home-terminal {
+  margin-top: 52px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: min(1vw, 12px);
+  background: var(--card);
+}
+
+.home-terminal-bar {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 44px;
+  padding: 0 18px;
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.home-terminal-bar > span {
+  width: 9px;
+  height: 9px;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  background: var(--secondary);
+}
+
+.home-terminal-bar strong {
+  margin-left: 6px;
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 450;
+  letter-spacing: 0.04em;
+}
+
+.home-terminal-lines {
+  min-height: 300px;
+  align-content: start;
+  padding: 26px 28px;
+  font-size: 14px;
+}
+
+.home-agent-tools {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 28px;
+  margin-top: 18px;
+}
+
+.home-agent-tools > div {
+  display: flex;
+  gap: 7px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.home-agent-tools dt {
+  color: var(--muted-foreground);
+}
+
+.home-agent-tools dd {
+  color: var(--home-faint);
+}
+
+.home-connect-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 16px 22px;
+  margin-top: 32px;
+}
+
+.home-connect-list {
+  margin-top: 14px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: min(1vw, 10px);
+  background: var(--card);
+}
+
+.home-connect-list button {
+  display: grid;
+  width: 100%;
+  min-height: 56px;
+  grid-template-columns: 190px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 16px;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border-soft);
+  background: transparent;
+  color: var(--muted-foreground);
+  text-align: left;
+}
+
+.home-connect-list button:last-child {
+  border-bottom: 0;
+}
+
+.home-connect-list button:hover,
+.home-connect-list button:focus-visible {
+  background: var(--secondary);
+}
+
+.home-connect-list button > span {
+  font-size: 13px;
+}
+
+.home-connect-list code {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--foreground);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.home-connect-list strong {
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 450;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.home-price {
+  padding-top: 184px;
+}
+
+.home-price h2 {
+  max-width: 16ch;
+  margin-top: 16px;
+  font-size: clamp(40px, 5.4vw, 60px);
+}
+
+.home-price > p:last-of-type {
+  max-width: 54ch;
+  margin-top: 22px;
+  color: var(--muted-foreground);
+  font-size: 17px;
+}
+
+.home-price-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px 28px;
+  margin-top: 28px;
+}
+
+.home-finale {
+  padding-top: 164px;
+  text-align: center;
+}
+
+.home-finale h2 {
+  max-width: 20ch;
+  margin-inline: auto;
+  font-size: clamp(40px, 5.4vw, 60px);
+}
+
+.home-finale > p {
+  max-width: 44ch;
+  margin: 20px auto 0;
+  color: var(--muted-foreground);
+  font-size: 17px;
+}
+
+.home-finale-actions {
+  display: flex;
+  justify-content: center;
+  margin-top: 34px;
+}
+
+.home-finale .waitlist-form {
+  width: min(430px, 100%);
+}
+
+.home-finale-note {
+  font-size: 12px !important;
+}
+
+.home-finale-note a {
+  color: var(--foreground);
+  text-decoration: underline;
+  text-decoration-color: var(--border);
+  text-underline-offset: 3px;
+}
+
+.home-page .site-footer {
+  position: relative;
+  overflow: hidden;
+  margin-top: 156px;
+}
+
+.home-footer-watermark {
+  position: absolute;
+  right: 0;
+  bottom: -0.34em;
+  left: 0;
+  color: color-mix(in srgb, var(--foreground) 2%, transparent);
+  font-size: clamp(120px, 24vw, 340px);
+  font-weight: 560;
+  letter-spacing: -0.05em;
+  line-height: 1;
+  text-align: center;
+  -webkit-text-stroke: 1px color-mix(in srgb, var(--foreground) 10%, transparent);
+  pointer-events: none;
+  user-select: none;
+}
+
+.home-page .footer-inner {
+  position: relative;
+  padding-bottom: 140px;
+}
+
+@media (max-width: 960px) {
+  .home-demo-body {
+    grid-template-columns: minmax(0, 1fr) 250px;
+  }
+
+  .home-artifact {
+    padding-inline: 28px;
+  }
+
+  .home-artifact-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .home-artifact-copy {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0 24px;
+  }
+
+  .home-artifact-copy h2,
+  .home-artifact-copy > p {
+    grid-column: 1;
+  }
+
+  .home-artifact-button,
+  .home-artifact-price {
+    grid-column: 2;
+  }
+
+  .home-artifact-button {
+    grid-row: 1;
+    margin-top: 0;
+  }
+
+  .home-artifact-price {
+    grid-row: 2;
+  }
+
+  .home-chapter-body {
+    grid-template-columns: 1fr;
+    gap: 40px;
+  }
+
+  .home-specimen {
+    width: min(560px, 100%);
+  }
+}
+
+@media (max-width: 760px) {
+  .home-hero {
+    padding-top: 118px;
+  }
+
+  .home-stage h1 {
+    font-size: clamp(42px, 12vw, 62px);
+  }
+
+  .home-hero-copy {
+    margin-top: 24px;
+    font-size: 17px;
+  }
+
+  .home-demo {
+    margin-top: 54px;
+  }
+
+  .home-figure-label span:last-child,
+  .home-demo-lock,
+  .home-demo-presence {
+    display: none;
+  }
+
+  .home-demo-body {
+    min-height: 0;
+    grid-template-columns: 1fr;
+  }
+
+  .home-artifact {
+    padding: 26px 20px;
+  }
+
+  .home-artifact-hero {
+    gap: 24px;
+    margin-top: 24px;
+  }
+
+  .home-artifact-copy {
+    display: block;
+  }
+
+  .home-artifact-button {
+    margin-top: 18px;
+  }
+
+  .home-artifact-copy .home-artifact-price {
+    margin-top: 10px;
+  }
+
+  .home-demo-comments {
+    padding: 16px;
+    border-top: 1px solid var(--border-soft);
+    border-left: 0;
+  }
+
+  .home-comments-empty {
+    min-height: 120px;
+  }
+
+  .home-demo-stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .home-demo-stats > div {
+    padding: 14px 12px 0 0;
+  }
+
+  .home-demo-stats > div + div {
+    padding-left: 12px;
+  }
+
+  .home-demo-stats > div:nth-child(3) {
+    padding-left: 0;
+    border-left: 0;
+  }
+
+  .home-demo-stats > div:nth-child(n + 3) {
+    margin-top: 14px;
+    padding-top: 14px;
+    border-top: 1px solid var(--border-soft);
+  }
+
+  .home-version-tabs button small {
+    font-size: 11px;
+  }
+
+  .home-chapter,
+  .home-agent,
+  .home-price {
+    padding-top: 116px;
+  }
+
+  .home-chapter > h2 {
+    font-size: clamp(48px, 16vw, 70px);
+  }
+
+  .home-chapter-body {
+    margin-top: 26px;
+  }
+
+  .home-agent-heading > p:last-child,
+  .home-price > p:last-of-type,
+  .home-finale > p {
+    font-size: 16px;
+  }
+
+  .home-terminal {
+    margin-top: 38px;
+  }
+
+  .home-terminal-lines {
+    min-height: 0;
+    overflow-x: auto;
+    padding: 20px 16px;
+    font-size: 12px;
+    white-space: nowrap;
+  }
+
+  .home-connect-list button {
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 6px 12px;
+    padding: 14px;
+  }
+
+  .home-connect-list button > span {
+    grid-column: 1;
+  }
+
+  .home-connect-list code {
+    grid-column: 1 / -1;
+    grid-row: 2;
+    overflow: visible;
+    text-overflow: clip;
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+
+  .home-connect-list strong {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
+  .home-finale {
+    padding-top: 116px;
+  }
+
+  .home-page .site-footer {
+    margin-top: 112px;
+  }
+
+  .home-page .footer-inner {
+    padding-bottom: 112px;
+  }
+}
+
+@media (max-width: 480px) {
+  .home-hero-actions {
+    align-items: stretch;
+  }
+
+  .home-hero-actions .button {
+    width: 100%;
+    min-height: 48px;
+  }
+
+  .home-figure-label {
+    display: block;
+  }
+
+  .home-demo-bar {
+    padding-inline: 12px;
+  }
+
+  .home-demo-bar > span[data-demo-meta] {
+    display: none;
+  }
+
+  .home-artifact-nav {
+    gap: 12px;
+  }
+
+  .home-artifact-nav span:nth-child(2),
+  .home-artifact-nav span:nth-child(3) {
+    display: none;
+  }
+
+  .home-artifact-copy h2 {
+    font-size: 34px;
+  }
+
+  .home-artifact-placeholder {
+    min-height: 190px;
+  }
+
+  .home-version-tabs button small {
+    display: none;
+  }
+
+  .home-version-summary {
+    display: grid;
+    gap: 4px;
+  }
+
+  .home-chapter-copy p {
+    font-size: 16px;
+  }
+
+  .home-chapter-copy .home-chapter-lede {
+    font-size: 20px;
+  }
+
+  .home-library-list,
+  .home-share-options {
+    padding-inline: 14px;
+  }
+
+  .home-share-link {
+    margin-inline: 14px;
+  }
+
+  .home-agent-tools {
+    display: grid;
+    gap: 7px;
+  }
+
+  .home-connect-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .home-connect-actions .button,
+  .home-connect-actions .text-link {
+    width: 100%;
+    min-height: 48px;
+    justify-content: center;
+  }
+
+  .home-price-links {
+    display: grid;
+  }
+
+  .home-price-links .text-link {
+    min-height: 44px;
+  }
+}
 .subpage-hero {
   max-width: var(--copy-width);
   padding-top: 148px;
@@ -1283,22 +2091,8 @@ strong {
 }
 
 @media (max-width: 960px) {
-  .product-grid {
-    grid-template-columns: 170px minmax(0, 1fr);
-  }
-
-  .product-comments {
-    display: none;
-  }
-
-  .feature-list,
   .example-grid {
     grid-template-columns: repeat(2, 1fr);
-  }
-
-  .agent-layout {
-    grid-template-columns: 1fr;
-    gap: 42px;
   }
 
   .price-card {
@@ -1334,99 +2128,23 @@ strong {
     display: block;
   }
 
-  .page-hero,
   .subpage-hero {
     padding-top: 118px;
   }
 
-  .page-hero h1 {
-    font-size: clamp(38px, 12vw, 56px);
-  }
-
-  .page-hero .lede,
   .subpage-hero .lede {
     font-size: 17px;
   }
 
-  .product-window {
-    margin-top: 54px;
-  }
-
-  .product-bar {
-    padding-inline: 12px;
-  }
-
-  .product-path,
-  .product-bar > .status-dot,
-  .product-bar > span:last-child {
-    display: none;
-  }
-
-  .product-grid {
-    min-height: 0;
-    grid-template-columns: 1fr;
-  }
-
-  .product-rail {
-    display: none;
-  }
-
-  .artifact-sheet {
-    padding: 32px 22px;
-  }
-
-  .artifact-row {
-    grid-template-columns: 88px 1fr;
-    gap: 12px;
-  }
-
-  .proof-list,
-  .feature-list,
   .example-grid,
   .principle-list,
   .pricing-grid {
     grid-template-columns: 1fr;
   }
 
-  .proof-list > div {
-    padding: 18px 0;
-  }
-
-  .proof-list > div + div {
-    padding-left: 0;
-    border-top: 1px solid var(--border-soft);
-    border-left: 0;
-  }
-
   .marketing-section,
   .content-section {
     padding-top: 96px;
-  }
-
-  .section-heading {
-    grid-template-columns: 1fr;
-    gap: 14px;
-  }
-
-  .feature-list {
-    margin-top: 38px;
-  }
-
-  .feature-list > div {
-    min-height: 0;
-    padding: 22px;
-  }
-
-  .agent-layout {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .setup-row {
-    grid-template-columns: 62px minmax(0, 1fr);
-  }
-
-  .setup-row span:last-child {
-    display: none;
   }
 
   .access-panel {
@@ -1450,18 +2168,6 @@ strong {
 }
 
 @media (max-width: 420px) {
-  .hero-actions {
-    align-items: stretch;
-    flex-direction: column;
-  }
-
-  .hero-actions .button,
-  .hero-actions .text-link {
-    width: 100%;
-    min-height: 48px;
-    justify-content: center;
-  }
-
   .waitlist-form {
     flex-direction: column;
     padding: 8px;

--- a/apps/web/public/site/site.js
+++ b/apps/web/public/site/site.js
@@ -142,6 +142,67 @@ function initWaitlists() {
   }
 }
 
+function initHomeDemo() {
+  const demo = document.querySelector("[data-home-demo]")
+  if (!(demo instanceof HTMLElement)) return
+
+  const versions = {
+    1: {
+      heading: "OSC-8 Synthesizer",
+      summary: "A portable eight-voice synthesizer with a built-in speaker and battery.",
+      meta: "HTML · v1",
+      badge: "Draft",
+      comments: "0",
+      message: "First draft",
+    },
+    2: {
+      heading: "Eight voices. Zero menus.",
+      summary: "Every parameter is already on the surface. No pages, no shift keys, no manual.",
+      meta: "HTML · v2",
+      badge: "Updated",
+      comments: "2",
+      message: "Product drawing and clearer direction",
+    },
+    3: {
+      heading: "Eight voices. Zero menus.",
+      summary: "Every parameter is already on the surface. No pages, no shift keys, no manual. Battery for an afternoon.",
+      meta: "HTML · v3",
+      badge: "Current",
+      comments: "3",
+      message: "Measured specs added after review",
+    },
+  }
+
+  const heading = demo.querySelector("[data-demo-heading]")
+  const summary = demo.querySelector("[data-demo-summary]")
+  const meta = demo.querySelector("[data-demo-meta]")
+  const badge = demo.querySelector("[data-demo-badge]")
+  const comments = demo.querySelector("[data-demo-comment-count]")
+  const versionLabel = demo.querySelector("[data-demo-version-label]")
+  const versionMessage = demo.querySelector("[data-demo-version-message]")
+  const buttons = [...demo.querySelectorAll("[data-demo-version]")]
+
+  const showVersion = (version) => {
+    const next = versions[version]
+    if (!next) return
+    demo.dataset.version = version
+    if (heading) heading.textContent = next.heading
+    if (summary) summary.textContent = next.summary
+    if (meta) meta.textContent = next.meta
+    if (badge) badge.textContent = next.badge
+    if (comments) comments.textContent = next.comments
+    if (versionLabel) versionLabel.textContent = `v${version}`
+    if (versionMessage) versionMessage.textContent = next.message
+    for (const button of buttons) {
+      button.setAttribute("aria-pressed", String(button.dataset.demoVersion === version))
+    }
+  }
+
+  for (const button of buttons) {
+    button.addEventListener("click", () => showVersion(button.dataset.demoVersion))
+  }
+}
+
 applyTheme()
 
 document.addEventListener("DOMContentLoaded", () => {
@@ -149,6 +210,7 @@ document.addEventListener("DOMContentLoaded", () => {
   initNav()
   initCopyButtons()
   initWaitlists()
+  initHomeDemo()
   for (const button of document.querySelectorAll("[data-theme-toggle]")) {
     button.addEventListener("click", cycleTheme)
   }


### PR DESCRIPTION
## Summary

- restore the earlier editorial landing-page structure and narrative
- keep the shared public-site shell, themes, navigation, footer, and guardrails
- replace the automatic animated demo with a calmer user-controlled version walkthrough
- add responsive accessibility coverage for the walkthrough

## Validation

- `pnpm verify`
- `pnpm --filter @derive/web test:e2e:public` (35 passed, 1 skipped)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789573649&installation_model_id=428097&pr_number=749&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F749&signature=7e5b6891612eb5bb030fcae0fd8df2d8d69a9e6b91e3a087d324ee45b7f951c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->