### PR TITLE
Retry the preview deploy, like the production one already does

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -93,11 +93,30 @@ jobs:
           echo "name=$NAME" >> "$GITHUB_OUTPUT"
           echo "url=$URL" >> "$GITHUB_OUTPUT"
 
+      # Retried, for the reason the production deploy in ci.yml is retried: Cloudflare
+      # answers `Received a malformed response from the API` on a healthy upload often
+      # enough to matter, and it succeeds verbatim on a re-run. That was already known
+      # and handled on the production path; this one was left bare, so the same
+      # transient showed up here as a red check on a pull request whose build had
+      # succeeded moments earlier — costing a maintainer the time to work out that the
+      # failure said nothing about their change.
+      #
+      # A preview deploy is idempotent (it uploads a new immutable version of a Worker
+      # named for the PR), so a retry can only help.
       - name: Deploy the preview
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: pnpm --filter @derive/api exec wrangler deploy --config wrangler.preview.toml
+        run: |
+          for attempt in 1 2 3; do
+            if pnpm --filter @derive/api exec wrangler deploy --config wrangler.preview.toml; then
+              exit 0
+            fi
+            echo "::warning::preview deploy failed (attempt $attempt/3); retrying" >&2
+            sleep $((attempt * 10))
+          done
+          echo "preview deploy failed three times" >&2
+          exit 1
 
       # Secrets are per-Worker, so a freshly-created preview has none and every authenticated
       # route 500s without them.


### PR DESCRIPTION
#773 came back with a red `preview` check today. The build had succeeded seconds
earlier; the failure was:

```
✘ [ERROR] Received a malformed response from the API
  upstream connect error or disconnect/reset before headers. reset reason: connection termination
```

That is the **exact** transient `ci.yml`'s production deploy already documents and
retries three times:

> Retried because this step's failure mode is a transient upstream one: Cloudflare
> answered `Received a malformed response from the API` on three separate uploads
> in one afternoon, each of which succeeded verbatim on a re-run.

The preview path was left bare, so the same upstream hiccup surfaces as a red
check on a pull request and costs somebody the time to work out that it says
nothing about their change. It cost exactly that today.

A preview deploy is idempotent — it uploads a new immutable version of a Worker
named for the PR — so a retry can only help. Same three attempts and the same
backoff as the production path, so the two now fail for the same reasons and only
those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/774"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789742158&installation_model_id=428097&pr_number=774&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F774&signature=bfc24c7fc7b2f48085e6efd8c784bdc72adda53f6be2720572edb4099c9ea307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->