### PR TITLE
Describe guards and shells in the present tense

### DIFF
--- a/apps/api/scripts/apply-pg-schema.ts
+++ b/apps/api/scripts/apply-pg-schema.ts
@@ -42,10 +42,9 @@ const url = u.toString()
 const store = await PgMetaStore.create(url, (e) => console.error("pool error:", e.message))
 console.log("app schema applied")
 
-// (The one-time pre-v2 access backfill used to run here, after the DDL. Retired
-// with the v1 `visibility`/`general_role` columns — an instance upgrading straight
-// from a pre-v2 build runs deploy/drop-v1-access.sql instead, which folds the old
-// values into the access fields before dropping them.)
+// An instance upgrading from a build that still carries the v1
+// `visibility`/`general_role` columns runs deploy/drop-v1-access.sql separately,
+// which folds those values into the access fields before dropping them.
 
 // Better Auth schema: derived from the live auth config (the single source of
 // truth), reconciled by Better Auth's own migrator. baseUrl/secret are dummies —

--- a/apps/web/src/components/shared/public-frame.tsx
+++ b/apps/web/src/components/shared/public-frame.tsx
@@ -8,9 +8,8 @@ import { signupSourceSearch } from "@/lib/signup-source"
 // shared profile today (the artifact viewer has its own richer PublicViewer). A slim
 // brand header (→ home) + the growth verbs, the content as the hero, and a quiet
 // "Made with Derive" footer: the same public-shell language as PublicViewer, minus the
-// artifact-specific identity/presence. Replaces the old anon nav rail — an anon never
-// sees app chrome now, just this frame around the render. `returnTo` sends Sign in
-// back here afterward.
+// artifact-specific identity/presence. An anon never sees app chrome, just this frame
+// around the render. `returnTo` sends Sign in back here afterward.
 export function PublicFrame({ returnTo, children }: { returnTo: string; children: ReactNode }) {
   return (
     <div className="flex min-h-0 flex-1 flex-col bg-background">

--- a/scripts/check-agent-package-files.mjs
+++ b/scripts/check-agent-package-files.mjs
@@ -29,9 +29,9 @@ const errors = []
 
 // The published set must be closed under its own workspace dependencies: a
 // `workspace:*` dependency on a package outside this list ships a version spec
-// the registry cannot resolve (the internal @derive/* scope is never published).
-// @derive-to/mcp@0.6.0 went out depending on a package that did not exist on npm;
-// this check makes that a CI failure instead of a broken release.
+// the registry cannot resolve (the internal @derive/* scope is never published),
+// and `pnpm publish` rewrites the spec without checking that the target exists —
+// so the closure has to be asserted here, before anything is packed.
 const publishedNames = new Set(
   packages.map((pkg) => {
     const manifest = JSON.parse(readFileSync(join(root, pkg.dir, "package.json"), "utf8"))
@@ -74,4 +74,6 @@ if (errors.length) {
   process.exit(1)
 }
 
-console.log("agent-package-files: CLI and MCP tarballs include their Derive skill resources")
+console.log(
+  "agent-package-files: published tarballs carry their required files, and the set is dependency-closed",
+)


### PR DESCRIPTION
A sweep of everything changed since the last present-tense pass, plus a fresh tree-wide search for history narration. Four sites now state what the code does rather than what came before: the published-set closure check gives its structural reason (pnpm rewrites workspace specs without checking the registry) and its success line covers the whole set; the pg schema script points at drop-v1-access.sql in the present tense; the public frame describes what an anonymous visitor sees. History stays in CHANGELOG.md, docs/decisions/, and git.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789920679&installation_model_id=428097&pr_number=790&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F790&signature=cc1c0b4fa70c7cbfe041661b3334ce9d1dbf17fe908048d959ef02ec3705a9df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->