### PR TITLE
Add signed-in guest artifact view

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -232,7 +232,11 @@
           },
           "public_history": {
             "type": "boolean",
-            "description": "Owner opt-in: the anonymous public page shows version history. When false, anonymous detail responses carry only the current version."
+            "description": "Owner opt-in: readers without artifact standing can browse version history. When false, their detail responses carry only the current version."
+          },
+          "is_workspace_member": {
+            "type": "boolean",
+            "description": "True when the signed-in caller has an active seat in the artifact's workspace. False for link-only readers and members acting in another workspace."
           },
           "org_id": {
             "type": "string",

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -17,6 +17,7 @@ import {
   encodeCursor,
   formatDiff,
   groupSessions,
+  hasArtifactStanding,
   heavyAssetsAdvisory,
   isHtmlLike,
   isMarkdownBundle,
@@ -1445,6 +1446,9 @@ export const artifactRoutes = (ctx: AppContext) => {
             }
           : undefined,
       )
+      // Workbench actions are scoped to the active workspace. A membership in a
+      // different workspace must not enable controls backed by the active workspace.
+      const isWorkspaceMember = !!viewer && actor.orgRole != null
       if (!can(actor, "read", artifact.workspace_access, artifact.link_role)) {
         // A workspace mismatch is recoverable without weakening the boundary. Tell
         // a signed-in member where to switch only when their full standing would
@@ -1513,6 +1517,7 @@ export const artifactRoutes = (ctx: AppContext) => {
           versions: [],
           sessions: [],
           my_role: effectiveRole(actor, artifact.workspace_access, artifact.link_role),
+          is_workspace_member: isWorkspaceMember,
           tags: [],
           favorite: false,
           collections: [],
@@ -1533,13 +1538,10 @@ export const artifactRoutes = (ctx: AppContext) => {
         viewerId: actor.kind === "user" ? (actor.userId ?? null) : null,
       })
       const allVersions = detail.versions
-      // The public-history gate: unless the owner opted the public page in, an
-      // anonymous caller's history collapses to the current version — the payload
-      // must not leak what the page won't show (version messages and author names
-      // are workbench material). Everything below (versions, sessions, bylines)
-      // derives from this list, so trimming here keeps the response consistent.
+      // Private history requires a workspace seat or collaborator grant. A world
+      // link remains current-version-only even when its holder is signed in.
       const versions =
-        actor.kind === "anon" && !artifact.public_history
+        !hasArtifactStanding(actor, artifact.workspace_access) && !artifact.public_history
           ? allVersions.filter((v) => v.n === artifact.current_version)
           : allVersions
       const me = actor.kind === "user" ? actor.userId : null
@@ -1692,6 +1694,7 @@ export const artifactRoutes = (ctx: AppContext) => {
         }),
         sessions: groupSessions(versions, versionWindowMs),
         my_role: myRole,
+        is_workspace_member: isWorkspaceMember,
         // Show the Made-with-Derive mark on this artifact's public surfaces? False
         // only for white-label workspaces that are also entitled to it (beta, or an
         // active subscription); the viewer reads this single boolean so workspace
@@ -1699,9 +1702,7 @@ export const artifactRoutes = (ctx: AppContext) => {
         // ride in from artifactDetail's batch, so the common case (white-label off)
         // costs no round trip at all here.
         badge: !(await effectiveWhiteLabel(artifact.org_id, detail.settings)),
-        // Owner opt-in: the anonymous public page shows version history. The
-        // client uses it to render the byline dropdown; the server enforces it
-        // above (trimmed versions) and in raw.ts (old-version bytes).
+        // The owner may expose history to readers who lack standing on the artifact.
         public_history: !!artifact.public_history,
         // Open-thread count for the public viewer's sign-in-to-comment pill. Anon
         // never sees comment bodies (collaboration, not content — see comments.ts),
@@ -1762,7 +1763,15 @@ export const artifactRoutes = (ctx: AppContext) => {
         // a different URL every fetch, which silently defeated the cache — measured, an
         // open whose URL matched served in 13ms from cache; the next one re-downloaded
         // 15KB. Validity is unchanged (verifyState still enforces the same max age).
-        raw_token: signState({ rid: artifact.id }, deps.encryptionKey ?? "", rawTokenIssuedAt),
+        raw_token: signState(
+          {
+            rid: artifact.id,
+            history:
+              artifact.public_history || hasArtifactStanding(actor, artifact.workspace_access),
+          },
+          deps.encryptionKey ?? "",
+          rawTokenIssuedAt,
+        ),
         // The detail record can outlive the capability in the browser query cache.
         // Make the lifetime explicit so the viewer never pins an expired token while
         // React Query refreshes the record in the background.

--- a/apps/api/src/routes/raw.ts
+++ b/apps/api/src/routes/raw.ts
@@ -1,4 +1,9 @@
-import { ANCHOR_CLIENT_JS, type ArtifactRecord, isDerivedFactName } from "@derive/core"
+import {
+  ANCHOR_CLIENT_JS,
+  type ArtifactRecord,
+  hasArtifactStanding,
+  isDerivedFactName,
+} from "@derive/core"
 import type { Context } from "hono"
 import { Hono } from "hono"
 import type { AppContext } from "../context"
@@ -28,15 +33,12 @@ export const rawRoutes = (ctx: AppContext) => {
   const { meta, blobs, deps, authorize, actorFor, background } = ctx
   const app = new Hono()
 
-  // The public-history gate: unless the owner opted the public page into history,
-  // an anonymous caller reads only the CURRENT version — an old version's bytes are
-  // as hidden as the workbench that lists them. Applies to the viewer entry points
-  // (cookie + raw_token) only: the preview route's token is a server-minted
-  // capability for exactly one artifact+version, and proposals aren't versions.
-  const anonHistoryBlocked = async (c: Context, artifact: ArtifactRecord, n: number) =>
+  // Private history requires artifact standing. The preview route is exempt because
+  // its server-minted token already names one artifact and version.
+  const privateHistoryBlocked = async (c: Context, artifact: ArtifactRecord, n: number) =>
     n !== artifact.current_version &&
     !artifact.public_history &&
-    (await actorFor(c, artifact)).kind === "anon"
+    !hasArtifactStanding(await actorFor(c, artifact), artifact.workspace_access)
 
   // The comment-anchor client, referenced by URL from artifact HTML. Artifact
   // pages are cached immutable; this is cached short so the client can evolve
@@ -101,7 +103,7 @@ export const rawRoutes = (ctx: AppContext) => {
     if (!Number.isInteger(v) || v < 1 || v > artifact.current_version)
       return fail(c, 404, `no version ${v}`)
     if (!(await authorize(c, "read", artifact))) return fail(c, 404, "not found")
-    if (await anonHistoryBlocked(c, artifact, v)) return fail(c, 404, "not found")
+    if (await privateHistoryBlocked(c, artifact, v)) return fail(c, 404, "not found")
 
     // THE SERIES EXPORT: one JSON object per version, oldest first. This is the substrate
     // the rest of the querying story stands on — a page charts its own history from it, an
@@ -110,10 +112,8 @@ export const rawRoutes = (ctx: AppContext) => {
     // consumer queries, which is why there is no query language here to defend.
     // JSONL on purpose: a new version is a LINE append, and it streams.
     if (wantsSeries) {
-      // An anonymous caller who may not read history gets only the current point — the
-      // export must never be a way around the public-history gate.
-      const anonCurrentOnly = await anonHistoryBlocked(c, artifact, 1)
-      const series = anonCurrentOnly
+      const currentOnly = await privateHistoryBlocked(c, artifact, 1)
+      const series = currentOnly
         ? await meta.getVersionData(artifact.id, artifact.current_version, slot)
         : await meta.getVersionDataSeries(artifact.id, slot, 1, artifact.current_version, 5000)
       if (!series.length) return fail(c, 404, `no facts "${slot}"`)
@@ -225,14 +225,19 @@ export const rawRoutes = (ctx: AppContext) => {
     const n = Number(c.req.param("n"))
     const artifact = await meta.getByShortId(shortId)
     if (!artifact || !Number.isInteger(n)) return c.text("not found", 404)
-    const claim = verifyState<{ rid: string }>(
+    const claim = verifyState<{ rid: string; history?: boolean }>(
       c.req.param("token"),
       deps.encryptionKey ?? "",
       RAW_TOKEN_MAX_AGE_MS,
     )
     const ok = claim?.rid === artifact.id || (await authorize(c, "read", artifact))
     if (!ok) return c.text("not found", 404)
-    if (await anonHistoryBlocked(c, artifact, n)) return c.text("not found", 404)
+    const historyAllowed =
+      claim?.rid === artifact.id && claim.history !== undefined
+        ? claim.history
+        : !(await privateHistoryBlocked(c, artifact, n))
+    if (n !== artifact.current_version && !artifact.public_history && !historyAllowed)
+      return c.text("not found", 404)
     return serveVersion(
       c,
       artifact,
@@ -282,7 +287,7 @@ export const rawRoutes = (ctx: AppContext) => {
     const artifact = await meta.getByShortId(shortId)
     if (!artifact || !Number.isInteger(n)) return c.text("not found", 404)
     if (!(await authorize(c, "read", artifact))) return c.text("not found", 404)
-    if (await anonHistoryBlocked(c, artifact, n)) return c.text("not found", 404)
+    if (await privateHistoryBlocked(c, artifact, n)) return c.text("not found", 404)
     return serveVersion(c, artifact, n, `/raw/${shortId}/v/${c.req.param("n")}/`)
   })
 

--- a/apps/api/src/schemas.ts
+++ b/apps/api/src/schemas.ts
@@ -146,7 +146,13 @@ export const Artifact = z
       .boolean()
       .optional()
       .describe(
-        "Owner opt-in: the anonymous public page shows version history. When false, anonymous detail responses carry only the current version.",
+        "Owner opt-in: readers without artifact standing can browse version history. When false, their detail responses carry only the current version.",
+      ),
+    is_workspace_member: z
+      .boolean()
+      .optional()
+      .describe(
+        "True when the signed-in caller has an active seat in the artifact's workspace. False for link-only readers and members acting in another workspace.",
       ),
     org_id: z
       .string()

--- a/apps/api/test/comment-access.test.ts
+++ b/apps/api/test/comment-access.test.ts
@@ -57,8 +57,10 @@ describe("comment access via the general-access link", () => {
     const bobView = await (await view(shortId, as(bob.email))).json()
     expect(bobView.my_role).toBe("commenter")
     expect(bobView.link_role).toBe("commenter")
+    expect(bobView.is_workspace_member).toBe(false)
     const anonView = await (await view(shortId)).json()
     expect(anonView.my_role).toBe("viewer")
+    expect(anonView.is_workspace_member).toBe(false)
   })
 
   it("revoking the comment grant locks commenting again", async () => {
@@ -125,6 +127,10 @@ describe("comment access via workspace seat", () => {
         )
       ).ok,
     ).toBe(true)
+    const memoView = await (
+      await app.request(`/v1/artifacts/${a.short_id}`, { headers: as(memo.email) })
+    ).json()
+    expect(memoView.is_workspace_member).toBe(true)
 
     // Otto is signed in but outside the workspace: the same URL is inert (404,
     // indistinguishable from not existing). Anonymous likewise.

--- a/apps/api/test/public-history.test.ts
+++ b/apps/api/test/public-history.test.ts
@@ -1,5 +1,16 @@
 import { describe, expect, it } from "vitest"
-import { anonApp, app, bearer, meta, TEST_TOKEN, upload } from "./helpers"
+import {
+  anonApp,
+  app,
+  as,
+  bearer,
+  makeAuthedApp,
+  meta,
+  publishAs,
+  TEST_TOKEN,
+  type TestUser,
+  upload,
+} from "./helpers"
 
 const idOf = async (res: Response): Promise<string> => (await res.json()).short_id
 
@@ -19,10 +30,8 @@ const addVersion = async (short: string) => {
   if (res.status !== 201 && res.status !== 200) throw new Error(`version failed: ${res.status}`)
 }
 
-// public_history (the launch-essay toggle): the owner opts the ANONYMOUS public
-// page into version history. Off (the default), anon must not see history at all —
-// not in the payload, not via a hand-typed @vN, not via old-version raw. Signed-in
-// readers are untouched either way (auth is the gate, like comments).
+// Private history is visible to members and collaborators, not world-link holders.
+// public_history opts those link readers in, whether or not they are signed in.
 describe("public history", () => {
   it("defaults off: anon detail carries only the current version and public_history false", async () => {
     const short = await idOf(await upload("ph.md", "# One", { visibility: "public", title: "PH" }))
@@ -35,7 +44,7 @@ describe("public history", () => {
     expect(detail.sessions.length).toBe(1)
   })
 
-  it("authenticated callers keep full history regardless of the flag", async () => {
+  it("the authenticated owner keeps full history regardless of the flag", async () => {
     const short = await idOf(await upload("pha.md", "# One", { visibility: "public", title: "A" }))
     await addVersion(short)
 
@@ -76,5 +85,57 @@ describe("public history", () => {
     await meta.setPublicHistory(art.id, 1)
     const oldOn = await anonApp.request(`/raw/${short}/v/1/index.md`)
     expect(oldOn.status).toBe(200)
+  })
+})
+
+describe("private history standing", () => {
+  const owner: TestUser = { id: "u_ph_owner", email: "owner@ph.test", name: "Owner" }
+  const stranger: TestUser = {
+    id: "u_ph_stranger",
+    email: "stranger@ph.test",
+    name: "Stranger",
+  }
+  const { app } = makeAuthedApp("private-history-standing", [owner, stranger], undefined, {
+    isolated: true,
+  })
+
+  it("a signed-in world-link holder gets only current history and a current-only raw token", async () => {
+    await app.request("/v1/me", { headers: as(owner.email) })
+    await app.request("/v1/me", { headers: as(stranger.email) })
+    const first = await (await publishAs(app, "<h1>One</h1>", {}, as(owner.email))).json()
+    const short = first.short_id as string
+    const access = await app.request(`/v1/artifacts/${short}/access`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json", ...as(owner.email) },
+      body: JSON.stringify({ linkRole: "viewer" }),
+    })
+    expect(access.status).toBe(200)
+    expect((await publishAs(app, "<h1>Two</h1>", {}, as(owner.email), short)).status).toBe(201)
+
+    const outside = await (
+      await app.request(`/v1/artifacts/${short}`, { headers: as(stranger.email) })
+    ).json()
+    expect(outside.is_workspace_member).toBe(false)
+    expect(outside.versions.map((v: { n: number }) => v.n)).toEqual([2])
+    expect(
+      (
+        await app.request(`/raw/${short}/v/1/t/${outside.raw_token}/index.html`, {
+          headers: as(stranger.email),
+        })
+      ).status,
+    ).toBe(404)
+
+    const inside = await (
+      await app.request(`/v1/artifacts/${short}`, { headers: as(owner.email) })
+    ).json()
+    expect(inside.is_workspace_member).toBe(true)
+    expect(inside.versions.map((v: { n: number }) => v.n)).toEqual([1, 2])
+    expect(
+      (
+        await app.request(`/raw/${short}/v/1/t/${inside.raw_token}/index.html`, {
+          headers: as(owner.email),
+        })
+      ).status,
+    ).toBe(200)
   })
 })

--- a/apps/api/test/workspace-artifact-access.test.ts
+++ b/apps/api/test/workspace-artifact-access.test.ts
@@ -232,6 +232,7 @@ describe("artifact access follows the active workspace", () => {
     expect(worldElsewhere.status).toBe(200)
     const worldElsewhereBody = await worldElsewhere.json()
     expect(worldElsewhereBody.my_role).toBe("viewer")
+    expect(worldElsewhereBody.is_workspace_member).toBe(false)
     // Neither creator ownership nor a foreign workspace seat may disclose the
     // collection metadata wrapped around an otherwise portable artifact.
     expect(worldElsewhereBody.collection_access).toEqual([])
@@ -250,6 +251,7 @@ describe("artifact access follows the active workspace", () => {
     expect(sharedDetail.status).toBe(200)
     const sharedDetailBody = await sharedDetail.json()
     expect(sharedDetailBody.my_role).toBe("editor")
+    expect(sharedDetailBody.is_workspace_member).toBe(false)
     expect(sharedDetailBody.collection_access).toEqual([
       expect.objectContaining({ id: collection.id, my_role: "viewer" }),
     ])
@@ -275,6 +277,6 @@ describe("artifact access follows the active workspace", () => {
       headers: atOrigin,
     })
     expect(restored.status).toBe(200)
-    expect((await restored.json()).my_role).toBe("owner")
+    expect(await restored.json()).toMatchObject({ my_role: "owner", is_workspace_member: true })
   })
 })

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -55,6 +55,61 @@ test("owner shares an artifact and the member appears", async ({ owner, secondUs
   await expect(owner.locator('[data-testid^="share-member-row-"]')).toHaveCount(2)
 })
 
+test("a signed-in link holder gets guest chrome and can copy into their workspace", async ({
+  owner,
+  secondUser,
+}) => {
+  const shortId = await publishArtifact(owner, "guest.md", "# Someone else's document")
+  await secondUser.page.goto(`/artifacts/${shortId}`)
+
+  await expect(secondUser.page.getByTestId("artifact-make-copy")).toBeVisible()
+  await expect(secondUser.page.getByTestId("share-trigger")).toHaveCount(0)
+  await expect(secondUser.page.getByTestId("artifact-inline-edit")).toHaveCount(0)
+  await expect(secondUser.page.getByTestId("artifact-show-comments")).toHaveCount(0)
+  await expect(secondUser.page.getByTestId("library-menu")).toHaveCount(0)
+
+  await secondUser.page.getByTestId("artifact-more").click()
+  await expect(secondUser.page.getByTestId("artifact-report")).toBeVisible()
+  await expect(secondUser.page.getByTestId("artifact-create-from")).toHaveCount(0)
+  await expect(secondUser.page.getByTestId("artifact-collections")).toHaveCount(0)
+  await expect(secondUser.page.getByTestId("artifact-insights")).toHaveCount(0)
+  await secondUser.page.keyboard.press("Escape")
+
+  await secondUser.page.getByTestId("artifact-make-copy").click()
+  await expect(secondUser.page).not.toHaveURL(new RegExp(shortId))
+  await expect(secondUser.page.getByTestId("share-trigger")).toBeVisible()
+  await expect(secondUser.page.getByTestId("artifact-make-copy")).toHaveCount(0)
+})
+
+test("guest comment and edit links keep only their granted collaboration", async ({
+  owner,
+  secondUser,
+}) => {
+  const shortId = await publishArtifact(
+    owner,
+    "guest-roles.html",
+    "<h1>Guest roles</h1>",
+    "text/html",
+  )
+  const setLinkRole = async (linkRole: "commenter" | "editor") => {
+    const response = await owner.request.patch(`/v1/artifacts/${shortId}/access`, {
+      data: { linkRole },
+    })
+    expect(response.ok(), `access patch: ${response.status()}`).toBeTruthy()
+  }
+
+  await setLinkRole("commenter")
+  await secondUser.page.goto(`/artifacts/${shortId}`)
+  await expect(secondUser.page.getByTestId("artifact-show-comments")).toBeVisible()
+  await expect(secondUser.page.getByTestId("artifact-inline-edit")).toContainText("Suggest edits")
+  await expect(secondUser.page.getByTestId("share-trigger")).toHaveCount(0)
+
+  await setLinkRole("editor")
+  await secondUser.page.reload()
+  await expect(secondUser.page.getByTestId("artifact-inline-edit")).toContainText("Suggest edits")
+  await expect(secondUser.page.getByTestId("share-trigger")).toHaveCount(0)
+})
+
 test("brandprint 'Review & comment' opens the pending profile proposal", async ({ owner }) => {
   // The profile hand-off state, seeded through the real API: a v1 profile stub, a
   // workspace Brandprint pointing at it, and an open proposal standing in for the

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -7008,8 +7008,10 @@ export interface components {
             badge?: boolean;
             /** @description Open-thread count for the sign-in-to-comment pill; present only for anonymous callers on a link that grants commenting. */
             open_comment_count?: number;
-            /** @description Owner opt-in: the anonymous public page shows version history. When false, anonymous detail responses carry only the current version. */
+            /** @description Owner opt-in: readers without artifact standing can browse version history. When false, their detail responses carry only the current version. */
             public_history?: boolean;
+            /** @description True when the signed-in caller has an active seat in the artifact's workspace. False for link-only readers and members acting in another workspace. */
+            is_workspace_member?: boolean;
             /** @description The artifact's workspace id; drives move-to-workspace. */
             org_id?: string;
             /** @description Signed, short-lived token for fetching raw content; detail responses only. */

--- a/apps/web/src/pages/artifact/artifact-document.tsx
+++ b/apps/web/src/pages/artifact/artifact-document.tsx
@@ -47,7 +47,7 @@ export function ArtifactDocument({
   presentOverlay = false,
   controlsIdle = false,
   onPresent,
-  anonView = false,
+  readOnlyView = false,
 }: {
   shown: number
   currentVersion: number
@@ -88,9 +88,8 @@ export function ArtifactDocument({
   /** No input for a beat: the presentation controls fade out of the way. */
   controlsIdle?: boolean
   onPresent?: () => void
-  /** Anonymous public viewer: the past-version strip keeps only "Back to current"
-   *  (diff and restore are workbench affordances an anon caller can't use). */
-  anonView?: boolean
+  /** Public and guest readers cannot diff or restore an older version. */
+  readOnlyView?: boolean
 }) {
   const past = shown !== currentVersion
   return (
@@ -100,9 +99,9 @@ export function ArtifactDocument({
       {past && (
         <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1.5 border-b border-primary/30 bg-primary/5 px-4 py-2 text-sm">
           <span className="font-medium text-primary">
-            Viewing an earlier version{anonView ? ` (v${shown})` : ""}
+            Viewing an earlier version{readOnlyView ? ` (v${shown})` : ""}
           </span>
-          {!anonView && (
+          {!readOnlyView && (
             <>
               <span className="text-muted-foreground">·</span>
               <Button
@@ -116,7 +115,7 @@ export function ArtifactDocument({
             </>
           )}
           <span className="flex-1" />
-          {!anonView && (
+          {!readOnlyView && (
             <Button
               variant="outline"
               size="sm"
@@ -133,7 +132,7 @@ export function ArtifactDocument({
             data-testid="artifact-back-to-current"
             onClick={onBackToCurrent}
           >
-            {anonView ? `Back to current (v${currentVersion})` : "Back to current"}
+            {readOnlyView ? `Back to current (v${currentVersion})` : "Back to current"}
           </Button>
         </div>
       )}

--- a/apps/web/src/pages/artifact/artifact-top-bar.tsx
+++ b/apps/web/src/pages/artifact/artifact-top-bar.tsx
@@ -19,17 +19,8 @@ import { MoveToWorkspaceDialog, ReportDialog, StarButton } from "./header-action
 import { ReworkConnectDialog, ReworkMenuItem } from "./rework-menu-item"
 import { ShareButton } from "./share-dialog"
 
-/**
- * The right side of the workbench header (signed-in viewers only). Grouped by spacing,
- * not rules — two clusters read left → right by hierarchy:
- *   [ Share · ★ · ⋯ ]        [ comments ]
- *     actions cluster          the discussion panel toggle (terminal)
- * The filled-ink Share leads as the one primary; the favorited star is glanceable
- * state; the ⋯ holds everything else (Focus/Present, Collections, Insights/
- * History/Proposals, Edit/Lock/Report). Comments hugs the panel it opens. Presence +
- * the cursor picker are the ambient cluster the page renders ahead of this. Props-
- * driven; the page keeps the cache writes.
- */
+/** Actions for signed-in artifact readers. Members receive workspace controls;
+ * guests receive copy and only the collaboration granted by the link. */
 export function ArtifactTopBar(props: {
   shortId: string
   /** Feeds the collections picker's "similar title" suggestions. */
@@ -53,6 +44,9 @@ export function ArtifactTopBar(props: {
   isMobile: boolean
   panelOpen: boolean
   openCount: number
+  isGuest: boolean
+  isCopying: boolean
+  commentsAvailable: boolean
   showEdit: boolean
   editLabel: string
   /** Inline (click-to-type) editing — the primary edit affordance, shown as a real
@@ -90,8 +84,9 @@ export function ArtifactTopBar(props: {
   onArchive: () => void
   /** Enter focus/hero mode — strip the chrome to just the render. */
   onFocus: () => void
+  onCopy: () => void
 }) {
-  const { shortId, openProposals, proposalsTotal } = props
+  const { shortId, openProposals, proposalsTotal, isGuest } = props
   const { pref: cursorPref, setPref: setCursorPref } = useCursorPref()
   const [reportOpen, setReportOpen] = useState(false)
   const [collectionsOpen, setCollectionsOpen] = useState(false)
@@ -121,17 +116,29 @@ export function ArtifactTopBar(props: {
             {props.inlineEditLabel}
           </Button>
         )}
-        <ShareButton
-          shortId={shortId}
-          myRole={props.myRole}
-          workspaceAccess={props.workspaceAccess}
-          linkRole={props.linkRole}
-          listed={props.listed}
-          passwordProtected={props.passwordProtected}
-          publicHistory={props.publicHistory}
-          collectionAccess={props.collectionAccess}
-          videoMoment={props.videoMoment}
-        />
+        {isGuest ? (
+          <Button
+            variant="default"
+            size="sm"
+            data-testid="artifact-make-copy"
+            disabled={props.isCopying}
+            onClick={props.onCopy}
+          >
+            {props.isCopying ? "Copying…" : "Make a copy"}
+          </Button>
+        ) : (
+          <ShareButton
+            shortId={shortId}
+            myRole={props.myRole}
+            workspaceAccess={props.workspaceAccess}
+            linkRole={props.linkRole}
+            listed={props.listed}
+            passwordProtected={props.passwordProtected}
+            publicHistory={props.publicHistory}
+            collectionAccess={props.collectionAccess}
+            videoMoment={props.videoMoment}
+          />
+        )}
         <StarButton shortId={shortId} favorite={props.favorite} onChange={props.onFavorite} />
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
@@ -144,7 +151,7 @@ export function ArtifactTopBar(props: {
             >
               <Icon name="more" size={16} className="text-muted-foreground" />
               {/* Open proposals waiting on review — the ink unread-dot grammar. */}
-              {openProposals > 0 && (
+              {!isGuest && openProposals > 0 && (
                 <span
                   aria-hidden
                   className="absolute top-1 right-1 size-1.5 rounded-full bg-primary"
@@ -162,9 +169,11 @@ export function ArtifactTopBar(props: {
                 <Icon name="present" size={16} /> Present
               </DropdownMenuItem>
             )}
-            <DropdownMenuItem data-testid="artifact-create-from" onSelect={props.onCreateFrom}>
-              <Icon name="derive" size={16} /> Create from this
-            </DropdownMenuItem>
+            {!isGuest && (
+              <DropdownMenuItem data-testid="artifact-create-from" onSelect={props.onCreateFrom}>
+                <Icon name="derive" size={16} /> Create from this
+              </DropdownMenuItem>
+            )}
             {/* Opt out of the live-cursor layer: peers vanish and yours stops broadcasting.
                 Kept open on toggle so the state reads back; the preference persists per-browser. */}
             <DropdownMenuCheckboxItem
@@ -175,35 +184,43 @@ export function ArtifactTopBar(props: {
             >
               <MousePointer2Off className="size-4" aria-hidden /> Hide live cursors
             </DropdownMenuCheckboxItem>
-            <DropdownMenuSeparator />
+            {!isGuest && <DropdownMenuSeparator />}
 
             {/* Organize — opens as a dialog. */}
-            <DropdownMenuItem
-              data-testid="artifact-collections"
-              onSelect={() => setCollectionsOpen(true)}
-            >
-              <Icon name="collections" size={16} /> Add to collection
-              {props.collections.length > 0 && (
-                <span className="ml-auto font-mono text-2xs tabular-nums text-muted-foreground">
-                  {props.collections.length}
-                </span>
-              )}
-            </DropdownMenuItem>
+            {!isGuest && (
+              <DropdownMenuItem
+                data-testid="artifact-collections"
+                onSelect={() => setCollectionsOpen(true)}
+              >
+                <Icon name="collections" size={16} /> Add to collection
+                {props.collections.length > 0 && (
+                  <span className="ml-auto font-mono text-2xs tabular-nums text-muted-foreground">
+                    {props.collections.length}
+                  </span>
+                )}
+              </DropdownMenuItem>
+            )}
 
             {/* Apply the Brandprint — the ask-agent handoff scoped to the whole artifact.
                 The item brings its own leading separator, so both vanish together when it
                 renders nothing (anonymous viewer, pending or failed reads). */}
-            <ReworkMenuItem shortId={shortId} onConnect={() => setReworkConnectOpen(true)} />
+            {!isGuest && (
+              <ReworkMenuItem shortId={shortId} onConnect={() => setReworkConnectOpen(true)} />
+            )}
 
             {/* Activity. */}
-            <DropdownMenuSeparator />
-            <DropdownMenuItem data-testid="artifact-insights" onSelect={props.onInsights}>
-              <Icon name="insights" size={16} /> Insights
-            </DropdownMenuItem>
-            <DropdownMenuItem data-testid="artifact-history" onSelect={props.onHistory}>
-              <Icon name="history" size={16} /> Version history
-            </DropdownMenuItem>
-            {proposalsTotal > 0 && (
+            {(!isGuest || props.publicHistory || props.showEdit) && <DropdownMenuSeparator />}
+            {!isGuest && (
+              <DropdownMenuItem data-testid="artifact-insights" onSelect={props.onInsights}>
+                <Icon name="insights" size={16} /> Insights
+              </DropdownMenuItem>
+            )}
+            {(!isGuest || props.publicHistory) && (
+              <DropdownMenuItem data-testid="artifact-history" onSelect={props.onHistory}>
+                <Icon name="history" size={16} /> Version history
+              </DropdownMenuItem>
+            )}
+            {!isGuest && proposalsTotal > 0 && (
               <DropdownMenuItem data-testid="artifact-review" onSelect={props.onReview}>
                 <Icon name="review" size={16} />
                 {openProposals > 0 ? `Review proposals (${openProposals})` : "Proposals"}
@@ -211,31 +228,33 @@ export function ArtifactTopBar(props: {
             )}
 
             {/* Manage. */}
-            {(props.showEdit || props.canLock || props.canArchive) && <DropdownMenuSeparator />}
+            {!isGuest && (props.showEdit || props.canLock || props.canArchive) && (
+              <DropdownMenuSeparator />
+            )}
             {props.showEdit && (
               <DropdownMenuItem data-testid="artifact-edit" onSelect={props.onStartEdit}>
                 <Icon name="edit" size={16} />
                 {props.editLabel}
               </DropdownMenuItem>
             )}
-            {props.canLock && (
+            {!isGuest && props.canLock && (
               <DropdownMenuItem data-testid="artifact-lock" onSelect={props.onLockToggle}>
                 <Icon name={props.locked ? "unlock" : "lock"} size={16} />
                 {props.locked ? "Unlock changes" : "Lock changes"}
               </DropdownMenuItem>
             )}
-            {props.canArchive && (
+            {!isGuest && props.canArchive && (
               <DropdownMenuItem data-testid="artifact-archive" onSelect={props.onArchive}>
                 <Icon name={props.archived ? "undo" : "archive"} size={16} />
                 {props.archived ? "Restore to library" : "Archive"}
               </DropdownMenuItem>
             )}
-            {props.canMove && (
+            {!isGuest && props.canMove && (
               <DropdownMenuItem data-testid="artifact-move" onSelect={() => setMoveOpen(true)}>
                 <Icon name="move" size={16} /> Move to workspace…
               </DropdownMenuItem>
             )}
-            {props.canMove && props.automateBeta && (
+            {!isGuest && props.canMove && props.automateBeta && (
               <DropdownMenuItem
                 data-testid="artifact-automate"
                 onSelect={() => setAutomateOpen(true)}
@@ -253,7 +272,7 @@ export function ArtifactTopBar(props: {
 
       {/* Comments — the discussion panel toggle, terminal (hugs the panel it opens);
           held apart by spacing. On phones the bottom-right FAB owns this. */}
-      {!props.isMobile && (
+      {!props.isMobile && props.commentsAvailable && (
         <Button
           variant="ghost"
           size="sm"
@@ -273,23 +292,29 @@ export function ArtifactTopBar(props: {
       )}
 
       {/* Portaled dialogs — invisible until opened from the ⋯ menu. */}
-      <CollectionsDialog
-        shortId={shortId}
-        artifactTitle={props.artifactTitle}
-        inCollections={props.collections}
-        onChange={props.onCollections}
-        open={collectionsOpen}
-        onOpenChange={setCollectionsOpen}
-      />
+      {!isGuest && (
+        <CollectionsDialog
+          shortId={shortId}
+          artifactTitle={props.artifactTitle}
+          inCollections={props.collections}
+          onChange={props.onCollections}
+          open={collectionsOpen}
+          onOpenChange={setCollectionsOpen}
+        />
+      )}
       <ReportDialog shortId={shortId} open={reportOpen} onOpenChange={setReportOpen} />
-      <MoveToWorkspaceDialog
-        shortId={shortId}
-        currentOrgId={props.orgId}
-        open={moveOpen}
-        onOpenChange={setMoveOpen}
-      />
-      <ReworkConnectDialog open={reworkConnectOpen} onOpenChange={setReworkConnectOpen} />
-      <AutomateDialog shortId={shortId} open={automateOpen} onOpenChange={setAutomateOpen} />
+      {!isGuest && (
+        <>
+          <MoveToWorkspaceDialog
+            shortId={shortId}
+            currentOrgId={props.orgId}
+            open={moveOpen}
+            onOpenChange={setMoveOpen}
+          />
+          <ReworkConnectDialog open={reworkConnectOpen} onOpenChange={setReworkConnectOpen} />
+          <AutomateDialog shortId={shortId} open={automateOpen} onOpenChange={setAutomateOpen} />
+        </>
+      )}
     </>
   )
 }

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -2,7 +2,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useBlocker, useNavigate, useParams, useSearch } from "@tanstack/react-router"
 import { Minimize2 } from "lucide-react"
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react"
-import { ApiError, api } from "@/api"
+import { ApiError, api, workspaceDisplayName } from "@/api"
 import { useShell } from "@/components/chrome/shell-context"
 import { Icon } from "@/components/icons"
 import { ConfirmDialog } from "@/components/shared/confirm-dialog"
@@ -18,6 +18,7 @@ import {
   commentsQuery,
   rawArtifactUrl,
   workspaceSettingsQuery,
+  workspacesQuery,
 } from "@/lib/queries"
 import { rawTokenNeedsRefresh } from "@/lib/raw-token"
 import { ago } from "@/lib/time"
@@ -147,6 +148,10 @@ export function Artifact() {
     dataUpdatedAt: artifactFetchedAt,
     refetch,
   } = useQuery(artifactQuery(shortId, qc))
+  const isAnon = !me
+  // List rows do not carry caller membership. Defer guest-only behavior until
+  // the detail response resolves rather than briefly rendering the wrong controls.
+  const isGuest = !!me && !seeded && art?.is_workspace_member === false
 
   // A restored/in-memory detail can carry a raw capability that expired long before
   // this click. Refresh it before the iframe gets a src; otherwise the first token is
@@ -195,13 +200,18 @@ export function Artifact() {
   }, [search.use, loading, me, shortId, ref, nav])
   // The tab is named after the document, like the workbench header (title, else id).
   useDocumentTitle(art ? (art.title ?? shortId) : null)
-  // Comments are signed-in-only (the API 404s anon by design) — don't fire the
-  // query just to watch it fail on every public view.
-  const { data: comments = [] } = useQuery({ ...commentsQuery(shortId), enabled: !!me })
-  // Agents this viewer can hand a revision to (the "ask an agent" flow). Empty for
-  // an anon viewer (the query is authed) or a workspace with no agents — then the
-  // affordance simply doesn't appear.
-  const { data: agents = [] } = useQuery({ ...artifactAgentsQuery(shortId), enabled: !!me })
+  const commentsAvailable =
+    !!me && !seeded && !!art && (!isGuest || canCommentWithRole(art.my_role))
+  const { data: comments = [] } = useQuery({
+    ...commentsQuery(shortId),
+    enabled: commentsAvailable,
+  })
+  // Workspace tools are loaded only when their workspace is active.
+  const { data: agents = [] } = useQuery({
+    ...artifactAgentsQuery(shortId),
+    enabled: !!me && art?.is_workspace_member === true,
+  })
+  const { data: workspaces } = useQuery({ ...workspacesQuery(), enabled: isGuest })
   // A password artifact returns 401 until the visitor unlocks it — show the
   // password prompt rather than the not-found state or a bounce to login.
   const locked = failed && error instanceof ApiError && error.status === 401
@@ -289,7 +299,11 @@ export function Artifact() {
   const [rail, setRail] = useState<RailTab>("comments")
   // BETA: chat only renders where the workspace has opted in. The server refuses too —
   // this just avoids showing a tab that would 404 (see the chat-session route).
-  const settings = useQuery({ ...workspaceSettingsQuery(), staleTime: 60_000 }).data
+  const settings = useQuery({
+    ...workspaceSettingsQuery(),
+    staleTime: 60_000,
+    enabled: !!me && art?.is_workspace_member === true,
+  }).data
   const chatBeta = settings?.chatBeta === true
   // Automations are BETA the same way, read from the same fetch.
   const automateBeta = settings?.automateBeta === true
@@ -623,6 +637,7 @@ export function Artifact() {
     // URL's version rather than the shown one. The two differ only while the mode
     // is open (it freezes the view), and the mode can't be re-entered from inside.
     canEdit: canEditArtifactDoc(art, version ?? art?.current_version, editing),
+    forceProposal: isGuest,
     // The frame always contains rendered HTML, including for Markdown. Only an
     // HTML/deck source supports the opening-tag operation; Markdown keeps image
     // replacement but gets no resize handle.
@@ -653,7 +668,9 @@ export function Artifact() {
   const inspectSessionActive =
     inlineEdit.active &&
     inlineEdit.allowElementEdits &&
-    (art?.my_role === "editor" || art?.my_role === "owner")
+    !isGuest &&
+    !!art &&
+    canPublishArtifact(art)
   const hadInspectSession = useRef(false)
   useEffect(() => {
     if (inspectSessionActive) {
@@ -689,6 +706,21 @@ export function Artifact() {
     mutationFn: () => api.reinstate(shortId),
     success: "Reinstated",
     onSuccess: () => load(),
+  })
+  const copyMut = useApiMutation({
+    mutationFn: () => api.deriveArtifact(shortId),
+    invalidate: [["artifacts"], ["summary"]],
+    success: (copy) => {
+      const workspace = workspaces?.workspaces.find((w) => w.id === copy.org_id)
+      return workspace
+        ? `Copied to ${workspaceDisplayName(workspace)}`
+        : "Copied to your current workspace"
+    },
+    onSuccess: (copy) =>
+      nav({
+        to: "/artifacts/$ref",
+        params: { ref: refFor({ short_id: copy.short_id, title: copy.title }) },
+      }),
   })
   const lockMut = useApiMutation({
     mutationFn: (next: boolean) => api.setLocked(shortId, next),
@@ -775,13 +807,14 @@ export function Artifact() {
   // cannot render it. Surface the retry state instead of leaving Loading preview… forever.
   if (failed && rawTokenStale && !pinnedForShown)
     return <ArtifactLoadError onRetry={() => refetch()} onBack={() => nav({ to: "/" })} />
-  // The public-history gate, client half: an anonymous @vN link on an artifact whose
-  // owner kept history private is a 404, not a downgrade — the server already
-  // refuses the old version's bytes (raw.ts), so render the same not-found the
-  // hand-typed-id case gets rather than a broken frame. Only once auth has
-  // SETTLED anonymous: while it loads, `me` is null for signed-in users too,
-  // and they must not flash a not-found for a version they can see.
-  if (!loading && !me && shown !== art.current_version && !art.public_history)
+  // A requested version omitted by the server is not readable. Return the same
+  // not-found state as the raw endpoint instead of mounting a frame that will 404.
+  if (
+    !loading &&
+    shown !== art.current_version &&
+    !art.public_history &&
+    !art.versions.some((v) => v.n === shown)
+  )
     return <ArtifactNotFound onBack={() => nav({ to: "/" })} />
   // The `t/:raw_token` segment is the sandboxed iframe's own proof of access: it has no
   // `allow-same-origin` (by design — the content must never touch our cookies/storage),
@@ -818,16 +851,16 @@ export function Artifact() {
   // never requested.
   const rawSrc =
     seeded || (rawTokenStale && !pinnedForShown) ? null : rawArtifactUrl(shortId, shown, rawToken)
-  // Editors publish directly; commenters propose a candidate for review.
-  const canPublish = art.my_role === "editor" || art.my_role === "owner"
+  // Direct publishing is a workbench capability. Guest edits always become proposals.
+  const canPublish = !isGuest && (art.my_role === "editor" || art.my_role === "owner")
   // md vs html drives syntax highlighting + how the live preview renders.
   const format = formatOf(art)
   // Lock: any editor can toggle it (advanced menu). While locked, even an editor
   // must propose — `effectiveCanPublish` flips the edit flow to the propose path.
   const canLock = canPublish
-  const canMove = art.my_role === "owner"
+  const canMove = !isGuest && art.my_role === "owner"
   const isLocked = !!art.locked
-  const effectiveCanPublish = canPublishArtifact(art)
+  const effectiveCanPublish = !isGuest && canPublishArtifact(art)
   // The ONE eligibility base both edit affordances (inline + raw source) share, so
   // a new rule can't land in one and not the other; the deck test likewise has a
   // single spelling that the isDeck prop and the inline gate both read.
@@ -838,16 +871,9 @@ export function Artifact() {
   const canInspect = canPublish && inlineEdit.allowElementEdits
   const inspectEnabled = canInspect && inlineEdit.active
   const isDeckLike = !!deck || art.current_content_type === "text/x-derive-deck"
-  // A logged-out visitor on a public/link artifact: strictly view-only. They get
-  // the document + live presence/cursors (Google-Docs style) and nothing else —
-  // no favorite, collections, share, report, comments, or version tools.
-  // The API gates every one of those for anon (anonLocked); hiding them here keeps
-  // the chrome honest so there's no dead/forbidden affordance to bump into.
-  const isAnon = !me
-  // Commenting needs commenter+ (matches the API's `comment` gate). A signed-in viewer
-  // reading via a view-only link sees comments but gets no write affordance. An
-  // anonymous visitor never qualifies — PublicViewer carries their sign-in-to-comment
-  // nudge (auth is the gate; see the access matrix).
+  // Commenting needs commenter+ (matches the API's `comment` gate). An outside
+  // view-link holder gets no conversation surface; commenter/editor links do.
+  // Anonymous visitors never qualify — PublicViewer carries their sign-in nudge.
   const canComment = canCommentWithRole(art.my_role)
 
   // Sort threads into pinned (anchored & present in this live doc), general
@@ -879,10 +905,9 @@ export function Artifact() {
   // entry point — there's no top-bar toggle or `c` key on a phone, and a hidden
   // panel made comments unreachable). Computed here rather than in the panel hook
   // so a desktop→mobile resize with a persisted "hidden" can't strand a phone.
-  const effectivePanel = isMobile && !isAnon ? "open" : panel
+  const effectivePanel = isMobile && commentsAvailable ? "open" : panel
 
-  // The rendered artifact frame — identical for the anon public viewer and the authed
-  // workbench, so build it once and place it in both branches (no prop drift).
+  // Build the document once; public, guest, and workbench layouts share this surface.
   const documentEl = (
     <ArtifactDocument
       shown={shown}
@@ -931,7 +956,7 @@ export function Artifact() {
       presentOverlay={present.overlay}
       controlsIdle={present.idle}
       onPresent={present.toggle}
-      anonView={isAnon}
+      readOnlyView={isAnon || isGuest}
     />
   )
 
@@ -1031,7 +1056,7 @@ export function Artifact() {
       {/* data-artifact-view: while the workbench is mounted, globals.css drops the
           film-grain overlay so Derive's material steps back inside the author's document. */}
       <div data-artifact-view className="flex min-h-0 flex-1 flex-col">
-        <FocusShellSync focus={focus} />
+        <FocusShellSync focus={focus || isGuest} />
         {/* The workbench bar — full-width now (sidebar-first shell), so the
               comments panel docks BELOW it instead of squeezing it into the
               remaining width. The page owns its toolbar: the artifact title (the
@@ -1077,7 +1102,7 @@ export function Artifact() {
             )}
             <Presence viewers={live.viewers} selfId={me?.id} compact={isMobile} />
           </div>
-          {!isAnon && (
+          {!isAnon && !seeded && (
             <ArtifactTopBar
               shortId={shortId}
               artifactTitle={art.title ?? undefined}
@@ -1096,6 +1121,9 @@ export function Artifact() {
               isMobile={isMobile}
               panelOpen={panel === "open"}
               openCount={openCount}
+              isGuest={isGuest}
+              isCopying={copyMut.isPending}
+              commentsAvailable={commentsAvailable}
               // The source editor unmounts the iframe — mid-inline-session that
               // silently discards typed edits, so its entry hides while editing.
               showEdit={canEditDoc && !inlineEdit.active}
@@ -1144,6 +1172,7 @@ export function Artifact() {
               onStartEdit={startEdit}
               onToggleComments={() => setPanel((pn) => (pn === "open" ? "hidden" : "open"))}
               onFocus={() => setFocus(true)}
+              onCopy={() => copyMut.mutate()}
             />
           )}
         </div>
@@ -1237,7 +1266,7 @@ export function Artifact() {
                 the empty panel. On mobile NEITHER exists (the toggle is desktop-only,
                 there's no keyboard), so the FAB is the sole entry point and must show
                 even at zero — otherwise a comment-less doc has no way into comments. */}
-            {!isAnon && !focus && !isMobile && panel === "hidden" && openCount > 0 && (
+            {commentsAvailable && !focus && !isMobile && panel === "hidden" && openCount > 0 && (
               <DocFab
                 title="Show comments (c)"
                 testId="artifact-comments-fab"
@@ -1264,7 +1293,7 @@ export function Artifact() {
             )}
           </div>
 
-          {!focus && (
+          {!focus && commentsAvailable && (
             <ArtifactComments
               rail={rail}
               onRail={setRail}
@@ -1307,7 +1336,9 @@ export function Artifact() {
               canComment={canComment}
               reviewCard={
                 // Top of the comments rail, not its own pane; members who can act only.
-                canComment ? <ReviewCard shortId={shortId} refreshKey={reviewTick} /> : undefined
+                !isGuest && canComment ? (
+                  <ReviewCard shortId={shortId} refreshKey={reviewTick} />
+                ) : undefined
               }
               onSheetHeight={setSheetInset}
               docLive={docLive}

--- a/apps/web/src/pages/artifact/use-inline-edit.ts
+++ b/apps/web/src/pages/artifact/use-inline-edit.ts
@@ -98,6 +98,8 @@ export function useInlineEdit(p: {
    *  bundle, not GitHub-managed). Gates every entry point — the header button, the
    *  `e` shortcut, and the Edit verb on a selection. */
   canEdit: boolean
+  /** Force saved edits through review even when the effective role is editor. */
+  forceProposal?: boolean
   /** The stored source can carry selector-scoped element operations. Markdown is
    *  rendered as HTML in the frame, but does not support that source operation. */
   allowElementEdits: boolean
@@ -471,7 +473,7 @@ export function useInlineEdit(p: {
   })
   const swapImage = (oldSrc: string) => {
     const art = p.art
-    if (!art || !canPublishArtifact(art)) {
+    if (!art || p.forceProposal || !canPublishArtifact(art)) {
       toast("Replacing an image needs edit access on this artifact.", { id: "inline-edit-image" })
       return
     }
@@ -499,7 +501,7 @@ export function useInlineEdit(p: {
       // anything that moved), which is the closest thing to a clean auto-merge.
       const base = art.current_version
       const message = editMessage(collected)
-      if (canPublishArtifact(art)) {
+      if (!p.forceProposal && canPublishArtifact(art)) {
         const a = await api.publishEdits(p.shortId, collected, base, message)
         return { kind: "published", version: a.current_version }
       }

--- a/apps/web/src/routes/artifacts.$ref.tsx
+++ b/apps/web/src/routes/artifacts.$ref.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { artifactQuery, commentsQuery, meQuery } from "../lib/queries"
 import { Artifact } from "../pages/artifact"
+import { canCommentWithRole } from "../pages/artifact/lib/comment-access"
 import { candidateShortIds } from "../pages/artifact/parse-ref"
 import { WorkbenchSkeleton } from "../pages/artifact/workbench-skeleton"
 
@@ -58,10 +59,10 @@ export const Route = createFileRoute("/artifacts/$ref")({
       for (const id of candidateShortIds(params.ref)) {
         const art = await queryClient.ensureQueryData(artifactQuery(id)).catch(() => null)
         if (art) {
-          // Comments are signed-in-only (the API 404s anon by design) — warm them
-          // only for a session the page will actually read them with.
-          if (queryClient.getQueryData(meQuery().queryKey))
-            queryClient.prefetchQuery(commentsQuery(id))
+          const signedIn = queryClient.getQueryData(meQuery().queryKey)
+          const commentsAvailable =
+            art.is_workspace_member === true || canCommentWithRole(art.my_role)
+          if (signedIn && commentsAvailable) queryClient.prefetchQuery(commentsQuery(id))
           return
         }
       }

--- a/packages/core/src/permissions.test.ts
+++ b/packages/core/src/permissions.test.ts
@@ -4,6 +4,7 @@ import {
   type Actor,
   can,
   effectiveRole,
+  hasArtifactStanding,
   isRole,
   type LinkRole,
   maxRole,
@@ -212,6 +213,18 @@ describe("effectiveRole — the anonymous invariant", () => {
     expect(effectiveRole({ kind: "anon", locked: true, unlocked: true }, "none", "viewer")).toBe(
       "viewer",
     )
+  })
+})
+
+describe("hasArtifactStanding", () => {
+  it("counts collaborator grants and active workspace seats, but not world links", () => {
+    expect(hasArtifactStanding({ kind: "token" })).toBe(true)
+    expect(hasArtifactStanding({ kind: "anon" }, "member")).toBe(false)
+    expect(hasArtifactStanding(user(), "member")).toBe(false)
+    expect(hasArtifactStanding(user({ orgRole: "viewer" }), "none")).toBe(false)
+    expect(hasArtifactStanding(user({ orgRole: "viewer" }), "member")).toBe(true)
+    expect(hasArtifactStanding(user({ artifactRole: "commenter" }), "none")).toBe(true)
+    expect(hasArtifactStanding(user({ inheritedLinkRole: "editor" }), "member")).toBe(false)
   })
 })
 

--- a/packages/core/src/permissions.ts
+++ b/packages/core/src/permissions.ts
@@ -134,6 +134,17 @@ export function effectiveRole(
   return maxRole(explicit, seat, world, inheritedWorld)
 }
 
+/** Whether access comes from an active workspace seat or collaborator grant,
+ * rather than a world link. */
+export function hasArtifactStanding(
+  actor: Actor,
+  workspaceAccess: WorkspaceAccess = "none",
+): boolean {
+  if (actor.kind === "token") return true
+  if (actor.kind !== "user") return false
+  return actor.artifactRole != null || (workspaceAccess === "member" && actor.orgRole != null)
+}
+
 /** The one authorization gate. */
 export function can(
   actor: Actor,


### PR DESCRIPTION
## What

- distinguish signed-in non-members from workspace members in artifact API responses
- present non-members with a calm guest view and explicit copy, star, report, comment, and edit-proposal affordances
- keep private history and workspace-only controls behind standing membership
- align route prefetching, dialog mounting, cache invalidation, and tests with the access model
- remove stale helpers and tighten naming and comments found during senior review

## Why

A signed-in visitor who was not a workspace member inherited member-oriented UI state. That blurred the boundary between public artifact access and workspace standing, exposed controls that could not work, and made the guest path difficult to reason about.

## Impact

Public artifact reading remains unchanged. Signed-in guests now see only capabilities actually granted by the artifact or link, while members retain the existing workspace experience.

## Verification

- `pnpm verify`
- 4,011 coverage tests passed
- focused Playwright coverage for guest viewing and copy behavior

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/763"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789657037&installation_model_id=428097&pr_number=763&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F763&signature=6cbacff4301bec927114a7e9b3ee16737aa4095e641edbd0b7cbe66334f7c959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->