### PR TITLE
fix(skills): unpinned manifest skills load current; skills listing filters in the store

### DIFF
--- a/apps/api/src/mcp-tools/find.ts
+++ b/apps/api/src/mcp-tools/find.ts
@@ -540,7 +540,7 @@ export function registerFindTool(tc: ToolContext): void {
       // askable context. A tag filter resolves to an id set first (mirrors the HTTP ?tag=
       // path); viewerId keeps private rows scoped to the agent's human (mirrors `reach`).
       const ids = tag ? await ctx.meta.artifactIdsByTag(tag.trim().toLowerCase()) : undefined
-      const arts =
+      const rows =
         ids && ids.length === 0
           ? []
           : await ctx.meta.listArtifacts({
@@ -548,9 +548,9 @@ export function registerFindTool(tc: ToolContext): void {
               ids,
               viewerId: actingFor?.id ?? agent.id,
               archived: archived ? "only" : "exclude",
+              // Skill-ness is the denormalized content type; the store filters it.
+              ...(skills ? { contentType: SKILL_CONTENT_TYPE } : {}),
             })
-      // Skill-ness isn't a store-level filter (it's the denormalized content type).
-      const rows = skills ? arts.filter((a) => a.current_content_type === SKILL_CONTENT_TYPE) : arts
       const tagMap = await ctx.meta.tagsForArtifacts(rows.map((a) => a.id))
       const artifactRows = rows.map((a) => ({
         type: "artifact" as const,

--- a/apps/api/test/artifacts.test.ts
+++ b/apps/api/test/artifacts.test.ts
@@ -334,6 +334,23 @@ describe("api surface", () => {
     expect(await content.text()).toBe("<h1>Entry</h1>")
   })
 
+  it("listArtifacts filters by content type at the store", async () => {
+    // find(skills:true) used to page the whole library and filter in memory; the
+    // store-level filter is what makes a skills listing cheap. Both dialects run
+    // this file (sqlite by default, pg via DERIVE_TEST_DB=pg).
+    const zip = zipSync({
+      "SKILL.md": new TextEncoder().encode("---\nname: filter-probe\n---\n# P"),
+    })
+    const { short_id: skillShort } = await (
+      await upload("skill.zip", zip, { title: "Filter probe" })
+    ).json()
+    await upload("plain-probe.md", "# plain", { title: "Plain probe" })
+    const rows = await meta.listArtifacts({ orgId: "default", contentType: "derive/skill" })
+    expect(rows.some((a) => a.short_id === skillShort)).toBe(true)
+    expect(rows.length).toBeGreaterThan(0)
+    expect(rows.every((a) => a.current_content_type === "derive/skill")).toBe(true)
+  })
+
   it("diffs two versions as text and json", async () => {
     const res = await upload("d.md", "# title\nalpha", { title: "D" })
     const { short_id } = await res.json()

--- a/packages/cli/src/runner.js
+++ b/packages/cli/src/runner.js
@@ -169,20 +169,28 @@ export class DeriveClient {
   }
 
   /** The skills.js `api`: enumerate a bundle version, fetch one file (bytes, so binary
-   *  assets survive), and read a single-file doc's source — all pinned by version. */
+   *  assets survive), and read a single-file doc's source. A pinned entry carries its
+   *  version; an unpinned one (version null) omits `v` so the server serves CURRENT —
+   *  interpolating the null ("?v=null") gets a 400 and silently disables the skill. */
   skillApi() {
+    const query = (params) => {
+      const s = Object.entries(params)
+        .filter(([, value]) => value != null)
+        .map(([k, value]) => `${k}=${encodeURIComponent(value)}`)
+        .join("&")
+      return s ? `?${s}` : ""
+    }
     return {
-      outline: (id, version) => this.call(`/v1/artifacts/${id}/content?outline=1&v=${version}`),
+      outline: (id, version) =>
+        this.call(`/v1/artifacts/${id}/content${query({ outline: 1, v: version })}`),
       file: async (id, path, version) =>
         Buffer.from(
           await (
-            await this.callRaw(
-              `/v1/artifacts/${id}/content?section=${encodeURIComponent(path)}&v=${version}`,
-            )
+            await this.callRaw(`/v1/artifacts/${id}/content${query({ section: path, v: version })}`)
           ).arrayBuffer(),
         ),
       content: async (id, version) =>
-        (await this.callRaw(`/v1/artifacts/${id}/content?v=${version}`)).text(),
+        (await this.callRaw(`/v1/artifacts/${id}/content${query({ v: version })}`)).text(),
     }
   }
 

--- a/packages/cli/test/runner.test.js
+++ b/packages/cli/test/runner.test.js
@@ -15,6 +15,7 @@ import { describe, expect, it } from "vitest"
 import {
   buildPrompt,
   checkWritable,
+  DeriveClient,
   doctor,
   gitSafeEnv,
   loadRunnerConfig,
@@ -31,6 +32,39 @@ import {
   serveSession,
   syncRepos,
 } from "../src/runner.js"
+
+describe("skillApi", () => {
+  it("omits v for an unpinned skill and carries it when pinned", async () => {
+    // An unpinned manifest entry (version null) means "fetch current". Interpolating
+    // the null literally produced "?v=null", which the content route rejects with
+    // 400 "bad version" — the skill was then silently marked unavailable.
+    const paths = []
+    const c = new DeriveClient("http://x", "t")
+    c.call = async (p) => {
+      paths.push(p)
+      return {}
+    }
+    c.callRaw = async (p) => {
+      paths.push(p)
+      return { arrayBuffer: async () => new ArrayBuffer(0), text: async () => "" }
+    }
+    const api = c.skillApi()
+    await api.outline("ab12cd34", null)
+    await api.file("ab12cd34", "SKILL.md", undefined)
+    await api.content("ab12cd34", null)
+    await api.outline("ab12cd34", 3)
+    await api.file("ab12cd34", "a b.md", 3)
+    await api.content("ab12cd34", 3)
+    expect(paths).toEqual([
+      "/v1/artifacts/ab12cd34/content?outline=1",
+      "/v1/artifacts/ab12cd34/content?section=SKILL.md",
+      "/v1/artifacts/ab12cd34/content",
+      "/v1/artifacts/ab12cd34/content?outline=1&v=3",
+      "/v1/artifacts/ab12cd34/content?section=a%20b.md&v=3",
+      "/v1/artifacts/ab12cd34/content?v=3",
+    ])
+  })
+})
 
 describe("parseAnswer", () => {
   const good = `Here is my analysis.\n<answer>{"body_md":"32%","query":"select 1","confidence":0.9,"caveats":["small n"],"escalate":false,"escalation_reason":null}</answer>`

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -229,6 +229,10 @@ export interface ListArtifactsOpts {
   /** Archive shelf. Omitted/`exclude` is the ordinary live library; `only` powers
    *  the Archived view; `include` is for trusted maintenance reads. */
   archived?: "exclude" | "only" | "include"
+  /** Restrict to one stored content type via the denormalized `current_content_type`
+   *  column — e.g. `derive/skill` for a workspace's skills — so a typed listing
+   *  filters in the store instead of paging the whole library. */
+  contentType?: string
 }
 
 /** The browse sidebar's summary — see `ArtifactQueryStore.workspaceSummary`. */

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -223,6 +223,7 @@ export function artifactListConditions(
     created_at: Column
     updated_at: Column
     current_version: Column
+    current_content_type: Column
     id: Column
     org_id: Column
     listed: Column
@@ -241,6 +242,9 @@ export function artifactListConditions(
   // Anonymous / non-member callers only ever see the public directory — a
   // workspace-listed title must not leak to someone outside the workspace.
   if (opts?.publicOnly) conds.push(eq(art.listed, "public"))
+  // Typed listings (a workspace's skills) filter on the denormalized content type
+  // here rather than paging the library and filtering in memory.
+  if (opts?.contentType) conds.push(eq(art.current_content_type, opts.contentType))
   // A listing surfaces feed-listed rows (`workspace`/`public`) to members, plus any
   // row the viewer is an explicit member of (their own drafts, shares, collections)
   // — an UNlisted row (listed='none') never appears in a feed by access alone. The


### PR DESCRIPTION
## Why

Two defects surfaced while mapping the code for the shared-skills plan (workspace docs: `shared-skills-tvdnfjg6`, `shared-skills-the-build-5fzaxc5u`). This is PR 1 of that plan.

1. **Unpinned manifest skills never load.** The manifest grammar allows `- id: x` with no version, documented as "the runner fetches current" (`packages/cli/src/runner.js`, `apps/api/src/lib/manifest-pins.ts`). In fact the runner interpolated the null into the URL, the content route parsed `Number("null")` → NaN → `400 bad version`, and the skill was logged and silently marked unavailable. `derive context push` masks the bug by auto-pinning, which is why nobody hit it.
2. **`find(skills:true)` pages the whole library.** It listed every workspace artifact and filtered by content type in memory (`apps/api/src/mcp-tools/find.ts`).

## What

- `skillApi()` builds its query strings through a small null-dropping helper: a pinned entry carries `v=N`, an unpinned one omits `v` and the server serves current. Exact URLs pinned by a new test.
- `ListArtifactsOpts` gains `contentType`, applied in `artifactListConditions` — the one shared WHERE builder both dialects use — and `find(skills:true)` passes `derive/skill` through it. No behavior change: the existing browse test (`mcp.test.ts`, "filters to them with skills:true") pins parity, and a new store-level test proves the filter happens in the store on both dialects.

Deliberately not done here: the `?v=approved` semantics for unpinned skills — that's PR 3 of the plan (the approval gate); this PR restores the documented "current" behavior.

## Verified

- New tests watched failing first: the runner test failed on `?v=null` URLs, the store test failed on unfiltered rows.
- `pnpm verify` green locally via the pre-push hook (ci → typecheck → full coverage suite).
- Typecheck covers all four `artifactListConditions` callers against the extended column map.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/752"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789583521&installation_model_id=428097&pr_number=752&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F752&signature=9b4d007275b91c3feb8a3e6419854e1c089252ee76a8c3adabbb3917f2466b29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->