### PR TITLE
derive send-back hands the human the page when the server refuses a credential

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -45,7 +45,7 @@ derive status                 # review state and open threads
 derive comments               # full comment threads
 derive reply <thread-id> "Updated the evidence and conclusion."
 derive publish --name "Revision 2"
-derive send-back --note "Good to go — ship it"
+derive send-back                # opens the page; Send back is a signed-in browser gesture
 ```
 
 The Send back note is the human's answer — a note that reads "good to go" IS the

--- a/packages/cli/bin/derive.js
+++ b/packages/cli/bin/derive.js
@@ -27,7 +27,7 @@
 //   derive reply <thread_id> <message…>    reply in a thread
 //   derive resolve|reopen <comment_id>     set a thread's state
 //   derive status [--id] [--json]          the review round state + open threads
-//   derive send-back [--id] [--note m]     (human) return your answers to the agent
+//   derive send-back [--id] [--note m]     open the page to send your answers back (a browser gesture)
 //   derive doctor [--server url] [--token t]  report which optional features are configured
 //   derive runner serve|once|doctor|install   run a context's answer daemon, or drain once (npx-able anywhere)
 //   derive context push|dev                ship a context dir as its manifest / tune it live
@@ -1274,6 +1274,16 @@ if (LOOP.includes(cmd)) {
       headers: { "content-type": "application/json", ...auth },
       body: JSON.stringify({ note: flags.note ?? "" }),
     })
+    if (res.status === 403) {
+      // Settling a round is recorded as a person's decision, and only a signed-in
+      // browser session proves a person — a CLI credential acts FOR you, so the
+      // server refuses it here. Hand the human the page where the gesture lives.
+      const url = `${r.server}/a/${r.id}`
+      console.error("Send back records a human decision, so it needs your signed-in browser.")
+      console.error(`Opening ${url} — use the Send back box in the comments sidebar.`)
+      openBrowser(url)
+      process.exit(1)
+    }
     if (!res.ok) await die(res)
     const { round } = await res.json()
     console.log(`✓ sent back to the agent (round ${round.state})`)
@@ -1449,7 +1459,7 @@ if (cmd !== "publish") {
   derive reply <thread_id> <message…>      reply in a thread
   derive resolve|reopen <comment_id>       set a thread's state
   derive status [--id X] [--json]          review-round state + open threads (the loop's poll target)
-  derive send-back [--id X] [--note m]     (human) return your answers to the waiting agent
+  derive send-back [--id X] [--note m]     open the page to send your answers back (a browser gesture)
   derive runner serve|doctor|install       run a context's answer daemon (\`derive runner\` for flags)
   derive context push|dev                  ship a context dir as its manifest / tune it on the working tree
   derive skill add <short_id>              materialize a published skill into ./.claude/skills/ (pinned)


### PR DESCRIPTION
Found running the loop against the hosted instance after #786 deployed: the server (correctly) refuses any CLI credential at the direct-human gate — settling a round is recorded as a person's decision, and only a signed-in browser session proves a person. But the CLI's `send-back` verb dead-ended on that 403 and its usage lines and README presented it as a terminal action.

The verb now opens the artifact page and names the Send back box when the gate refuses; the usage lines and README describe the gesture as the browser action it is. No server change — the gate is working as pinned by the human-decision tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/788"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789917949&installation_model_id=428097&pr_number=788&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F788&signature=c92b3fc083bc8c4e3a61016f59174d4abcd78ede90e3b7288d05db96f9c68764"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->