### PR TITLE
Release chore: cli 0.5.0, mcp 0.6.0, and the changelog's first Removed section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,43 @@ for the recommended install and verification flow.
 
 ## [Unreleased]
 
+### Removed
+- **Proposals and the approval step.** The two review ceremonies are gone: ask-first
+  candidate versions awaiting an editor's decision, and the `approved` round state with
+  its served-version pointer. Review is one loop: every write publishes live as a kept,
+  restorable version; a review round is `pending` until the reviewer **Sends back**
+  their answers; and the note on that send-back is the whole decision — a note that
+  reads "good to go" is the go-signal. Gone with them: the
+  `/v1/artifacts/:id/proposals` routes and proposal storage, the `addressed` comment
+  state (threads are `open`/`resolved`/`outdated`), the `for_review` publish parameter
+  (`request_review` is the one ask), the approve endpoint, the Slack Approve buttons,
+  the `derive:propose` and `derive:review` OAuth scopes (existing grants keep
+  refreshing — the strings grant nothing), and approved-version pinning for skill
+  delivery — every read serves `current_version`. Existing databases run
+  `deploy/drop-proposals.sql` then `deploy/drop-approved-version.sql` once after
+  deploying; each normalizes persisted state before dropping the storage. The decision
+  record is `docs/decisions/0001-one-review-loop.md`.
+- `@derive-to/mcp` 0.6.0 — the stdio server matches the server: `publish` drops
+  `for_review`, the client drops `propose`, and a review round reports
+  `pending`/`sent_back`.
+- `@derive-to/cli` 0.5.0 — `derive approve` is gone; `derive send-back --note "…"` is
+  the human verb. Skill fetching reads current versions.
+
+### Changed
+- **Agent writes publish live, and the write policy is one switch.** An agent's write
+  lands exactly like a person's: a new version with the full publish fan-out (bell,
+  email, Slack, the open tab live-reloads). Asking for a look is `request_review` on
+  the publish, and the round, the email, and the Slack DM all carry the requester's
+  note. The five-dimensional write-policy machine (killswitch, workspace auto opt-in,
+  per-target publish/draft mode, model-confidence floor, outside-data rule) collapsed
+  to one workspace setting, `agentWrites`, on by default: off, agents stop writing
+  everywhere an agent credential can write — runs are neither materialized,
+  dispatched, nor claimed; chat's publish refuses with the drafted change surfaced in
+  the reply; agent-credentialed publishes are refused at the API on every surface;
+  staged upload URLs refuse at mint and at spend. A workspace whose legacy killswitch
+  was engaged upgrades to writes-off. An agent's write to the workspace brand profile
+  always opens a review round — its reveal is never silent.
+
 ### Added
 - **Reversible artifact archiving.** Artifacts can leave the active library without being
   deleted, appear in a dedicated archive, and be restored later.
@@ -95,16 +132,15 @@ for the recommended install and verification flow.
 - **Inline text editing.** An **Edit** button on the artifact workbench turns the
   rendered document itself into the editor: click any text, type, hit Save — a
   typo fix no longer needs the raw source or an agent round-trip. Works on phones
-  too (the save bar floats above the comments sheet). Editors publish
-  a new version directly; commenters (and locked artifacts) get **Suggest edits**,
-  which files the same change as a proposal for review. Under the hood each
+  too (the save bar floats above the comments sheet). Editing needs publish
+  standing; a commenter suggests the change in a comment instead. Under the hood each
   changed run travels as a **quote-scoped edit** (`{ quote: { exact, prefix,
   suffix }, new_text }`) — the write-side twin of the comment anchor — resolved
   server-side against the stored source with a strict matcher (context match, else
   a globally unique exact, else refuse), so an edit can never land on the wrong
   occurrence. For HTML artifacts the resolved span maps back to raw bytes through
   an offset-tracking projection that refuses to cross markup or split an entity;
-  replacements are escaped. The `edits` field on `POST /versions`, `/proposals`,
+  replacements are escaped. The `edits` field on `POST /versions`
   and the MCP `publish` tool accepts the new shape as an alternative to
   `{old_str, new_str}` (one shape per batch — the two resolve against different
   baselines, so mixing is refused rather than silently reordered), with the same

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@derive-to/cli",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "description": "CLI for Derive \u2014 create projects and publish durable, versioned artifacts from the terminal.",
   "keywords": [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@derive-to/mcp",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "type": "module",
   "description": "Stdio MCP server for Derive — find, read, comment on, and publish durable artifacts from compatible agents.",
   "mcpName": "to.derive/derive",


### PR DESCRIPTION
The release chore behind #785 and #786: version bumps that signal the breaking package surfaces, and the changelog's first **Removed** section.

## What's here

- **`@derive-to/cli` 0.4.0 → 0.5.0** — `derive approve` is gone; `derive send-back --note "…"` is the human verb, and skill fetching reads current versions.
- **`@derive-to/mcp` 0.5.1 → 0.6.0** — `publish` drops `for_review` (`request_review` remains the one ask), the client drops `propose`, and review rounds report `pending`/`sent_back`.
- **CHANGELOG** — a new `### Removed` + `### Changed` wave under `[Unreleased]` records the one-review-loop change (agent writes publish live behind the one `agentWrites` switch; proposals and the approval step removed, with the two one-shot deploy scripts named). Two earlier unreleased entries are amended so they stay true at release time; already-published package entries (0.5.0/0.5.1/0.4.x) are untouched history.
- **knip** — clean; the deletion left no dead code for it to find.

## Publish order

npm publish happens only after the server deploy is verified (a 0.6.0 stdio server against a pre-deploy API would offer a surface the API doesn't serve). Publish `@derive-to/cli` before `@derive-to/mcp` — the MCP package's `workspace:*` dependency on the CLI resolves to 0.5.0 at publish time.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/787"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789916899&installation_model_id=428097&pr_number=787&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F787&signature=84bdfd259788c679e00c71776c2f246951089203b1f33e6344804cc8a04cf9cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->