### PR TITLE
feat(skills): agents load the last human-approved skill version

### DIFF
--- a/apps/api/src/mcp-tools/read.ts
+++ b/apps/api/src/mcp-tools/read.ts
@@ -1,4 +1,5 @@
 import {
+  approvedOrCurrent,
   artifactUrl,
   DECK_TEMPLATE,
   type DocMap,
@@ -553,7 +554,13 @@ export function registerReadTool(tc: ToolContext): void {
       // after the artifact lookup, so a context named like a doc can never shadow it.
       if (!r) return (await contextPackage()) ?? notFound(docId)
       const a = r.a
-      const n = version ?? a.current_version
+      // A skill's default version is the one delivery serves (the last approved, else
+      // current), and it applies to EVERY rung — body, sections, outline, render — so
+      // the footer's "read this file" suggestions can't fetch a different version than
+      // the body they rode in on. An explicit `version` always wins.
+      const n =
+        version ??
+        (a.current_content_type === SKILL_CONTENT_TYPE ? approvedOrCurrent(a) : a.current_version)
       if (n < 1 || n > a.current_version)
         return err(`No version ${n} for "${short_id}" — it has versions 1..${a.current_version}.`)
       const v = await ctx.meta.getVersion(a.id, n)
@@ -976,15 +983,17 @@ export function registerReadTool(tc: ToolContext): void {
       const pages = Object.keys(manifest.files).map(cleanPath)
       // A skill reads as its document: the SKILL.md body, with the bundle's files
       // listed alongside. The common caller was just told to follow this procedure,
-      // so the outline-first bundle default is the wrong rung here. Explicit
-      // `section` still opens one file; a pinned past version keeps the bundle view.
+      // so the outline-first bundle default is the wrong rung here. `n` already
+      // defaulted to the served (approved-or-current) version above — the response
+      // says which. Explicit `section` still opens one file; naming any other
+      // version keeps the ordinary bundle view.
       if (
         a.current_content_type === SKILL_CONTENT_TYPE &&
         !section &&
         !wantMap &&
         !node &&
         !lines &&
-        n === a.current_version
+        n === approvedOrCurrent(a)
       ) {
         const reading = await skillReading(ctx, a)
         // A giant SKILL.md keeps the ordinary outline path below — the same ceiling
@@ -994,7 +1003,10 @@ export function registerReadTool(tc: ToolContext): void {
             short_id,
             title: reading.name ?? a.title,
             kind: "skill",
-            version: n,
+            version: reading.version,
+            ...(reading.version !== a.current_version
+              ? { note: `Approved version; the latest draft is v${a.current_version}.` }
+              : {}),
             url,
             content: reading.body,
             files: pages,

--- a/apps/api/src/mcp-util.ts
+++ b/apps/api/src/mcp-util.ts
@@ -7,6 +7,7 @@
 
 import {
   type ArtifactRecord,
+  approvedOrCurrent,
   type BundleManifest,
   bundleDoc,
   type ContextRecord,
@@ -285,7 +286,8 @@ export const summarizeComment = (c: {
 // multi-page artifact's actual files, not just its entry doc.
 export const manifestOf = (ctx: AppContext, v: VersionRecord) => sharedManifestOf(ctx.blobs, v)
 
-/** A skill's declared identity and reading body, from its current version: frontmatter
+/** A skill's declared identity and reading body, from its SERVED version — the last
+ *  human-approved one, or current when none exists (approvedOrCurrent): frontmatter
  *  name/description, the SKILL.md body with frontmatter stripped, and the bundle's
  *  other files (invisible unless announced). Never throws — null covers a missing
  *  version, an unreadable blob, and a corrupt manifest alike (sourceText re-parses the
@@ -299,9 +301,10 @@ export const skillReading = async (
   description: string | null
   body: string
   others: string[]
+  version: number
 } | null> => {
   try {
-    const v = await ctx.meta.getVersion(a.id, a.current_version)
+    const v = await ctx.meta.getVersion(a.id, approvedOrCurrent(a))
     const manifest = v ? await manifestOf(ctx, v) : null
     const entry = v ? await ctx.sourceText(v) : null // the SKILL.md, frontmatter intact
     if (!manifest || entry === null) return null
@@ -311,6 +314,7 @@ export const skillReading = async (
       description: info.description,
       body: parseFrontmatter(entry).body,
       others: info.files.map((f) => f.path).filter((p) => p !== info.entry),
+      version: approvedOrCurrent(a),
     }
   } catch {
     return null
@@ -374,7 +378,8 @@ export const skillsCatalog = async (
         short_id: a.short_id,
         name: reading?.name ?? a.title ?? a.short_id,
         description: reading?.description ?? null,
-        version: a.current_version,
+        // The version delivery serves — approved when a human has approved one.
+        version: approvedOrCurrent(a),
         read: `derive://skills/${a.short_id}`,
       }
     }),

--- a/apps/api/src/mcp.ts
+++ b/apps/api/src/mcp.ts
@@ -57,6 +57,7 @@ import {
   AGENT_INBOX_PAGE,
   type AgentRecord,
   type ArtifactRecord,
+  approvedOrCurrent,
   brandprintInstructions,
   DECK_TEMPLATE,
   pendingRequestsPointer,
@@ -286,8 +287,11 @@ async function buildServer(
       async (uri) => {
         if (m.body !== undefined)
           return { contents: [{ uri: uri.href, mimeType: m.mimeType, text: m.body }] }
+        // The lazy body serves the delivered version — approved when one exists —
+        // so a skill whose prepared body failed at connect can't fall back to an
+        // unapproved draft here.
         const art = await ctx.meta.getByShortId(doc.short_id)
-        const v = art ? await ctx.meta.getVersion(art.id, art.current_version) : null
+        const v = art ? await ctx.meta.getVersion(art.id, approvedOrCurrent(art)) : null
         const body = v ? await ctx.sourceText(v) : null
         return { contents: [{ uri: uri.href, mimeType: "text/markdown", text: body ?? "" }] }
       },

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -1,6 +1,7 @@
 import {
   type AnyDocEdit,
   type ArtifactRecord,
+  approvedOrCurrent,
   artifactUrl,
   assertedOnly,
   type BundleDoc,
@@ -2407,7 +2408,11 @@ export const artifactRoutes = (ctx: AppContext) => {
     if (!artifact || artifact.current_version === 0 || !(await authorize(c, "read", artifact)))
       return fail(c, 404, "not found")
     if (artifact.removed_at) return fail(c, 410, TOMBSTONE)
-    const v = c.req.query("v") ? Number(c.req.query("v")) : artifact.current_version
+    // "approved" resolves the human-approved version (current when none exists) — one
+    // sentinel every skill-delivery lane shares instead of each reimplementing the rule.
+    const vq = c.req.query("v")
+    const v =
+      vq === "approved" ? approvedOrCurrent(artifact) : vq ? Number(vq) : artifact.current_version
     if (!Number.isInteger(v)) return fail(c, 400, "bad version")
     const version = await meta.getVersion(artifact.id, v)
     if (!version) return fail(c, 404, `no version ${v}`)

--- a/apps/api/src/routes/contexts.ts
+++ b/apps/api/src/routes/contexts.ts
@@ -1,5 +1,6 @@
 import { refRouter } from "@derive/broker"
 import {
+  approvedOrCurrent,
   type ContextAskerRecord,
   type ContextRecord,
   decodeCursor,
@@ -1094,7 +1095,12 @@ export const contextRoutes = (ctx: AppContext) => {
         members.push({
           short_id: a.short_id,
           title: a.title,
-          version: a.current_version,
+          // Every member materializes at the version delivery serves: approved when a
+          // human has ever approved one, current otherwise (never-approved artifacts
+          // resolve to current, so plain notes behave as before). Keying this on
+          // skill-ness instead would let a draft that renames SKILL.md shed its gate
+          // and ride the notes lane at current.
+          version: approvedOrCurrent(a),
           is_skill: a.current_content_type === SKILL_CONTENT_TYPE,
         })
       }

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -1869,6 +1869,60 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(sec).toContain("echo ok")
   })
 
+  it("skill delivery serves the approved version once one exists", async () => {
+    const { app, token, meta } = appWithGrant(dir, "skillgate", "openid derive:read derive:publish")
+    const skill = JSON.parse(
+      toolText(
+        await call(app, token, "publish", {
+          title: "Gated skill",
+          files: { "SKILL.md": "---\nname: gated\n---\n\n# Gated\n\nApproved wording.\n" },
+        }),
+      ),
+    ).short_id
+    // Publish a draft v2 the team hasn't approved.
+    await call(app, token, "publish", {
+      short_id: skill,
+      files: { "SKILL.md": "---\nname: gated\n---\n\n# Gated\n\nDraft wording.\n" },
+    })
+    // Never approved: delivery serves current (the draft).
+    const before = JSON.parse(toolText(await call(app, token, "read", { short_id: skill })))
+    expect(before.version).toBe(2)
+    expect(before.content).toContain("Draft wording.")
+
+    // A human approves v1 (review round; the proposal path stamps the same pointer).
+    const art = await meta.getByShortId(skill)
+    if (!art) throw new Error("no artifact")
+    const round = `rr_gate_${skill}`
+    await meta.createReviewRound({
+      id: round,
+      artifact_id: art.id,
+      version: 1,
+      requested_by: "agent",
+      requested_for: "u_gate",
+    })
+    await meta.resolveReviewRound(round, { state: "approved" })
+
+    // Every delivery lane now serves v1; the response says so.
+    const gated = JSON.parse(toolText(await call(app, token, "read", { short_id: skill })))
+    expect(gated.version).toBe(1)
+    expect(gated.content).toContain("Approved wording.")
+    expect(gated.note).toContain("v2")
+    const uri = JSON.parse(
+      toolText(await call(app, token, "read", { short_id: `derive://skills/${skill}` })),
+    )
+    expect(uri.content).toContain("Approved wording.")
+    const cat = JSON.parse(
+      toolText(await call(app, token, "read", { short_id: "derive://skills" })),
+    )
+    expect(cat.workspace.find((s: { short_id: string }) => s.short_id === skill)?.version).toBe(1)
+
+    // Naming the draft explicitly still reads it, as an ordinary bundle.
+    const draft = JSON.parse(
+      toolText(await call(app, token, "read", { short_id: skill, version: 2 })),
+    )
+    expect(draft.pages).toBeDefined()
+  })
+
   it("instructions point at the skills catalog, with the workspace's count", async () => {
     const { app, token } = appWithGrant(dir, "skillinstr", "openid derive:read derive:publish")
     const before = (await rpc(app, token, initBody)).parsed?.result as { instructions?: string }

--- a/apps/api/test/skills-gate.test.ts
+++ b/apps/api/test/skills-gate.test.ts
@@ -1,0 +1,103 @@
+import { newId } from "@derive/core"
+import { describe, expect, it } from "vitest"
+import {
+  app,
+  as,
+  makeAuthedApp,
+  meta,
+  proposeAs,
+  publishAs,
+  type TestUser,
+  upload,
+} from "./helpers"
+
+// The approved-version gate: a proposal or review approval stamps
+// artifact.approved_version, and skill/agent delivery serves that version
+// (approvedOrCurrent) while humans keep seeing current. `?v=approved` on the
+// content API is the shared resolution point.
+
+const owner: TestUser = { id: "u_gate_owner", email: "owner@gate.test", name: "Gwen" }
+const ed: TestUser = { id: "u_gate_ed", email: "ed@gate.test", name: "Ed" }
+
+describe("approved_version writes", () => {
+  it("a proposal approval stamps the decided version", async () => {
+    const { app: a, meta: m } = makeAuthedApp("skills-gate-prop", [owner, ed], "editor")
+    const shortId = (
+      await (await publishAs(a, "<h1>one</h1>", { visibility: "org" }, as(owner.email))).json()
+    ).short_id
+    const pr = await (await proposeAs(a, shortId, "<h1>two</h1>", as(ed.email))).json()
+    const ap = await a.request(`/v1/artifacts/${shortId}/proposals/${pr.id}/approve`, {
+      method: "POST",
+      headers: as(owner.email),
+    })
+    expect(ap.status).toBe(200)
+    const art = await m.getByShortId(shortId)
+    expect(art?.approved_version).toBe(2)
+    expect(art?.current_version).toBe(2)
+
+    // A later direct publish moves current past approved; the pointer stays put.
+    await publishAs(a, "<h1>three</h1>", {}, as(owner.email), shortId)
+    const after = await m.getByShortId(shortId)
+    expect(after?.current_version).toBe(3)
+    expect(after?.approved_version).toBe(2)
+  })
+
+  it("a review-round approval stamps the round's version and never lowers it", async () => {
+    const short = (await (await upload("g.md", "# one", { title: "Gate doc" })).json()).short_id
+    await upload("g.md", "# two", {}, short)
+    const art = await meta.getByShortId(short)
+    if (!art) throw new Error("no artifact")
+
+    const r2 = newId("rr")
+    await meta.createReviewRound({
+      id: r2,
+      artifact_id: art.id,
+      version: 2,
+      requested_by: "agent",
+      requested_for: "u_gate_owner",
+    })
+    await meta.resolveReviewRound(r2, { state: "approved" })
+    expect((await meta.getByShortId(short))?.approved_version).toBe(2)
+
+    // Approving a stale round (requested at v1) must not roll delivery back.
+    const r1 = newId("rr")
+    await meta.createReviewRound({
+      id: r1,
+      artifact_id: art.id,
+      version: 1,
+      requested_by: "agent",
+      requested_for: "u_gate_ed",
+    })
+    await meta.resolveReviewRound(r1, { state: "approved" })
+    expect((await meta.getByShortId(short))?.approved_version).toBe(2)
+  })
+})
+
+describe("?v=approved on the content API", () => {
+  it("resolves the approved version, and current when none exists", async () => {
+    const short = (await (await upload("s.md", "# one", { title: "Sentinel doc" })).json()).short_id
+    // Never approved: the sentinel serves current.
+    await upload("s.md", "# two", {}, short)
+    expect(await (await app.request(`/v1/artifacts/${short}/content?v=approved`)).text()).toBe(
+      "# two",
+    )
+
+    const art = await meta.getByShortId(short)
+    if (!art) throw new Error("no artifact")
+    const round = newId("rr")
+    await meta.createReviewRound({
+      id: round,
+      artifact_id: art.id,
+      version: 1,
+      requested_by: "agent",
+      requested_for: "u_gate_owner",
+    })
+    await meta.resolveReviewRound(round, { state: "approved" })
+
+    // Approved v1 gates the sentinel to v1; the plain read still serves current.
+    expect(await (await app.request(`/v1/artifacts/${short}/content?v=approved`)).text()).toBe(
+      "# one",
+    )
+    expect(await (await app.request(`/v1/artifacts/${short}/content`)).text()).toBe("# two")
+  })
+})

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -74,7 +74,9 @@ The local compatibility server is `npx -y @derive-to/mcp` and shares `derive log
 Skills: `read("derive://skills")` returns the catalog (core skills plus the connected
 workspace's own team skills); read one with `derive://skills/<name-or-short-id>`.
 Reading a skill artifact by short id returns its SKILL.md body with the bundle's
-files listed.
+files listed. Skill delivery serves the last human-approved version when one exists
+(a proposal or review approval sets it); until a skill is ever approved, it serves
+current. `?v=approved` on the content API resolves the same rule.
 
 Remote tools (ten): find, read, catch_up, comment, stage, publish, organize,
 checkpoint, use, list_workspaces.

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -17,6 +17,7 @@ CREATE TABLE IF NOT EXISTS artifact (
   spa INTEGER NOT NULL DEFAULT 0,
   locked INTEGER NOT NULL DEFAULT 0,
   current_version INTEGER NOT NULL DEFAULT 0,
+  approved_version INTEGER,
   current_content_type TEXT,
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
   updated_at TEXT,

--- a/packages/cli/src/skills.js
+++ b/packages/cli/src/skills.js
@@ -36,20 +36,36 @@ export function skillSlug(name) {
   return s || null
 }
 
-/** Fetch one pinned skill version's files WITHOUT writing them (so a caller can resolve
- *  a collision-free directory name across the whole set before touching disk). Returns
- *  { name, entry, files: Map<path, bytes> }; throws if the version has no readable tree. */
+/** Fetch one skill version's files WITHOUT writing them (so a caller can resolve a
+ *  collision-free directory name across the whole set before touching disk). Returns
+ *  { name, entry, files: Map<path, bytes> }; throws if the version has no readable tree.
+ *
+ *  A pinned entry fetches its exact version. An unpinned one (version null) asks the
+ *  server for "approved" — the last human-approved version, current when none exists.
+ *  Only a server that predates that sentinel (it 400s "bad version") falls back to
+ *  plain current; any other failure fails the skill. A broad catch here would serve
+ *  the unapproved draft on a transient error, silently defeating the gate. */
 export async function fetchSkill(api, { id, version }) {
-  const outline = await api.outline(id, version)
-  const pages = outline?.pages ?? []
-  if (pages.length === 0) throw new Error("no files in this version")
-  const entry = String(outline.entry ?? "SKILL.md").replace(/^\//, "")
-  const files = new Map()
-  for (const p of pages) {
-    const path = String(p.path).replace(/^\//, "")
-    files.set(path, await api.file(id, path, version))
+  const fetchAt = async (v) => {
+    const outline = await api.outline(id, v)
+    const pages = outline?.pages ?? []
+    if (pages.length === 0) throw new Error("no files in this version")
+    const entry = String(outline.entry ?? "SKILL.md").replace(/^\//, "")
+    const files = new Map()
+    for (const p of pages) {
+      const path = String(p.path).replace(/^\//, "")
+      files.set(path, await api.file(id, path, v))
+    }
+    return { name: skillNameFrom(files.get(entry)), entry, files }
   }
-  return { name: skillNameFrom(files.get(entry)), entry, files }
+  if (version != null) return fetchAt(version)
+  try {
+    return await fetchAt("approved")
+  } catch (e) {
+    if (!/→ 400\b/.test(String(e?.message ?? e))) throw e
+    console.error(`[skills] ${id}: server predates v=approved, serving current`)
+    return fetchAt(null)
+  }
 }
 
 /** Write a fetched skill under destRoot/<dir>/. A skills dir is DERIVED state (like the

--- a/packages/cli/test/skills.test.js
+++ b/packages/cli/test/skills.test.js
@@ -4,6 +4,7 @@ import { join } from "node:path"
 import { describe, expect, it } from "vitest"
 import {
   conventionsBlock,
+  fetchSkill,
   materializeNotes,
   materializeSkills,
   mergeSkillLayers,
@@ -122,6 +123,41 @@ describe("materializeSkills", () => {
     )
     expect(cat[0]).toMatchObject({ id: "missing", ok: false })
     expect(cat[1]).toMatchObject({ id: "ok1", dir: "good", ok: true })
+  })
+})
+
+describe("fetchSkill version resolution", () => {
+  const skillFiles = { entry: "SKILL.md", files: { "SKILL.md": "---\nname: vprobe\n---\n" } }
+
+  it("a pinned entry fetches its exact version; an unpinned one asks for approved", async () => {
+    const api = mockApi({ sk: { 3: skillFiles, approved: skillFiles } })
+    await fetchSkill(api, { id: "sk", version: 3 })
+    const unpinned = await fetchSkill(api, { id: "sk", version: null })
+    expect(unpinned.name).toBe("vprobe")
+  })
+
+  it("falls back to current only for the old-server 400, never on other failures", async () => {
+    // An old self-host 400s v=approved; the skill must degrade to current, not drop.
+    const oldServer = {
+      ...mockApi({ sk: { null: skillFiles } }),
+      outline: async (id, v) => {
+        if (v === "approved")
+          throw new Error(`/v1/artifacts/${id}/content?outline=1&v=approved → 400: bad version`)
+        return mockApi({ sk: { null: skillFiles } }).outline(id, v)
+      },
+    }
+    expect((await fetchSkill(oldServer, { id: "sk", version: null })).name).toBe("vprobe")
+
+    // A transient failure must FAIL the skill, not silently serve the unapproved draft.
+    const flaky = {
+      ...mockApi({ sk: { null: skillFiles } }),
+      outline: async (id, v) => {
+        if (v === "approved")
+          throw new Error(`/v1/artifacts/${id}/content?outline=1&v=approved → 503`)
+        return mockApi({ sk: { null: skillFiles } }).outline(id, v)
+      },
+    }
+    await expect(fetchSkill(flaky, { id: "sk", version: null })).rejects.toThrow("503")
   })
 })
 

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -134,6 +134,10 @@ export interface ArtifactRecord {
   /** Locked: direct publishes are rejected; changes must go through a proposal. */
   locked: 0 | 1
   current_version: number
+  /** The last version a human approved (a proposal's decided_version, or a review
+   *  round's version — never lowered). Null until the first approval. Agent skill
+   *  delivery serves `approved_version ?? current_version` (see approvedOrCurrent). */
+  approved_version: number | null
   /** Denormalized from the current version row — updated on every publish. */
   current_content_type: string | null
   created_at: string

--- a/packages/core/src/skill.ts
+++ b/packages/core/src/skill.ts
@@ -91,3 +91,12 @@ export const workspaceSkillsInstructions = (count: number): string =>
   count > 0
     ? `${count === 100 ? "100+" : count} team skill${count === 1 ? "" : "s"} here — read derive://skills for the catalog. `
     : `Team skills: read derive://skills for the catalog. `
+
+/** The version agent skill delivery serves. A never-reviewed skill serves current, so
+ *  solo workspaces feel no gate; the first human approval pins delivery to the approved
+ *  version, and later drafts stop reaching agents until someone approves again. An
+ *  explicit manifest pin still wins over this — a pin is a deliberate fixed choice. */
+export const approvedOrCurrent = (a: {
+  approved_version: number | null
+  current_version: number
+}): number => a.approved_version ?? a.current_version

--- a/packages/db/src/d1.ts
+++ b/packages/db/src/d1.ts
@@ -86,6 +86,7 @@ export function createD1Store(d1: D1Database): MetaStore {
           .prepare(
             `UPDATE artifact
              SET current_version = current_version + 1,
+                 approved_version = current_version + 1,
                  current_content_type = (SELECT content_type FROM proposal WHERE id = ? AND state = 'open'),
                  updated_at = ?,
                  author_name = (SELECT author FROM proposal WHERE id = ? AND state = 'open'),

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -60,6 +60,11 @@ export const artifact = pgTable("artifact", {
   spa: integer("spa").$type<0 | 1>().notNull().default(0),
   locked: integer("locked").$type<0 | 1>().notNull().default(0),
   current_version: integer("current_version").notNull().default(0),
+  // The last version a human approved: proposal approval stamps its decided_version,
+  // review-round approval stamps the round's version (never lowering it). Null until
+  // the first approval. Agent skill delivery serves approved_version ?? current_version,
+  // so approving once implicitly gates later drafts. Nullable — ADD COLUMN clean.
+  approved_version: integer("approved_version"),
   current_content_type: text("current_content_type"),
   created_at: text("created_at").notNull().$defaultFn(isoNow),
   // Set on every new version; null until first versioned (coalesces to created_at).

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -3984,6 +3984,8 @@ export class PgMetaStore implements MetaStore {
         .update(artifact)
         .set({
           current_version: n,
+          // The approved-version pointer: this new version IS the approved one.
+          approved_version: n,
           current_content_type: p.content_type,
           updated_at: now,
           author_name: p.author,
@@ -4086,7 +4088,20 @@ export class PgMetaStore implements MetaStore {
       .set({ ...fields, resolved_at: new Date().toISOString() })
       .where(and(eq(reviewRound.id, id), eq(reviewRound.state, "pending")))
       .returning()
-    return rows[0] ?? null
+    const updated = rows[0] ?? null
+    // An approval moves the artifact's approved-version pointer, never lowering it:
+    // the round's version is what the human actually looked at, and a stale round
+    // approved after a newer one must not roll delivery back. Rounds at version 0
+    // (an unversioned artifact) stamp nothing — approved_version = 0 would read as
+    // "serve version 0" through approvedOrCurrent, not as "never approved".
+    if (updated && fields.state === "approved" && updated.version > 0)
+      await this.db
+        .update(artifact)
+        .set({
+          approved_version: sql`GREATEST(COALESCE(${artifact.approved_version}, 0), ${updated.version})`,
+        })
+        .where(eq(artifact.id, updated.artifact_id))
+    return updated
   }
 
   // ---- Contexts + sessions -------------------------------------------------

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -3371,13 +3371,29 @@ export function makeRepos(db: SqliteDb) {
       resolved_by?: string | null
       resolved_by_name?: string | null
     },
-  ): Promise<ReviewRoundRecord | null> =>
-    (await db
-      .update(reviewRound)
-      .set({ ...fields, resolved_at: new Date().toISOString() })
-      .where(and(eq(reviewRound.id, id), eq(reviewRound.state, "pending")))
-      .returning()
-      .get()) ?? null
+  ): Promise<ReviewRoundRecord | null> => {
+    const updated =
+      (await db
+        .update(reviewRound)
+        .set({ ...fields, resolved_at: new Date().toISOString() })
+        .where(and(eq(reviewRound.id, id), eq(reviewRound.state, "pending")))
+        .returning()
+        .get()) ?? null
+    // An approval moves the artifact's approved-version pointer, never lowering it:
+    // the round's version is what the human actually looked at, and a stale round
+    // approved after a newer one must not roll delivery back. Rounds at version 0
+    // (an unversioned artifact) stamp nothing — approved_version = 0 would read as
+    // "serve version 0" through approvedOrCurrent, not as "never approved".
+    if (updated && fields.state === "approved" && updated.version > 0)
+      await db
+        .update(artifact)
+        .set({
+          approved_version: sql`MAX(COALESCE(${artifact.approved_version}, 0), ${updated.version})`,
+        })
+        .where(eq(artifact.id, updated.artifact_id))
+        .run()
+    return updated
+  }
 
   // ---- Contexts + sessions -------------------------------------------------
   const createContext = async (x: NewContext): Promise<ContextRecord> =>

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -78,6 +78,9 @@ export const artifact = sqliteTable("artifact", {
   // proposal → approval flow (any editor can toggle it).
   locked: integer("locked").$type<0 | 1>().notNull().default(0),
   current_version: integer("current_version").notNull().default(0),
+  // The last version a human approved (see pg-schema.ts). Null until first approval;
+  // agent skill delivery serves approved_version ?? current_version.
+  approved_version: integer("approved_version"),
   current_content_type: text("current_content_type"),
   created_at: text("created_at").notNull().default(now),
   // Set on every new version (publish/sync); null until first versioned. Drives the

--- a/packages/db/src/sqlite.ts
+++ b/packages/db/src/sqlite.ts
@@ -277,6 +277,8 @@ export function createSqliteStore(path: string): MetaStore & { close(): void } {
         tx.update(artifact)
           .set({
             current_version: n,
+            // The approved-version pointer: this new version IS the approved one.
+            approved_version: n,
             current_content_type: p.content_type,
             updated_at: now,
             author_name: p.author,

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -1994,6 +1994,9 @@ export function runStoreContract(
       expect([amy, bob].filter(Boolean)).toHaveLength(1)
       expect(await store.listVersions(a.id)).toHaveLength(1)
       expect((await store.getArtifactById(a.id))?.current_version).toBe(1)
+      // Approval stamps the delivery pointer — asserted here so all three drivers
+      // (sqlite, pg, d1) keep it; the D1 batch once omitted it and failed open.
+      expect((await store.getArtifactById(a.id))?.approved_version).toBe(1)
       expect((await store.getProposal(p.id))?.decided_by_id).toBe(amy ? "u_amy" : "u_bob")
       await expect(
         store.decideProposal(p.id, {
@@ -2029,6 +2032,22 @@ export function runStoreContract(
       const settled = (await store.listReviewRounds(a.id)).find((item) => item.id === round.id)
       expect(settled?.state).toBe(approved ? "approved" : "sent_back")
       expect(settled?.resolved_by).toBe(approved ? "u_amy" : "u_bob")
+      // A version-0 round never stamps the delivery pointer (0 would read as "serve
+      // version 0", not "never approved"); a real round does, on every driver.
+      expect((await store.getArtifactById(a.id))?.approved_version).toBeNull()
+      const real = await store.createReviewRound({
+        id: uuid(),
+        artifact_id: a.id,
+        version: 1,
+        requested_by: "agent_1",
+        requested_for: "u_bob",
+      })
+      await store.resolveReviewRound(real.id, {
+        state: "approved",
+        resolved_by: "u_bob",
+        resolved_by_name: "Bob",
+      })
+      expect((await store.getArtifactById(a.id))?.approved_version).toBe(1)
     })
   })
 


### PR DESCRIPTION
## Why

PR 3 of the shared-skills plan (workspace docs: `shared-skills-tvdnfjg6`, `shared-skills-the-build-5fzaxc5u`). Skills are instructions injected into agents, and every delivery lane served the latest draft. This is the differentiating half of the feature: agents load the last version a human approved.

## What

One nullable column and one rule.

- **`artifact.approved_version`** (pg + sqlite + regenerated d1 schema, additive) is stamped by the two human approval paths: proposal approval sets its `decided_version` inside the existing transaction; review-round approval sets the round's version — never lowering it, and never stamping a version-0 round (0 would read as "serve version 0" through the `??` rule).
- **Delivery serves `approvedOrCurrent` = `approved_version ?? current_version`.** A never-reviewed skill behaves exactly as before; the first approval turns the gate on implicitly. No flag.
- Applied at: the content API's `?v=approved` sentinel; the MCP read tool's default version for skills (body, sections, outline, render share one default so the files an agent is steered to match the body it read); `skillReading` + the `derive://skills` catalog; **all** Brandprint members in the runner config (keying on skill-ness would let a draft that renames SKILL.md shed the gate and ride the notes lane at current); and the runner's unpinned manifest fetches (`v=approved`, falling back to current **only** on the old-server 400 — any other failure fails the skill rather than silently serving the draft).
- Explicit manifest pins still win. Humans see current everywhere they did before.

## Control review

An adversarial review ran against the design, lane by lane (18 delivery/read lanes enumerated). Its verdict: pointer integrity is strong — both approval routes are double-gated (`authorize("approve")` + `requireDirectHuman`), no MCP tool can decide a review, direct publishes never auto-approve.

Fixed from its findings, in this PR:
- The **D1 driver's** proposal-approve batch omitted the pointer — fail-open for proposal-gated workspaces. Fixed, and the store contract now asserts the stamp on all three drivers (the d1 lane runs it in workerd).
- The runner's **catch-all fallback** would have served the draft on any transient error, indistinguishably. Narrowed to the old-server 400 with a log line; a 503 now fails the skill (fail-closed), pinned by test.
- The Brandprint resource's **lazy body fallback** served current for a skill whose approved blob was unreadable. It now serves the delivered version.
- **Version-0 rounds** would have stamped `approved_version = 0`, which reads as "serve v0", not "never approved". Guarded, pinned in the store contract.

Accepted and documented (each needs its own design, none is an unprivileged bypass):
- **No un-approve/rollback path.** Restoring old content creates a new version but does not move the pointer; recovery is publish-good-then-approve. An explicit un-approve lever is follow-up work.
- A **GitHub-sync kind change** replaces the artifact, resetting the gate — new artifacts are ungated by design.
- **Pin trust equals manifest write-control**: whoever can publish a manifest can pin a draft. The existing lever is locking the manifest artifact.
- The **human surfaces** (`/content` without the sentinel, `/raw`, `.md` pages) deliberately serve current; an agent that self-fetches by URL bypasses the gated lanes.
- A **workspace move** carries the pointer across tenants.

## Verified

- New tests watched failing (the serving rule was disabled and both suites failed for the right reason, then restored). Store-contract assertions run on sqlite, pg, and real-workerd D1 (`pnpm test:d1`, 178 pass).
- `pnpm verify` green via the pre-push hook; the five affected api suites (gate, mcp, both budgets, contexts) pass 150 tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/758"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789595136&installation_model_id=428097&pr_number=758&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F758&signature=3f0e925f27cab1fa802f3c1f28d7b715afc5b5358d6b5fbc54c66145fe69983d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->