### PR TITLE
site: retire the beta framing across the marketing pages

### DIFF
--- a/apps/web/public/security.html
+++ b/apps/web/public/security.html
@@ -122,7 +122,7 @@ footer a:hover{color:var(--fg)}
         <svg class="i-moon" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><path d="M11.8 8.6A5.2 5.2 0 1 1 5.4 2.2a4.2 4.2 0 0 0 6.4 6.4Z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/></svg>
         <svg class="i-sys" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><circle cx="7" cy="7" r="5.4" stroke="currentColor" stroke-width="1.3"/><path d="M7 1.6v10.8A5.4 5.4 0 0 0 7 1.6Z" fill="currentColor"/></svg>
       </button>
-      <a class="site-nav__signin" href="/login?src=nav_signin">Sign in to Beta <span class="arr" aria-hidden="true">→</span></a>
+      <a class="site-nav__signin" href="/login?src=nav_signin">Sign in <span class="arr" aria-hidden="true">→</span></a>
     </div>
   </div>
 </nav>

--- a/apps/web/public/site/examples.html
+++ b/apps/web/public/site/examples.html
@@ -47,7 +47,7 @@
         <svg class="i-moon" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><path d="M11.8 8.6A5.2 5.2 0 1 1 5.4 2.2a4.2 4.2 0 0 0 6.4 6.4Z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/></svg>
         <svg class="i-sys" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><circle cx="7" cy="7" r="5.4" stroke="currentColor" stroke-width="1.3"/><path d="M7 1.6v10.8A5.4 5.4 0 0 0 7 1.6Z" fill="currentColor"/></svg>
       </button>
-      <a class="site-nav__signin" href="/login?src=examples_signin">Sign in to Beta <span class="arr" aria-hidden="true">→</span></a>
+      <a class="site-nav__signin" href="/login?src=examples_signin">Sign in <span class="arr" aria-hidden="true">→</span></a>
     </div>
   </div>
 </nav>

--- a/apps/web/public/site/index.html
+++ b/apps/web/public/site/index.html
@@ -411,19 +411,6 @@ html.light .pcursor .flag{color:#fff}
 .dcomment .who .chip.rob{background:color-mix(in srgb,var(--gold) 16%,transparent);border-color:color-mix(in srgb,var(--gold) 35%,transparent);color:var(--gold)}
 .dcomment .who .chip.ada{background:color-mix(in srgb,var(--share) 16%,transparent);border-color:color-mix(in srgb,var(--share) 35%,transparent);color:var(--share)}
 
-/* waitlist form */
-.waitlist{display:flex}
-.waitlist form{
-  display:flex;gap:8px;padding:6px;border-radius:12px;
-  background:var(--card);border:1px solid var(--border);width:min(430px,100%);
-}
-.waitlist input{flex:1;min-width:0;background:transparent;border:0;outline:0;color:var(--fg);font:inherit;font-size:14px;padding:0 12px}
-.waitlist input::placeholder{color:var(--faint)}
-.waitlist form:focus-within{border-color:var(--fg)}
-.waitlist .btn{height:38px;font-size:14px;padding:0 18px}
-.waitlist-done{display:none;align-items:center;gap:10px;height:52px;padding:0 18px;border-radius:12px;border:1px solid var(--border);background:var(--card);font-size:14px}
-.waitlist-done .tick{color:var(--success)}
-
 /* ══════════ MANIFESTO ══════════ */
 .manifesto{padding-top:190px}
 .manifesto .m-line{
@@ -570,36 +557,16 @@ html.light .pcursor .flag{color:#fff}
   .hookup .hk-row code{white-space:normal;overflow:visible;text-overflow:clip;overflow-wrap:anywhere}
 }
 
-/* ══════════ PRICING STATEMENT ══════════ */
-.price{padding-top:210px}
-.price h2{font-size:clamp(34px,5vw,58px);line-height:1.08;max-width:16ch}
-.price .p-sub{margin-top:22px;font-size:17px;color:var(--muted-fg);max-width:54ch;line-height:1.7}
-.price .p-sub strong{color:var(--fg);font-weight:500}
-.tier-line{
-  margin-top:48px;border-top:1px solid var(--border-soft);border-bottom:1px solid var(--border-soft);
-  display:grid;grid-template-columns:repeat(4,1fr);
-}
-@media(max-width:760px){.tier-line{grid-template-columns:repeat(2,1fr)}}
-.tl-cell{padding:26px 22px 28px;border-left:1px solid var(--border-soft)}
-.tl-cell:first-child{border-left:0}
-@media(max-width:760px){.tl-cell:nth-child(3){border-left:0}.tl-cell:nth-child(n+3){border-top:1px solid var(--border-soft)}}
-.tl-cell .tn{font-family:var(--font-mono);font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--muted-fg)}
-.tl-cell .tp{margin-top:10px;font-size:26px;font-weight:500;letter-spacing:-0.02em}
-.tl-cell .tp small{font-size:12px;color:var(--muted-fg);font-weight:400;letter-spacing:0}
-.tl-cell .td{margin-top:6px;font-size:12.5px;color:var(--faint);line-height:1.55}
-.price .p-links{margin-top:30px;display:flex;gap:26px;align-items:center;font-size:14px}
-.price .p-links a{color:var(--fg);border-bottom:1px solid var(--border);padding-bottom:2px}
-.price .p-links a:hover{border-bottom-color:var(--fg)}
-.price .p-vow{margin-top:56px;font-size:15px;color:var(--muted-fg);max-width:60ch;line-height:1.75}
-.price .p-vow strong{color:var(--fg);font-weight:500}
-
 /* ══════════ FINALE ══════════ */
 .finale{padding-top:230px;position:relative;text-align:center}
 .finale .state-line{margin-bottom:24px}
 .finale .derivation{font-size:clamp(32px,5vw,72px);margin:0 auto;max-width:22ch}
 .finale .derivation .word{margin-right:.18em}
 .finale .f-sub{margin:24px auto 0;max-width:46ch;font-size:17px;color:var(--muted-fg);line-height:1.7}
-.finale .waitlist{margin:40px auto 0;justify-content:center}
+.finale .f-sub strong{color:var(--fg);font-weight:500}
+.finale .f-cta{margin:40px auto 0;display:flex;gap:26px;align-items:center;justify-content:center;flex-wrap:wrap}
+.finale .f-cta a:not(.btn){font-size:14px;color:var(--fg);border-bottom:1px solid var(--border);padding-bottom:2px}
+.finale .f-cta a:not(.btn):hover{border-bottom-color:var(--fg)}
 .finale .f-alt{margin-top:18px;font-family:var(--font-mono);font-size:12px;color:var(--faint)}
 .finale .f-alt a{color:var(--muted-fg);border-bottom:1px solid var(--border)}
 .finale .f-alt a:hover{color:var(--fg)}
@@ -633,10 +600,6 @@ footer{margin-top:170px;position:relative;overflow:hidden;border-top:1px solid v
   .derivation{margin-top:20px}
   .hero .sub{margin-top:26px}
   .hero .cta-row{margin-top:26px;align-self:stretch}
-  .waitlist{width:100%;justify-content:center}
-  .waitlist input{font-size:16px} /* <16px makes iOS zoom the page on focus */
-  .waitlist-done{height:auto;min-height:52px;padding:12px 16px}
-
   .demo{margin-top:52px;padding:0 20px}
   .demo-titlebar{padding:10px 14px;gap:9px}
   .demo-titlebar .doc-meta,.demo-titlebar .tb-lock,.face-label{display:none}
@@ -672,22 +635,14 @@ footer{margin-top:170px;position:relative;overflow:hidden;border-top:1px solid v
   .bigterm{margin-top:36px}
   .bigterm .tbody{padding:18px 16px;min-height:280px;line-height:1.95}
 
-  .price{padding-top:128px}
-  .price .p-sub{margin-top:18px;font-size:16px}
-
   .finale{padding-top:150px}
   .finale .f-sub{margin-top:20px;font-size:16px}
-  .finale .waitlist{margin-top:32px}
+  .finale .f-cta{margin-top:32px}
   .finale .f-alt{line-height:2.2}
 
   footer{margin-top:104px}
   .watermark{font-size:29vw}
   .foot-inner{padding:36px 20px 100px;gap:14px 22px}
-}
-@media(max-width:360px){
-  .waitlist form{flex-direction:column;padding:8px}
-  .waitlist input{padding:10px 8px}
-  .waitlist .btn{width:100%}
 }
 
 @media (prefers-reduced-motion: reduce){
@@ -718,7 +673,7 @@ footer{margin-top:170px;position:relative;overflow:hidden;border-top:1px solid v
         <svg class="i-moon" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><path d="M11.8 8.6A5.2 5.2 0 1 1 5.4 2.2a4.2 4.2 0 0 0 6.4 6.4Z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/></svg>
         <svg class="i-sys" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><circle cx="7" cy="7" r="5.4" stroke="currentColor" stroke-width="1.3"/><path d="M7 1.6v10.8A5.4 5.4 0 0 0 7 1.6Z" fill="currentColor"/></svg>
       </button>
-      <a class="site-nav__signin" href="/login?src=nav_signin">Sign in to Beta <span class="arr" aria-hidden="true">→</span></a>
+      <a class="site-nav__signin" href="/login?src=nav_signin">Sign in <span class="arr" aria-hidden="true">→</span></a>
     </div>
   </div>
 </nav>
@@ -1113,16 +1068,6 @@ Then pick something real we've worked on recently (a plan, a report, a designed 
   </div>
 </section>
 
-<!-- ══════════ PRICING ══════════ -->
-<section class="price wrap" id="pricing">
-  <div class="eyebrow reveal">Pricing</div>
-  <h2 class="reveal" style="margin-top:16px">Free while it's in beta.</h2>
-  <p class="p-sub reveal">Every feature, no card required. When billing arrives someday, publishing and reading stay free, and <strong>nothing you've shipped goes dark.</strong></p>
-  <div class="p-links reveal">
-    <a href="/pricing">The pricing we intend, published early →</a>
-  </div>
-</section>
-
 <!-- ══════════ FINALE ══════════ -->
 <section class="finale wrap" id="finale">
   <div class="state-line" id="stateLine">
@@ -1137,15 +1082,10 @@ Then pick something real we've worked on recently (a plan, a report, a designed 
       <span class="word final-word" id="w3">derived.<span class="under" aria-hidden="true"></span></span>
     </span>
   </h2>
-  <p class="f-sub">Nothing you're proud of ships in one pass. It's free while we're in beta, so sign up and we'll email your access link, or clone the repo and run the whole thing tonight.</p>
-  <div class="waitlist">
-    <form data-waitlist data-derive-source="homepage_waitlist" action="/v1/beta/signup" method="post" novalidate>
-      <input type="email" name="email" placeholder="you@company.com" required autocomplete="email" aria-label="Work email">
-      <button class="btn btn-primary" type="submit">Get beta access</button>
-    </form>
-    <div class="waitlist-done" role="status">
-      <span class="tick">✓</span><span>Check your email. Your access link is on the way.</span>
-    </div>
+  <p class="f-sub">Nothing you're proud of ships in one pass. Sign up, connect your agent, and publish your first artifact in minutes. The Free plan is free forever, no card required, and <strong>nothing you ship goes dark.</strong></p>
+  <div class="f-cta">
+    <a class="btn btn-primary" href="/login?signup=1&amp;src=homepage_finale">Start Deriving for Free</a>
+    <a href="/pricing">See pricing →</a>
   </div>
   <p class="f-alt">
     <button class="replay" id="replay" type="button" aria-label="Replay the edit">
@@ -1217,30 +1157,6 @@ document.querySelectorAll('[data-copy], [data-copy-from]').forEach(el => {
       if (tag) tag.textContent = 'COPY';
       else if (prev !== null) labelEl.textContent = prev;
     }, 1800);
-  });
-});
-
-/* beta signup: the API records the email and sends the access link */
-document.querySelectorAll('[data-waitlist]').forEach(form => {
-  form.addEventListener('submit', async e => {
-    e.preventDefault();
-    const email = form.email.value.trim();
-    if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) { form.email.focus(); return; }
-    const btn = form.querySelector('button');
-    const label = btn.textContent;
-    btn.disabled = true; btn.textContent = 'Sending…';
-    let ok = false;
-    try {
-      const res = await fetch(form.action, {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({email, source_kind:form.dataset.deriveSource, landing_path:location.pathname})});
-      ok = res.ok;
-    } catch {}
-    if (!ok) {
-      btn.disabled = false; btn.textContent = 'Try again';
-      setTimeout(() => { btn.textContent = label; }, 2400);
-      return;
-    }
-    form.style.display = 'none';
-    form.parentElement.querySelector('.waitlist-done').style.display = 'inline-flex';
   });
 });
 

--- a/apps/web/public/site/pricing.html
+++ b/apps/web/public/site/pricing.html
@@ -5,10 +5,10 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="color-scheme" content="dark">
 <title>Pricing | Derive</title>
-<meta name="description" content="Free while we're in beta. This is the pricing we intend to charge, published early, so nothing about it surprises you.">
+<meta name="description" content="Start free. Pay for the seats that publish and approve, never for the people who read and comment.">
 <meta property="og:type" content="website">
 <meta property="og:title" content="Pricing | Derive">
-<meta property="og:description" content="Free while we're in beta. This is the pricing we intend to charge, published early.">
+<meta property="og:description" content="Start free. Pay for the seats that publish and approve, never for the people who read and comment.">
 <meta property="og:url" content="https://derive.to/pricing">
 <meta property="og:image" content="https://derive.to/site/og-approval.png">
 <meta name="twitter:card" content="summary_large_image">
@@ -20,7 +20,7 @@
   "@type": "WebPage",
   "name": "Pricing | Derive",
   "url": "https://derive.to/pricing",
-  "description": "Free while we're in beta. This is the pricing we intend to charge, published early.",
+  "description": "Start free. Pay for the seats that publish and approve, never for the people who read and comment.",
   "isPartOf": { "@id": "https://derive.to/#website" },
   "publisher": { "@id": "https://derive.to/#organization" }
 }
@@ -78,14 +78,6 @@ header.head.wrap{padding:150px 24px 0;text-align:center}
 .head h1{font-size:clamp(32px,5vw,52px);line-height:1.1;margin:18px auto 0;max-width:20ch}
 .head .lede{margin:22px auto 0;max-width:56ch;font-size:16px;color:var(--muted-fg)}
 .head .lede strong{color:var(--fg);font-weight:500}
-.beta{
-  margin:30px auto 0;display:inline-flex;align-items:baseline;gap:10px;
-  border:1px solid var(--border);border-radius:8px;padding:12px 18px;background:var(--card);
-  font-size:14px;color:var(--muted-fg);max-width:62ch;text-align:left;
-}
-.beta .k{font-family:var(--font-mono);font-size:10px;letter-spacing:.06em;color:var(--warning);white-space:nowrap;position:relative;top:-1px}
-.beta strong{color:var(--fg);font-weight:500}
-
 .tiers{margin-top:64px;display:grid;grid-template-columns:repeat(4,1fr);border:1px solid var(--border);border-radius:12px;overflow:hidden;background:var(--card)}
 @media(max-width:960px){.tiers{grid-template-columns:repeat(2,1fr)}}
 @media(max-width:560px){.tiers{grid-template-columns:1fr}}
@@ -128,14 +120,9 @@ section.wrap{padding:120px 24px 0}
 section.wrap.final{padding:130px 24px 0;text-align:center}
 .final h2{font-size:clamp(28px,4vw,40px)}
 .final .body{margin:16px auto 0;max-width:50ch;font-size:15px;color:var(--muted-fg)}
-.waitlist{margin:32px auto 0;display:flex;justify-content:center}
-.waitlist form{display:flex;gap:8px;padding:6px;border-radius:12px;background:var(--card);border:1px solid var(--border);width:min(440px,100%)}
-.waitlist input{flex:1;min-width:0;background:transparent;border:0;outline:0;color:var(--fg);font:inherit;font-size:14px;padding:0 12px}
-.waitlist input::placeholder{color:var(--muted-fg)}
-.waitlist form:focus-within{border-color:var(--fg)}
-.waitlist .btn{height:36px;border-radius:8px}
-.waitlist-done{display:none;align-items:center;gap:10px;height:50px;padding:0 18px;border-radius:12px;border:1px solid var(--border);background:var(--card);font-size:14px}
-.waitlist-done .tick{color:var(--success)}
+.final .cta{margin:32px auto 0;display:flex;gap:26px;align-items:center;justify-content:center;flex-wrap:wrap}
+.final .cta a:not(.btn){font-size:14px;color:var(--fg);border-bottom:1px solid var(--border);padding-bottom:2px}
+.final .cta a:not(.btn):hover{border-bottom-color:var(--fg)}
 
 footer{margin-top:130px;border-top:1px solid var(--border-soft)}
 .foot-inner{max-width:var(--maxw);margin:0 auto;padding:34px 24px 44px;display:flex;align-items:center;gap:16px 28px;flex-wrap:wrap}
@@ -152,14 +139,7 @@ footer{margin-top:130px;border-top:1px solid var(--border-soft)}
   section.wrap{padding-top:92px}
   section.wrap.final{padding-top:100px}
   .principle{padding:22px 20px}
-  .waitlist input{font-size:16px} /* <16px makes iOS zoom the page on focus */
-  .waitlist-done{height:auto;min-height:50px;padding:12px 16px}
   footer{margin-top:96px}
-}
-@media(max-width:360px){
-  .waitlist form{flex-direction:column;padding:8px}
-  .waitlist input{padding:10px 8px}
-  .waitlist .btn{width:100%}
 }
 @media (prefers-reduced-motion: reduce){*,*::before,*::after{animation:none!important;transition:none!important}}
 </style>
@@ -185,7 +165,7 @@ footer{margin-top:130px;border-top:1px solid var(--border-soft)}
         <svg class="i-moon" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><path d="M11.8 8.6A5.2 5.2 0 1 1 5.4 2.2a4.2 4.2 0 0 0 6.4 6.4Z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/></svg>
         <svg class="i-sys" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><circle cx="7" cy="7" r="5.4" stroke="currentColor" stroke-width="1.3"/><path d="M7 1.6v10.8A5.4 5.4 0 0 0 7 1.6Z" fill="currentColor"/></svg>
       </button>
-      <a class="site-nav__signin" href="/login?src=nav_signin">Sign in to Beta <span class="arr" aria-hidden="true">→</span></a>
+      <a class="site-nav__signin" href="/login?src=nav_signin">Sign in <span class="arr" aria-hidden="true">→</span></a>
     </div>
   </div>
 </nav>
@@ -194,8 +174,8 @@ footer{margin-top:130px;border-top:1px solid var(--border-soft)}
 
 <header class="head wrap">
   <div class="eyebrow">Pricing</div>
-  <h1>Free while we're in beta.</h1>
-  <p class="lede">Every feature, no card required. Below is the pricing we intend to charge, <strong>published early so nothing about it surprises you.</strong> The short version: the link is free; teams pay for the seats that publish and approve, never for the people who read and comment.</p>
+  <h1>Start free. Pay for editors.</h1>
+  <p class="lede">The Free plan is free forever, no card required. The short version: <strong>the link is free</strong>; teams pay for the seats that publish and approve, never for the people who read and comment.</p>
 </header>
 
 <div class="wrap">
@@ -204,7 +184,7 @@ footer{margin-top:130px;border-top:1px solid var(--border-soft)}
       <div class="tname">Free</div>
       <p class="tfor">For individuals, independent projects, and small teams.</p>
       <div class="price">$0 <small>forever</small></div>
-      <a class="btn btn-ghost" href="#join">Get beta access</a>
+      <a class="btn btn-ghost" href="/login?signup=1&amp;src=pricing_free">Start for free</a>
       <ul>
         <li>Up to <strong>3 editors</strong> per workspace</li>
         <li><strong>Unlimited viewers and commenters</strong></li>
@@ -218,7 +198,7 @@ footer{margin-top:130px;border-top:1px solid var(--border-soft)}
       <div class="tname">Team <span class="tag">MOST TEAMS</span></div>
       <p class="tfor">For teams whose agents ship work that needs review.</p>
       <div class="price">$15 <small>per editor / month · $12 billed annually</small></div>
-      <a class="btn btn-primary" href="#join">Get beta access</a>
+      <a class="btn btn-primary" href="/login?signup=1&amp;src=pricing_team">Start with Team</a>
       <ul>
         <li>Everything in Free, plus</li>
         <li><strong>Unlimited editors</strong></li>
@@ -234,7 +214,7 @@ footer{margin-top:130px;border-top:1px solid var(--border-soft)}
       <div class="tname">Business</div>
       <p class="tfor">For organizations that need control and accountability.</p>
       <div class="price">$30 <small>per editor / month · $25 billed annually</small></div>
-      <a class="btn btn-ghost" href="#join">Get beta access</a>
+      <a class="btn btn-ghost" href="/login?signup=1&amp;src=pricing_business">Start with Business</a>
       <ul>
         <li>Everything in Team, plus</li>
         <li>250 GB pooled storage, then ~$1 per extra 10 GB/month</li>
@@ -311,24 +291,18 @@ footer{margin-top:130px;border-top:1px solid var(--border-soft)}
       <p class="a">Derive is fair source (<strong>FSL-1.1-ALv2</strong>): use, modify, and self-host it freely for anything except selling Derive itself as a service. Every release converts to <strong>Apache-2.0</strong> two years after it ships.</p>
     </details>
     <details>
-      <summary>When does billing start?</summary>
-      <p class="a">Not before we’ve told you. We’ll announce dates well ahead, existing workspaces will get a grace period, and <strong>the free tier stays</strong>.</p>
+      <summary>Do we need a card to start?</summary>
+      <p class="a">No. <strong>The Free plan needs no card and has no time limit.</strong> When your team outgrows it, upgrade in the app; your artifacts and links are never affected.</p>
     </details>
   </div>
 </section>
 
-<section class="final wrap" id="join">
-  <h2>Nothing here should surprise you.</h2>
-  <p class="body">That's the point of publishing pricing before billing exists. Sign up for the beta and hold us to it.</p>
-  <div class="waitlist">
-    <form data-waitlist data-derive-source="pricing_waitlist" action="/v1/beta/signup" method="post" novalidate>
-      <input type="email" name="email" placeholder="you@company.com" required autocomplete="email" aria-label="Work email">
-      <button class="btn btn-primary" type="submit">Get beta access</button>
-    </form>
-    <div class="waitlist-done" role="status">
-      <span class="tick">✓</span>
-      <span>Check your email. Your access link is on the way.</span>
-    </div>
+<section class="final wrap">
+  <h2>Make things worth keeping.</h2>
+  <p class="body">Your team and its agents have never made more. Give the work one home: a permanent link, every version, a review you can stand behind. Start free and grow when your team does.</p>
+  <div class="cta">
+    <a class="btn btn-primary" href="/login?signup=1&amp;src=pricing_cta">Start Deriving for Free</a>
+    <a href="mailto:hello@derive.to">Talk to us →</a>
   </div>
 </section>
 
@@ -358,28 +332,6 @@ footer{margin-top:130px;border-top:1px solid var(--border-soft)}
 <script>
 const nav = document.getElementById('nav');
 addEventListener('scroll', () => nav.classList.toggle('scrolled', scrollY > 8), {passive:true});
-document.querySelectorAll('[data-waitlist]').forEach(form => {
-  form.addEventListener('submit', async e => {
-    e.preventDefault();
-    const email = form.email.value.trim();
-    if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) { form.email.focus(); return; }
-    const btn = form.querySelector('button');
-    const label = btn.textContent;
-    btn.disabled = true; btn.textContent = 'Sending…';
-    let ok = false;
-    try {
-      const res = await fetch(form.action, {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({email, source_kind:form.dataset.deriveSource, landing_path:location.pathname})});
-      ok = res.ok;
-    } catch {}
-    if (!ok) {
-      btn.disabled = false; btn.textContent = 'Try again';
-      setTimeout(() => { btn.textContent = label; }, 2400);
-      return;
-    }
-    form.style.display = 'none';
-    form.parentElement.querySelector('.waitlist-done').style.display = 'inline-flex';
-  });
-});
 </script>
 </body>
 </html>

--- a/apps/web/public/site/privacy.html
+++ b/apps/web/public/site/privacy.html
@@ -78,13 +78,13 @@ header.head.wrap{padding:150px 24px 0;text-align:center}
 .head h1{font-size:clamp(32px,5vw,52px);line-height:1.1;margin:18px auto 0;max-width:20ch}
 .head .lede{margin:22px auto 0;max-width:56ch;font-size:16px;color:var(--muted-fg)}
 .head .lede strong{color:var(--fg);font-weight:500}
-.beta{
+.note{
   margin:30px auto 0;display:inline-flex;align-items:baseline;gap:10px;
   border:1px solid var(--border);border-radius:8px;padding:12px 18px;background:var(--card);
   font-size:14px;color:var(--muted-fg);max-width:62ch;text-align:left;
 }
-.beta .k{font-family:var(--font-mono);font-size:10px;letter-spacing:.06em;color:var(--warning);white-space:nowrap;position:relative;top:-1px}
-.beta strong{color:var(--fg);font-weight:500}
+.note .k{font-family:var(--font-mono);font-size:10px;letter-spacing:.06em;color:var(--warning);white-space:nowrap;position:relative;top:-1px}
+.note strong{color:var(--fg);font-weight:500}
 
 section.wrap{padding:120px 24px 0}
 .section-head{max-width:640px}
@@ -149,7 +149,7 @@ footer{margin-top:130px;border-top:1px solid var(--border-soft)}
         <svg class="i-moon" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><path d="M11.8 8.6A5.2 5.2 0 1 1 5.4 2.2a4.2 4.2 0 0 0 6.4 6.4Z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/></svg>
         <svg class="i-sys" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><circle cx="7" cy="7" r="5.4" stroke="currentColor" stroke-width="1.3"/><path d="M7 1.6v10.8A5.4 5.4 0 0 0 7 1.6Z" fill="currentColor"/></svg>
       </button>
-      <a class="site-nav__signin" href="/login?src=nav_signin">Sign in to Beta <span class="arr" aria-hidden="true">→</span></a>
+      <a class="site-nav__signin" href="/login?src=nav_signin">Sign in <span class="arr" aria-hidden="true">→</span></a>
     </div>
   </div>
 </nav>
@@ -160,7 +160,7 @@ footer{margin-top:130px;border-top:1px solid var(--border-soft)}
   <div class="eyebrow">Privacy</div>
   <h1>Your data, in simple terms.</h1>
   <p class="lede">Derive stores what it takes to run your workspace: an account, the content you publish, and the bare usage signals that keep the product honest with you. Nothing more, and nothing sold. <strong>Effective August 10, 2026.</strong></p>
-  <div class="beta">
+  <div class="note">
     <span class="k">NOTE</span>
     <span>This page is a <strong>plain-language summary, not legal advice</strong>. It describes how Derive actually handles data. Full transparency, no surprises here.</span>
   </div>


### PR DESCRIPTION
## What

The public site still presented Derive as a gated beta: "Sign in to Beta" in the nav, "Get beta access" email forms that mailed back the same /login?signup=1 link they could have offered directly, and pricing framed as intent rather than fact. This PR retires all of it.

- Nav: "Sign in to Beta" → "Sign in" on the homepage, examples, pricing, privacy, and security pages
- Homepage: the pricing-teaser section is folded into the finale. One "Start Deriving for Free" CTA sits under "Good work is derived.", linking straight to the create-account form (/login?signup=1) with per-placement src attribution, and a quiet "See pricing" link beside it
- Pricing: H1 is now "Start free. Pay for editors."; tier buttons deep-link to signup with per-tier src slugs; the lede, FAQ ("When does billing start?" → "Do we need a card to start?"), and closer no longer claim billing doesn't exist; the page closes on the brand line "Make things worth keeping."
- Both beta-signup email forms and their CSS/JS are removed. /v1/beta/signup stays for anything still linking to it
- Privacy: the note box's .beta class renamed to .note (its copy was never about the beta), and dead beta-ribbon plus old tier-grid CSS removed

## Verification

- Rendered every page locally in dark and light themes and checked screenshots at desktop width
- All CTA hrefs verified in-browser (five signup deep links plus two mailto links)
- grep -ri beta across apps/web/public comes back clean
- Full pre-commit CI passed. Pre-push verify failed only on the two known-flaky apps/api suites (mcp.test.ts, slack-routes.test.ts); all 55 apps/web test files pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/766"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789683488&installation_model_id=428097&pr_number=766&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F766&signature=0a2256317de16b4c264ff5253da95c2dd9f61146f381ccf889a243e93d7add2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->