### PR TITLE
Hold typescript at 6, and write down why

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,6 +48,32 @@ updates:
       semver-major-days: 30
       semver-minor-days: 7
       semver-patch-days: 3
+    ignore:
+      # TypeScript 7 is the native (Go) port, and its npm package is a different
+      # artifact rather than a newer version of the old one. Its main export is
+      # `{ version, versionMajorMinor }` — the JavaScript compiler API moved to
+      # `typescript/unstable/*`, and the entry point these scripts need is not
+      # there at all: `unstable/ast` exposes SyntaxKind, the is-predicates, a
+      # factory, a scanner and a visitor, but no parser. The `createSourceFile` it
+      # does export is the FACTORY (build a node from parts), not the one that
+      # turns a file's text into a tree. `unstable/sync` is project-oriented
+      # (parseConfigFile, updateSnapshot), so the equivalent would mean loading a
+      # project rather than parsing a string.
+      #
+      # Four guardrails and one test parse standalone files that way:
+      #   scripts/check-mutations.mjs, check-workspace-reload.mjs,
+      #   check-testids.mjs, check-surfaces.mjs, apps/api/test/authz-coverage.test.ts
+      #
+      # Rewriting them against an API TypeScript itself labels `unstable` is not a
+      # trade worth making right now, and it buys nothing on speed: `typecheck`
+      # already runs on tsgo (@typescript/native-preview, pinned at a 7.0.0-dev
+      # build), so this repo is on the TS7-generation compiler where it counts.
+      # `typescript` is here for the compiler API and as the tsc cross-check.
+      #
+      # Revisit when the parser surface stabilises — drop this entry and the PR
+      # comes back.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       npm-routine:
         patterns: ["*"]


### PR DESCRIPTION
Closes the #729 blocker — by deciding not to take it, with the reason recorded.

The PR failed with `TypeError: Cannot read properties of undefined (reading
'Latest')` — that's `ts.ScriptTarget.Latest` on a package that no longer has it.

**TypeScript 7 is the native (Go) port, and its npm artifact is a different thing
rather than a newer version of the old one.** Its main export is
`{ version, versionMajorMinor }` and nothing else. The JavaScript compiler API
moved to `typescript/unstable/*` — and the piece these scripts need isn't there:

| entrypoint | has |
|---|---|
| `unstable/ast` | SyntaxKind, is-predicates, factory, scanner, visitor — **no parser** |
| `unstable/ast/factory` | `createSourceFile` — the **factory** (build a node from parts), not the parser |
| `unstable/sync` | project-oriented: `parseConfigFile`, `updateSnapshot` |

I checked every unstable entrypoint for anything parse-shaped before concluding.

Four guardrails and one test parse standalone files that way —
`check-mutations`, `check-workspace-reload`, `check-testids`, `check-surfaces`,
and `authz-coverage.test.ts`. Restructuring all five against an API TypeScript
itself labels `unstable` isn't a trade worth making to satisfy a bot.

**It also buys nothing where it would matter.** `typecheck` already runs on tsgo
(`@typescript/native-preview`, pinned at a `7.0.0-dev` build), so this repo is on
the TS7-generation compiler for the thing people actually wait on. `typescript`
remains for the compiler API and the `typecheck:tsc` cross-check.

So: a deliberate hold with a stated expiry condition, rather than a stale PR
nobody closes. Revisit when the parser surface stabilises — drop the entry and
the PR comes back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789743453&installation_model_id=428097&pr_number=777&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F777&signature=d9ea0cf4e820a9e2c508f7d04ae7113cd90dda32d7ef15b171e9d242ad41699e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->