### PR TITLE
Fix a comment that points at a deleted script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -451,10 +451,12 @@ jobs:
   # pushes — roughly 138 minutes of runner time a month and a hundred Cloudflare
   # Worker versions that differed in nothing.
   #
-  # The paths live in .github/actions/changed, and scripts/check-docs-paths.mjs
-  # asserts they cover every source in apps/docs/docs-manifest.mjs. That guardrail
-  # is the load-bearing half: the failure mode of a stale filter is not a broken
-  # build, it is a page that quietly stops updating, which nothing would report.
+  # The answer comes from scripts/docs-affected.mjs, which reads
+  # apps/docs/docs-manifest.mjs directly — the site's pages come from canonical
+  # sources scattered across the repo (SECURITY.md, three package READMEs), and
+  # that manifest is the only place they are listed. Reading it beats keeping a
+  # second copy here: the failure mode of a stale filter is not a broken build, it
+  # is a page that quietly stops updating, which nothing would report.
   deploy-docs:
     if: >-
       github.repository == 'derive-to/derive' && github.event_name == 'push' &&


### PR DESCRIPTION
Found by auditing main for references to files this session deleted.

The note above `deploy-docs` in `ci.yml` still described the design that shipped a
few hours earlier — a path list duplicated in `.github/actions/changed`, policed by
`scripts/check-docs-paths.mjs`:

> The paths live in .github/actions/changed, and scripts/check-docs-paths.mjs
> asserts they cover every source in apps/docs/docs-manifest.mjs.

That script was **deleted** in #779 when the duplication was removed. The action now
asks `scripts/docs-affected.mjs`, which reads `apps/docs/docs-manifest.mjs` directly.

Nothing behaves differently, so no gate was ever going to catch this. It's worth a
commit anyway: the comment sent a reader to a file that doesn't exist, about a
guardrail that no longer needs to exist — **in the one place someone would look
before changing which paths trigger a docs deploy.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/781"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789750351&installation_model_id=428097&pr_number=781&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F781&signature=cc2f0a5f6a624e0a96002a15102bc347f697d2927dbf58c1362be547d6663744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->