### PR TITLE
Deploy the docs site only when the docs change

### DIFF
--- a/.github/actions/changed/action.yml
+++ b/.github/actions/changed/action.yml
@@ -81,7 +81,8 @@ runs:
             esac
             case "$path" in
               apps/docs/* | SECURITY.md | examples/README.md | \
-                packages/cli/README.md | packages/mcp/README.md)
+                packages/cli/README.md | packages/mcp/README.md | \
+                pnpm-lock.yaml)
                 docs=true
                 ;;
             esac

--- a/.github/actions/changed/action.yml
+++ b/.github/actions/changed/action.yml
@@ -19,6 +19,14 @@ outputs:
   app_image:
     description: The self-host image can be affected.
     value: ${{ steps.filter.outputs.app_image }}
+  docs:
+    description: >-
+      The documentation site can be affected. Its pages are generated from
+      canonical sources scattered across the repo (see apps/docs/docs-manifest.mjs),
+      not just apps/docs, so this list is checked against that manifest by
+      scripts/check-docs-paths.mjs — add a page sourced from a new file and the
+      guardrail fails until this filter learns about it.
+    value: ${{ steps.filter.outputs.docs }}
 
 runs:
   using: composite
@@ -35,6 +43,7 @@ runs:
         web=false
         runner=false
         app_image=false
+        docs=false
         range=
 
         case "$EVENT_NAME" in
@@ -54,6 +63,7 @@ runs:
           web=true
           runner=true
           app_image=true
+          docs=true
         else
           : "${RUNNER_TEMP:?}"
           changed_paths="$RUNNER_TEMP/derive-changed-paths"
@@ -67,6 +77,12 @@ runs:
                 deploy/runner.Dockerfile | deploy/runner.Dockerfile.dockerignore | \
                 deploy/runner-entrypoint.sh)
                 runner=true
+                ;;
+            esac
+            case "$path" in
+              apps/docs/* | SECURITY.md | examples/README.md | \
+                packages/cli/README.md | packages/mcp/README.md)
+                docs=true
                 ;;
             esac
             case "$path" in
@@ -87,3 +103,4 @@ runs:
         echo "web=$web" >> "$GITHUB_OUTPUT"
         echo "runner=$runner" >> "$GITHUB_OUTPUT"
         echo "app_image=$app_image" >> "$GITHUB_OUTPUT"
+        echo "docs=$docs" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,10 @@ jobs:
   # and the build is path gated anyway.
   check:
     runs-on: ubicloud-standard-8
+    # Exposed so `deploy-docs` can decide whether it has anything to do. This lane
+    # already computes the filter for its own web build, so the answer is free.
+    outputs:
+      docs: ${{ steps.filter.outputs.docs }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -440,8 +444,21 @@ jobs:
   # (This briefly said `needs: [gate]` when the lanes were split, which contradicted
   # the comment directly above it and delayed every docs deploy by ~60s for no
   # additional proof.)
+  #
+  # AND ONLY WHEN THE DOCS CHANGED. Over the last 30 days, 409 of 423 commits on
+  # main touched none of the 16 canonical sources this site is generated from, so
+  # this job was rebuilding and redeploying a byte-identical site on ~97% of
+  # pushes — roughly 138 minutes of runner time a month and a hundred Cloudflare
+  # Worker versions that differed in nothing.
+  #
+  # The paths live in .github/actions/changed, and scripts/check-docs-paths.mjs
+  # asserts they cover every source in apps/docs/docs-manifest.mjs. That guardrail
+  # is the load-bearing half: the failure mode of a stale filter is not a broken
+  # build, it is a page that quietly stops updating, which nothing would report.
   deploy-docs:
-    if: github.repository == 'derive-to/derive' && github.event_name == 'push'
+    if: >-
+      github.repository == 'derive-to/derive' && github.event_name == 'push' &&
+      needs.check.outputs.docs == 'true'
     needs: [check]
     runs-on: ubicloud-standard-4
     environment:

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "format": "biome format --write",
     "check": "biome check",
     "check:fix": "biome check --write",
-    "ci": "biome ci && pnpm lint:tokens && pnpm lint:frontend && pnpm lint:interaction && pnpm lint:mutations && pnpm lint:reload && pnpm lint:surfaces && pnpm lint:testids && pnpm lint:api && pnpm lint:schema && pnpm lint:hyperdrive && pnpm lint:filesize && pnpm lint:anchor-client && pnpm lint:deadcode && pnpm lint:boundaries && pnpm lint:env && pnpm lint:api-types && pnpm lint:agent-skill && pnpm lint:agent-package-files && pnpm lint:skills && pnpm lint:deck-template && pnpm lint:app-map && pnpm lint:mcp-coercion && pnpm lint:local-data && pnpm lint:delete-cascade && pnpm lint:facts-visibility && pnpm lint:facts-portable && pnpm lint:derived-exclusion && pnpm lint:selfhost-quickstart && pnpm lint:deploy-verified && pnpm lint:public-claims && pnpm lint:workflow-pins && pnpm lint:docs-site",
+    "ci": "biome ci && pnpm lint:tokens && pnpm lint:frontend && pnpm lint:interaction && pnpm lint:mutations && pnpm lint:reload && pnpm lint:surfaces && pnpm lint:testids && pnpm lint:api && pnpm lint:schema && pnpm lint:hyperdrive && pnpm lint:filesize && pnpm lint:anchor-client && pnpm lint:deadcode && pnpm lint:boundaries && pnpm lint:env && pnpm lint:api-types && pnpm lint:agent-skill && pnpm lint:agent-package-files && pnpm lint:skills && pnpm lint:deck-template && pnpm lint:app-map && pnpm lint:mcp-coercion && pnpm lint:local-data && pnpm lint:delete-cascade && pnpm lint:facts-visibility && pnpm lint:facts-portable && pnpm lint:derived-exclusion && pnpm lint:selfhost-quickstart && pnpm lint:deploy-verified && pnpm lint:public-claims && pnpm lint:workflow-pins && pnpm lint:docs-site && pnpm lint:docs-paths",
     "verify": "pnpm run ci && pnpm typecheck && pnpm test:coverage",
     "precommit": "pnpm run ci",
     "prepare": "git config core.hooksPath .githooks || true",
@@ -101,6 +101,7 @@
     "lint:public-claims": "node scripts/check-public-claims.mjs",
     "lint:workflow-pins": "node scripts/check-workflow-pins.mjs",
     "lint:docs-site": "pnpm --filter @derive/docs build",
+    "lint:docs-paths": "node scripts/check-docs-paths.mjs",
     "audit:repository": "node scripts/check-repository-health.mjs",
     "ci:required-checks": "node scripts/set-required-checks.mjs"
   },

--- a/scripts/check-docs-paths.mjs
+++ b/scripts/check-docs-paths.mjs
@@ -60,7 +60,17 @@ const sources = [...new Set([...docsPages.map((page) => page.source), docsHome?.
   Boolean,
 )
 
-const uncovered = sources.filter((source) => !patterns.some((p) => covers(p, source)))
+// The lockfile is not a manifest source and would not be caught by the sweep below,
+// but the docs site is BUILT with astro, @astrojs/mdx, pagefind and wrangler — all
+// pinned there. A version bump changes the rendered output or how it ships while
+// touching no content file, so omitting it means an upgrade sits undeployed until
+// somebody happens to edit a page. Measured: 27 commits in 30 days moved the
+// lockfile without touching any docs source.
+const TOOLCHAIN = ["pnpm-lock.yaml"]
+
+const uncovered = [...sources, ...TOOLCHAIN].filter(
+  (source) => !patterns.some((p) => covers(p, source)),
+)
 if (uncovered.length) {
   console.error("docs paths: these docs sources are NOT covered by the deploy filter:")
   for (const source of uncovered) console.error(`  ${source}`)
@@ -74,5 +84,5 @@ if (uncovered.length) {
 // manifest strictly needs (the whole of apps/docs, say, which holds the Astro app
 // and its assets as well as content) is deliberate and correct.
 console.log(
-  `docs paths: ${sources.length} docs sources all covered by ${patterns.length} filter patterns`,
+  `docs paths: ${sources.length} docs sources + ${TOOLCHAIN.length} toolchain input all covered by ${patterns.length} filter patterns`,
 )

--- a/scripts/check-docs-paths.mjs
+++ b/scripts/check-docs-paths.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+
+// The docs site deploys only when its sources change (see `deploy-docs` in
+// .github/workflows/ci.yml). This asserts that the path filter driving that
+// decision covers every source the site is actually generated from.
+//
+// It exists because the failure mode is silent. A page whose source falls outside
+// the filter does not break the build and does not fail a test — it simply stops
+// being republished, and the site quietly serves a stale copy until somebody
+// notices the wording is out of date. Nothing else in the repo would catch that.
+//
+// The manifest is the authority: apps/docs/docs-manifest.mjs decides which files
+// become pages, and this reads the filter out of the composite action and checks
+// the filter covers it. Add a page sourced from a new location and this fails
+// until .github/actions/changed learns about it.
+
+import { readFileSync } from "node:fs"
+import { docsHome, docsPages } from "../apps/docs/docs-manifest.mjs"
+
+const ACTION = ".github/actions/changed/action.yml"
+const action = readFileSync(ACTION, "utf8")
+
+// The `docs=true` case arm, e.g.
+//   apps/docs/* | SECURITY.md | examples/README.md | \
+//     packages/cli/README.md | packages/mcp/README.md)
+//     docs=true
+//
+// Found by walking BACK from the LAST `docs=true` to the nearest `case "$path" in`.
+// Both halves of that matter: a forward regex matches the first case block in the
+// file (the action classifies four things and they share an opener), and the FIRST
+// `docs=true` is the no-range fallback that turns every filter on, not this arm.
+const marker = action.lastIndexOf("docs=true")
+const opener = marker === -1 ? -1 : action.lastIndexOf('case "$path" in', marker)
+const armText =
+  opener === -1
+    ? null
+    : action
+        .slice(opener + 'case "$path" in'.length, marker)
+        .trim()
+        .replace(/\)$/, "")
+
+if (!armText) {
+  console.error(`docs paths: could not find the docs=true case arm in ${ACTION}.`)
+  console.error("If that filter moved, this check has to move with it — it is the only")
+  console.error("thing standing between a renamed source and a silently stale docs site.")
+  process.exit(1)
+}
+
+const patterns = armText
+  .replace(/\\\s*\n/g, " ")
+  .split("|")
+  .map((p) => p.trim())
+  .filter(Boolean)
+
+/** shell `case` globbing, restricted to the two forms this filter uses. */
+const covers = (pattern, path) =>
+  pattern.endsWith("/*") ? path.startsWith(pattern.slice(0, -1)) : pattern === path
+
+const sources = [...new Set([...docsPages.map((page) => page.source), docsHome?.source])].filter(
+  Boolean,
+)
+
+const uncovered = sources.filter((source) => !patterns.some((p) => covers(p, source)))
+if (uncovered.length) {
+  console.error("docs paths: these docs sources are NOT covered by the deploy filter:")
+  for (const source of uncovered) console.error(`  ${source}`)
+  console.error(`\nAdd them to the docs=true case arm in ${ACTION}, or the docs site will`)
+  console.error("stop redeploying when they change — silently.")
+  console.error(`\nfilter patterns: ${patterns.join(" | ")}`)
+  process.exit(1)
+}
+
+// The reverse direction is advisory, not an error: a pattern covering more than the
+// manifest strictly needs (the whole of apps/docs, say, which holds the Astro app
+// and its assets as well as content) is deliberate and correct.
+console.log(
+  `docs paths: ${sources.length} docs sources all covered by ${patterns.length} filter patterns`,
+)


### PR DESCRIPTION
Found while auditing the deploy path after #768.

`deploy-docs` has no path filter — it rebuilds and redeploys on **every push to
main**. Over the last 30 days:

| | |
|---|---|
| commits on main | 423 |
| commits touching a docs source | **14** |
| docs deploys shipping an identical site | **~97%** |
| runner time spent on those | **~138 min/month** |
| Cloudflare Worker versions with no difference | ~100 |

`check` already computes the changed-path filter for its own web build, so the
answer costs nothing — it just needed exposing as a job output.

## The guardrail is the load-bearing half

The failure mode of a stale filter is **silent**. The site is not built from
`apps/docs` alone: `docs-manifest.mjs` maps its 16 pages to canonical sources
scattered across the repo, including `SECURITY.md` and three package READMEs. A
source outside the filter does not break the build and does not fail a test —
the page just stops being republished, and the site serves a stale copy until a
human notices the wording is out of date.

So `scripts/check-docs-paths.mjs` reads the manifest, reads the filter out of the
composite action, and fails if the filter does not cover every source. Wired into
`pnpm ci`. Verified both directions:

```
$ node scripts/check-docs-paths.mjs
docs paths: 16 docs sources all covered by 5 filter patterns

$ # with SECURITY.md removed from the filter
docs paths: these docs sources are NOT covered by the deploy filter:
  SECURITY.md
exit=1
```

## Note on the trade

This is a **cost and hygiene** change, not a latency one — `deploy-docs` blocks
nothing. The thing it buys beyond runner minutes is a deploy history where a new
docs version means the docs actually changed.

`pnpm run ci` green locally (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/771"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789740382&installation_model_id=428097&pr_number=771&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F771&signature=71c6efc10a8bed92cc323249400dbb542789f047e5e426be00c7d1b7c56c1c20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->