### PR TITLE
Cache the image builds with BuildKit (experiment)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,36 @@ jobs:
         uses: ./.github/actions/changed
       - uses: ./.github/actions/setup
 
+      # A docker-container builder, which the default `docker` driver is not: the
+      # gha cache backend below needs one.
+      #
+      # WHAT THIS CAN AND CANNOT BUY, because the honest number is smaller than the
+      # reputation. Timed from the self-host build's own layers (run 32257111555):
+      #
+      #   pnpm --filter @derive/api deploy --prod   21.8s   source-dependent
+      #   playwright install --only-shell chromium  19.0s   source-dependent, see below
+      #   pnpm --filter @derive/web build           15.9s   source-dependent
+      #   pnpm fetch                                11.2s   LOCKFILE-dependent
+      #   base pull + COPY + export                 10.6s   partly cacheable
+      #   boot + readiness + release-bundle test    ~32s    the proof; never cacheable
+      #
+      # Only what sits ABOVE `COPY . .` survives a source change, and that is
+      # `pnpm fetch`, `pnpm install --offline` and the base pull — roughly 16s of an
+      # 80s build. Everything after the COPY re-runs by construction, including the
+      # Playwright step: it invokes `node node_modules/playwright/cli.js` from the
+      # COPYed production graph, so it is downstream of the source by definition and
+      # no amount of layer reordering moves it. Pre-seeding /ms-playwright from a
+      # prebuilt base image is the only thing that would, and that is a separate
+      # change with a version-coupling problem of its own.
+      #
+      # So: expect ~16s, minus whatever restoring a multi-gigabyte cache costs, and
+      # be prepared for it to be a wash. The Actions cache is 10 GB per repository
+      # and evicts, so a cache that thrashes is worse than none. The two images get
+      # separate scopes to keep them from evicting each other. THIS IS AN EXPERIMENT
+      # WITH A NUMBER ATTACHED: compare a cold run against a warm one before
+      # believing it earns its place.
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
       # The runner image builds from packages/cli — this catches a CLI change that
       # breaks the container (deps, bin layout) before someone finds out on a box.
       # Build-only; no registry push.
@@ -226,7 +256,10 @@ jobs:
         # No token/context on purpose: a healthy image exits 1 with the house
         # one-liner, not a stack trace — proves node, the CLI, and its deps wired.
         run: |
-          docker build -f deploy/runner.Dockerfile -t derive-runner:ci .
+          docker buildx build -f deploy/runner.Dockerfile -t derive-runner:ci \
+            --cache-from type=gha,scope=runner-image \
+            --cache-to type=gha,scope=runner-image,mode=max \
+            --load .
           out=$(docker run --rm derive-runner:ci serve 2>&1) && exit 1 || true
           echo "$out" | grep -q "error: a context id and an agent token are required"
 
@@ -239,7 +272,10 @@ jobs:
           mkdir -p deploy/backups
           printf '%s\n' 'build-context-secret-canary' > deploy/.env
           printf '%s\n' 'build-context-backup-canary' > deploy/backups/build-context-canary
-          docker build -f deploy/Dockerfile --build-arg REVISION="$GITHUB_SHA" -t derive:ci .
+          docker buildx build -f deploy/Dockerfile --build-arg REVISION="$GITHUB_SHA" -t derive:ci \
+            --cache-from type=gha,scope=selfhost-image \
+            --cache-to type=gha,scope=selfhost-image,mode=max \
+            --load .
 
           # Exercise the same download-and-handoff script used after a real GitHub release. This
           # local URL is the PR-safe seam; the tag workflow supplies GitHub's anonymous URL.

--- a/apps/api/src/previews.ts
+++ b/apps/api/src/previews.ts
@@ -425,3 +425,5 @@ export const startPreviewWorker = (deps: RenderTickDeps, intervalMs = 1500): Pre
     poke: () => tick(),
   }
 }
+
+// touch: warm-cache measurement, reverted before merge


### PR DESCRIPTION
Stacked on #768 — review that one first; this diff is one file.

## What and why

After #768 the critical path is the `images` lane: **128s, of which 112s is a
Docker build that starts from nothing** because GitHub runners are fresh VMs and
nothing was caching layers. This wires both image builds through buildx with the
Actions cache backend, on separate scopes so they cannot evict each other.

## This is an experiment, with the number stated up front

Timed from the build's own layers on
[run 32257111555](https://github.com/derive-to/derive/actions/runs/32257111555):

| layer | time | cacheable across a source change? |
|---|---|---|
| `pnpm --filter @derive/api deploy --prod` | 21.8s | no |
| `playwright install --only-shell chromium` | 19.0s | **no — see below** |
| `pnpm --filter @derive/web build` | 15.9s | no |
| `pnpm fetch` | 11.2s | **yes** — lockfile only |
| base pull + COPY + export | 10.6s | partly |
| boot + readiness + release-bundle handoff | ~32s | never — it is the proof |

Only what sits above `COPY . .` survives a source change: **~16s of an 80s
build.** Everything after re-runs by construction.

That includes Playwright, which was the obvious target and turned out to be
unreachable: it runs `node node_modules/playwright/cli.js` from the **COPYed**
production graph, so it is downstream of the source by definition and no layer
reordering moves it. Only a prebuilt base image would, and that carries a
version-coupling problem worth its own change. (Worth noting `--only-shell` is
already doing its job — 19s, not the 90–180s the docs cite for a full install.)

**So expect ~16s, minus the cost of restoring a multi-gigabyte cache, and be
prepared for a wash.** The Actions cache is 10 GB per repository and evicts.

## How it gets decided

Actions caches are branch-scoped, so this branch measures itself: the first run
is cold and writes the cache, a second push reads it. If warm does not beat cold
by enough to justify the moving parts, this PR gets closed rather than merged.

## Not in here

A **prebuilt runtime base image** (node + Playwright shell + Debian deps, pushed
to GHCR on a schedule) is the only way to make that 19s cacheable. It needs the
base's Playwright version to track the app's, so it wants its own change with a
graceful-degradation design — keep the `RUN playwright install` line so a stale
base costs a download rather than a broken image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/769"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789738948&installation_model_id=428097&pr_number=769&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F769&signature=58d920115ad9da94502be376d9b98eeebc08955f00227bb868806021c4c859aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->