### PR TITLE
Stop the docs deploy waiting on the schema lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,9 +430,19 @@ jobs:
   # It deliberately does not share the product Worker's database bindings or
   # deploy transaction: a docs-only change should ship without a schema lane,
   # and a docs failure must not put the hosted application at risk.
+  #
+  # `needs: [check]`, NOT the gate, and that is the point of the paragraph above.
+  # The gate waits for Postgres, D1, workerd and the self-host image; a docs-only
+  # change touches none of them, and making the docs site wait on a schema lane is
+  # the coupling this job was separated to avoid. `check` is what actually covers
+  # it — `pnpm ci` runs `lint:docs-site`, which is the full Astro build.
+  #
+  # (This briefly said `needs: [gate]` when the lanes were split, which contradicted
+  # the comment directly above it and delayed every docs deploy by ~60s for no
+  # additional proof.)
   deploy-docs:
     if: github.repository == 'derive-to/derive' && github.event_name == 'push'
-    needs: [gate]
+    needs: [check]
     runs-on: ubicloud-standard-4
     environment:
       name: docs-production


### PR DESCRIPTION
A regression I introduced in #768, caught while auditing the deploy path.

The lane split changed `deploy-docs` from `needs: [check]` to `needs: [gate]`,
which contradicts the comment sitting directly above it:

> Documentation has its own hostname, build, asset collection, and Worker. It
> deliberately does not share the product Worker's database bindings or deploy
> transaction: **a docs-only change should ship without a schema lane**, and a
> docs failure must not put the hosted application at risk.

`gate` waits for Postgres, D1, workerd and the self-host image. A docs-only
change touches none of them, so this bought no extra proof and delayed every
docs deploy by ~60s.

Back to `needs: [check]` — `pnpm ci` runs `lint:docs-site`, which is the full
Astro build plus the built-output check, so that lane is what actually covers
docs. `deploy` keeps `needs: [gate]`, because shipping the product Worker does
depend on every lane. The two differing is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/770"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789739829&installation_model_id=428097&pr_number=770&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F770&signature=b8678b44830e508fc7f82e6dd0bd42f19b9bf122daddfb68db95f58e0ba471e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->