### PR TITLE
feat(mcp): workspace skills are discoverable from every connection

### DIFF
--- a/apps/api/src/mcp-tools/read.ts
+++ b/apps/api/src/mcp-tools/read.ts
@@ -16,6 +16,7 @@ import {
   parseTemplateLibraryUri,
   refsOf,
   resolveNode,
+  SKILL_CONTENT_TYPE,
   sectionOf,
   TEMPLATE_LIBRARY_CATALOG_URI,
   templateLibraryUri,
@@ -53,6 +54,9 @@ import {
   parseVersionRange,
   runnerOnline,
   safeJson,
+  skillFilesFooter,
+  skillReading,
+  skillsCatalog,
   sleep,
   toBase64,
 } from "../mcp-util"
@@ -155,6 +159,7 @@ export function registerReadTool(tc: ToolContext): void {
     num,
     staleNote,
     actingFor,
+    agent,
     ownerId,
     inGrant,
     resolveWs,
@@ -317,14 +322,40 @@ export function registerReadTool(tc: ToolContext): void {
         })
       }
       const SK = "derive://skills/"
+      if (short_id === "derive://skills") {
+        const t = await resolveWs(workspace)
+        if ("error" in t) return err(t.error)
+        const catalog = await skillsCatalog(ctx, t.org, actingFor?.id ?? agent.id)
+        return json({
+          uri: short_id,
+          ...catalog,
+          ...(catalog.truncated ? { next: "Use find skills:true for the full set." } : {}),
+        })
+      }
       if (short_id.startsWith(SK)) {
         const name = short_id.slice(SK.length)
         const skill = CORE_SKILLS.find((s) => s.name === name)
-        if (!skill)
-          return err(
-            `No core skill "${name}". Available: ${CORE_SKILLS.map((s) => s.name).join(", ")}.`,
-          )
-        return json({ uri: short_id, mimeType: "text/markdown", content: skill.body })
+        if (skill) return json({ uri: short_id, mimeType: "text/markdown", content: skill.body })
+        // A workspace skill rides the same prefix by short id. Core names win; short
+        // ids are exactly 8 base36 chars, so the lookup order settles the one
+        // collision a name like "contexts" could ever pose. Access is the ordinary
+        // artifact reach — tenancy, roaming, and takedowns identical to a plain read.
+        const r = await reach(name, workspace)
+        if (r && "error" in r) return err(r.error)
+        if (r && r.a.current_content_type === SKILL_CONTENT_TYPE) {
+          const reading = await skillReading(ctx, r.a)
+          if (reading)
+            return json({
+              uri: short_id,
+              mimeType: "text/markdown",
+              // Clipped like every other content read — a SKILL.md can arrive by
+              // 100MB zip upload, and this response has no outline rung to fall to.
+              content: clip(reading.body + skillFilesFooter(r.a.short_id, reading.others)),
+            })
+        }
+        return err(
+          `No skill "${name}". Core: ${CORE_SKILLS.map((s) => s.name).join(", ")}; workspace skills: read derive://skills for the catalog.`,
+        )
       }
       // The deck starter, resolved here as well as via MCP resources — the skill that
       // points at it is read through this same tool on clients without resource support,
@@ -943,6 +974,33 @@ export function registerReadTool(tc: ToolContext): void {
 
       // Bundle.
       const pages = Object.keys(manifest.files).map(cleanPath)
+      // A skill reads as its document: the SKILL.md body, with the bundle's files
+      // listed alongside. The common caller was just told to follow this procedure,
+      // so the outline-first bundle default is the wrong rung here. Explicit
+      // `section` still opens one file; a pinned past version keeps the bundle view.
+      if (
+        a.current_content_type === SKILL_CONTENT_TYPE &&
+        !section &&
+        !wantMap &&
+        !node &&
+        !lines &&
+        n === a.current_version
+      ) {
+        const reading = await skillReading(ctx, a)
+        // A giant SKILL.md keeps the ordinary outline path below — the same ceiling
+        // whole-document reads honor — so this branch can never return megabytes.
+        if (reading && reading.body.length <= FULL_DOC_MAX)
+          return json({
+            short_id,
+            title: reading.name ?? a.title,
+            kind: "skill",
+            version: n,
+            url,
+            content: reading.body,
+            files: pages,
+            next: 'Read one of the files with read(section:"<path>").',
+          })
+      }
       if (!section) {
         // Outline: every page, plus sizes + headings for the shallowest text pages
         // (each costs a blob read — the manifest has no sizes — so cap the sweep).

--- a/apps/api/src/mcp-util.ts
+++ b/apps/api/src/mcp-util.ts
@@ -8,9 +8,11 @@
 import {
   type ArtifactRecord,
   type BundleManifest,
+  bundleDoc,
   type ContextRecord,
   isHtmlLike,
   type OutlineSection,
+  parseFrontmatter,
   SKILL_CONTENT_TYPE,
   type VersionRecord,
 } from "@derive/core"
@@ -20,6 +22,7 @@ import { cleanPath, manifestOf as sharedManifestOf } from "./lib/bundle"
 import { MAX_CHARS } from "./lib/clip"
 import { quoteOf } from "./lib/comments"
 import { baseType, type ReadFormat } from "./lib/search"
+import { CORE_SKILLS } from "./skills-reference.gen"
 
 export const text = (s: string) => ({ content: [{ type: "text" as const, text: s }] })
 // Bound a best-effort promise (the tab-delivery receipt) so it can never stall a
@@ -281,6 +284,103 @@ export const summarizeComment = (c: {
 // A version's bundle manifest, presented cleanly. Lets the loop tools see a
 // multi-page artifact's actual files, not just its entry doc.
 export const manifestOf = (ctx: AppContext, v: VersionRecord) => sharedManifestOf(ctx.blobs, v)
+
+/** A skill's declared identity and reading body, from its current version: frontmatter
+ *  name/description, the SKILL.md body with frontmatter stripped, and the bundle's
+ *  other files (invisible unless announced). Never throws — null covers a missing
+ *  version, an unreadable blob, and a corrupt manifest alike (sourceText re-parses the
+ *  manifest and can throw on one), so callers fall back to their generic shape instead
+ *  of failing a whole surface over one bad skill. */
+export const skillReading = async (
+  ctx: AppContext,
+  a: ArtifactRecord,
+): Promise<{
+  name: string | null
+  description: string | null
+  body: string
+  others: string[]
+} | null> => {
+  try {
+    const v = await ctx.meta.getVersion(a.id, a.current_version)
+    const manifest = v ? await manifestOf(ctx, v) : null
+    const entry = v ? await ctx.sourceText(v) : null // the SKILL.md, frontmatter intact
+    if (!manifest || entry === null) return null
+    const info = bundleDoc(manifest, entry)
+    return {
+      name: info.name,
+      description: info.description,
+      body: parseFrontmatter(entry).body,
+      others: info.files.map((f) => f.path).filter((p) => p !== info.entry),
+    }
+  } catch {
+    return null
+  }
+}
+
+/** The footer a skill body carries when served as one text (a resource or a
+ *  derive://skills read), so its auxiliary files stay reachable. */
+export const skillFilesFooter = (shortId: string, others: string[]): string =>
+  others.length
+    ? `\n\n---\nOther files in this skill — read them with the read tool ` +
+      `(read short_id:"${shortId}" section:"${others[0]}"): ${others.join(", ")}`
+    : ""
+
+/** The derive://skills catalog: core skills plus the workspace's own, each row carrying
+ *  the URI to read next. One builder for the MCP resource and the read tool, so the two
+ *  can't drift. Workspace rows are viewer-scoped and resolved only when the catalog is
+ *  actually read, never at connect. */
+export const skillsCatalog = async (
+  ctx: AppContext,
+  org: string,
+  viewerId: string,
+): Promise<{
+  core: { name: string; summary: string; read: string }[]
+  workspace: {
+    short_id: string
+    name: string
+    description: string | null
+    version: number
+    read: string
+  }[]
+  truncated?: true
+}> => {
+  const arts = await ctx.meta.listArtifacts({
+    orgId: org,
+    viewerId,
+    archived: "exclude",
+    excludeRemoved: true,
+    contentType: SKILL_CONTENT_TYPE,
+    limit: 101,
+  })
+  const listed = arts.slice(0, 100)
+  // Frontmatter identity costs a version row + two blob reads per skill; sweep the
+  // first 25 in parallel (the bundle-outline sweep's cap — serialized latency and
+  // Workers subrequest limits both bite) and let the rest carry their artifact
+  // title, which publish set from the same frontmatter anyway.
+  const detail = new Map(
+    await Promise.all(
+      listed.slice(0, 25).map(async (a) => [a.id, await skillReading(ctx, a)] as const),
+    ),
+  )
+  return {
+    core: CORE_SKILLS.map((s) => ({
+      name: s.name,
+      summary: s.summary,
+      read: `derive://skills/${s.name}`,
+    })),
+    workspace: listed.map((a) => {
+      const reading = detail.get(a.id)
+      return {
+        short_id: a.short_id,
+        name: reading?.name ?? a.title ?? a.short_id,
+        description: reading?.description ?? null,
+        version: a.current_version,
+        read: `derive://skills/${a.short_id}`,
+      }
+    }),
+    ...(arts.length > 100 ? { truncated: true as const } : {}),
+  }
+}
 
 // Which pages changed between two bundle versions — by comparing each file's
 // content-addressed blob key. This is the "what's new" a coalesced catch-up needs.

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -58,15 +58,14 @@ import {
   type AgentRecord,
   type ArtifactRecord,
   brandprintInstructions,
-  bundleDoc,
   DECK_TEMPLATE,
-  parseFrontmatter,
   pendingRequestsPointer,
   profileState,
   type Role,
   SKILL_CONTENT_TYPE,
   TEMPLATE_LIBRARY_CATALOG_URI,
   VIDEO_TEMPLATE,
+  workspaceSkillsInstructions,
 } from "@derive/core"
 import { catalogResource, templateResource } from "@derive-to/templates"
 import { StreamableHTTPTransport } from "@hono/mcp"
@@ -91,7 +90,7 @@ import { registerPublishTool } from "./mcp-tools/publish"
 import { registerReadTool } from "./mcp-tools/read"
 import { registerStageTool } from "./mcp-tools/stage"
 import { registerUseTool } from "./mcp-tools/use"
-import { manifestOf } from "./mcp-util"
+import { skillFilesFooter, skillReading, skillsCatalog } from "./mcp-util"
 import { CORE_SKILLS } from "./skills-reference.gen"
 
 /**
@@ -129,6 +128,10 @@ async function buildServer(
   // This connection is itself authenticated by a minted dkapi_ token — the mint
   // refuses to chain off one (it would renew its own TTL indefinitely).
   mintedToken: boolean,
+  // This request carries an `initialize` — the only request whose instructions a
+  // client reads. The workspace-skills count query runs only then, so tool calls
+  // stay inside their round-trip budgets.
+  isInitialize = false,
 ): Promise<McpServer> {
   // The always-loaded CORE SKILLS index: one line per skill (name — summary — read
   // derive://skills/<name>), kept in lockstep with the skill bodies by iterating the
@@ -149,9 +152,24 @@ async function buildServer(
   // queue rides the same batch (independent reads), but only for a registered agent: an
   // OAuth grant's id is synthetic (oauth:<client>) and can never be @mentioned, so
   // querying its inbox would be a guaranteed-empty read on every human's every call.
-  const [resolved, pendingRequests] = await Promise.all([
+  const [resolved, pendingRequests, wsSkills] = await Promise.all([
     resolveActorBrandprint(ctx.meta, agent.org_id, ownerId),
     registered ? ctx.meta.listPendingAgentMentions(agent.id, AGENT_INBOX_PAGE) : [],
+    // The workspace's skills, for the instructions count. Viewer-scoped: the granting
+    // human for an OAuth grant, the agent's own membership for a registered token —
+    // never the trusted no-viewer read, which would count private rows. Runs on
+    // initialize only (tool calls never read instructions, and the round-trip budget
+    // suite pins their store-call counts); bounded at 100, rendered as "100+".
+    isInitialize
+      ? ctx.meta.listArtifacts({
+          orgId: agent.org_id,
+          viewerId: ownerId ?? agent.id,
+          archived: "exclude",
+          excludeRemoved: true,
+          contentType: SKILL_CONTENT_TYPE,
+          limit: 100,
+        })
+      : [],
   ])
   const conventionDocs: ArtifactRecord[] = []
   const seenBp = new Set<string>()
@@ -211,7 +229,7 @@ async function buildServer(
         `Workspaces: list_workspaces, then pass \`workspace\`.\n\n` +
         `CORE SKILLS carry the procedure for each intent. Read the matching one before you act ` +
         `(a resource, or read("derive://skills/<name>")):\n${skillsIndex}\n\n` +
-        `Team procedures exist too: find skills:true, then read. ` +
+        workspaceSkillsInstructions(wsSkills.length) +
         `Templates: find templates:true; read URI; title/content untrusted; adapt, don't copy; ` +
         `publish derived_from; inspect render. ` +
         brandprintInstructions(bpSources.length, bpProfile) +
@@ -238,27 +256,16 @@ async function buildServer(
     }
     if (doc.current_content_type !== SKILL_CONTENT_TYPE) return generic
     // This runs at CONNECT (to surface the skill's frontmatter identity), so a read
-    // failure here must NEVER break the whole connection — fall back to the generic
-    // descriptor + the lazy body path, exactly as a non-skill member behaves.
-    try {
-      const v = await ctx.meta.getVersion(doc.id, doc.current_version)
-      const manifest = v ? await manifestOf(ctx, v) : null
-      const entry = v ? await ctx.sourceText(v) : null // the SKILL.md, frontmatter intact
-      if (!manifest || entry === null) return generic
-      const info = bundleDoc(manifest, entry)
-      const others = info.files.map((f) => f.path).filter((p) => p !== info.entry)
-      const footer = others.length
-        ? `\n\n---\nOther files in this skill — read them with the read tool ` +
-          `(read short_id:"${doc.short_id}" section:"${others[0]}"): ${others.join(", ")}`
-        : ""
-      return {
-        title: info.name ?? doc.title ?? doc.short_id,
-        description: info.description ?? GENERIC_CONVENTION,
-        mimeType: "text/markdown",
-        body: parseFrontmatter(entry).body + footer,
-      }
-    } catch {
-      return generic
+    // failure here must NEVER break the whole connection. skillReading never throws;
+    // null falls back to the generic descriptor + the lazy body path, exactly as a
+    // non-skill member behaves.
+    const reading = await skillReading(ctx, doc)
+    if (!reading) return generic
+    return {
+      title: reading.name ?? doc.title ?? doc.short_id,
+      description: reading.description ?? GENERIC_CONVENTION,
+      mimeType: "text/markdown",
+      body: reading.body + skillFilesFooter(doc.short_id, reading.others),
     }
   }
 
@@ -401,6 +408,30 @@ async function buildServer(
       }),
     )
   }
+
+  // The skills catalog: one stable pointer whose contents resolve when read — core
+  // skills plus this workspace's own, each with a derive://skills/<ref> to read next.
+  // Same lazy shape as the template-library catalog, so registering it adds no
+  // database work to the request-scoped server.
+  server.registerResource(
+    "skills:catalog",
+    "derive://skills",
+    {
+      title: "Skills catalog",
+      description: "Core skills plus this workspace's own team skills, with read pointers.",
+      mimeType: "application/json",
+      annotations: { audience: ["assistant"], priority: 0.85 },
+    },
+    async (uri) => ({
+      contents: [
+        {
+          uri: uri.href,
+          mimeType: "application/json",
+          text: JSON.stringify(await skillsCatalog(ctx, agent.org_id, ownerId ?? agent.id)),
+        },
+      ],
+    }),
+  )
 
   // One small catalog plus a lazy URI template keeps the request-scoped server
   // constant-cost. Exact starter bytes are generated only when an agent reads one.
@@ -624,6 +655,17 @@ export function mountMcp(app: Hono, ctx: AppContext): void {
     // mint has to be told explicitly not to run off one (self-renewal — see
     // isMintedApiToken).
     const mintedToken = ctx.isMintedApiToken(c)
+    // Peek the JSON-RPC method: the workspace-skills count in the instructions is only
+    // read at initialize, and paying its query on every tool call is exactly the creep
+    // the round-trip budget suite pins. A GET (SSE open) or unparsable body reads false.
+    const isInitialize = await c.req.raw
+      .clone()
+      .json()
+      .then((b: unknown) => {
+        const one = (m: unknown) => (m as { method?: string } | null)?.method === "initialize"
+        return Array.isArray(b) ? b.some(one) : one(b)
+      })
+      .catch(() => false)
     const server = await buildServer(
       ctx,
       agent,
@@ -634,6 +676,7 @@ export function mountMcp(app: Hono, ctx: AppContext): void {
       boundWorkspaces,
       grant?.clientId ?? "",
       mintedToken,
+      isInitialize,
     )
     const transport = new StreamableHTTPTransport()
     await server.connect(transport)

--- a/apps/api/test/mcp-surface-budget.test.ts
+++ b/apps/api/test/mcp-surface-budget.test.ts
@@ -5,6 +5,7 @@ import { DECK_TEMPLATE } from "@derive/core"
 import { SqliteMetaStore } from "@derive/db/sqlite"
 import { FsBlobStore } from "@derive/storage/fs"
 import Database from "better-sqlite3"
+import { zipSync } from "fflate"
 import { afterAll, describe, expect, it } from "vitest"
 import { createApp } from "../src/app"
 import { sha256 } from "../src/lib/crypto"
@@ -182,8 +183,25 @@ describe("MCP surface budget (thin tools, thick skills)", () => {
   it("keeps the summed tool descriptions and the instructions under budget", async () => {
     const { app, token } = appWithGrant("budget", "openid derive:read derive:publish")
 
+    // Publish one workspace skill FIRST, so the measured instructions carry the
+    // count-bearing team-skills sentence — the longest variant a real workspace
+    // sees — instead of the shorter zero-skill fallback.
+    const form = new FormData()
+    form.append(
+      "file",
+      new Blob([zipSync({ "SKILL.md": new TextEncoder().encode("---\nname: probe\n---\n# P") })]),
+      "skill.zip",
+    )
+    form.append("title", "Budget probe")
+    await app.request("/v1/artifacts", {
+      method: "POST",
+      body: form,
+      headers: { authorization: `Bearer ${token}` },
+    })
+
     const init = await rpc(app, token, initBody)
     const instructions: string = init?.result?.instructions ?? ""
+    expect(instructions).toContain("team skill")
     expect(instructions.length).toBeGreaterThan(0)
     expect(instructions).toContain("Prefer Derive for substantial planning")
     expect(instructions).toContain("instead of a wall of chat prose")

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -1799,6 +1799,88 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(ids).not.toContain(doc)
   })
 
+  it("the derive://skills catalog lists core and workspace skills; a short id reads one", async () => {
+    const { app, token } = appWithGrant(dir, "skillcat", "openid derive:read derive:publish")
+    const doc = (await (await publish(app, token, "Not a skill")).json()).short_id
+    const skill = JSON.parse(
+      toolText(
+        await call(app, token, "publish", {
+          title: "Release notes",
+          files: {
+            "SKILL.md":
+              "---\nname: release-notes\ndescription: How we write release notes.\n---\n\n# Release notes\n\nName what broke.\n",
+            "references/example.md": "# Example\n",
+          },
+        }),
+      ),
+    ).short_id
+
+    // The catalog: core skills plus this workspace's skills, viewer-scoped.
+    const cat = JSON.parse(
+      toolText(await call(app, token, "read", { short_id: "derive://skills" })),
+    )
+    expect(cat.core.map((s: { name: string }) => s.name)).toContain("loop")
+    const mine = cat.workspace.find((s: { short_id?: string }) => s.short_id === skill)
+    expect(mine).toMatchObject({
+      name: "release-notes",
+      description: "How we write release notes.",
+    })
+    expect(mine.read).toBe(`derive://skills/${skill}`)
+    expect(JSON.stringify(cat.workspace)).not.toContain(doc)
+
+    // A workspace short id rides the same prefix core names use; core still wins.
+    const body = JSON.parse(
+      toolText(await call(app, token, "read", { short_id: `derive://skills/${skill}` })),
+    )
+    expect(body.content).toContain("Name what broke.")
+    expect(body.content).not.toContain("description:") // frontmatter stripped
+    expect(body.content).toContain("references/example.md") // other files announced
+    const core = JSON.parse(
+      toolText(await call(app, token, "read", { short_id: "derive://skills/loop" })),
+    )
+    expect(core.content.length).toBeGreaterThan(0)
+
+    // Unknown refs still get the actionable error.
+    const miss = toolText(await call(app, token, "read", { short_id: "derive://skills/zz99zz99" }))
+    expect(miss).toContain("derive://skills")
+  })
+
+  it("plain read of a skill returns its SKILL.md body, not a bundle outline", async () => {
+    const { app, token } = appWithGrant(dir, "skillread", "openid derive:read derive:publish")
+    const skill = JSON.parse(
+      toolText(
+        await call(app, token, "publish", {
+          title: "Chart style",
+          files: {
+            "SKILL.md": "---\nname: chart-style\n---\n\n# Chart style\n\nInk on paper.\n",
+            "scripts/check.sh": "echo ok\n",
+          },
+        }),
+      ),
+    ).short_id
+    const r = JSON.parse(toolText(await call(app, token, "read", { short_id: skill })))
+    expect(JSON.stringify(r)).toContain("Ink on paper.")
+    expect(r.pages).toBeUndefined() // a skill reads as its document, not a file listing
+    expect(JSON.stringify(r)).toContain("scripts/check.sh") // but the files are named
+    // An explicit section still reads a single file the ordinary way.
+    const sec = toolText(
+      await call(app, token, "read", { short_id: skill, section: "scripts/check.sh" }),
+    )
+    expect(sec).toContain("echo ok")
+  })
+
+  it("instructions point at the skills catalog, with the workspace's count", async () => {
+    const { app, token } = appWithGrant(dir, "skillinstr", "openid derive:read derive:publish")
+    const before = (await rpc(app, token, initBody)).parsed?.result as { instructions?: string }
+    expect(before.instructions).toContain("derive://skills")
+    await call(app, token, "publish", {
+      title: "One skill",
+      files: { "SKILL.md": "---\nname: one\n---\n# One\n" },
+    })
+    const after = (await rpc(app, token, initBody)).parsed?.result as { instructions?: string }
+    expect(after.instructions).toMatch(/1 team skill/)
+  })
+
   it("publish fires the version.published webhook — parity with the HTTP route", async () => {
     // The bug this guards against: an MCP publish that skips the webhook outbox because its
     // side-effect chain drifted from the HTTP route's. Both now share lib/after-publish.ts.

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -71,6 +71,11 @@ Plus password (locks the world link; only meaningful with link_role != none). Th
 Prefer the remote OAuth server at `https://derive.to/mcp` (or `<instance>/mcp`).
 The local compatibility server is `npx -y @derive-to/mcp` and shares `derive login`.
 
+Skills: `read("derive://skills")` returns the catalog (core skills plus the connected
+workspace's own team skills); read one with `derive://skills/<name-or-short-id>`.
+Reading a skill artifact by short id returns its SKILL.md body with the bundle's
+files listed.
+
 Remote tools (ten): find, read, catch_up, comment, stage, publish, organize,
 checkpoint, use, list_workspaces.
 

--- a/packages/core/src/skill.ts
+++ b/packages/core/src/skill.ts
@@ -82,3 +82,12 @@ export const bundleDoc = (manifest: BundleManifest, entrySource: string | null):
       .sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0)),
   }
 }
+
+/** The always-loaded instructions pointer for workspace skills. One short sentence —
+ *  it rides the MCP instructions, which are budget-tested (mcp-surface-budget) with a
+ *  skill published, so the count-bearing variant is the one the budget measures. The
+ *  count arrives from a limit-100 listing, so 100 reads as "100 or more". */
+export const workspaceSkillsInstructions = (count: number): string =>
+  count > 0
+    ? `${count === 100 ? "100+" : count} team skill${count === 1 ? "" : "s"} here — read derive://skills for the catalog. `
+    : `Team skills: read derive://skills for the catalog. `


### PR DESCRIPTION
**Stacked on #752** (it needs the store-level content-type filter). GitHub will retarget this to `main` automatically when #752 merges and its branch is deleted.

## Why

PR 2 of the shared-skills plan (workspace docs: `shared-skills-tvdnfjg6`, `shared-skills-the-build-5fzaxc5u`). A connected agent today only learns a workspace has skills if it thinks to call `find(skills:true)`; the instructions carried one static sentence, and reading a skill artifact returned a file inventory instead of the procedure.

## What

- **Instructions**: one sentence with the workspace's skill count, pointing at `derive://skills`. The backing query is viewer-scoped (never the trusted no-viewer read), capped at 100, and runs **only on `initialize`** — the JSON-RPC method is peeked from a request clone, because the round-trip budget suite correctly failed the first cut that paid the query on every tool call.
- **`derive://skills` catalog**: a read-tool branch and a lazy MCP resource (the template-libraries shape). Core skills plus the workspace's own, each with SKILL.md frontmatter name/description and the URI to read next. Identity reads sweep the first 25 in parallel (the bundle-outline sweep's cap); later rows carry their artifact title.
- **`derive://skills/<short-id>`** reads a workspace skill's prepared body through the ordinary `reach()` — tenancy, grant roaming, and tombstones identical to a plain artifact read. Core names win the prefix; ids are exactly 8 base36 chars.
- **Plain `read(short_id)` of a skill** returns the SKILL.md body with the files listed, instead of a bundle outline. Explicit `section`/`map`/pinned-version reads keep the old behavior; a SKILL.md over `FULL_DOC_MAX` falls back to the outline, and the URI read clips — both new paths honor the same ceilings every other content read does.
- `brandprintMember` now shares the `skillReading` helper (output byte-identical; the existing Brandprint resource test pins it).

Deliberately not done: per-skill MCP resources for workspace skills (the catalog + read cover discovery without re-implementing authorization in a resource handler), and the local `@derive-to/mcp` compat server's read parity (follow-up).

## Verified

- New tests watched failing first (catalog, URI read, plain-read body, instructions count).
- Adversarial review ran against the diff; its four findings are all fixed in this PR: unclipped skill bodies, the per-request count query (now initialize-only after the round-trip budget suite also caught it), the serialized catalog N+1 (parallel, capped at 25), and the budget suite measuring only the zero-skill instructions variant (it now publishes a skill first, so the count-bearing sentence is what the 2,400-char budget measures).
- `pnpm verify` green via the pre-push hook; mcp.test.ts 108, budget 5, round-trip budget 3 all pass.
