### PR TITLE
Give the marketing pages one container and one navigation

### DIFF
--- a/apps/web/e2e/public-quality/accessibility.spec.ts
+++ b/apps/web/e2e/public-quality/accessibility.spec.ts
@@ -84,6 +84,95 @@ test("marketing skip link moves focus to the primary content", async ({ page }) 
   await expect(page.locator("#main-content")).toBeFocused()
 })
 
+// Every public page is meant to carry the same shell. Asserting it per page is
+// what stops one of them drifting back to its own navigation.
+// The sign-in source is the one value the shell varies on purpose: signup
+// attribution is a pinned, deliberately small set, not ambient click tracking.
+const marketingPages = [
+  { path: "/site/index.html", current: null, signin: "nav_signin" },
+  { path: "/site/pricing.html", current: "/pricing", signin: "nav_signin" },
+  { path: "/site/examples.html", current: "/examples", signin: "examples_signin" },
+  { path: "/site/privacy.html", current: null, signin: "nav_signin" },
+  { path: "/security.html", current: null, signin: "nav_signin" },
+]
+
+for (const { path, current, signin } of marketingPages) {
+  test(`marketing shell is consistent on ${path}`, async ({ page }, testInfo) => {
+    await page.goto(`${siteOrigin}${path}`)
+
+    const nav = page.locator("nav.site-nav")
+    await expect(nav).toBeVisible()
+
+    // The same markup ships everywhere; below 480px the shell shows only the
+    // sign-in action and leaves the rest to each page's footer. Match on href so
+    // the assertion holds whether or not the link is currently displayed.
+    const compact = testInfo.project.name === "mobile"
+    for (const href of [
+      "https://docs.derive.to/",
+      "/examples",
+      "/pricing",
+      "https://github.com/derive-to/derive",
+    ]) {
+      const link = nav.locator(`a[href="${href}"]`)
+      await expect(link).toHaveCount(1)
+      if (!compact) await expect(link).toBeVisible()
+    }
+    await expect(nav.getByRole("link", { name: /Sign in to Beta/ })).toBeVisible()
+    await expect(nav.getByRole("link", { name: /Sign in to Beta/ })).toHaveAttribute(
+      "href",
+      `/login?src=${signin}`,
+    )
+
+    // The active page marks itself, and only itself.
+    await expect(nav.locator('[aria-current="page"]')).toHaveCount(current ? 1 : 0)
+    if (current)
+      await expect(nav.locator(`a[href="${current}"]`)).toHaveAttribute("aria-current", "page")
+
+    // The shared container must never push the page sideways.
+    expect(
+      await page.evaluate(
+        () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+      ),
+    ).toBe(true)
+
+    // Content clears the fixed navigation rather than hiding beneath it.
+    const overlap = await page.evaluate(() => {
+      const main = document.querySelector("#main-content")
+      const bar = document.querySelector("nav.site-nav")
+      if (!main || !bar) return null
+      return main.getBoundingClientRect().top - bar.getBoundingClientRect().bottom
+    })
+    expect(overlap).not.toBeNull()
+    if (path !== "/site/index.html") expect(overlap).toBeGreaterThanOrEqual(0)
+  })
+}
+
+test("marketing theme control cycles and is remembered", async ({ page }) => {
+  await page.goto(`${siteOrigin}/site/pricing.html`)
+  const toggle = page.locator("[data-theme-toggle]")
+
+  await expect(toggle).toHaveAttribute("data-mode", "dark")
+  await expect(page.locator("html")).toHaveClass(/dark/)
+
+  await toggle.click()
+  await expect(toggle).toHaveAttribute("data-mode", "light")
+  await expect(page.locator("html")).toHaveClass(/light/)
+
+  // The choice is shared across the marketing pages, not stored per page.
+  await page.goto(`${siteOrigin}/security.html`)
+  await expect(page.locator("html")).toHaveClass(/light/)
+  await expect(page.locator("[data-theme-toggle]")).toHaveAttribute("data-mode", "light")
+})
+
+test("marketing skip link works on a page that had no navigation before", async ({ page }) => {
+  await page.goto(`${siteOrigin}/security.html`)
+  await page.keyboard.press("Tab")
+  const skip = page.getByRole("link", { name: "Skip to content" })
+  await expect(skip).toBeFocused()
+  await page.keyboard.press("Enter")
+  await expect(page.locator("#main-content")).toBeFocused()
+})
+
 test("docs search loads the local browser index", async ({ page }) => {
   await page.goto(`${docsOrigin}/`)
   await page.locator("[data-search-open]").first().click()

--- a/apps/web/public/security.html
+++ b/apps/web/public/security.html
@@ -47,6 +47,17 @@
 </script>
 <link rel="icon" href="/brand/favicon.svg" type="image/svg+xml">
 <link rel="icon" href="/brand/favicon.png" type="image/png">
+<script>
+/* theme boot: set the class before first paint (the choice lives in localStorage) */
+(function(){
+  var m = null; try { m = localStorage.getItem('derive-theme'); } catch (e) {}
+  if (m !== 'light' && m !== 'system') m = 'dark';
+  var light = m === 'light' || (m === 'system' && matchMedia('(prefers-color-scheme: light)').matches);
+  var c = document.documentElement.classList;
+  c.toggle('light', light); c.toggle('dark', !light);
+})();
+</script>
+<link rel="stylesheet" href="/site/shell.css">
 <style>
 @font-face {
   font-family: "Geist";
@@ -59,13 +70,7 @@
   font-weight: 100 900; font-style: normal; font-display: swap;
 }
 :root {
-  --bg:#0a0b0d; --fg:#f3f4f6; --card:#101216; --secondary:#16181d;
-  --muted-fg:#969aa2; --accent:#1b1d23; --border:#23252b; --border-soft:#191b1f;
-  --primary:#f3f4f6; --primary-fg:#0a0b0d;
-  --radius:4px;
-  --font-sans:"Geist",system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
-  --font-mono:"Geist Mono",ui-monospace,Menlo,Consolas,monospace;
-  --maxw:720px;
+--maxw: var(--maxw-prose);
 }
 *,*::before,*::after{box-sizing:border-box}
 html{-webkit-text-size-adjust:100%}
@@ -76,10 +81,6 @@ body{
 }
 ::selection{background:rgba(243,244,246,.18)}
 a{color:inherit}
-.wrap{max-width:var(--maxw);margin:0 auto;padding:0 24px}
-header{padding:28px 0}
-.wordmark{display:inline-flex;align-items:center;gap:8px;font-weight:500;text-decoration:none}
-.wordmark svg{display:block}
 main{padding:40px 0 120px}
 .eyebrow{font-family:var(--font-mono);font-size:11px;font-weight:500;letter-spacing:.08em;text-transform:uppercase;color:var(--muted-fg)}
 h1{font-weight:500;letter-spacing:-0.022em;font-size:32px;margin:10px 0 14px;text-wrap:balance}
@@ -101,18 +102,32 @@ footer{border-top:1px solid var(--border-soft);padding:22px 0;color:var(--muted-
 footer a{text-decoration:none}
 footer a:hover{color:var(--fg)}
 </style>
+<script src="/site/shell.js" defer></script>
 </head>
 <body>
-<header class="wrap">
-  <a class="wordmark" href="/">
-    <svg width="15" height="15" viewBox="0 0 18 18" fill="none" aria-hidden="true">
-      <path d="M3 15V3h5.2a6 6 0 0 1 0 12H3Z" stroke="currentColor" stroke-width="1.6"/>
-      <path d="M11.5 15 15 3" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
-    </svg>
-    Derive
-  </a>
-</header>
-<main class="wrap">
+<a class="skip-link" href="#main-content">Skip to content</a>
+
+<nav class="site-nav" aria-label="Primary">
+  <div class="wrap site-nav__inner">
+    <a class="site-nav__brand" href="/">
+      <img class="wm-dark" src="/brand/wordmark-light.svg" alt="Derive">
+      <img class="wm-light" src="/brand/wordmark-dark.svg" alt="Derive">
+    </a>
+    <div class="site-nav__links">
+      <a href="https://docs.derive.to/">Docs</a>
+      <a href="/examples">Examples</a>
+      <a href="/pricing">Pricing</a>
+      <a href="https://github.com/derive-to/derive">GitHub</a>
+      <button class="site-nav__theme" type="button" data-theme-toggle aria-label="Theme">
+        <svg class="i-sun" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><circle cx="7" cy="7" r="3" stroke="currentColor" stroke-width="1.3"/><path d="M7 .8v1.7M7 11.5v1.7M.8 7h1.7M11.5 7h1.7M2.6 2.6l1.2 1.2M10.2 10.2l1.2 1.2M11.4 2.6l-1.2 1.2M3.8 10.2l-1.2 1.2" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg>
+        <svg class="i-moon" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><path d="M11.8 8.6A5.2 5.2 0 1 1 5.4 2.2a4.2 4.2 0 0 0 6.4 6.4Z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/></svg>
+        <svg class="i-sys" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><circle cx="7" cy="7" r="5.4" stroke="currentColor" stroke-width="1.3"/><path d="M7 1.6v10.8A5.4 5.4 0 0 0 7 1.6Z" fill="currentColor"/></svg>
+      </button>
+      <a class="site-nav__signin" href="/login?src=nav_signin">Sign in to Beta <span class="arr" aria-hidden="true">→</span></a>
+    </div>
+  </div>
+</nav>
+<main id="main-content" tabindex="-1" class="wrap">
   <span class="eyebrow">Security &amp; abuse</span>
   <h1>Report abuse or a vulnerability</h1>
   <p class="lede">Derive hosts pages and documents published by its users, including on subdomains of

--- a/apps/web/public/security.html
+++ b/apps/web/public/security.html
@@ -4,10 +4,10 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="color-scheme" content="dark">
-<title>Security & abuse — Derive</title>
+<title>Security and abuse | Derive</title>
 <meta name="description" content="How to report abusive content hosted on Derive, and how to report a security vulnerability.">
 <meta property="og:type" content="website">
-<meta property="og:title" content="Security &amp; abuse — Derive">
+<meta property="og:title" content="Security and abuse | Derive">
 <meta property="og:description" content="How to report abusive content hosted on Derive, and how to report a security vulnerability.">
 <meta property="og:url" content="https://derive.to/security">
 <meta property="og:image" content="https://derive.to/site/og-approval.png">
@@ -19,7 +19,7 @@
 {
   "@context": "https://schema.org",
   "@type": "WebPage",
-  "name": "Security & abuse — Derive",
+  "name": "Security and abuse | Derive",
   "url": "https://derive.to/security",
   "description": "How to report abusive content hosted on Derive, and how to report a security vulnerability.",
   "isPartOf": { "@id": "https://derive.to/#website" },
@@ -116,8 +116,8 @@ footer a:hover{color:var(--fg)}
   <span class="eyebrow">Security &amp; abuse</span>
   <h1>Report abuse or a vulnerability</h1>
   <p class="lede">Derive hosts pages and documents published by its users, including on subdomains of
-  <strong>derive.page</strong>, our dedicated user-content domain. If something hosted there — or anywhere
-  on Derive — is being used for phishing, malware, impersonation, or other abuse, we want to know.</p>
+  <strong>derive.page</strong>, our dedicated user-content domain. If something hosted there, or anywhere
+  on Derive, is being used for phishing, malware, impersonation, or other abuse, we want to know.</p>
 
   <section>
     <h2>Report abusive content</h2>
@@ -129,7 +129,7 @@ footer a:hover{color:var(--fg)}
   <section>
     <h2>Report a security vulnerability</h2>
     <a class="addr" href="mailto:security@derive.to">security@derive.to</a>
-    <p>For vulnerabilities in Derive itself — the app, the API, or the hosting of user content. Please give
+    <p>For vulnerabilities in Derive itself (the app, the API, or the hosting of user content). Please give
     us a reasonable window to remediate before public disclosure. The server is
     <a href="https://github.com/derive-to/derive">source available</a>; issues in the code are also welcome there.</p>
   </section>

--- a/apps/web/public/site/examples.html
+++ b/apps/web/public/site/examples.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Workflow examples — Derive</title>
+<title>Workflow examples | Derive</title>
 <meta name="description" content="Publishable examples of the complete Derive review loop: a launch page, research brief, and living status report.">
 <meta property="og:type" content="website">
 <meta property="og:title" content="Derive workflow examples">
@@ -27,6 +27,6 @@ derive login
 derive publish</pre><div class="truth"><strong>Then invite a real review.</strong> Select the intended link role in Derive, ask a reviewer to comment on the exact output, let a compatible agent address every thread, and approve only the resulting named version.</div></div></section>
   <section class="section"><div class="section-label">Proof standard</div><div><h2>What we will and will not call evidence.</h2><div class="steps"><div class="step"><div><b>Official samples stay labeled</b><span>Illustrative metrics, companies, and scenarios are never presented as customer results.</span></div></div><div class="step"><div><b>Customer stories require consent</b><span>A real case names the workflow, baseline, revisions, outcome, and limits its participant approved for publication.</span></div></div><div class="step"><div><b>A link alone is not adoption</b><span>Success means publish → non-author feedback → revision → named approval, repeated in real work.</span></div></div></div></div></section>
 </main>
-<footer><div class="foot wrap"><span>Derive · review and approval for agent-made work</span><div><a href="https://docs.derive.to/">Docs</a><a href="/privacy">Privacy</a><a href="/security">Security</a></div></div></footer>
+<footer><div class="foot wrap"><span>Derive · a workspace for agent-made artifacts</span><div><a href="https://docs.derive.to/">Docs</a><a href="/privacy">Privacy</a><a href="/security">Security</a></div></div></footer>
 </body>
 </html>

--- a/apps/web/public/site/examples.html
+++ b/apps/web/public/site/examples.html
@@ -13,15 +13,48 @@
 <meta name="twitter:card" content="summary_large_image">
 <link rel="canonical" href="https://derive.to/examples">
 <link rel="icon" href="/brand/favicon.svg" type="image/svg+xml">
+<script>
+/* theme boot: set the class before first paint (the choice lives in localStorage) */
+(function(){
+  var m = null; try { m = localStorage.getItem('derive-theme'); } catch (e) {}
+  if (m !== 'light' && m !== 'system') m = 'dark';
+  var light = m === 'light' || (m === 'system' && matchMedia('(prefers-color-scheme: light)').matches);
+  var c = document.documentElement.classList;
+  c.toggle('light', light); c.toggle('dark', !light);
+})();
+</script>
+<link rel="stylesheet" href="/site/shell.css">
 <link rel="stylesheet" href="/site/guides.css">
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"CollectionPage","name":"Derive workflow examples","url":"https://derive.to/examples","description":"Official, publishable examples of review and approval workflows for agent-made work."}</script>
+<script src="/site/shell.js" defer></script>
 </head>
 <body>
-<nav><div class="nav wrap"><a class="wordmark" href="/"><img src="/brand/wordmark-light.svg" alt="Derive"></a><a href="https://docs.derive.to/">Docs</a><a href="/examples" aria-current="page">Examples</a><a href="/pricing">Pricing</a><a href="https://github.com/derive-to/derive">GitHub</a><a class="signin" href="/login?src=examples_signin">Sign in →</a></div></nav>
+<a class="skip-link" href="#main-content">Skip to content</a>
+
+<nav class="site-nav" aria-label="Primary">
+  <div class="wrap site-nav__inner">
+    <a class="site-nav__brand" href="/">
+      <img class="wm-dark" src="/brand/wordmark-light.svg" alt="Derive">
+      <img class="wm-light" src="/brand/wordmark-dark.svg" alt="Derive">
+    </a>
+    <div class="site-nav__links">
+      <a href="https://docs.derive.to/">Docs</a>
+      <a href="/examples" aria-current="page">Examples</a>
+      <a href="/pricing">Pricing</a>
+      <a href="https://github.com/derive-to/derive">GitHub</a>
+      <button class="site-nav__theme" type="button" data-theme-toggle aria-label="Theme">
+        <svg class="i-sun" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><circle cx="7" cy="7" r="3" stroke="currentColor" stroke-width="1.3"/><path d="M7 .8v1.7M7 11.5v1.7M.8 7h1.7M11.5 7h1.7M2.6 2.6l1.2 1.2M10.2 10.2l1.2 1.2M11.4 2.6l-1.2 1.2M3.8 10.2l-1.2 1.2" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg>
+        <svg class="i-moon" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><path d="M11.8 8.6A5.2 5.2 0 1 1 5.4 2.2a4.2 4.2 0 0 0 6.4 6.4Z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/></svg>
+        <svg class="i-sys" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><circle cx="7" cy="7" r="5.4" stroke="currentColor" stroke-width="1.3"/><path d="M7 1.6v10.8A5.4 5.4 0 0 0 7 1.6Z" fill="currentColor"/></svg>
+      </button>
+      <a class="site-nav__signin" href="/login?src=examples_signin">Sign in to Beta <span class="arr" aria-hidden="true">→</span></a>
+    </div>
+  </div>
+</nav>
 <header><div class="wrap"><div class="eyebrow">Official examples</div><h1>Review the work, not a product promise.</h1><p class="lede">Each example is source you can inspect and publish yourself, paired with a concrete review request. They demonstrate Derive; they are not fabricated customer work or synthetic case studies.</p><div class="quick"><a class="button primary" href="#examples">Browse examples</a><a class="button" href="https://github.com/derive-to/derive/tree/main/examples">View all source</a></div></div></header>
-<main class="wrap">
+<main id="main-content" tabindex="-1" class="wrap">
   <section class="section" id="examples"><div class="section-label">Three complete jobs</div><div><h2>Start with work that needs a decision.</h2><p class="intro">The value appears when another person reviews the artifact, an agent revises it, and a named reviewer closes the loop.</p><div class="grid"><a class="card" href="https://derive.to/artifacts/example-launch-page-5cmep9l9"><h3>Designed launch page</h3><p>Review the real visual hierarchy, promise, evidence labels, and calls to action before release.</p><span class="go">Open live artifact →</span></a><a class="card" href="https://derive.to/artifacts/example-research-brief-ms66yju2"><h3>Decision-oriented research brief</h3><p>Challenge sources and inference strength, then approve the recommendation and its limits.</p><span class="go">Open live artifact →</span></a><a class="card" href="https://derive.to/artifacts/example-living-status-f49k4yvg"><h3>Living status report</h3><p>Keep changing metrics, risks, owners, and decisions at one URL across recurring reviews.</p><span class="go">Open live artifact →</span></a><a class="card" href="https://github.com/derive-to/derive/blob/main/examples/README.md"><h3>Run the complete loop</h3><p>Follow the publish, attributable feedback, focused revision, and named approval procedure.</p><span class="go">Read the workflow and source →</span></a></div></div></section>
-  <section class="section"><div class="section-label">Use one</div><div><h2>Publish with the workspace default.</h2><p class="intro">The example configurations intentionally omit access fields so cloning one never widens visibility without your decision.</p><pre>git clone https://github.com/derive-to/derive.git
+  <section class="section"><div class="section-label">Use one</div><div><h2>Publish with the workspace default.</h2><p class="intro">The example configurations intentionally omit access fields so cloning one never widens visibility without your decision.</p><pre tabindex="0">git clone https://github.com/derive-to/derive.git
 cd derive/examples/launch-page
 derive login
 derive publish</pre><div class="truth"><strong>Then invite a real review.</strong> Select the intended link role in Derive, ask a reviewer to comment on the exact output, let a compatible agent address every thread, and approve only the resulting named version.</div></div></section>

--- a/apps/web/public/site/guides.css
+++ b/apps/web/public/site/guides.css
@@ -1,17 +1,11 @@
 @font-face{font-family:"Geist";src:url("/site/geist.woff2") format("woff2");font-weight:100 900;font-display:swap}
 @font-face{font-family:"Geist Mono";src:url("/site/geist-mono.woff2") format("woff2");font-weight:100 900;font-display:swap}
-:root{color-scheme:dark;--bg:#0a0b0d;--fg:#f3f4f6;--card:#101216;--muted:#969aa2;--faint:#7f8590;--line:#252831;--accent:#c7c1ff;--good:#8ed2a0;--max:1120px}
+:root{color-scheme:dark;--bg:#0a0b0d;--fg:#f3f4f6;--card:#101216;--muted:#969aa2;--faint:#7f8590;--line:#252831;--accent:#c7c1ff;--good:#8ed2a0}
 *{box-sizing:border-box}
 html{scroll-behavior:smooth;-webkit-text-size-adjust:100%}
 body{margin:0;background:var(--bg);color:var(--fg);font:16px/1.65 "Geist",system-ui,sans-serif;letter-spacing:-.01em}
 a{color:inherit;text-decoration:none;cursor:pointer}
 a:focus-visible{outline:2px solid var(--accent);outline-offset:4px}
-.wrap{width:min(var(--max),calc(100% - 48px));margin:auto}
-nav{position:sticky;top:0;z-index:10;border-bottom:1px solid var(--line);background:rgba(10,11,13,.88);backdrop-filter:blur(18px)}
-.nav{height:64px;display:flex;align-items:center;gap:26px}
-.wordmark{margin-right:auto;display:flex;align-items:center}.wordmark img{width:96px;height:auto}
-.nav a:not(.wordmark){font-size:14px;color:var(--muted)}.nav a:hover{color:var(--fg)}
-.signin{padding:8px 13px;border:1px solid var(--line);border-radius:8px;color:var(--fg)!important}
 header{padding:96px 0 72px;border-bottom:1px solid var(--line)}
 .eyebrow{font:600 11px/1 "Geist Mono",monospace;letter-spacing:.1em;text-transform:uppercase;color:var(--accent)}
 h1,h2,h3{margin:0;font-weight:560;letter-spacing:-.04em;text-wrap:balance}
@@ -33,7 +27,10 @@ main{padding:72px 0 120px}
 .step{counter-increment:step;display:grid;grid-template-columns:44px 1fr;gap:14px;padding:20px;background:var(--card)}
 .step:before{content:counter(step,decimal-leading-zero);font:600 12px/1.6 "Geist Mono",monospace;color:var(--accent)}
 .step b{display:block;margin-bottom:3px}.step span{color:var(--muted);font-size:14px}
+/* Grid items default to min-width:auto, which lets a wide code block stretch
+   the page instead of scrolling inside itself. */
+.section>*,.grid>*{min-width:0}
 pre{overflow:auto;margin:22px 0 0;padding:18px 20px;border:1px solid var(--line);border-radius:10px;background:#07080a;color:#ddd;font:13px/1.7 "Geist Mono",monospace}
 .truth{padding:24px;border-left:2px solid var(--good);background:var(--card);color:var(--muted)}.truth strong{color:var(--fg)}
 footer{border-top:1px solid var(--line);padding:34px 0;color:var(--muted);font-size:13px}.foot{display:flex;justify-content:space-between;gap:24px}.foot div{display:flex;gap:20px}
-@media(max-width:760px){.wrap{width:min(100% - 30px,var(--max))}.nav a:not(.wordmark):not(.signin){display:none}header{padding:68px 0 54px}.section{grid-template-columns:1fr;gap:18px;padding:42px 0}.grid{grid-template-columns:1fr}.foot{flex-direction:column}}
+@media(max-width:760px){header{padding:68px 0 54px}.section{grid-template-columns:1fr;gap:18px;padding:42px 0}.grid{grid-template-columns:1fr}.foot{flex-direction:column}}

--- a/apps/web/public/site/index.html
+++ b/apps/web/public/site/index.html
@@ -14,10 +14,10 @@
   c.toggle('light', light); c.toggle('dark', !light);
 })();
 </script>
-<title>Derive — Review and approval for agent-made work.</title>
-<meta name="description" content="Turn agent output into approved work. Keep every version, comment, revision, and decision at one durable URL. Fair Source and self-hostable.">
+<title>Derive | Keep agent-made work visible</title>
+<meta name="description" content="A workspace for agent-made artifacts you can keep, share, and improve. Every version, comment, revision, and decision stays at one durable URL. Fair Source and self-hostable.">
 <meta property="og:type" content="website">
-<meta property="og:title" content="Derive — Turn agent output into approved work.">
+<meta property="og:title" content="Derive | Keep agent-made work visible">
 <meta property="og:description" content="One durable URL for every version, comment, revision, and decision. Hosted or self-hosted.">
 <meta property="og:url" content="https://derive.to/">
 <meta property="og:image" content="https://derive.to/site/og-approval.png">
@@ -57,7 +57,7 @@
       "applicationCategory": "BusinessApplication",
       "operatingSystem": "Web",
       "url": "https://derive.to/",
-      "description": "Derive is review and approval for work made by AI agents. It is Fair Source and self-hostable.",
+      "description": "Derive is a workspace for agent-made artifacts you can keep, share, and improve. It is Fair Source and self-hostable.",
       "isAccessibleForFree": true,
       "publisher": { "@id": "https://derive.to/#organization" }
     }
@@ -759,11 +759,11 @@ footer{margin-top:170px;position:relative;overflow:hidden;border-top:1px solid v
 <!-- ══════════ HERO ══════════ -->
 <header class="hero" id="hero">
   <div class="stage">
-    <div class="eyebrow hero-eyebrow">Review and approval for agent-made work</div>
+    <div class="eyebrow hero-eyebrow">A workspace for agent-made artifacts</div>
     <h1 class="derivation grad-ink">Turn agent output into approved&nbsp;work.</h1>
     <p class="sub">Give every plan, report, page, or deck one durable URL. People review the exact work, a compatible agent reads the feedback and revises it, and a named approval closes the loop. <strong>Hosted or self-hosted.</strong></p>
     <div class="cta-row">
-      <button class="btn btn-primary hero-cta" type="button" data-copy-from="agentPrompt" data-copied-label="Copied — now paste it into your agent">
+      <button class="btn btn-primary hero-cta" type="button" data-copy-from="agentPrompt" data-copied-label="Copied. Now paste it into your agent">
         <svg width="13" height="13" viewBox="0 0 14 14" fill="none" aria-hidden="true"><rect x="4.5" y="4.5" width="8" height="8" rx="1.5" stroke="currentColor" stroke-width="1.3"/><path d="M9.5 4.5v-2a1.5 1.5 0 0 0-1.5-1.5H3A1.5 1.5 0 0 0 1.5 2.5V8A1.5 1.5 0 0 0 3 9.5h1.5" stroke="currentColor" stroke-width="1.3"/></svg>
         <span class="copy-label">Copy instructions for my agent</span>
       </button>
@@ -774,7 +774,7 @@ footer{margin-top:170px;position:relative;overflow:hidden;border-top:1px solid v
 
   <!-- Product walkthrough: representative UI, not a live customer artifact. -->
   <div class="demo">
-    <div class="fig">FIG. 01 — product walkthrough · the review loop</div>
+    <div class="fig">FIG. 01 · product walkthrough · the review loop</div>
     <div class="demo-stage">
       <span class="tick tl" aria-hidden="true"></span><span class="tick tr" aria-hidden="true"></span>
       <span class="tick bl" aria-hidden="true"></span><span class="tick br" aria-hidden="true"></span>
@@ -803,7 +803,7 @@ footer{margin-top:170px;position:relative;overflow:hidden;border-top:1px solid v
               <div class="lcol">
                 <div class="lphead" id="lpH">OSC-8 Synthesizer</div>
                 <p class="lsub" id="lpSub"></p>
-                <span class="lbtn" id="lpBtn">Preorder — €249</span>
+                <span class="lbtn" id="lpBtn">Preorder · €249</span>
                 <div class="lprice" id="lpPrice"></div>
               </div>
               <div class="figslot">
@@ -933,13 +933,13 @@ footer{margin-top:170px;position:relative;overflow:hidden;border-top:1px solid v
 <div class="ocean" role="img" aria-label="Ephemeral chat fragments drift past a single kept artifact.">
   <div class="ghosts" aria-hidden="true">
     <div class="gcol g1">
-      <span class="ghost">sure! here's a revised draft —</span>
+      <span class="ghost">sure! here's a revised draft...</span>
       <span class="ghost plain">can you resend the latest version?</span>
       <span class="ghost">wait, that was the old one</span>
       <span class="ghost plain">[conversation expired]</span>
       <span class="ghost">which doc is current??</span>
       <span class="ghost plain">pasted in slack, somewhere</span>
-      <span class="ghost">sure! here's a revised draft —</span>
+      <span class="ghost">sure! here's a revised draft...</span>
       <span class="ghost plain">can you resend the latest version?</span>
       <span class="ghost">wait, that was the old one</span>
       <span class="ghost plain">[conversation expired]</span>
@@ -1017,7 +1017,7 @@ footer{margin-top:170px;position:relative;overflow:hidden;border-top:1px solid v
     <div>
       <p class="ch-lede reveal">Your team's library, anyone's link.</p>
       <p class="ch-text reveal">Everything your team publishes lands in one library, so "where's that thing?" always has the same answer. When work needs to leave the building, you send a link: <strong>put a password on it for a client, open it to anyone who has it, or keep it inside the team.</strong> Whoever opens it sees the real, rendered page in their browser, not a zip or a PDF export.</p>
-      <p class="ch-text reveal">Every link carries a role you chose: viewer, commenter, or editor. <strong>Anyone with viewing access can read without an account; commenting or editing requires sign-in</strong>, so feedback has an accountable author. You can revoke a link the moment you change your mind.</p>
+      <p class="ch-text reveal">Every link carries a role you chose: viewer, commenter, or editor. <strong>Anyone with viewing access can read without an account. Commenting and editing require sign-in.</strong> Feedback always has an accountable author. You can revoke a link the moment you change your mind.</p>
     </div>
     <div class="ch-spec reveal">
       <div class="spec-card">
@@ -1116,15 +1116,15 @@ footer{margin-top:170px;position:relative;overflow:hidden;border-top:1px solid v
     <div class="tbody" id="termBody"><span class="cursor" id="termCursor"></span></div>
   </div>
   <p class="cast reveal"><span><b>publish</b> save a revision</span><span><b>catch_up</b> what changed + open feedback</span><span><b>comment</b> reply or resolve</span><span><b>read</b> any artifact, any version</span></p>
-  <script type="text/plain" id="agentPrompt">I'd like you to set up Derive — where the work we make gets published, reviewed, and kept.
+  <script type="text/plain" id="agentPrompt">I'd like you to set up Derive as the place where we keep, share, and improve our work.
 
 Install the skill if I have npm: npx skills add derive-to/derive --skill derive
 Otherwise, read https://derive.to/skill.md and follow it (MCP server: https://derive.to/mcp).
 
-Then pick something real we've worked on recently — a plan, a report, a designed page — and publish it. If I'm not connected to Derive, use the anonymous draft flow: no account needed, and it returns a live URL plus a claim link. Send me both so I can see it and claim it.</script>
+Then pick something real we've worked on recently (a plan, a report, a designed page) and publish it. If I'm not connected to Derive, use the anonymous draft flow: no account needed, and it returns a live URL plus a claim link. Send me both so I can see it and claim it.</script>
   <div class="hk-lead reveal">
-    <button class="btn btn-primary" type="button" data-copy-from="agentPrompt" data-copied-label="Copied — paste it into your agent">Copy instructions for my agent</button>
-    <span class="hk-leadnote">one paste into a compatible agent — it connects and publishes your first page</span>
+    <button class="btn btn-primary" type="button" data-copy-from="agentPrompt" data-copied-label="Copied. Paste it into your agent">Copy instructions for my agent</button>
+    <span class="hk-leadnote">one paste into a compatible agent: it connects and publishes your first page</span>
   </div>
   <div class="hookup reveal">
     <button class="hk-row" type="button" data-copy="npx skills add derive-to/derive --skill derive" title="Copy">
@@ -1137,7 +1137,7 @@ Then pick something real we've worked on recently — a plan, a report, a design
       <code>claude mcp add --transport http derive https://derive.to/mcp</code>
       <span class="hk-copy" aria-hidden="true">COPY</span>
     </button>
-    <button class="hk-row" type="button" data-copy="curl -F file=@page.html https://derive.to/v1/drafts" title="Copy. Publishes an expiring draft — claim it into a workspace whenever.">
+    <button class="hk-row" type="button" data-copy="curl -F file=@page.html https://derive.to/v1/drafts" title="Copy. Publishes an expiring draft. Claim it into a workspace whenever.">
       <span class="hk-what">No agent, no account</span>
       <code>curl -F file=@page.html https://derive.to/v1/drafts</code>
       <span class="hk-copy" aria-hidden="true">COPY</span>
@@ -1301,13 +1301,13 @@ function editPlay(){
   at(150,  () => w1.classList.add('on'));
   at(900,  () => {
     w1.classList.add('struck');
-    note.textContent = 'v2 · "good takes more than one pass." — Maeva';
+    note.textContent = 'v2 · "good takes more than one pass." · Maeva';
   });
   at(1080, () => w2.classList.add('on'));
   at(1650, () => {
     w1.classList.add('settle');
     w2.classList.add('struck');
-    note.textContent = 'v3 · "a prompt isn\'t craft." — Maeva';
+    note.textContent = 'v3 · "a prompt isn\'t craft." · Maeva';
   });
   at(1830, () => w3.classList.add('on'));
   at(2350, () => {
@@ -1550,20 +1550,20 @@ const DOC = {
   1: { meta:'HTML · v1', v1:true,
        h:`<span class="hlspan" id="t2" style="--hlc:${GOLD}">OSC-8 Synthesizer</span>`,
        sub:'A portable 8-voice synthesizer with a built-in speaker and battery. Available for preorder now.',
-       btn:'Preorder — €249', price:'',
-       fig:'FIG. 1 — placeholder · unresolved', hint:'', specs:false,
+       btn:'Preorder · €249', price:'',
+       fig:'FIG. 1 · placeholder · unresolved', hint:'', specs:false,
        line:['v1','agent · claude-code','first draft · a template with a hole where the product goes'] },
   2: { meta:'HTML · v2', v1:false,
        h:'Eight voices.<br><em>Zero menus.</em>',
        sub:'Every parameter is a knob you can touch. No pages, no shift keys, no manual. Battery for a weekend.',
        btn:'Preorder', price:`<span class="hlspan" id="t3" style="--hlc:${VIOLET}">€249</span> · ships worldwide`,
-       fig:'FIG. 1 — top assembly · 1:2', hint:'', specs:false,
+       fig:'FIG. 1 · top assembly · 1:2', hint:'', specs:false,
        line:['v2','agent · claude-code','revision · drawn like a filing, and the type leads'] },
   3: { meta:'HTML · v3', v1:false,
        h:'Eight voices.<br><em>Zero menus.</em>',
        sub:'Every parameter is a knob you can touch. No pages, no shift keys, no manual. Battery for a weekend.',
-       btn:'Preorder — €249', price:'<b>Ships March</b> · 30-day returns · case + cable included',
-       fig:'FIG. 1 — exploded view · 1:2 · unit №0043', hint:'hover to open it up', specs:true,
+       btn:'Preorder · €249', price:'<b>Ships March</b> · 30-day returns · case + cable included',
+       fig:'FIG. 1 · exploded view · 1:2 · unit №0043', hint:'hover to open it up', specs:true,
        line:['v3','agent · claude-code','measured specs · the exploded view is the anchor'] },
 };
 const demoBody = $('demoBody'), demoFrame = document.querySelector('.demo-frame');

--- a/apps/web/public/site/index.html
+++ b/apps/web/public/site/index.html
@@ -64,6 +64,17 @@
   ]
 }
 </script>
+<script>
+/* theme boot: set the class before first paint (the choice lives in localStorage) */
+(function(){
+  var m = null; try { m = localStorage.getItem('derive-theme'); } catch (e) {}
+  if (m !== 'light' && m !== 'system') m = 'dark';
+  var light = m === 'light' || (m === 'system' && matchMedia('(prefers-color-scheme: light)').matches);
+  var c = document.documentElement.classList;
+  c.toggle('light', light); c.toggle('dark', !light);
+})();
+</script>
+<link rel="stylesheet" href="/site/shell.css">
 <style>
 /* ── Geist, shipped with the site (zero third-party requests) ── */
 @font-face{
@@ -78,44 +89,33 @@
 }
 
 :root{
-  color-scheme:dark;
-  --bg:#0a0b0d; --fg:#f3f4f6; --card:#101216; --secondary:#16181d;
-  --muted:#969aa2; --faint:#7f8590; --accent:#1b1d23; --border:#23252b; --border-soft:#191b1f;
-  --primary:#f3f4f6; --primary-fg:#0a0b0d; --primary-hover:#fff;
-  --success:#74b085; --warning:#fb923c;
+  color-scheme:dark; --faint:#7f8590; --primary-hover:#fff;
   --gold:#c2a15e; --share:#8781b0;
   --scrim:#030712; --scrim-fg:#f4f5f8;
   --ink-top:#ffffff; --ink-bot:rgba(243,244,246,.60);
   --wire:#c6cad1; --wire-dim:#41454d; --key-fill:#1b1d22; --ph-line:#3a3e45;
   --halo:rgba(3,7,18,.9);
   --wm-ink:rgba(243,244,246,.02); --wm-stroke:rgba(243,244,246,.11);
-  --sans:"Geist",system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
-  --mono:"Geist Mono",ui-monospace,Menlo,Consolas,monospace;
-  --maxw:1260px;
 }
 /* light: the same ink, on paper */
 html.light{
-  color-scheme:light;
-  --bg:#f7f7f5; --fg:#16171b; --card:#fdfdfc; --secondary:#eeeeeb;
-  --muted:#5d626b; --faint:#666b74; --accent:#e9e9e6; --border:#d9d9d4; --border-soft:#e7e7e2;
-  --primary:#16171b; --primary-fg:#f7f7f5; --primary-hover:#000;
-  --success:#286b41; --warning:#b45309;
+  color-scheme:light; --faint:#666b74; --primary-hover:#000;
   --gold:#8f6f2f; --share:#5f5a94;
   --ink-top:#000000; --ink-bot:rgba(22,23,27,.62);
   --wire:#3f444c; --wire-dim:#b9bdc3; --key-fill:#2b2d33; --ph-line:#c7cacf;
   --halo:rgba(247,247,245,.92);
   --wm-ink:rgba(22,23,27,.025); --wm-stroke:rgba(22,23,27,.10);
 }
+/* the hero runs under the transparent nav, so undo the shell offset */
+body{padding-top:0}
 *,*::before,*::after{box-sizing:border-box}
 html{-webkit-text-size-adjust:100%;scroll-behavior:smooth}
 body{
   margin:0;background:var(--bg);color:var(--fg);
-  font-family:var(--sans);font-size:16px;line-height:1.6;letter-spacing:-0.011em;
+  font-family:var(--font-sans);font-size:16px;line-height:1.6;letter-spacing:-0.011em;
   -webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;
   overflow-x:hidden;
 }
-.skip-link{position:fixed;top:8px;left:8px;z-index:1000;padding:9px 12px;border-radius:6px;background:var(--fg);color:var(--bg);transform:translateY(-150%)}
-.skip-link:focus{transform:translateY(0)}
 a:focus-visible,button:focus-visible{outline:2px solid var(--fg);outline-offset:4px}
 ::selection{background:color-mix(in srgb,var(--fg) 18%,transparent)}
 a{color:inherit;text-decoration:none;cursor:default}
@@ -129,8 +129,7 @@ body::after{
 }
 html.light body::after{mix-blend-mode:multiply;opacity:.05}
 
-.wrap{max-width:var(--maxw);margin:0 auto;padding:0 28px}
-.eyebrow{font-family:var(--mono);font-size:11px;font-weight:500;letter-spacing:.1em;text-transform:uppercase;color:var(--muted)}
+.eyebrow{font-family:var(--font-mono);font-size:11px;font-weight:500;letter-spacing:.1em;text-transform:uppercase;color:var(--muted-fg)}
 h1,h2,h3{font-weight:500;letter-spacing:-0.025em;margin:0}
 p{margin:0;text-wrap:pretty}
 
@@ -150,30 +149,8 @@ p{margin:0;text-wrap:pretty}
 .btn-ghost:hover{background:var(--secondary)}
 
 /* ── nav: nearly nothing ── */
-nav{position:fixed;inset:0 0 auto;z-index:100;border-bottom:1px solid transparent;
-  background:color-mix(in srgb,var(--bg) 78%,transparent);
-  -webkit-backdrop-filter:blur(14px);backdrop-filter:blur(14px)}
 nav.scrolled{border-bottom-color:var(--border-soft)}
-.nav-inner{max-width:var(--maxw);margin:0 auto;padding:0 28px;height:64px;display:flex;align-items:center;gap:26px}
-.wordmark{display:flex;align-items:center}
-.wordmark img{height:26px;width:auto;display:block}
-.wordmark .wm-light{display:none}
-html.light .wordmark .wm-dark{display:none}
-html.light .wordmark .wm-light{display:block}
 /* theme toggle — cycles system → light → dark */
-.theme-btn{display:inline-flex;align-items:center;justify-content:center;width:30px;height:30px;border-radius:7px;color:var(--muted)}
-.theme-btn:hover{color:var(--fg);background:var(--secondary)}
-.theme-btn svg{display:none}
-.theme-btn[data-mode="light"] .i-sun{display:block}
-.theme-btn[data-mode="dark"] .i-moon{display:block}
-.theme-btn[data-mode="system"] .i-sys{display:block}
-.nav-right{margin-left:auto;display:flex;align-items:center;gap:24px;font-size:14px}
-.nav-right a{color:var(--muted)}
-.nav-right a:hover{color:var(--fg)}
-.nav-right .nav-signin{color:var(--fg)}
-.nav-right .nav-signin .arr{display:inline-block;transition:transform .18s ease}
-.nav-right .nav-signin:hover .arr{transform:translateX(3px)}
-@media(max-width:480px){.nav-right a:not(.nav-signin){display:none}}
 
 /* ══════════ HERO — the tagline, then the artifact ══════════ */
 .hero{position:relative;padding:150px 0 0}
@@ -182,10 +159,10 @@ html.light .wordmark .wm-light{display:block}
   display:flex;flex-direction:column;align-items:center;text-align:center;
 }
 .state-line{
-  font-family:var(--mono);font-size:12px;letter-spacing:.04em;color:var(--muted);
+  font-family:var(--font-mono);font-size:12px;letter-spacing:.04em;color:var(--muted-fg);
   min-height:20px;display:flex;align-items:center;justify-content:center;gap:10px;
 }
-.state-line .vdot{width:6px;height:6px;border-radius:50%;background:var(--muted);transition:background .3s}
+.state-line .vdot{width:6px;height:6px;border-radius:50%;background:var(--muted-fg);transition:background .3s}
 .state-line.approved .vdot{background:var(--success)}
 .state-line .note{transition:opacity .3s}
 
@@ -220,7 +197,7 @@ html.light .wordmark .wm-light{display:block}
 .word.approved .under{width:100%}
 
 .hero .sub{
-  margin-top:36px;max-width:52ch;font-size:clamp(16px,1.6vw,19px);color:var(--muted);line-height:1.65;
+  margin-top:36px;max-width:52ch;font-size:clamp(16px,1.6vw,19px);color:var(--muted-fg);line-height:1.65;
 }
 .hero .sub strong{color:var(--fg);font-weight:500}
 .hero .cta-row{
@@ -235,9 +212,9 @@ html.light .wordmark .wm-light{display:block}
 .hero-cta.copied{background:var(--primary-hover)}
 .hero-proof{margin-top:10px;height:42px;font-size:14px}
 .hero-cta-note{
-  margin-top:14px;font-size:13.5px;color:var(--muted);max-width:56ch;text-align:center;line-height:1.6;text-wrap:balance;
+  margin-top:14px;font-size:13.5px;color:var(--muted-fg);max-width:56ch;text-align:center;line-height:1.6;text-wrap:balance;
 }
-.hero-eyebrow{margin-bottom:0;color:var(--muted);font-size:14px;letter-spacing:.14em}
+.hero-eyebrow{margin-bottom:0;color:var(--muted-fg);font-size:14px;letter-spacing:.14em}
 /* the tagline in gradient ink: lit at the cap line, settling toward the baseline */
 .grad-ink{
   background-image:linear-gradient(178deg,var(--ink-top) 6%,var(--fg) 44%,var(--ink-bot) 100%);
@@ -245,13 +222,13 @@ html.light .wordmark .wm-light{display:block}
 }
 .wl-note-slot{min-height:0;transition:min-height .3s ease}
 .replay{
-  font-family:var(--mono);font-size:11px;letter-spacing:.06em;color:var(--faint);
+  font-family:var(--font-mono);font-size:11px;letter-spacing:.06em;color:var(--faint);
   display:inline-flex;align-items:center;gap:7px;margin-top:0;
 }
-.replay:hover{color:var(--muted)}
+.replay:hover{color:var(--muted-fg)}
 .hero .foot-hint{
   margin-top:22px;text-align:center;
-  font-family:var(--mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--faint);
+  font-family:var(--font-mono);font-size:10px;letter-spacing:.14em;text-transform:uppercase;color:var(--faint);
   opacity:.8;
 }
 
@@ -259,11 +236,11 @@ html.light .wordmark .wm-light{display:block}
 .demo{max-width:var(--maxw);margin:84px auto 0;padding:0 28px}
 .fig{
   display:flex;align-items:center;gap:10px;margin-bottom:12px;
-  font-family:var(--mono);font-size:10px;letter-spacing:.08em;text-transform:uppercase;color:var(--muted);
+  font-family:var(--font-mono);font-size:10px;letter-spacing:.08em;text-transform:uppercase;color:var(--muted-fg);
 }
 .fig::after{content:"";flex:1;border-top:1px dashed var(--border)}
 .demo-stage{position:relative}
-.demo-stage .tick{position:absolute;width:13px;height:13px;color:var(--muted);opacity:.6}
+.demo-stage .tick{position:absolute;width:13px;height:13px;color:var(--muted-fg);opacity:.6}
 .demo-stage .tick::before,.demo-stage .tick::after{content:"";position:absolute;background:currentColor}
 .demo-stage .tick::before{left:6px;top:0;width:1px;height:13px}
 .demo-stage .tick::after{left:0;top:6px;width:13px;height:1px}
@@ -275,11 +252,11 @@ html.light .wordmark .wm-light{display:block}
 .demo-frame.resetting{opacity:.35}
 .demo-titlebar{display:flex;align-items:center;gap:12px;padding:12px 18px;border-bottom:1px solid var(--border-soft)}
 .demo-titlebar .doc-title{font-size:14px;font-weight:500;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.demo-titlebar .doc-meta{font-family:var(--mono);font-size:11px;color:var(--muted);letter-spacing:.02em}
+.demo-titlebar .doc-meta{font-family:var(--font-mono);font-size:11px;color:var(--muted-fg);letter-spacing:.02em}
 .demo-titlebar .spacer{flex:1}
 .abadge{
   display:none;align-items:center;gap:6px;border-radius:6px;padding:3px 9px;
-  font-family:var(--mono);font-size:11px;letter-spacing:.03em;
+  font-family:var(--font-mono);font-size:11px;letter-spacing:.03em;
   background:color-mix(in srgb,var(--success) 12%,transparent);color:var(--success);
 }
 .abadge.show{display:inline-flex}
@@ -288,7 +265,7 @@ html.light .wordmark .wm-light{display:block}
 @media(max-width:840px){.demo-body{grid-template-columns:minmax(0,1fr)}.demo-comments{border-left:0;border-top:1px solid var(--border-soft)}}
 .doc{padding:34px 44px 36px;text-align:left;display:flex;flex-direction:column}
 /* the OSC-8 launch page inside the frame — pure ink, drawn like a filing */
-.doc .lnav{display:flex;align-items:baseline;gap:16px;font-family:var(--mono);font-size:10px;letter-spacing:.12em;text-transform:uppercase;color:var(--faint)}
+.doc .lnav{display:flex;align-items:baseline;gap:16px;font-family:var(--font-mono);font-size:10px;letter-spacing:.12em;text-transform:uppercase;color:var(--faint)}
 .doc .lnav .wm{color:var(--fg);font-weight:600;letter-spacing:.16em}
 .doc .lnav .lb{margin-left:auto;color:var(--fg);border-bottom:1px solid var(--fg);padding-bottom:1px}
 .doc .lhero{display:flex;gap:38px;align-items:flex-start;margin-top:28px}
@@ -296,20 +273,20 @@ html.light .wordmark .wm-light{display:block}
 .doc .lphead{font-size:32px;letter-spacing:-0.03em;line-height:1.1;margin:0;font-weight:500;min-height:74px}
 .doc .lphead em{font-style:normal;position:relative}
 .doc .lphead em::after{content:"";position:absolute;left:0;right:0;bottom:1px;height:2px;background:var(--fg);border-radius:2px}
-.doc .lsub{margin-top:12px;font-size:13.5px;line-height:1.6;color:var(--muted);min-height:64px}
+.doc .lsub{margin-top:12px;font-size:13.5px;line-height:1.6;color:var(--muted-fg);min-height:64px}
 .doc .lbtn{display:inline-block;margin-top:16px;background:var(--fg);color:var(--bg);border-radius:7px;padding:8px 16px;font-size:12.5px;font-weight:600}
-.doc .lprice{margin-top:11px;font-family:var(--mono);font-size:11px;color:var(--faint);min-height:16px}
+.doc .lprice{margin-top:11px;font-family:var(--font-mono);font-size:11px;color:var(--faint);min-height:16px}
 .doc .lprice b{color:var(--fg);font-weight:600}
 .doc .figslot{flex:1;min-width:0;position:relative}
 .doc .lph{height:248px;border:1px dashed var(--ph-line);border-radius:8px;position:relative}
 .doc .lph::before,.doc .lph::after{content:"";position:absolute;inset:0;background:linear-gradient(to top right,transparent calc(50% - .5px),var(--ph-line) 50%,transparent calc(50% + .5px))}
 .doc .lph::after{transform:scaleX(-1)}
-.doc .lph > span{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-family:var(--mono);font-size:10px;letter-spacing:.14em;color:var(--faint)}
+.doc .lph > span{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-family:var(--font-mono);font-size:10px;letter-spacing:.14em;color:var(--faint)}
 .doc .lph > span.hlspan{position:absolute;inset:auto;left:50%;top:50%;transform:translate(-50%,-50%);padding:2px 6px}
 .doc .draw3d{position:relative;height:248px;display:none;cursor:crosshair}
 .doc .draw3d canvas{position:absolute;inset:0;width:100%;height:100%;display:block}
 .doc .draw3d svg.leads{position:absolute;inset:0;width:100%;height:100%;pointer-events:none}
-.doc .draw3d .g-lbl{position:absolute;font-family:var(--mono);font-size:9px;letter-spacing:.1em;text-transform:uppercase;color:var(--muted);white-space:nowrap;pointer-events:none;transform:translate(-50%,-50%);text-shadow:0 1px 8px var(--card)}
+.doc .draw3d .g-lbl{position:absolute;font-family:var(--font-mono);font-size:9px;letter-spacing:.1em;text-transform:uppercase;color:var(--muted-fg);white-space:nowrap;pointer-events:none;transform:translate(-50%,-50%);text-shadow:0 1px 8px var(--card)}
 .doc .draw3d .g-lbl b{color:var(--fg);font-weight:500}
 .doc .lpsvg{display:none;height:248px}
 .doc .lpsvg svg{display:block;width:100%;height:100%}
@@ -318,17 +295,17 @@ html.light .wordmark .wm-light{display:block}
 .doc .lpsvg [stroke="#f3f4f6"]{stroke:var(--fg)}
 .doc .lpsvg [stroke="#41454d"]{stroke:var(--wire-dim)}
 .doc .lpsvg [fill="#1b1d22"]{fill:var(--key-fill)}
-.doc .lpsvg [fill="#969aa2"]{fill:var(--muted)}
+.doc .lpsvg [fill="#969aa2"]{fill:var(--muted-fg)}
 .doc .lpsvg [fill="#5c616b"]{fill:var(--faint)}
-.doc .figcapline{display:flex;justify-content:space-between;gap:12px;font-family:var(--mono);font-size:9.5px;letter-spacing:.1em;color:var(--faint);margin-top:9px;text-transform:uppercase;min-height:13px}
+.doc .figcapline{display:flex;justify-content:space-between;gap:12px;font-family:var(--font-mono);font-size:9.5px;letter-spacing:.1em;color:var(--faint);margin-top:9px;text-transform:uppercase;min-height:13px}
 .doc .lspecs{margin-top:24px;border-top:1px solid var(--border-soft);padding-top:2px;display:none;flex-wrap:wrap}
 .doc .lspecs.show{display:flex;animation:replyIn .4s ease-out}
 .doc .lspecs .sp{flex:1;min-width:120px;padding:12px 14px 0 0;border-right:1px solid var(--border-soft);margin-right:14px}
 .doc .lspecs .sp:last-child{border-right:0;margin-right:0}
 .doc .lspecs .sp .v{font-size:19px;font-weight:500;letter-spacing:-0.01em}
-.doc .lspecs .sp .v small{font-size:11px;color:var(--muted);font-weight:400;margin-left:2px}
-.doc .lspecs .sp .k{font-family:var(--mono);font-size:9px;letter-spacing:.12em;text-transform:uppercase;color:var(--faint);margin-top:3px}
-.doc .lspecs-note{display:none;font-family:var(--mono);font-size:9px;letter-spacing:.08em;color:var(--faint);margin-top:12px;text-transform:uppercase}
+.doc .lspecs .sp .v small{font-size:11px;color:var(--muted-fg);font-weight:400;margin-left:2px}
+.doc .lspecs .sp .k{font-family:var(--font-mono);font-size:9px;letter-spacing:.12em;text-transform:uppercase;color:var(--faint);margin-top:3px}
+.doc .lspecs-note{display:none;font-family:var(--font-mono);font-size:9px;letter-spacing:.08em;color:var(--faint);margin-top:12px;text-transform:uppercase}
 .doc .lspecs-note.show{display:block}
 /* v1: the any-template wireframe register the comments tear apart */
 .doc.v1 .lnav{color:#787f88}
@@ -348,26 +325,26 @@ html.light .doc.v1 .lbtn{border-color:#c3c7cc;color:#6f747c}
 .flash{animation:flash 1.1s ease-out}
 @keyframes flash{0%{background:color-mix(in srgb,var(--fg) 9%,transparent)}100%{background:transparent}}
 .demo-comments{border-left:1px solid var(--border-soft);padding:20px 18px;display:flex;flex-direction:column;gap:11px;text-align:left}
-.demo-comments .pane-label{font-family:var(--mono);font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--muted)}
+.demo-comments .pane-label{font-family:var(--font-mono);font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--muted-fg)}
 .dcomment{
   display:none;border:1px solid var(--border-soft);border-radius:8px;padding:11px 13px;
 }
 .dcomment.show{display:block;animation:replyIn .35s ease-out}
 /* a resolved thread folds to one line after a beat, freeing room for open ones */
-.dcomment .mini{display:none;align-items:center;gap:8px;font-family:var(--mono);font-size:10.5px;letter-spacing:.02em;color:var(--muted);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.dcomment .mini{display:none;align-items:center;gap:8px;font-family:var(--font-mono);font-size:10.5px;letter-spacing:.02em;color:var(--muted-fg);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 .dcomment .mini .tk{color:var(--success);flex:none}
 .dcomment .mini .mq{color:var(--faint);font-style:italic;overflow:hidden;text-overflow:ellipsis}
 .dcomment.collapsed{padding:9px 13px;animation:replyIn .3s ease-out}
 .dcomment.collapsed .who,.dcomment.collapsed .quote,.dcomment.collapsed .text,.dcomment.collapsed .state,.dcomment.collapsed .reply{display:none}
 .dcomment.collapsed .mini{display:flex}
 .dcomment .who{display:flex;align-items:center;gap:8px;font-size:12px;font-weight:500}
-.dcomment .who .chip{width:18px;height:18px;border-radius:50%;background:var(--secondary);border:1px solid var(--border);display:inline-flex;align-items:center;justify-content:center;font-family:var(--mono);font-size:9px;color:var(--muted)}
-.dcomment .quote{margin-top:8px;padding-left:10px;border-left:2px solid var(--border);font-size:12px;color:var(--muted);font-style:italic}
+.dcomment .who .chip{width:18px;height:18px;border-radius:50%;background:var(--secondary);border:1px solid var(--border);display:inline-flex;align-items:center;justify-content:center;font-family:var(--font-mono);font-size:9px;color:var(--muted-fg)}
+.dcomment .quote{margin-top:8px;padding-left:10px;border-left:2px solid var(--border);font-size:12px;color:var(--muted-fg);font-style:italic}
 .dcomment .text{margin-top:8px;font-size:13px;color:var(--fg)}
-.dcomment .state{margin-top:10px;font-family:var(--mono);font-size:10px;letter-spacing:.04em;color:var(--muted)}
+.dcomment .state{margin-top:10px;font-family:var(--font-mono);font-size:10px;letter-spacing:.04em;color:var(--muted-fg)}
 .dcomment.resolved .state{color:var(--success)}
 .dcomment.resolved{border-color:color-mix(in srgb,var(--success) 34%,var(--border-soft))}
-.comments-empty{font-size:13px;color:var(--muted);margin:auto 0;text-align:center;opacity:.7}
+.comments-empty{font-size:13px;color:var(--muted-fg);margin:auto 0;text-align:center;opacity:.7}
 .timeline{margin-top:26px}
 .scrub{position:relative;height:44px;display:flex;align-items:center}
 .scrub-track{position:absolute;left:0;right:0;height:2px;background:var(--border);border-radius:1px}
@@ -377,17 +354,17 @@ html.light .doc.v1 .lbtn{border-color:#c3c7cc;color:#6f747c}
 .scrub .stop{width:10px;height:10px;border-radius:50%;background:var(--bg);border:1px solid var(--border);transition:border-color .2s,background .2s}
 .scrub .stop.passed{border-color:var(--fg);background:var(--fg)}
 .scrub-labels{display:flex;justify-content:space-between;margin-top:2px}
-.scrub-labels span{font-family:var(--mono);font-size:11px;color:var(--muted);letter-spacing:.03em}
+.scrub-labels span{font-family:var(--font-mono);font-size:11px;color:var(--muted-fg);letter-spacing:.03em}
 .scrub-labels span.on{color:var(--fg)}
 .version-line{
   margin-top:16px;display:flex;align-items:baseline;gap:12px;min-height:22px;
-  font-family:var(--mono);font-size:12px;letter-spacing:.01em;text-align:left;
+  font-family:var(--font-mono);font-size:12px;letter-spacing:.01em;text-align:left;
 }
 .version-line .vn{color:var(--fg);font-weight:500}
-.version-line .vauthor{color:var(--muted)}
-.version-line .vmsg{color:var(--muted)}
+.version-line .vauthor{color:var(--muted-fg)}
+.version-line .vmsg{color:var(--muted-fg)}
 .version-line .tdot{
-  display:none;width:6px;height:6px;border-radius:50%;background:var(--muted);
+  display:none;width:6px;height:6px;border-radius:50%;background:var(--muted-fg);
   align-self:center;animation:tpulse 1s ease-in-out infinite;
 }
 .version-line.typing .tdot{display:inline-block}
@@ -420,17 +397,17 @@ html.light .pcursor .flag{color:#fff}
 .face .fc{
   width:20px;height:20px;border-radius:50%;border:1.5px solid var(--card);
   display:inline-flex;align-items:center;justify-content:center;
-  font-family:var(--mono);font-size:9px;margin-left:-6px;
+  font-family:var(--font-mono);font-size:9px;margin-left:-6px;
 }
 .face .fc:first-child{margin-left:0}
 .face .fc.g{background:color-mix(in srgb,var(--gold) 22%,var(--secondary));color:var(--gold)}
 .face .fc.v{background:color-mix(in srgb,var(--share) 22%,var(--secondary));color:var(--share)}
-.face .fc.n{background:var(--secondary);color:var(--muted)}
+.face .fc.n{background:var(--secondary);color:var(--muted-fg)}
 .face .fc.y{background:color-mix(in srgb,var(--success) 22%,var(--secondary));color:var(--success);opacity:0;transform:scale(.5);transition:opacity .25s ease,transform .25s cubic-bezier(.2,.9,.3,1.4)}
 .face .fc.y.in{opacity:1;transform:none}
-.face-label{font-family:var(--mono);font-size:10px;letter-spacing:.04em;color:var(--faint);margin-left:9px}
-.dcomment .who .ext{font-family:var(--mono);font-size:9px;letter-spacing:.05em;color:var(--faint);border:1px solid var(--border);border-radius:4px;padding:1px 5px;margin-left:4px}
-.tb-lock{display:inline-flex;align-items:center;gap:6px;border-radius:6px;padding:3px 9px;font-family:var(--mono);font-size:11px;background:var(--secondary);color:var(--muted);border:1px solid var(--border)}
+.face-label{font-family:var(--font-mono);font-size:10px;letter-spacing:.04em;color:var(--faint);margin-left:9px}
+.dcomment .who .ext{font-family:var(--font-mono);font-size:9px;letter-spacing:.05em;color:var(--faint);border:1px solid var(--border);border-radius:4px;padding:1px 5px;margin-left:4px}
+.tb-lock{display:inline-flex;align-items:center;gap:6px;border-radius:6px;padding:3px 9px;font-family:var(--font-mono);font-size:11px;background:var(--secondary);color:var(--muted-fg);border:1px solid var(--border)}
 .hlspan{
   background-image:linear-gradient(var(--hlc,transparent),var(--hlc,transparent));
   background-repeat:no-repeat;background-size:0% 100%;border-radius:2px;
@@ -464,10 +441,10 @@ html.light .pcursor .flag{color:#fff}
   max-width:24ch;
 }
 .manifesto .m-line + .m-line{margin-top:64px}
-.manifesto .m-line .q{color:var(--muted)}
-.manifesto .m-kicker{font-family:var(--mono);font-size:11px;letter-spacing:.1em;text-transform:uppercase;color:var(--muted);margin-bottom:34px;display:flex;align-items:center;gap:12px}
+.manifesto .m-line .q{color:var(--muted-fg)}
+.manifesto .m-kicker{font-family:var(--font-mono);font-size:11px;letter-spacing:.1em;text-transform:uppercase;color:var(--muted-fg);margin-bottom:34px;display:flex;align-items:center;gap:12px}
 .manifesto .m-kicker::after{content:"";flex:1;max-width:120px;border-top:1px dashed var(--border)}
-.m-answer{margin-top:72px;max-width:62ch;font-size:18px;color:var(--muted);line-height:1.7}
+.m-answer{margin-top:72px;max-width:62ch;font-size:18px;color:var(--muted-fg);line-height:1.7}
 .m-answer strong{color:var(--fg);font-weight:500}
 
 /* ══════════ THE OCEAN — chats scroll away, artifacts stay ══════════ */
@@ -482,7 +459,7 @@ html.light .pcursor .flag{color:#fff}
 .gcol.g3{animation-duration:44s;animation-delay:-9s}
 @keyframes drift{from{transform:translateY(0)}to{transform:translateY(-50%)}}
 .ghost{
-  font-family:var(--mono);font-size:12px;color:var(--fg);opacity:.16;white-space:nowrap;
+  font-family:var(--font-mono);font-size:12px;color:var(--fg);opacity:.16;white-space:nowrap;
   border:1px solid var(--border-soft);border-radius:8px;padding:9px 13px;background:var(--card);
 }
 .ghost.plain{border:0;background:none;opacity:.11}
@@ -494,32 +471,32 @@ html.light .pcursor .flag{color:#fff}
   box-shadow:0 0 0 1px color-mix(in srgb,var(--fg) 4%,transparent),0 0 80px 30px var(--halo);
   display:flex;flex-direction:column;gap:12px;min-width:min(430px,88vw);
 }
-.kept-card .kc-top{display:flex;align-items:center;gap:10px;font-family:var(--mono);font-size:12.5px;color:var(--fg)}
+.kept-card .kc-top{display:flex;align-items:center;gap:10px;font-family:var(--font-mono);font-size:12.5px;color:var(--fg)}
 .kept-card .kc-top .lock{color:var(--success);display:inline-flex}
-.kept-card .kc-meta{display:flex;align-items:center;gap:14px;font-family:var(--mono);font-size:11px;color:var(--muted);letter-spacing:.03em}
+.kept-card .kc-meta{display:flex;align-items:center;gap:14px;font-family:var(--font-mono);font-size:11px;color:var(--muted-fg);letter-spacing:.03em}
 .kept-card .kc-meta .ok{color:var(--success)}
 .kept-line{
   font-size:clamp(22px,3vw,32px);font-weight:500;letter-spacing:-0.02em;text-align:center;
   text-shadow:0 0 24px var(--bg);
 }
-.kept-line em{font-style:normal;color:var(--muted)}
+.kept-line em{font-style:normal;color:var(--muted-fg)}
 
 /* ══════════ CHAPTERS ══════════ */
 .chapter{padding-top:210px}
 .chapter .ch-head{display:flex;align-items:baseline;gap:22px}
-.chapter .ch-num{font-family:var(--mono);font-size:13px;color:var(--faint);letter-spacing:.1em}
+.chapter .ch-num{font-family:var(--font-mono);font-size:13px;color:var(--faint);letter-spacing:.1em}
 .chapter h2{font-size:clamp(44px,7vw,92px);line-height:1;letter-spacing:-0.035em}
 .chapter .ch-body{margin-top:30px;display:grid;grid-template-columns:minmax(0,60ch) 1fr;gap:64px;align-items:start}
 @media(max-width:880px){.chapter .ch-body{grid-template-columns:minmax(0,1fr)}}
 .chapter .ch-lede{font-size:clamp(18px,2vw,22px);color:var(--fg);line-height:1.5;font-weight:400}
-.chapter .ch-text{margin-top:18px;font-size:16px;color:var(--muted);line-height:1.7}
+.chapter .ch-text{margin-top:18px;font-size:16px;color:var(--muted-fg);line-height:1.7}
 .chapter .ch-text strong{color:var(--fg);font-weight:500}
 .chapter .ch-spec{justify-self:end;width:100%;max-width:520px}
 @media(max-width:880px){.chapter .ch-spec{justify-self:start}}
 
 .spec-card{border:1px solid var(--border);border-radius:12px;background:var(--card);overflow:hidden}
-.spec-bar{display:flex;align-items:center;gap:8px;padding:10px 14px;border-bottom:1px solid var(--border-soft);font-family:var(--mono);font-size:11px;color:var(--muted);letter-spacing:.05em}
-.spec-body{padding:16px 18px;font-family:var(--mono);font-size:12.5px;line-height:1.9;color:var(--muted)}
+.spec-bar{display:flex;align-items:center;gap:8px;padding:10px 14px;border-bottom:1px solid var(--border-soft);font-family:var(--font-mono);font-size:11px;color:var(--muted-fg);letter-spacing:.05em}
+.spec-body{padding:16px 18px;font-family:var(--font-mono);font-size:12.5px;line-height:1.9;color:var(--muted-fg)}
 .spec-body .c{color:var(--fg)}
 .spec-body .ok{color:var(--success)}
 .spec-body .dim{color:var(--faint)}
@@ -530,43 +507,43 @@ html.light .pcursor .flag{color:#fff}
 .share-row:first-child{border-top:0}
 .share-row .sr-label{color:var(--fg);font-weight:500;flex:1}
 .share-row .sr-sub{display:block;font-weight:400;font-size:11.5px;color:var(--faint);margin-top:2px}
-.share-row .sr-val{font-family:var(--mono);font-size:11.5px;color:var(--muted);display:flex;align-items:center;gap:8px}
+.share-row .sr-val{font-family:var(--font-mono);font-size:11.5px;color:var(--muted-fg);display:flex;align-items:center;gap:8px}
 .share-link{
   display:flex;align-items:center;gap:10px;border:1px solid var(--border);border-radius:8px;
-  background:var(--bg);padding:9px 12px;font-family:var(--mono);font-size:12px;color:var(--fg);
+  background:var(--bg);padding:9px 12px;font-family:var(--font-mono);font-size:12px;color:var(--fg);
   margin-bottom:6px;
 }
 .share-link .share-url{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.share-link .copy{margin-left:auto;font-size:10px;letter-spacing:.05em;color:var(--muted);border:1px solid var(--border);border-radius:5px;padding:2px 8px}
+.share-link .copy{margin-left:auto;font-size:10px;letter-spacing:.05em;color:var(--muted-fg);border:1px solid var(--border);border-radius:5px;padding:2px 8px}
 .share-link .lock{color:var(--success);display:inline-flex}
 .sw{position:relative;width:30px;height:17px;border-radius:999px;background:var(--fg);flex:none}
 .sw::after{content:"";position:absolute;top:2px;right:2px;width:13px;height:13px;border-radius:50%;background:var(--bg)}
 .sw.off{background:var(--secondary);border:1px solid var(--border)}
-.sw.off::after{right:auto;left:2px;top:1px;background:var(--muted)}
+.sw.off::after{right:auto;left:2px;top:1px;background:var(--muted-fg)}
 .pwdots{letter-spacing:2px;color:var(--fg)}
 
 .thread{padding:16px 18px;display:flex;flex-direction:column;gap:14px}
 .thread .t-item{font-size:13px;line-height:1.55}
 .thread .t-who{font-weight:500;font-size:12.5px;display:flex;gap:8px;align-items:center}
-.thread .t-who .chip{width:18px;height:18px;border-radius:50%;background:var(--secondary);border:1px solid var(--border);display:inline-flex;align-items:center;justify-content:center;font-family:var(--mono);font-size:9px;color:var(--muted)}
-.thread .t-quote{margin-top:7px;padding-left:10px;border-left:2px solid var(--border);color:var(--muted);font-style:italic;font-size:12px}
+.thread .t-who .chip{width:18px;height:18px;border-radius:50%;background:var(--secondary);border:1px solid var(--border);display:inline-flex;align-items:center;justify-content:center;font-family:var(--font-mono);font-size:9px;color:var(--muted-fg)}
+.thread .t-quote{margin-top:7px;padding-left:10px;border-left:2px solid var(--border);color:var(--muted-fg);font-style:italic;font-size:12px}
 .thread .t-text{margin-top:7px;color:var(--fg)}
-.thread .t-state{font-family:var(--mono);font-size:10px;letter-spacing:.05em;color:var(--success)}
+.thread .t-state{font-family:var(--font-mono);font-size:10px;letter-spacing:.05em;color:var(--success)}
 
 /* ══════════ LOOP / TERMINAL ══════════ */
 .loop{padding-top:210px}
 .loop .section-head{max-width:620px}
 .loop h2{font-size:clamp(32px,4.6vw,52px);line-height:1.1;margin-top:16px}
-.loop .l-sub{margin-top:20px;font-size:17px;color:var(--muted);max-width:54ch;line-height:1.7}
+.loop .l-sub{margin-top:20px;font-size:17px;color:var(--muted-fg);max-width:54ch;line-height:1.7}
 .loop .l-sub strong{color:var(--fg);font-weight:500}
 .bigterm{
   margin-top:56px;border:1px solid var(--border);border-radius:14px;background:var(--card);overflow:hidden;
 }
 .bigterm .tb{display:flex;align-items:center;gap:8px;padding:13px 18px;border-bottom:1px solid var(--border-soft)}
 .bigterm .dot{width:10px;height:10px;border-radius:50%;background:var(--secondary);border:1px solid var(--border)}
-.bigterm .tl{margin-left:8px;font-family:var(--mono);font-size:11px;color:var(--muted);letter-spacing:.05em}
+.bigterm .tl{margin-left:8px;font-family:var(--font-mono);font-size:11px;color:var(--muted-fg);letter-spacing:.05em}
 .bigterm .tbody{
-  padding:26px 30px;font-family:var(--mono);font-size:clamp(12px,1.35vw,14.5px);line-height:2.1;color:var(--muted);
+  padding:26px 30px;font-family:var(--font-mono);font-size:clamp(12px,1.35vw,14.5px);line-height:2.1;color:var(--muted-fg);
   min-height:340px;
 }
 .bigterm .ln{display:block;white-space:pre-wrap;overflow-wrap:break-word}
@@ -577,12 +554,12 @@ html.light .pcursor .flag{color:#fff}
 @keyframes blink{50%{opacity:0}}
 .loop .cast{
   margin-top:22px;display:flex;gap:10px 26px;flex-wrap:wrap;
-  font-family:var(--mono);font-size:11.5px;letter-spacing:.03em;color:var(--faint);
+  font-family:var(--font-mono);font-size:11.5px;letter-spacing:.03em;color:var(--faint);
 }
-.loop .cast span b{color:var(--muted);font-weight:500}
+.loop .cast span b{color:var(--muted-fg);font-weight:500}
 /* ── connect yours: one paste for the agent, or the three commands by hand ── */
 .hk-lead{margin-top:34px;display:flex;align-items:center;gap:16px;flex-wrap:wrap}
-.hk-lead .hk-leadnote{font-size:13px;color:var(--muted);max-width:40ch}
+.hk-lead .hk-leadnote{font-size:13px;color:var(--muted-fg);max-width:40ch}
 .hookup{margin-top:14px;border:1px solid var(--border-soft);border-radius:10px;background:var(--card);overflow:hidden}
 .hookup .hk-row{
   display:flex;align-items:center;gap:16px;width:100%;text-align:left;background:none;border:0;
@@ -590,12 +567,12 @@ html.light .pcursor .flag{color:#fff}
 }
 .hookup .hk-row + .hk-row{border-top:1px solid var(--border-soft)}
 .hookup .hk-row:hover,.hookup .hk-row:focus-visible{background:var(--secondary)}
-.hookup .hk-what{flex:none;width:21ch;font-size:12.5px;color:var(--muted)}
+.hookup .hk-what{flex:none;width:21ch;font-size:12.5px;color:var(--muted-fg)}
 .hookup .hk-row code{
-  flex:1;min-width:0;font-family:var(--mono);font-size:12px;color:var(--fg);
+  flex:1;min-width:0;font-family:var(--font-mono);font-size:12px;color:var(--fg);
   white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
 }
-.hookup .hk-copy{flex:none;font-family:var(--mono);font-size:9.5px;letter-spacing:.08em;color:var(--faint);border:1px solid var(--border);border-radius:5px;padding:2px 7px}
+.hookup .hk-copy{flex:none;font-family:var(--font-mono);font-size:9.5px;letter-spacing:.08em;color:var(--faint);border:1px solid var(--border);border-radius:5px;padding:2px 7px}
 .hookup .hk-row.copied .hk-copy{color:var(--success);border-color:color-mix(in srgb,var(--success) 45%,transparent)}
 @media(max-width:680px){
   .hookup .hk-row{flex-wrap:wrap;gap:6px 12px}
@@ -606,7 +583,7 @@ html.light .pcursor .flag{color:#fff}
 /* ══════════ PRICING STATEMENT ══════════ */
 .price{padding-top:210px}
 .price h2{font-size:clamp(34px,5vw,58px);line-height:1.08;max-width:16ch}
-.price .p-sub{margin-top:22px;font-size:17px;color:var(--muted);max-width:54ch;line-height:1.7}
+.price .p-sub{margin-top:22px;font-size:17px;color:var(--muted-fg);max-width:54ch;line-height:1.7}
 .price .p-sub strong{color:var(--fg);font-weight:500}
 .tier-line{
   margin-top:48px;border-top:1px solid var(--border-soft);border-bottom:1px solid var(--border-soft);
@@ -616,14 +593,14 @@ html.light .pcursor .flag{color:#fff}
 .tl-cell{padding:26px 22px 28px;border-left:1px solid var(--border-soft)}
 .tl-cell:first-child{border-left:0}
 @media(max-width:760px){.tl-cell:nth-child(3){border-left:0}.tl-cell:nth-child(n+3){border-top:1px solid var(--border-soft)}}
-.tl-cell .tn{font-family:var(--mono);font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--muted)}
+.tl-cell .tn{font-family:var(--font-mono);font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--muted-fg)}
 .tl-cell .tp{margin-top:10px;font-size:26px;font-weight:500;letter-spacing:-0.02em}
-.tl-cell .tp small{font-size:12px;color:var(--muted);font-weight:400;letter-spacing:0}
+.tl-cell .tp small{font-size:12px;color:var(--muted-fg);font-weight:400;letter-spacing:0}
 .tl-cell .td{margin-top:6px;font-size:12.5px;color:var(--faint);line-height:1.55}
 .price .p-links{margin-top:30px;display:flex;gap:26px;align-items:center;font-size:14px}
 .price .p-links a{color:var(--fg);border-bottom:1px solid var(--border);padding-bottom:2px}
 .price .p-links a:hover{border-bottom-color:var(--fg)}
-.price .p-vow{margin-top:56px;font-size:15px;color:var(--muted);max-width:60ch;line-height:1.75}
+.price .p-vow{margin-top:56px;font-size:15px;color:var(--muted-fg);max-width:60ch;line-height:1.75}
 .price .p-vow strong{color:var(--fg);font-weight:500}
 
 /* ══════════ FINALE ══════════ */
@@ -631,10 +608,10 @@ html.light .pcursor .flag{color:#fff}
 .finale .state-line{margin-bottom:24px}
 .finale .derivation{font-size:clamp(32px,5vw,72px);margin:0 auto;max-width:22ch}
 .finale .derivation .word{margin-right:.18em}
-.finale .f-sub{margin:24px auto 0;max-width:46ch;font-size:17px;color:var(--muted);line-height:1.7}
+.finale .f-sub{margin:24px auto 0;max-width:46ch;font-size:17px;color:var(--muted-fg);line-height:1.7}
 .finale .waitlist{margin:40px auto 0;justify-content:center}
-.finale .f-alt{margin-top:18px;font-family:var(--mono);font-size:12px;color:var(--faint)}
-.finale .f-alt a{color:var(--muted);border-bottom:1px solid var(--border)}
+.finale .f-alt{margin-top:18px;font-family:var(--font-mono);font-size:12px;color:var(--faint)}
+.finale .f-alt a{color:var(--muted-fg);border-bottom:1px solid var(--border)}
 .finale .f-alt a:hover{color:var(--fg)}
 
 /* giant watermark footer */
@@ -650,15 +627,15 @@ footer{margin-top:170px;position:relative;overflow:hidden;border-top:1px solid v
   display:flex;align-items:center;gap:16px 30px;flex-wrap:wrap;
 }
 .foot-inner .fm{display:flex;align-items:center;gap:9px;font-size:14px;font-weight:500}
-.foot-links{display:flex;gap:22px;font-size:13px;color:var(--muted)}
+.foot-links{display:flex;gap:22px;font-size:13px;color:var(--muted-fg)}
 .foot-links a:hover{color:var(--fg)}
-.foot-inner .license{margin-left:auto;font-family:var(--mono);font-size:11px;color:var(--faint);letter-spacing:.02em}
+.foot-inner .license{margin-left:auto;font-family:var(--font-mono);font-size:11px;color:var(--faint);letter-spacing:.02em}
 @media(max-width:720px){.foot-inner .license{margin-left:0;width:100%}}
 
 /* ══════════ MOBILE — the poster, folded to phone width ══════════ */
 @media(max-width:640px){
   .wrap{padding:0 20px}
-  .nav-inner{padding:0 18px;height:58px;gap:16px}
+  
 
   .hero{padding-top:112px}
   .hero .stage{padding:0 20px}
@@ -729,28 +706,29 @@ footer{margin-top:170px;position:relative;overflow:hidden;border-top:1px solid v
   .reveal{opacity:1;transform:none}
 }
 </style>
+<script src="/site/shell.js" defer></script>
 </head>
 <body>
 
 <a class="skip-link" href="#main-content">Skip to content</a>
 
-<nav id="nav">
-  <div class="nav-inner">
-    <a class="wordmark" href="#">
+<nav class="site-nav" aria-label="Primary">
+  <div class="wrap site-nav__inner">
+    <a class="site-nav__brand" href="/">
       <img class="wm-dark" src="/brand/wordmark-light.svg" alt="Derive">
       <img class="wm-light" src="/brand/wordmark-dark.svg" alt="Derive">
     </a>
-    <div class="nav-right">
+    <div class="site-nav__links">
       <a href="https://docs.derive.to/">Docs</a>
       <a href="/examples">Examples</a>
       <a href="/pricing">Pricing</a>
       <a href="https://github.com/derive-to/derive">GitHub</a>
-      <button class="theme-btn" id="themeBtn" type="button" data-mode="dark" aria-label="Theme: dark" title="Theme: dark">
+      <button class="site-nav__theme" type="button" data-theme-toggle aria-label="Theme">
         <svg class="i-sun" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><circle cx="7" cy="7" r="3" stroke="currentColor" stroke-width="1.3"/><path d="M7 .8v1.7M7 11.5v1.7M.8 7h1.7M11.5 7h1.7M2.6 2.6l1.2 1.2M10.2 10.2l1.2 1.2M11.4 2.6l-1.2 1.2M3.8 10.2l-1.2 1.2" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg>
         <svg class="i-moon" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><path d="M11.8 8.6A5.2 5.2 0 1 1 5.4 2.2a4.2 4.2 0 0 0 6.4 6.4Z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/></svg>
         <svg class="i-sys" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><circle cx="7" cy="7" r="5.4" stroke="currentColor" stroke-width="1.3"/><path d="M7 1.6v10.8A5.4 5.4 0 0 0 7 1.6Z" fill="currentColor"/></svg>
       </button>
-      <a class="nav-signin" href="/login?src=nav_signin">Sign in to Beta <span class="arr">→</span></a>
+      <a class="site-nav__signin" href="/login?src=nav_signin">Sign in to Beta <span class="arr" aria-hidden="true">→</span></a>
     </div>
   </div>
 </nav>
@@ -1777,32 +1755,8 @@ function typeTerm(){
 const tio = new IntersectionObserver(es => es.forEach(en => { if (en.isIntersecting) { typeTerm(); tio.disconnect(); } }), {threshold:.35});
 tio.observe(document.querySelector('.bigterm'));
 
-/* ══ theme: light / dark / system (the boot script in <head> painted the right one) ══ */
-const themeBtn = $('themeBtn');
-const sysLight = matchMedia('(prefers-color-scheme: light)');
-const THEME_KEY = 'derive-theme';
-function themeMode(){
-  let m = null; try { m = localStorage.getItem(THEME_KEY); } catch {}
-  return m === 'light' || m === 'system' ? m : 'dark';
-}
-function applyTheme(){
-  const mode = themeMode();
-  const light = mode === 'light' || (mode === 'system' && sysLight.matches);
-  const c = document.documentElement.classList;
-  c.toggle('light', light); c.toggle('dark', !light);
-  themeBtn.dataset.mode = mode;
-  themeBtn.setAttribute('aria-label', 'Theme: ' + mode);
-  themeBtn.title = 'Theme: ' + mode;
-  glSetTheme(light);
-}
-themeBtn.addEventListener('click', () => {
-  const order = ['dark', 'light', 'system'];
-  const next = order[(order.indexOf(themeMode()) + 1) % order.length];
-  try { localStorage.setItem(THEME_KEY, next); } catch {}
-  applyTheme();
-});
-sysLight.addEventListener('change', () => { if (themeMode() === 'system') applyTheme(); });
-applyTheme();
+/* ══ theme: shell.js owns the control; the canvas repaints on its event ══ */
+document.addEventListener('derive:theme', (e) => glSetTheme(e.detail.light));
 </script>
 </body>
 </html>

--- a/apps/web/public/site/pricing.html
+++ b/apps/web/public/site/pricing.html
@@ -4,10 +4,10 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="color-scheme" content="dark">
-<title>Pricing — Derive</title>
-<meta name="description" content="Free while we're in beta. This is the pricing we intend to charge, published early — so nothing about it surprises you.">
+<title>Pricing | Derive</title>
+<meta name="description" content="Free while we're in beta. This is the pricing we intend to charge, published early, so nothing about it surprises you.">
 <meta property="og:type" content="website">
-<meta property="og:title" content="Pricing — Derive">
+<meta property="og:title" content="Pricing | Derive">
 <meta property="og:description" content="Free while we're in beta. This is the pricing we intend to charge, published early.">
 <meta property="og:url" content="https://derive.to/pricing">
 <meta property="og:image" content="https://derive.to/site/og-approval.png">
@@ -18,7 +18,7 @@
 {
   "@context": "https://schema.org",
   "@type": "WebPage",
-  "name": "Pricing — Derive",
+  "name": "Pricing | Derive",
   "url": "https://derive.to/pricing",
   "description": "Free while we're in beta. This is the pricing we intend to charge, published early.",
   "isPartOf": { "@id": "https://derive.to/#website" },

--- a/apps/web/public/site/pricing.html
+++ b/apps/web/public/site/pricing.html
@@ -27,6 +27,17 @@
 </script>
 <link rel="icon" href="/brand/favicon.svg" type="image/svg+xml">
 <link rel="icon" href="/brand/favicon.png" type="image/png">
+<script>
+/* theme boot: set the class before first paint (the choice lives in localStorage) */
+(function(){
+  var m = null; try { m = localStorage.getItem('derive-theme'); } catch (e) {}
+  if (m !== 'light' && m !== 'system') m = 'dark';
+  var light = m === 'light' || (m === 'system' && matchMedia('(prefers-color-scheme: light)').matches);
+  var c = document.documentElement.classList;
+  c.toggle('light', light); c.toggle('dark', !light);
+})();
+</script>
+<link rel="stylesheet" href="/site/shell.css">
 <style>
 @font-face {
   font-family: "Geist";
@@ -37,16 +48,6 @@
   font-family: "Geist Mono";
   src: url("/site/geist-mono.woff2") format("woff2");
   font-weight: 100 900; font-style: normal; font-display: swap;
-}
-:root {
-  --bg:#0a0b0d; --fg:#f3f4f6; --card:#101216; --secondary:#16181d;
-  --muted-fg:#969aa2; --accent:#1b1d23; --border:#23252b; --border-soft:#191b1f;
-  --primary:#f3f4f6; --primary-fg:#0a0b0d;
-  --success:#74b085; --warning:#fb923c;
-  --radius:4px;
-  --font-sans:"Geist",system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
-  --font-mono:"Geist Mono",ui-monospace,Menlo,Consolas,monospace;
-  --maxw:1060px;
 }
 *,*::before,*::after{box-sizing:border-box}
 html{-webkit-text-size-adjust:100%}
@@ -63,7 +64,6 @@ body::after{
   background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.82' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
   mix-blend-mode:screen;opacity:.05;
 }
-.wrap{max-width:var(--maxw);margin:0 auto;padding:0 24px}
 .eyebrow{font-family:var(--font-mono);font-size:11px;font-weight:500;letter-spacing:.08em;text-transform:uppercase;color:var(--muted-fg)}
 h1,h2,h3{font-weight:500;letter-spacing:-0.022em;text-wrap:balance;margin:0}
 p{text-wrap:pretty;margin:0}
@@ -76,26 +76,10 @@ p{text-wrap:pretty;margin:0}
 .btn-primary:hover{background:#fff}
 .btn-ghost{color:var(--fg);border-color:var(--border)}
 .btn-ghost:hover{background:var(--secondary)}
-
-nav{
-  position:fixed;top:0;left:0;right:0;z-index:100;
-  background:color-mix(in srgb,var(--bg) 82%,transparent);
-  -webkit-backdrop-filter:blur(12px);backdrop-filter:blur(12px);
-  border-bottom:1px solid transparent;
-}
 nav.scrolled{border-bottom-color:var(--border-soft)}
-.nav-inner{max-width:var(--maxw);margin:0 auto;padding:0 24px;height:60px;display:flex;align-items:center;gap:28px}
-.wordmark{display:flex;align-items:center}
-.wordmark img{height:24px;width:auto;display:block}
-.nav-links{display:flex;gap:22px;font-size:14px;color:var(--muted-fg);margin-left:8px}
-.nav-links a:hover{color:var(--fg)}
-.nav-links a.on{color:var(--fg)}
-.nav-cta{margin-left:auto;display:flex;align-items:center}
-.nav-cta .nav-signin{font-size:14px;color:var(--fg)}
 .nav-cta .nav-signin .arr{display:inline-block;transition:transform .18s ease}
 .nav-cta .nav-signin:hover .arr{transform:translateX(3px)}
-.nav-cta .btn{height:32px;padding:0 14px;border-radius:6px;font-size:13px}
-@media(max-width:720px){.nav-links{display:none}}
+@media(max-width:720px){}
 
 header.head.wrap{padding:150px 24px 0;text-align:center}
 .head h1{font-size:clamp(32px,5vw,52px);line-height:1.1;margin:18px auto 0;max-width:20ch}
@@ -186,25 +170,34 @@ footer{margin-top:130px;border-top:1px solid var(--border-soft)}
 }
 @media (prefers-reduced-motion: reduce){*,*::before,*::after{animation:none!important;transition:none!important}}
 </style>
+<script src="/site/shell.js" defer></script>
 </head>
 <body>
 
-<nav id="nav">
-  <div class="nav-inner">
-    <a class="wordmark" href="/">
-      <img src="/brand/wordmark-light.svg" alt="Derive">
+<a class="skip-link" href="#main-content">Skip to content</a>
+
+<nav class="site-nav" aria-label="Primary">
+  <div class="wrap site-nav__inner">
+    <a class="site-nav__brand" href="/">
+      <img class="wm-dark" src="/brand/wordmark-light.svg" alt="Derive">
+      <img class="wm-light" src="/brand/wordmark-dark.svg" alt="Derive">
     </a>
-    <div class="nav-links">
+    <div class="site-nav__links">
       <a href="https://docs.derive.to/">Docs</a>
       <a href="/examples">Examples</a>
-      <a class="on" href="/pricing">Pricing</a>
+      <a href="/pricing" aria-current="page">Pricing</a>
       <a href="https://github.com/derive-to/derive">GitHub</a>
-    </div>
-    <div class="nav-cta">
-      <a class="nav-signin" href="/login?src=nav_signin">Sign in to Beta <span class="arr">→</span></a>
+      <button class="site-nav__theme" type="button" data-theme-toggle aria-label="Theme">
+        <svg class="i-sun" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><circle cx="7" cy="7" r="3" stroke="currentColor" stroke-width="1.3"/><path d="M7 .8v1.7M7 11.5v1.7M.8 7h1.7M11.5 7h1.7M2.6 2.6l1.2 1.2M10.2 10.2l1.2 1.2M11.4 2.6l-1.2 1.2M3.8 10.2l-1.2 1.2" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg>
+        <svg class="i-moon" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><path d="M11.8 8.6A5.2 5.2 0 1 1 5.4 2.2a4.2 4.2 0 0 0 6.4 6.4Z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/></svg>
+        <svg class="i-sys" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><circle cx="7" cy="7" r="5.4" stroke="currentColor" stroke-width="1.3"/><path d="M7 1.6v10.8A5.4 5.4 0 0 0 7 1.6Z" fill="currentColor"/></svg>
+      </button>
+      <a class="site-nav__signin" href="/login?src=nav_signin">Sign in to Beta <span class="arr" aria-hidden="true">→</span></a>
     </div>
   </div>
 </nav>
+
+<main id="main-content" tabindex="-1">
 
 <header class="head wrap">
   <div class="eyebrow">Pricing</div>
@@ -345,6 +338,8 @@ footer{margin-top:130px;border-top:1px solid var(--border-soft)}
     </div>
   </div>
 </section>
+
+</main>
 
 <footer>
   <div class="foot-inner">

--- a/apps/web/public/site/privacy.html
+++ b/apps/web/public/site/privacy.html
@@ -27,6 +27,17 @@
 </script>
 <link rel="icon" href="/brand/favicon.svg" type="image/svg+xml">
 <link rel="icon" href="/brand/favicon.png" type="image/png">
+<script>
+/* theme boot: set the class before first paint (the choice lives in localStorage) */
+(function(){
+  var m = null; try { m = localStorage.getItem('derive-theme'); } catch (e) {}
+  if (m !== 'light' && m !== 'system') m = 'dark';
+  var light = m === 'light' || (m === 'system' && matchMedia('(prefers-color-scheme: light)').matches);
+  var c = document.documentElement.classList;
+  c.toggle('light', light); c.toggle('dark', !light);
+})();
+</script>
+<link rel="stylesheet" href="/site/shell.css">
 <style>
 @font-face {
   font-family: "Geist";
@@ -39,14 +50,7 @@
   font-weight: 100 900; font-style: normal; font-display: swap;
 }
 :root {
-  --bg:#0a0b0d; --fg:#f3f4f6; --card:#101216; --secondary:#16181d;
-  --muted-fg:#969aa2; --accent:#1b1d23; --border:#23252b; --border-soft:#191b1f;
-  --primary:#f3f4f6; --primary-fg:#0a0b0d;
-  --success:#74b085; --warning:#fb923c;
-  --radius:4px;
-  --font-sans:"Geist",system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
-  --font-mono:"Geist Mono",ui-monospace,Menlo,Consolas,monospace;
-  --maxw:1060px;
+--maxw: var(--maxw-prose);
 }
 *,*::before,*::after{box-sizing:border-box}
 html{-webkit-text-size-adjust:100%}
@@ -63,29 +67,13 @@ body::after{
   background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.82' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
   mix-blend-mode:screen;opacity:.05;
 }
-.wrap{max-width:var(--maxw);margin:0 auto;padding:0 24px}
 .eyebrow{font-family:var(--font-mono);font-size:11px;font-weight:500;letter-spacing:.08em;text-transform:uppercase;color:var(--muted-fg)}
 h1,h2,h3{font-weight:500;letter-spacing:-0.022em;text-wrap:balance;margin:0}
 p{text-wrap:pretty;margin:0}
-nav{
-  position:fixed;top:0;left:0;right:0;z-index:100;
-  background:color-mix(in srgb,var(--bg) 82%,transparent);
-  -webkit-backdrop-filter:blur(12px);backdrop-filter:blur(12px);
-  border-bottom:1px solid transparent;
-}
 nav.scrolled{border-bottom-color:var(--border-soft)}
-.nav-inner{max-width:var(--maxw);margin:0 auto;padding:0 24px;height:60px;display:flex;align-items:center;gap:28px}
-.wordmark{display:flex;align-items:center}
-.wordmark img{height:24px;width:auto;display:block}
-.nav-links{display:flex;gap:22px;font-size:14px;color:var(--muted-fg);margin-left:8px}
-.nav-links a:hover{color:var(--fg)}
-.nav-links a.on{color:var(--fg)}
-.nav-cta{margin-left:auto;display:flex;align-items:center}
-.nav-cta .nav-signin{font-size:14px;color:var(--fg)}
 .nav-cta .nav-signin .arr{display:inline-block;transition:transform .18s ease}
 .nav-cta .nav-signin:hover .arr{transform:translateX(3px)}
-.nav-cta .btn{height:32px;padding:0 14px;border-radius:6px;font-size:13px}
-@media(max-width:720px){.nav-links{display:none}}
+@media(max-width:720px){}
 
 header.head.wrap{padding:150px 24px 0;text-align:center}
 .head h1{font-size:clamp(32px,5vw,52px);line-height:1.1;margin:18px auto 0;max-width:20ch}
@@ -140,25 +128,34 @@ footer{margin-top:130px;border-top:1px solid var(--border-soft)}
 }
 @media (prefers-reduced-motion: reduce){*,*::before,*::after{animation:none!important;transition:none!important}}
 </style>
+<script src="/site/shell.js" defer></script>
 </head>
 <body>
 
-<nav id="nav">
-  <div class="nav-inner">
-    <a class="wordmark" href="/">
-      <img src="/brand/wordmark-light.svg" alt="Derive">
+<a class="skip-link" href="#main-content">Skip to content</a>
+
+<nav class="site-nav" aria-label="Primary">
+  <div class="wrap site-nav__inner">
+    <a class="site-nav__brand" href="/">
+      <img class="wm-dark" src="/brand/wordmark-light.svg" alt="Derive">
+      <img class="wm-light" src="/brand/wordmark-dark.svg" alt="Derive">
     </a>
-    <div class="nav-links">
+    <div class="site-nav__links">
       <a href="https://docs.derive.to/">Docs</a>
       <a href="/examples">Examples</a>
       <a href="/pricing">Pricing</a>
       <a href="https://github.com/derive-to/derive">GitHub</a>
-    </div>
-    <div class="nav-cta">
-      <a class="nav-signin" href="/login">Sign in to Beta <span class="arr">→</span></a>
+      <button class="site-nav__theme" type="button" data-theme-toggle aria-label="Theme">
+        <svg class="i-sun" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><circle cx="7" cy="7" r="3" stroke="currentColor" stroke-width="1.3"/><path d="M7 .8v1.7M7 11.5v1.7M.8 7h1.7M11.5 7h1.7M2.6 2.6l1.2 1.2M10.2 10.2l1.2 1.2M11.4 2.6l-1.2 1.2M3.8 10.2l-1.2 1.2" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg>
+        <svg class="i-moon" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><path d="M11.8 8.6A5.2 5.2 0 1 1 5.4 2.2a4.2 4.2 0 0 0 6.4 6.4Z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/></svg>
+        <svg class="i-sys" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><circle cx="7" cy="7" r="5.4" stroke="currentColor" stroke-width="1.3"/><path d="M7 1.6v10.8A5.4 5.4 0 0 0 7 1.6Z" fill="currentColor"/></svg>
+      </button>
+      <a class="site-nav__signin" href="/login?src=nav_signin">Sign in to Beta <span class="arr" aria-hidden="true">→</span></a>
     </div>
   </div>
 </nav>
+
+<main id="main-content" tabindex="-1">
 
 <header class="head wrap">
   <div class="eyebrow">Privacy</div>
@@ -228,6 +225,8 @@ footer{margin-top:130px;border-top:1px solid var(--border-soft)}
   <h2>Nothing here should surprise you.</h2>
   <p class="body">That's the point of publishing this before you have to go looking for it. Questions go to hello@derive.to.</p>
 </section>
+
+</main>
 
 <footer>
   <div class="foot-inner">

--- a/apps/web/public/site/privacy.html
+++ b/apps/web/public/site/privacy.html
@@ -4,10 +4,10 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="color-scheme" content="dark">
-<title>Privacy — Derive</title>
+<title>Privacy | Derive</title>
 <meta name="description" content="How Derive collects, stores, and protects your data, in plain language: what we collect, what we never do, who processes it, and how to delete it.">
 <meta property="og:type" content="website">
-<meta property="og:title" content="Privacy — Derive">
+<meta property="og:title" content="Privacy | Derive">
 <meta property="og:description" content="How Derive collects, stores, and protects your data, in plain language.">
 <meta property="og:url" content="https://derive.to/privacy">
 <meta property="og:image" content="https://derive.to/site/og-approval.png">
@@ -18,7 +18,7 @@
 {
   "@context": "https://schema.org",
   "@type": "WebPage",
-  "name": "Privacy — Derive",
+  "name": "Privacy | Derive",
   "url": "https://derive.to/privacy",
   "description": "How Derive collects, stores, and protects your data, in plain language.",
   "isPartOf": { "@id": "https://derive.to/#website" },

--- a/apps/web/public/site/shell.css
+++ b/apps/web/public/site/shell.css
@@ -1,0 +1,229 @@
+/* Shared shell for the public marketing pages.
+ *
+ * This file owns exactly three things: the design tokens every page agrees on,
+ * the page container, and the primary navigation. Everything else stays in the
+ * page it belongs to, so a page can be redesigned without touching the shell
+ * and the shell can be corrected once instead of five times.
+ *
+ * Pages link this file first, then their own styles, so a page can still
+ * override a token when it genuinely needs to.
+ */
+
+:root {
+  color-scheme: dark;
+
+  /* Surfaces and text. Every marketing page already agreed on these values;
+   * they live here now so they can only be changed in one place. */
+  --bg: #0a0b0d;
+  --fg: #f3f4f6;
+  --card: #101216;
+  --secondary: #16181d;
+  --muted-fg: #969aa2;
+  --accent: #1b1d23;
+  --border: #23252b;
+  --border-soft: #191b1f;
+  --primary: #f3f4f6;
+  --primary-fg: #0a0b0d;
+  --success: #74b085;
+  --warning: #fb923c;
+
+  --radius: 4px;
+  --font-sans: "Geist", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --font-mono: "Geist Mono", ui-monospace, Menlo, Consolas, monospace;
+
+  /* One container, two widths. Marketing pages run wide; pages that are mostly
+   * long-form text run narrow so the measure stays readable. */
+  --maxw: 1260px;
+  --maxw-prose: 720px;
+  --gutter: 24px;
+  --nav-height: 64px;
+}
+
+html.light {
+  color-scheme: light;
+  --bg: #f7f7f5;
+  --fg: #16171b;
+  --card: #fdfdfc;
+  --secondary: #eeeeeb;
+  --muted-fg: #5d626b;
+  --accent: #e9e9e6;
+  --border: #d9d9d4;
+  --border-soft: #e7e7e2;
+  --primary: #16171b;
+  --primary-fg: #f7f7f5;
+  --success: #286b41;
+  --warning: #b45309;
+}
+
+/* Container ------------------------------------------------------------- */
+
+/* The navigation is fixed, so every page starts below it. The landing page
+ * deliberately runs its hero underneath a transparent nav and overrides this
+ * back to 0; that is the one case where a page should touch this rule. */
+body {
+  padding-top: var(--nav-height);
+}
+
+.wrap {
+  width: min(var(--maxw), 100% - var(--gutter) * 2);
+  margin-inline: auto;
+}
+
+/* Opt a page, or one section of a page, down to the reading measure. */
+.wrap-prose {
+  --maxw: var(--maxw-prose);
+}
+
+/* Navigation ------------------------------------------------------------ */
+
+.skip-link {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  z-index: 1000;
+  padding: 9px 12px;
+  border-radius: 6px;
+  background: var(--fg);
+  color: var(--bg);
+  transform: translateY(-150%);
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+/* The border is inside the declared height, so --nav-height is the whole bar and
+ * the body offset below can rely on it exactly. */
+.site-nav {
+  position: fixed;
+  inset: 0 0 auto;
+  z-index: 100;
+  box-sizing: border-box;
+  height: var(--nav-height);
+  border-bottom: 1px solid transparent;
+  background: color-mix(in srgb, var(--bg) 78%, transparent);
+  -webkit-backdrop-filter: blur(14px);
+  backdrop-filter: blur(14px);
+}
+
+.site-nav__inner {
+  height: 100%;
+  display: flex;
+  align-items: center;
+  gap: 26px;
+}
+
+.site-nav__brand {
+  display: flex;
+  align-items: center;
+}
+
+.site-nav__brand img {
+  height: 26px;
+  width: auto;
+  display: block;
+}
+
+/* The wordmark ships in two colourways; the theme decides which one shows. */
+.site-nav__brand .wm-light {
+  display: none;
+}
+
+html.light .site-nav__brand .wm-dark {
+  display: none;
+}
+
+html.light .site-nav__brand .wm-light {
+  display: block;
+}
+
+.site-nav__links {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  font-size: 14px;
+}
+
+.site-nav__links a {
+  color: var(--muted-fg);
+  text-decoration: none;
+}
+
+.site-nav__links a:hover,
+.site-nav__links a[aria-current="page"] {
+  color: var(--fg);
+}
+
+.site-nav__signin {
+  color: var(--fg);
+}
+
+.site-nav__signin .arr {
+  display: inline-block;
+  transition: transform 0.18s ease;
+}
+
+.site-nav__signin:hover .arr {
+  transform: translateX(3px);
+}
+
+/* Theme control. The button cycles dark, light, then system; the icon shown
+ * reflects the stored choice rather than the resolved colour. */
+.site-nav__theme {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: 0;
+  border-radius: 7px;
+  background: none;
+  color: var(--muted-fg);
+  cursor: pointer;
+}
+
+.site-nav__theme:hover {
+  color: var(--fg);
+  background: var(--secondary);
+}
+
+.site-nav__theme svg {
+  display: none;
+}
+
+.site-nav__theme[data-mode="light"] .i-sun {
+  display: block;
+}
+
+.site-nav__theme[data-mode="dark"] .i-moon {
+  display: block;
+}
+
+.site-nav__theme[data-mode="system"] .i-sys {
+  display: block;
+}
+
+/* The script sets data-mode on load. Until it does, show one icon rather than
+ * an empty square, so the nav does not flicker on a slow connection. */
+.site-nav__theme:not([data-mode]) .i-moon {
+  display: block;
+}
+
+@media (max-width: 480px) {
+  :root {
+    --gutter: 18px;
+    --nav-height: 58px;
+  }
+
+  .site-nav__inner {
+    gap: 16px;
+  }
+
+  /* Below this width only the sign-in action stays; the rest of the
+   * navigation is reachable from the footer on every page. */
+  .site-nav__links a:not(.site-nav__signin) {
+    display: none;
+  }
+}

--- a/apps/web/public/site/shell.js
+++ b/apps/web/public/site/shell.js
@@ -1,0 +1,52 @@
+/* Theme control for the public marketing pages.
+ *
+ * The stored choice is one of "dark", "light" or "system". A small inline
+ * script in each page's <head> applies the resolved class before first paint,
+ * so this file only has to keep the button and the class in step afterwards.
+ *
+ * Pages that need to react to a theme change (a canvas that paints its own
+ * colours, for instance) listen for the "derive:theme" event on document
+ * rather than reaching into this file.
+ */
+;(() => {
+  const KEY = "derive-theme"
+  const ORDER = ["dark", "light", "system"]
+  const sysLight = matchMedia("(prefers-color-scheme: light)")
+  const button = document.querySelector("[data-theme-toggle]")
+
+  const mode = () => {
+    let stored = null
+    try {
+      stored = localStorage.getItem(KEY)
+    } catch {}
+    return stored === "light" || stored === "system" ? stored : "dark"
+  }
+
+  const apply = () => {
+    const current = mode()
+    const light = current === "light" || (current === "system" && sysLight.matches)
+    const classes = document.documentElement.classList
+    classes.toggle("light", light)
+    classes.toggle("dark", !light)
+    if (button) {
+      button.dataset.mode = current
+      button.setAttribute("aria-label", `Theme: ${current}`)
+      button.title = `Theme: ${current}`
+    }
+    document.dispatchEvent(new CustomEvent("derive:theme", { detail: { light, mode: current } }))
+  }
+
+  button?.addEventListener("click", () => {
+    const next = ORDER[(ORDER.indexOf(mode()) + 1) % ORDER.length]
+    try {
+      localStorage.setItem(KEY, next)
+    } catch {}
+    apply()
+  })
+
+  sysLight.addEventListener("change", () => {
+    if (mode() === "system") apply()
+  })
+
+  apply()
+})()

--- a/knip.json
+++ b/knip.json
@@ -23,7 +23,9 @@
         "src/components/ui/**",
         "e2e/**/*.screens.ts",
         "e2e/public-quality/static-server.mjs",
-        "public/site/guides.css"
+        "public/site/guides.css",
+        "public/site/shell.css",
+        "public/site/shell.js"
       ]
     },
     "packages/cli": {

--- a/scripts/check-public-claims.mjs
+++ b/scripts/check-public-claims.mjs
@@ -70,40 +70,26 @@ const forbidden = [
   {
     pattern: /turn agent output into approved work/i,
     reason: "formal approval is an optional control, not every artifact's promised outcome",
-    positioning: true,
   },
   {
     pattern: /review and approval for (?:work made by ai agents|agent-made work)/i,
     reason: "describe the full artifact workspace rather than one optional workflow",
-    positioning: true,
   },
   {
     pattern: /publish\s*(?:→|->)\s*review\s*(?:→|->)\s*revise\s*(?:→|->)\s*approve/i,
     reason: "do not present one formal review sequence as the path for every artifact",
-    positioning: true,
   },
   {
     pattern: /every artifact runs the same loop/i,
     reason: "private, shared, recurring, and formal-review artifacts are all valid",
-    positioning: true,
   },
   {
     pattern: /the loop is what you pay for/i,
     reason: "pricing pays for editor seats, not one required workflow",
-    positioning: true,
   },
 ]
 
 const licensingPath = "apps/docs/content/reference/licensing.md"
-
-// The public marketing site keeps its own editorial voice. Positioning wording and
-// em-dash punctuation are set per page there, so those two checks describe the docs,
-// README, and in-app surfaces instead. Every license, access, and agent claim below
-// still applies to the marketing pages.
-const marketingSite = new Set([
-  "apps/web/public/security.html",
-  ...walkText("apps/web/public/site"),
-])
 
 // Public prose should read like the rest of the product: short sentences and calm
 // punctuation. Comments and internal engineering docs are outside this copy check.
@@ -118,6 +104,8 @@ const publicProseFiles = new Set([
   ...walkText("examples"),
   "apps/web/public/llms.txt",
   "apps/web/public/llms-full.txt",
+  "apps/web/public/security.html",
+  ...walkText("apps/web/public/site"),
   "packages/mcp/SKILL.md",
 ])
 
@@ -174,9 +162,8 @@ for (const path of publicCopyFiles) {
     continue
   }
   for (const [index, line] of read(path).split("\n").entries()) {
-    for (const { pattern, reason, positioning } of forbidden) {
+    for (const { pattern, reason } of forbidden) {
       if (path === licensingPath && pattern.source === "\\bopen[- ]source\\b") continue
-      if (positioning && marketingSite.has(path)) continue
       if (pattern.test(line)) fail(`${path}:${index + 1}: ${reason}\n  ${line.trim()}`)
     }
   }
@@ -198,7 +185,7 @@ requireText("SECURITY.md", "Anonymous callers are always read-only", "match effe
 requireText("apps/web/public/site/index.html", "Fair Source and self-hostable", "accurate metadata")
 requireText(
   "apps/web/public/site/index.html",
-  "commenting or editing requires sign-in",
+  "Commenting and editing require sign-in.",
   "match the anonymous read-only invariant",
 )
 requireText("apps/web/src/pages/login.tsx", "Fair Source.", "do not claim OSI status")
@@ -214,7 +201,7 @@ requireText(
 )
 requireText("README.md", "a compatible agent over MCP", "scope agent compatibility")
 requireText("README.md", "a proposal a human approves", "preserve human approval")
-for (const path of ["README.md", "apps/docs/content/index.mdx"])
+for (const path of ["README.md", "apps/web/public/site/index.html", "apps/docs/content/index.mdx"])
   requireText(
     path,
     "keep, share, and improve",


### PR DESCRIPTION
Follow-up to #751. Two self-contained commits: first the marketing pages adopt
the current product language, then the five public pages get one container and
one navigation.

## Why the pages needed rewording first

#751 restored the pre-redesign pages, which carried the older positioning, and
scoped two `check-public-claims` rules away from them to let that through. That
left derive.to and the README describing the product differently.

The first commit rewords the pages instead, reusing wording already shipped in
the README and the docs index, and restores
`scripts/check-public-claims.mjs` byte for byte. The `marketingSite` exemption
and the `positioning` flags are gone, so every public surface is held to the
same rules again.

## The shell

The five pages had drifted into five layouts:

| | container | navigation | sign-in |
|---|---|---|---|
| index | `--maxw:1260px`, pad 28px | full nav + theme | `nav_signin` |
| pricing | `--maxw:1060px`, pad 24px | full nav | `nav_signin` |
| privacy | `--maxw:1060px`, pad 24px | full nav | bare `/login` |
| examples | `--max:1120px` | its own nav | `examples_signin` |
| security | `--maxw:720px`, pad 24px | none at all | bare `/login` |

All four already used the same ten colour values under two different token
names, so the shared parts extract without changing how any page looks.

`site/shell.css` owns exactly three things: the agreed tokens, the container,
and the navigation. `site/shell.js` owns the theme control. Page specific
styling stays in the page it belongs to, and pages link the shell first so a
page can still override a token when it genuinely needs to.

- one container: `--maxw` for marketing pages, `--maxw-prose` for text-heavy
  ones (security, privacy), one gutter everywhere
- one navigation on all five, `aria-current` on the page you are reading, and a
  `<main>` landmark and skip link on every page rather than one
- the theme control works on all five pages and the choice is shared, not
  stored per page
- `index` keeps its own design and overrides a single shell rule
  (`body{padding-top:0}`), because its hero is meant to run under the
  transparent bar. That is documented in the shell as the one legitimate case.

## Deliberate exception

The sign-in `src` stays per page. Signup attribution is a pinned set, so
examples keeps `examples_signin` while the rest use `nav_signin`; privacy and
security gain attribution they previously lacked. An earlier revision of this
branch flattened them all and `check-public-claims` correctly rejected it.

## Defects found by the new test

Asserting the shell per page caught three real problems, all fixed here:

1. the navigation's bottom border put it 1px over its declared height, so
   content sat under the bar on every page that was not the landing page
2. a code block on examples stretched the page 29px sideways on mobile through
   grid blowout. This predated the shell; the assertion simply surfaced it
3. once that block scrolled properly it needed keyboard access to satisfy WCAG

## Verification

`pnpm verify` passes. The full public-quality suite passes on desktop and
mobile, 46 tests, including axe WCAG A/AA on every marketing page in both
themes.

## Not included

Below 480px the navigation still collapses to the sign-in link only. #745
solved that with a `<details>` mobile menu, which was part of the design
reverted in #751, so reintroducing that pattern felt like a decision to make
deliberately rather than smuggle into a refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/753"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789585593&installation_model_id=428097&pr_number=753&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F753&signature=42453b3b1e216d0208269565551a82097964c6d986bd1e73ac1be624241e254c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->