### PR TITLE
ui: move archived work

### DIFF
--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -203,6 +203,25 @@ test("Brandprint lives in Settings, People is its own page, and old paths on bot
   await expect(owner).toHaveURL(/\/settings\/brandprint$/)
 })
 
+test("Archived lives inside the Library filter rather than the primary rail", async ({ owner }) => {
+  await owner.goto("/")
+  await expect(owner.getByTestId("nav-archived")).toHaveCount(0)
+
+  await owner.getByTestId("library-filter").click()
+  await owner.getByTestId("library-filter-archived").click()
+  await expect(owner).toHaveURL(/\/archived$/)
+  await expect(owner.getByRole("heading", { name: /Library/ })).toBeVisible()
+  await expect(owner.getByTestId("library-filter")).toHaveAttribute(
+    "aria-label",
+    "Filter: Archived",
+  )
+  await expect(owner.getByTestId("library-view-artifacts")).toHaveAttribute("data-state", "on")
+
+  await owner.getByTestId("library-filter").click()
+  await owner.getByTestId("library-filter-all").click()
+  await expect(owner).toHaveURL(/\/$|\/\?/)
+})
+
 test("starring a collection pins it to the sidebar's Starred group", async ({ owner }) => {
   await owner.goto("/")
   const name = `Shelf ${Date.now()}`

--- a/apps/web/src/components/chrome/nav-rail.tsx
+++ b/apps/web/src/components/chrome/nav-rail.tsx
@@ -120,10 +120,8 @@ function FilterItem({
   )
 }
 
-// A fixed-feed nav row: navigates to a top-level ROUTE (a named feed like /favorites
-// or /following, or the /people directory) rather than a library filter. The path IS
-// the destination — the FilterItem counterpart for feeds that earned their own route
-// (docs/decisions/0002).
+// A fixed-route nav row. Unlike FilterItem, these destinations are separate product
+// surfaces rather than ways to narrow the library.
 function NavItem({
   icon,
   label,
@@ -135,7 +133,7 @@ function NavItem({
   icon: IconName
   label: string
   count?: number
-  to: "/following" | "/contexts" | "/templates" | "/chat" | "/archived"
+  to: "/following" | "/contexts" | "/templates" | "/chat"
   active: boolean
   testId?: string
 }) {
@@ -379,7 +377,6 @@ export function NavRail() {
   const onTemplates = loc.pathname.startsWith("/templates")
   const onSettings = loc.pathname.startsWith("/settings")
   const onChat = loc.pathname.startsWith("/chat")
-  const onArchived = loc.pathname === "/archived"
   // Chat is on by default, so the row hides only once settings have RESOLVED and said otherwise
   // — `undefined` (still loading, or the read failed) keeps the row rather than blinking it out
   // and back on every cold boot. It rides the boot batch the rail already waits for, so this
@@ -536,9 +533,8 @@ export function NavRail() {
     <Sidebar collapsible="icon" variant="inset">
       <RailHeader showSearch />
       <SidebarContent>
-        {/* TIER 1 — primary navigation: the whole library at a glance, plus the
-            people directory. The rail's home base; it carries no section label
-            because it IS the top of the rail. */}
+        {/* TIER 1 — primary navigation. The rail's home base carries no section
+            label because it is the top of the rail. */}
         <SidebarGroup>
           <SidebarGroupContent>
             <SidebarMenu>
@@ -587,8 +583,8 @@ export function NavRail() {
         {/* Starred — the shelves you pinned, and the rail's ONLY collection list. Every
             collection used to be enumerated here, which grew until the navigation was a
             file browser; they live in the library's Collections view now, and this is
-            the handful you chose. Absent entirely until you star something, so a new
-            workspace opens on two nav rows rather than an empty heading. */}
+            the handful you chose. Absent entirely until you star something, so an
+            empty heading never consumes space. */}
         {starredCollections.length > 0 && (
           <SidebarGroup>
             <SidebarGroupLabel data-testid="sidebar-starred">Starred</SidebarGroupLabel>
@@ -598,21 +594,13 @@ export function NavRail() {
           </SidebarGroup>
         )}
 
-        {/* Tools — a running sync, notifications, Settings. Pinned to the foot of
+        {/* Tools — a running sync, notifications, and Settings. Pinned to the foot of
             the scroll (mt-auto); the whitespace above sets them apart, no divider. */}
         <SidebarGroup className="mt-auto">
           <SidebarGroupContent>
             <SidebarMenu>
               <SyncChip />
               <NotificationBell />
-              <NavItem
-                icon="archive"
-                label="Archived"
-                count={summary?.archived}
-                to="/archived"
-                active={onArchived}
-                testId="nav-archived"
-              />
               <SidebarMenuItem>
                 <SidebarMenuButton asChild isActive={onSettings} tooltip="Settings">
                   <Link

--- a/apps/web/src/pages/library/filter-menu.tsx
+++ b/apps/web/src/pages/library/filter-menu.tsx
@@ -8,22 +8,22 @@ import {
 import { cn } from "@/lib/utils"
 import type { LibrarySearch } from "./types"
 
-export type LibraryFilter = NonNullable<LibrarySearch["filter"]> | "all"
+export type LibraryFilter = NonNullable<LibrarySearch["filter"]> | "all" | "archived"
 
-// Four ways to narrow the home library, in ONE control. Favorites and "Shared with you"
-// were rail rows and "Created by me" was a tab, all pointing at the same list — four
-// permanent slots spent on states most people are never in. A menu costs one, and unlike
-// the routes it composes with where you already are: `Mine` inside a collection means your
-// documents in that collection.
+// Ways to narrow the library live in one control. Favorites and "Shared with you" were
+// rail rows, "Created by me" was a tab, and Archived was a permanent sidebar destination.
+// None is a separate product surface. The active-artifact facets compose with the current
+// collection; Archived opens its own server-backed shelf through the same control.
 //
 // Deliberately a menu and not a segmented control: the default is the answer almost every
-// time, so the other three should cost a click to reach and nothing to ignore.
+// time, so the alternatives should cost a click to reach and nothing to ignore.
 const OPTIONS: { value: LibraryFilter; label: string; hint: string }[] = [
   { value: "all", label: "All artifacts", hint: "Everything you can see here" },
   { value: "needs-you", label: "Needs you", hint: "Open threads you're in" },
   { value: "mine", label: "Mine", hint: "Artifacts you created" },
   { value: "shared", label: "Shared with me", hint: "Shared with you directly" },
   { value: "starred", label: "Starred", hint: "Artifacts you starred" },
+  { value: "archived", label: "Archived", hint: "Put away without deleting" },
 ]
 
 const filterLabel = (f: LibraryFilter): string =>

--- a/apps/web/src/pages/library/index.tsx
+++ b/apps/web/src/pages/library/index.tsx
@@ -106,6 +106,9 @@ function LibraryBody({ view }: { view: LibraryView }) {
   // one IS the `collection` filter, so the switch would be offering you the place you
   // are already standing.
   const showCollections = view === "all" && search.view === "collections" && !search.collection
+  // Archived is a lifecycle shelf within the library, not a separate destination. It keeps
+  // the library header and controls while its route preserves deep links and loader caching.
+  const onLibrarySurface = view === "all" || view === "archived"
   // Brandprint-pointed collections take artifacts through Settings, not the shelves.
   const brandprintIds = useBrandprintCollectionIds()
   const visibleCollections = collections.filter((c) => !brandprintIds.has(c.id))
@@ -506,7 +509,7 @@ function LibraryBody({ view }: { view: LibraryView }) {
           <div className="flex min-h-10 flex-wrap items-center gap-1.5">
             <h1 className="flex min-w-0 items-baseline gap-2">
               <span className="truncate font-serif text-lg font-semibold tracking-tight text-foreground">
-                {view === "all" ? "Library" : heading}
+                {onLibrarySurface ? "Library" : heading}
               </span>
               {identityCount !== undefined && (
                 <span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
@@ -554,7 +557,7 @@ function LibraryBody({ view }: { view: LibraryView }) {
             {filterField}
             {/* Feeds have no view row, so Display stays up here for them; home's moves
                 down beside Filter — the two are one kind of control and sit together. */}
-            {view !== "all" && (
+            {!onLibrarySurface && (
               <DisplayMenu
                 layout={layout}
                 onLayout={setLayout}
@@ -570,11 +573,10 @@ function LibraryBody({ view }: { view: LibraryView }) {
               showPublish && <NewArtifactButton />
             )}
           </div>
-          {/* The tab row, home only: Artifacts ⇄ Collections are views of one place,
-              which is what underline tabs say. The facet menu rides the same line as a
-              quiet chip — it reads as optional because it is. A named feed IS a filter,
-              so it gets neither. */}
-          {view === "all" && !search.collection ? (
+          {/* Artifacts and Collections are views of the library. The filter menu narrows
+              the artifact view, including its archived shelf; named activity feeds remain
+              separate routes and therefore do not render these controls. */}
+          {onLibrarySurface && !search.collection ? (
             <div className="mb-5 flex items-center gap-4 border-b border-border-soft">
               <ViewSwitch
                 value={showCollections ? "collections" : "artifacts"}
@@ -583,6 +585,7 @@ function LibraryBody({ view }: { view: LibraryView }) {
                     to: "/",
                     search: {
                       ...search,
+                      filter: view === "archived" ? undefined : search.filter,
                       view: next === "collections" ? "collections" : undefined,
                     },
                   })
@@ -593,13 +596,24 @@ function LibraryBody({ view }: { view: LibraryView }) {
                 <span className="flex items-center gap-1">
                   <FilterMenu
                     needsYou={feedbackCount}
-                    value={search.filter ?? "all"}
-                    onChange={(next) =>
-                      nav({
+                    value={view === "archived" ? "archived" : (search.filter ?? "all")}
+                    onChange={(next) => {
+                      if (next === "archived") {
+                        void nav({
+                          to: "/archived",
+                          search: { query: search.query, sort: search.sort },
+                        })
+                        return
+                      }
+                      void nav({
                         to: "/",
-                        search: { ...search, filter: next === "all" ? undefined : next },
+                        search: {
+                          ...search,
+                          filter: next === "all" ? undefined : next,
+                          view: undefined,
+                        },
                       })
-                    }
+                    }}
                   />
                   <DisplayMenu
                     labeled


### PR DESCRIPTION
Move archived artifacts from sidebar to library

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789924484&installation_model_id=428097&pr_number=792&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F792&signature=bed6a86a78dea273af932393f1b81e8ec609e8a750681173cf505acee06014d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->