### PR TITLE
Wait for artifact layouts before rendering previews

### DIFF
--- a/apps/api/src/preview-cf.ts
+++ b/apps/api/src/preview-cf.ts
@@ -4,6 +4,8 @@ import {
   assertRenderedDocumentOk,
   type Renderer,
   type ScreenshotOpts,
+  sampleRenderLayout,
+  waitForRenderQuiescence,
 } from "./previews"
 
 /**
@@ -26,6 +28,11 @@ export const cfBrowserRenderer = (binding: BrowserWorker): Renderer => ({
       assertNavigationOk(
         await page.goto(url, { waitUntil: "networkidle0", timeout: opts.timeoutMs }),
         url,
+      )
+      await waitForRenderQuiescence(
+        () => page.evaluate(sampleRenderLayout),
+        (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+        { timeoutMs: Math.min(2_500, Math.max(600, Math.floor(opts.timeoutMs / 5))) },
       )
       assertRenderedDocumentOk(
         await page.evaluate(() => {

--- a/apps/api/src/preview-node.ts
+++ b/apps/api/src/preview-node.ts
@@ -4,6 +4,8 @@ import {
   assertRenderedDocumentOk,
   type Renderer,
   type ScreenshotOpts,
+  sampleRenderLayout,
+  waitForRenderQuiescence,
 } from "./previews"
 
 /** A Renderer backed by a locally-installed Playwright Chromium. Node self-host only —
@@ -21,6 +23,11 @@ export const playwrightRenderer = (): Renderer => ({
       assertNavigationOk(
         await page.goto(url, { waitUntil: "networkidle", timeout: opts.timeoutMs }),
         url,
+      )
+      await waitForRenderQuiescence(
+        () => page.evaluate(sampleRenderLayout),
+        (ms) => page.waitForTimeout(ms),
+        { timeoutMs: Math.min(2_500, Math.max(600, Math.floor(opts.timeoutMs / 5))) },
       )
       assertRenderedDocumentOk(
         await page.evaluate(() => ({

--- a/apps/api/src/previews.ts
+++ b/apps/api/src/previews.ts
@@ -71,6 +71,125 @@ export interface Renderer {
   screenshot(url: string, opts: ScreenshotOpts): Promise<Uint8Array>
 }
 
+/** A cheap geometry fingerprint sampled inside the artifact page before a screenshot.
+ *  Network idle is not a render-complete signal: client code can populate a gallery on
+ *  the next task, image decode can move it, and a screenshot taken in that gap stores a
+ *  convincing shell with a blank middle. Both browser runtimes collect this same shape. */
+export interface RenderLayoutSnapshot {
+  readyState: string
+  pendingImages: number
+  scrollWidth: number
+  scrollHeight: number
+  bodyTextLength: number
+  visibleElements: number
+  layoutFingerprint: string
+}
+
+/** Runs inside Chromium through page.evaluate. Keep it closure-free and describe the tiny
+ * DOM surface explicitly because the Cloudflare Worker build intentionally has no DOM libs. */
+export const sampleRenderLayout = (): RenderLayoutSnapshot => {
+  const pageGlobal = globalThis as unknown as {
+    document: {
+      readyState: string
+      images: Array<{ loading: string; complete: boolean }>
+      documentElement: { scrollWidth: number; scrollHeight: number }
+      body?: {
+        innerText: string
+        scrollWidth: number
+        scrollHeight: number
+        querySelectorAll(selector: string): Array<{
+          tagName: string
+          getBoundingClientRect(): { left: number; top: number; width: number; height: number }
+        }>
+      } | null
+    }
+    getComputedStyle(element: unknown): { display: string; visibility: string }
+  }
+  const body = pageGlobal.document.body
+  let visibleElements = 0
+  const geometry: string[] = []
+  for (const element of body?.querySelectorAll("*") ?? []) {
+    const rect = element.getBoundingClientRect()
+    if (rect.width <= 0 || rect.height <= 0) continue
+    const style = pageGlobal.getComputedStyle(element)
+    if (style.display === "none" || style.visibility === "hidden") continue
+    visibleElements += 1
+    if (geometry.length < 500)
+      geometry.push(
+        `${element.tagName}:${Math.round(rect.left)},${Math.round(rect.top)},${Math.round(rect.width)},${Math.round(rect.height)}`,
+      )
+  }
+  return {
+    readyState: pageGlobal.document.readyState,
+    pendingImages: [...pageGlobal.document.images].filter(
+      (image) => image.loading !== "lazy" && !image.complete,
+    ).length,
+    scrollWidth: Math.max(pageGlobal.document.documentElement.scrollWidth, body?.scrollWidth ?? 0),
+    scrollHeight: Math.max(
+      pageGlobal.document.documentElement.scrollHeight,
+      body?.scrollHeight ?? 0,
+    ),
+    bodyTextLength: body?.innerText.length ?? 0,
+    visibleElements,
+    layoutFingerprint: geometry.join("|"),
+  }
+}
+
+export interface RenderQuiescenceOptions {
+  timeoutMs?: number
+  intervalMs?: number
+  /** Number of consecutive matching transitions. Two means three identical samples. */
+  stableTransitions?: number
+}
+
+const layoutKey = (sample: RenderLayoutSnapshot): string =>
+  [
+    sample.scrollWidth,
+    sample.scrollHeight,
+    sample.bodyTextLength,
+    sample.visibleElements,
+    sample.layoutFingerprint,
+  ].join(":")
+
+/** Wait until the loaded artifact has finished constructing its visible layout.
+ *
+ * This is deliberately geometry-based instead of timer-based. A fixed sleep still races a
+ * slower artifact, while `networkidle` fires before DOM work scheduled after a fetch. Three
+ * matching samples also tolerate animated canvases and videos: their element geometry is
+ * stable even though their pixels keep changing.
+ */
+export const waitForRenderQuiescence = async (
+  sample: () => Promise<RenderLayoutSnapshot>,
+  delay: (ms: number) => Promise<void>,
+  options: RenderQuiescenceOptions = {},
+): Promise<RenderLayoutSnapshot> => {
+  const timeoutMs = options.timeoutMs ?? 2_500
+  const intervalMs = options.intervalMs ?? 120
+  const stableTransitions = options.stableTransitions ?? 2
+  const attempts = Math.max(stableTransitions + 1, Math.ceil(timeoutMs / intervalMs))
+  let previousKey: string | null = null
+  let stable = 0
+  let last: RenderLayoutSnapshot | null = null
+
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    const current = await sample()
+    last = current
+    const ready = current.readyState === "complete" && current.pendingImages === 0
+    const key = layoutKey(current)
+    stable = ready && previousKey === key ? stable + 1 : 0
+    if (ready && stable >= stableTransitions) return current
+    // A matching geometry sample taken while the document was not ready is not a
+    // stable transition. Clear it so the first ready sample starts a fresh window.
+    previousKey = ready ? key : null
+    if (attempt < attempts - 1) await delay(intervalMs)
+  }
+
+  const state = last
+    ? `readyState=${last.readyState}, pendingImages=${last.pendingImages}, visibleElements=${last.visibleElements}`
+    : "no layout sample"
+  throw new Error(`render did not settle before screenshot (${state})`)
+}
+
 /**
  * Refuse to screenshot an error page.
  *

--- a/apps/api/test/previews.test.ts
+++ b/apps/api/test/previews.test.ts
@@ -19,6 +19,7 @@ import {
   runRenderTick,
   startPreviewWorker,
   sweepMissingRenders,
+  waitForRenderQuiescence,
 } from "../src/previews"
 
 // ---------------------------------------------------------------------------
@@ -387,6 +388,83 @@ describe("previews: refusing to screenshot an error page", () => {
     expect(msg).toContain("/pv/<redacted>/")
     expect(msg).not.toContain("SECRETSIG")
     expect(msg).not.toContain("eyJhbGciOi")
+  })
+})
+
+describe("previews: waiting for visible layout quiescence", () => {
+  const layout = (
+    fingerprint: string,
+    overrides: Partial<{
+      readyState: string
+      pendingImages: number
+      visibleElements: number
+      bodyTextLength: number
+    }> = {},
+  ) => ({
+    readyState: overrides.readyState ?? "complete",
+    pendingImages: overrides.pendingImages ?? 0,
+    scrollWidth: 1200,
+    scrollHeight: 1800,
+    bodyTextLength: overrides.bodyTextLength ?? 120,
+    visibleElements: overrides.visibleElements ?? 12,
+    layoutFingerprint: fingerprint,
+  })
+
+  it("waits past a stable shell until a late gallery has itself stabilized", async () => {
+    const samples = [
+      layout("shell", { visibleElements: 12 }),
+      layout("shell+gallery", { visibleElements: 47, bodyTextLength: 430 }),
+      layout("shell+gallery", { visibleElements: 47, bodyTextLength: 430 }),
+      layout("shell+gallery", { visibleElements: 47, bodyTextLength: 430 }),
+    ]
+    let calls = 0
+    let delays = 0
+
+    const settled = await waitForRenderQuiescence(
+      async () =>
+        samples[Math.min(calls++, samples.length - 1)] ?? layout("unexpected missing sample"),
+      async () => {
+        delays += 1
+      },
+      { intervalMs: 1, timeoutMs: 10, stableTransitions: 2 },
+    )
+
+    expect(settled.layoutFingerprint).toBe("shell+gallery")
+    expect(settled.visibleElements).toBe(47)
+    expect(calls).toBe(4)
+    expect(delays).toBe(3)
+  })
+
+  it("does not settle while eager images are still loading", async () => {
+    const samples = [
+      layout("complete-layout", { pendingImages: 1 }),
+      layout("complete-layout", { pendingImages: 1 }),
+      layout("complete-layout"),
+      layout("complete-layout"),
+      layout("complete-layout"),
+    ]
+    let calls = 0
+
+    await waitForRenderQuiescence(
+      async () =>
+        samples[Math.min(calls++, samples.length - 1)] ?? layout("unexpected missing sample"),
+      async () => {},
+      { intervalMs: 1, timeoutMs: 10, stableTransitions: 2 },
+    )
+
+    expect(calls).toBe(5)
+  })
+
+  it("fails instead of storing a screenshot when layout never settles", async () => {
+    let calls = 0
+    await expect(
+      waitForRenderQuiescence(
+        async () => layout(`moving-${calls++}`),
+        async () => {},
+        { intervalMs: 1, timeoutMs: 4, stableTransitions: 2 },
+      ),
+    ).rejects.toThrow(/render did not settle before screenshot/)
+    expect(calls).toBe(4)
   })
 })
 


### PR DESCRIPTION
## What changed

- Sample visible DOM geometry after network idle in both preview renderers.
- Require three identical, ready layout samples before storing a screenshot.
- Keep waiting while eager images are incomplete.
- Fail the render when the layout never settles instead of saving a convincing blank shell.

## Why

Client-rendered artifacts can add their primary gallery after network idle. The preview worker previously captured that transition and stored a shell with an empty central canvas. This makes render readiness depend on stable visible layout rather than network timing alone.

## Verification

- pnpm verify
- 250 API test files passed; 2 skipped
- 2,380 API tests passed; 3 skipped
- Node and Cloudflare Worker typechecks passed
- Added focused coverage for late gallery population, pending images, and never-settling layouts

## Reproduction artifact

https://derive.to/artifacts/sift-for-accenture-recommended-single-and-packet-2ks00lnp

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/755"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789587871&installation_model_id=428097&pr_number=755&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F755&signature=274ef88218bd858cc34cb5dabb838019711691f82fc8f743a69a1b3f92fc76ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->