### PR TITLE
Give Dependabot a cooldown, and stop it rebasing on every merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,38 @@
 version: 2
+
+# HOW THIS IS TUNED, and why it is not just "grouping".
+#
+# The grouping below has worked for a while and is not the problem. The problem
+# was volume and churn, measured on 2026-08-19:
+#
+#   46% of ALL CI runs came from dependabot branches
+#   every open PR had re-run CI ~5 times
+#   one branch had failed 9 times in a row with the SAME failure since Aug 14
+#
+# Two independent causes, and two independent fixes.
+#
+# CHURN — `rebase-strategy: disabled`. Dependabot rebases every open PR whenever
+# main moves, and this repo requires branches to be up to date to merge, so every
+# merge to main invalidated all of them at once. Three merges in one afternoon
+# triggered ~33 CI runs, all of which re-confirmed failures already known. Nothing
+# is lost by turning it off: an out-of-date branch has to be rebased before it can
+# merge anyway, so the rebase now happens when someone actually intends to act
+# (`@dependabot rebase`), rather than speculatively on everyone else's schedule.
+#
+# VOLUME — `cooldown`. A dependency is not worth a pull request the hour it ships.
+# Waiting lets the ecosystem find the breakage first, and it is also the control
+# that matters most against a compromised release: a malicious version is usually
+# caught and yanked within days, so age is protection. This repo already applies
+# that reasoning at resolution time via pnpm's `minimumReleaseAge` (24h, see
+# pnpm-workspace.yaml); cooldown applies it at PR-creation time, so the two layer
+# rather than duplicate.
+#
+# Majors get 30 days deliberately. Eight major PRs sat open for five days here,
+# every one of them blocked on a real incompatibility — typescript 7 failing lint
+# and coverage, @types/node 26 failing the install outright, better-sqlite3 13
+# breaking the native image build. None of those were actionable on arrival, and
+# opening a PR the day a major lands mostly buys a notification that the ecosystem
+# is not ready yet.
 updates:
   # App + package dependencies (pnpm workspace, resolved from the root lockfile).
   # Routine updates are grouped; majors stay isolated so their migrations and
@@ -9,6 +43,11 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 10
+    rebase-strategy: disabled
+    cooldown:
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
       npm-routine:
         patterns: ["*"]
@@ -23,6 +62,9 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    rebase-strategy: disabled
+    cooldown:
+      default-days: 7
     groups:
       actions:
         patterns: ["*"]
@@ -36,6 +78,9 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    rebase-strategy: disabled
+    cooldown:
+      default-days: 7
     groups:
       container-bases:
         patterns: ["*"]


### PR DESCRIPTION
## The measurement

On 2026-08-19, before this change:

| | |
|---|---|
| share of **all** CI runs from dependabot branches | **46%** |
| CI runs per open dependabot PR | ~5 |
| consecutive identical failures on one branch since Aug 14 | **9** |

Three merges to main in one afternoon triggered ~33 dependabot CI runs, every one
re-confirming a failure already known.

## Two causes, two fixes

**Churn — `rebase-strategy: disabled`.** Dependabot rebases every open PR whenever
main moves, and this repo requires branches to be up to date to merge, so every
merge invalidated all of them at once. Turning it off costs nothing: an
out-of-date branch has to be rebased before it can merge anyway, so the rebase now
happens when somebody intends to act (`@dependabot rebase`) instead of
speculatively on everyone else's schedule.

**Volume — `cooldown`.** A dependency isn't worth a PR the hour it ships. Waiting
lets the ecosystem find the breakage first, and age is also the control that
matters most against a compromised release — a malicious version is usually caught
and yanked within days.

```yaml
cooldown:
  semver-major-days: 30
  semver-minor-days: 7
  semver-patch-days: 3
```

This repo already applies that reasoning at *resolution* time via pnpm's
`minimumReleaseAge` (24h). `cooldown` applies it at *PR-creation* time, so the two
layer rather than duplicate.

30 days for majors is set on evidence: of the eight majors open for five days, the
ones genuinely blocked were blocked on **ecosystem readiness**, not on anything a
reviewer could act on — `@types/node` 26 failed the install outright,
`better-sqlite3` 13 broke the native image build.

## What this deliberately does *not* do

**No auto-merge workflow.** The common pattern is `dependabot/fetch-metadata` →
`gh pr review --approve` → `gh pr merge --auto`. It requires a bot rubber-stamping
the approving review, or a ruleset bypass. This repo SHA-pins every action, runs
OSV and gitleaks, and audits its own branch protection in
`check-repository-health.mjs` — automating around the review control would
undercut a thing it deliberately checks. Reducing volume is the better lever, and
that's what this does. Grouping is unchanged; it was already working and was never
the problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/772"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789741899&installation_model_id=428097&pr_number=772&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F772&signature=d990f7b8404c41fcd55c01b55a871ec51810a60084819a5ce8f8846d55bdce35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->