### PR TITLE
MCP reaches public artifacts outside the grant, read-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,15 @@ for the recommended install and verification flow.
   dependencies reach outside the published set.
 
 ### Changed
+- **MCP reads public artifacts outside the grant, read-only.** `read`, `find`'s
+  in-artifact grep, and `publish`'s `derived_from` now reach any artifact whose world
+  link is open (public or link-only, not password-locked, not an expired draft), at
+  viewer, exactly what an anonymous holder of its URL gets: the current version only
+  unless its history is public, facts as stored (no derivation on the reader's behalf),
+  renders as they are (no re-queue), and no comments, review state, revisions, or shelf
+  changes, which still need a seat. Such reads are logged as `mcp.reach.public`.
+  An agent can start from a public template in another workspace and record the
+  lineage; the Templates page's "Ask your agent" hands over the short id for every row.
 - **Templates are artifacts.** The Templates page, `GET /v1/templates`, and `find
   templates:true` now list artifacts carrying the `template` tag: the active workspace's
   own first (`shelf: "workspace"`), then public ones from any workspace

--- a/apps/api/src/mcp-tool-context.ts
+++ b/apps/api/src/mcp-tool-context.ts
@@ -15,11 +15,13 @@ import {
   type ArtifactRecord,
   type ContextRecord,
   capRole,
+  effectiveRole,
   type Role,
 } from "@derive/core"
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import { z } from "zod"
 import type { AppContext } from "./context"
+import { log } from "./log"
 import { err, json, staleAwareNumber, staleSchemaNote } from "./mcp-util"
 
 // The raw per-request values buildServer resolves and hands to makeToolContext.
@@ -48,6 +50,15 @@ export interface ToolContextBase {
 // The `workspace` argument shared by every workspace-scoped tool.
 const wsArg = z.string().optional().describe("Workspace id or name. Omit for your default.")
 
+/** An artifact `reach` resolved: where it lives, the role to act with there, and whether
+ *  that came from the world link (`public`) rather than a seat. */
+export interface Reached {
+  a: ArtifactRecord
+  org: string
+  role: Role
+  public: boolean
+}
+
 export interface ToolContext extends ToolContextBase {
   grantedWorkspaces: () => Promise<{ id: string; name: string; role: Role }[]>
   inGrant: (org: string) => boolean
@@ -58,9 +69,11 @@ export interface ToolContext extends ToolContextBase {
     /** `allowRemoved` sees PAST the takedown gate, for the one caller that acts on an
      *  artifact's shelf state rather than its content: without it, restoring is
      *  impossible, because reach refuses the very artifact you are trying to bring
-     *  back. Every other gate (workspace, membership, role) still applies. */
-    opts?: { allowRemoved?: boolean },
-  ) => Promise<{ a: ArtifactRecord; org: string; role: Role } | { error: string } | null>
+     *  back. Every other gate (workspace, membership, role) still applies.
+     *  `public` reaches an artifact no seat covers when its world link is open, at
+     *  viewer and flagged `public: true`. Content reads and lineage only. */
+    opts?: { allowRemoved?: boolean; public?: boolean },
+  ) => Promise<Reached | { error: string } | null>
   notFound: (shortId: string) => ReturnType<typeof err>
   wsArg: typeof wsArg
   /** A numeric parameter that coerces AND records a stale-schema proof (see
@@ -139,37 +152,54 @@ export function makeToolContext(base: ToolContextBase): ToolContext {
   // is found wherever it lives without the model naming the workspace.
   // `workspace_access = none` narrows further: touchable only through the
   // agent's human (or a legacy row of the agent's own) — a teammate's
-  // invite-only draft stays invisible over MCP.
+  // invite-only draft stays invisible over MCP unless its world link is open and the
+  // caller opted into `public`.
+  // `public` opts into the world link: an artifact no seat reaches (or that is not in
+  // the named `wsRef`) comes back at viewer when anyone with its URL could open it. Only
+  // content reads and lineage opt in; the collaboration tools never do, so comments,
+  // reviews, and shelf state stay behind a seat.
   // Returns the artifact plus the org + re-capped role to act with there.
   const reach = async (
     shortId: string,
     wsRef?: string,
-    opts?: { allowRemoved?: boolean },
-  ): Promise<{ a: ArtifactRecord; org: string; role: Role } | { error: string } | null> => {
+    opts?: { allowRemoved?: boolean; public?: boolean },
+  ): Promise<Reached | { error: string } | null> => {
     const a = await ctx.meta.getByShortId(shortId)
     if (!a) return null
     let org = defaultOrg
     let role = defaultRole
+    let seated = true
     if (wsRef) {
       const t = await resolveWs(wsRef)
       if ("error" in t) return t
-      if (a.org_id !== t.org) return null // named a workspace this artifact isn't in
-      org = t.org
-      role = t.role
+      if (a.org_id === t.org) {
+        org = t.org
+        role = t.role
+      } else if (opts?.public) seated = false
+      else return null // named a workspace this artifact isn't in
     } else if (a.org_id !== defaultOrg) {
       // Auto-roam to the doc's workspace only if it's within this grant and the
       // owner is a member. A doc in a workspace outside the grant reads as not found.
-      if (!ownerId || !inGrant(a.org_id)) return null
-      const m = await ctx.meta.getMembership(a.org_id, ownerId)
-      if (!m) return null
-      org = a.org_id
-      role = capRole(scopeForCap, m.role)
+      const m =
+        ownerId && inGrant(a.org_id) ? await ctx.meta.getMembership(a.org_id, ownerId) : null
+      if (m) {
+        org = a.org_id
+        role = capRole(scopeForCap, m.role)
+      } else seated = false
     }
-    if (a.workspace_access !== "member") {
+    if (seated && a.workspace_access !== "member") {
       const ok =
         (actingFor && (await ctx.meta.getArtifactMember(a.id, actingFor.id))) ||
         (await ctx.meta.getArtifactMember(a.id, agent.id))
-      if (!ok) return null
+      if (!ok) seated = false
+    }
+    if (!seated) {
+      // The anonymous rule: an open world link, not locked, not an expired draft.
+      const world = effectiveRole({ kind: "anon" }, a.workspace_access, a.link_role)
+      const expired = !!a.expires_at && a.expires_at <= new Date().toISOString()
+      if (!opts?.public || a.password_hash || world === null || expired) return null
+      org = a.org_id
+      role = "viewer"
     }
     // A taken-down artifact serves NO content, mirroring the web /raw 410: read, find,
     // comment, and publish all resolve through here, so gating it once covers every
@@ -180,7 +210,10 @@ export function makeToolContext(base: ToolContextBase): ToolContext {
     // make the artifact it needs unreachable and restoring impossible.
     if (a.removed_at && !opts?.allowRemoved)
       return { error: `"${shortId}" was taken down and is no longer available.` }
-    return { a, org, role }
+    // Marked so a cross-tenant scrape is tellable from ordinary reads.
+    if (!seated)
+      log.info("mcp.reach.public", { short_id: a.short_id, org: a.org_id, agent: agent.id })
+    return { a, org, role, public: !seated }
   }
   const notFound = (shortId: string) =>
     err(

--- a/apps/api/src/mcp-tools/find.ts
+++ b/apps/api/src/mcp-tools/find.ts
@@ -21,7 +21,16 @@ import { listTemplateArtifacts } from "../lib/template-artifacts"
 import { visibleArtifactIds } from "../lib/visibility"
 import { log } from "../log"
 import type { ToolContext } from "../mcp-tool-context"
-import { err, json, runnerOnline, safeJson, summarizeArtifact, text } from "../mcp-util"
+import {
+  err,
+  historyNotPublic,
+  json,
+  runnerOnline,
+  safeJson,
+  summarizeArtifact,
+  text,
+  versionOpenToWorld,
+} from "../mcp-util"
 
 // FIND — one tool over BROWSE (list_artifacts) + GREP/SEARCH (search) + the askable
 // CONTEXTS (list_contexts), discriminated by argument. The mode is decided by what's
@@ -298,8 +307,7 @@ export function registerFindTool(tc: ToolContext): void {
           truncated,
           next:
             (truncated ? "Refine query to narrow the shelf. " : "") +
-            "Read a result's uri (its short_id), publish a new artifact with derived_from set to it, and inspect the render. " +
-            "If read refuses a row (a workspace outside this grant), its url still serves the page as markdown; the person can start from it there with Make a copy.",
+            "Read a result's uri (its short_id), publish a new artifact with derived_from set to it, and inspect the render. A public row from another workspace reads at its current version.",
         })
       }
       // Claimed BEFORE mode 1, which owns `short_id` and would answer a `links_to` call with
@@ -322,13 +330,14 @@ export function registerFindTool(tc: ToolContext): void {
         const ctxLines = Math.min(Math.max(context ?? 0, 0), 5)
         const cap = Math.min(Math.max(max_matches ?? 40, 1), 200)
         const where = scope ?? "source"
-        const r = await reach(short_id, workspace)
+        const r = await reach(short_id, workspace, { public: true })
         if (r && "error" in r) return err(r.error)
         if (!r) return notFound(short_id)
         const a = r.a
         const n = version ?? a.current_version
         if (n < 1 || n > a.current_version)
           return err(`No version ${n} for "${short_id}" — it has versions 1..${a.current_version}.`)
+        if (r.public && !versionOpenToWorld(a, n)) return historyNotPublic(short_id, a)
         const v = await ctx.meta.getVersion(a.id, n)
         if (!v) return err(`Version ${n} of "${short_id}" is unavailable.`)
         const { groups, total, note } = await searchArtifactVersion(

--- a/apps/api/src/mcp-tools/publish.ts
+++ b/apps/api/src/mcp-tools/publish.ts
@@ -571,7 +571,9 @@ export function registerPublishTool(tc: ToolContext): void {
         if (!readable) return err(`No template starter "${derived_from}" you can reach.`)
         derivedFromId = entry.source_artifact_id
       } else if (derived_from) {
-        const source = await reach(derived_from, workspace)
+        // Lineage needs read reach only, so a public template in another workspace
+        // qualifies; the copy itself lands in the target workspace at the caller's role.
+        const source = await reach(derived_from, workspace, { public: true })
         if (!source || "error" in source)
           return err(
             source && "error" in source

--- a/apps/api/src/mcp-tools/read.ts
+++ b/apps/api/src/mcp-tools/read.ts
@@ -48,6 +48,7 @@ import {
   err,
   FULL_DOC_MAX,
   formatLabel,
+  historyNotPublic,
   IMAGE_INLINE_MAX,
   json,
   manifestOf,
@@ -61,6 +62,7 @@ import {
   skillsCatalog,
   sleep,
   toBase64,
+  versionOpenToWorld,
 } from "../mcp-util"
 import { CORE_SKILLS } from "../skills-reference.gen"
 
@@ -542,7 +544,8 @@ export function registerReadTool(tc: ToolContext): void {
         }
         docId = seg
       }
-      const r = await reach(docId, workspace)
+      // Opted into the world link: a public artifact outside the grant reads at viewer.
+      const r = await reach(docId, workspace, { public: true })
       if (r && "error" in r) return err(r.error)
       // A bare name that matches no artifact may still name a CONTEXT — tried only here,
       // after the artifact lookup, so a context named like a doc can never shadow it.
@@ -555,6 +558,7 @@ export function registerReadTool(tc: ToolContext): void {
       const n = version ?? a.current_version
       if (n < 1 || n > a.current_version)
         return err(`No version ${n} for "${short_id}" — it has versions 1..${a.current_version}.`)
+      if (r.public && !versionOpenToWorld(a, n)) return historyNotPublic(short_id, a)
       const v = await ctx.meta.getVersion(a.id, n)
       if (!v) return err(`Version ${n} of "${short_id}" is unavailable.`)
       const url = artifactUrl(ctx.deps.baseUrl, a)
@@ -590,11 +594,14 @@ export function registerReadTool(tc: ToolContext): void {
         // ran and switched off since, and "this instance renders nothing" would then discard
         // a true fact about the page (a font that never loaded, a layout that timed out) in
         // favour of a fact about the deployment. Both are said, in that order.
+        // The renderer's error text is the instance's own; a reader without a seat gets
+        // the fact of the failure only.
+        const why = !r.public && variant.error ? ` (${variant.error})` : ""
         if (!ctx.deps.renderPreviews && !(variant.status === "ready" && variant.key))
           return err(
             rendersOff(
               variant.status === "failed"
-                ? `The render:${render} of "${short_id}" v${n} failed (${variant.error ?? "transient error"}), and a fresh one`
+                ? `The render:${render} of "${short_id}" v${n} failed${why}, and a fresh one`
                 : `The render:${render} of "${short_id}" v${n}`,
               url,
             ),
@@ -611,8 +618,10 @@ export function registerReadTool(tc: ToolContext): void {
         // an older one would flip `failed` to `pending` PERMANENTLY: nothing ever renders
         // it, and the heal can't fire again because it only triggers on `failed`. That
         // trades an honest error message for "not ready yet, try again shortly" forever.
-        // An old version keeps its failure, which is the truthful answer.
-        if (variant.status === "failed" && n === a.current_version) {
+        // An old version keeps its failure, which is the truthful answer. The world link
+        // never re-queues: a reader with no seat serves only what has rendered, as the
+        // anonymous embed does.
+        if (variant.status === "failed" && n === a.current_version && !r.public) {
           // Use the shared notifier rather than enqueueing directly: on Workers it also
           // pokes the PreviewRenderer DO, so this read's wait loop can observe the repair
           // instead of depending on a later cron tick.
@@ -627,7 +636,12 @@ export function registerReadTool(tc: ToolContext): void {
         // ready nor failed and the caller passed `wait`, block up to that many seconds
         // (max 30), re-reading the version, before returning the not-ready message — a
         // bounded retry loop so the agent gets the render in one call after a fresh push.
-        if (wait && !(variant.status === "ready" && variant.key) && variant.status !== "failed") {
+        if (
+          wait &&
+          !r.public &&
+          !(variant.status === "ready" && variant.key) &&
+          variant.status !== "failed"
+        ) {
           const deadline = Date.now() + Math.min(Math.max(wait, 0), 30) * 1000
           while (
             Date.now() < deadline &&
@@ -671,20 +685,22 @@ export function registerReadTool(tc: ToolContext): void {
         }
         if (variant.status === "failed")
           return err(
-            `The render:${render} of "${short_id}" v${n} failed${requeued ? " again on a re-queued attempt" : ""}${variant.error ? ` (${variant.error})` : ""} — the page may still be fine; open ${url} to check. ` +
+            `The render:${render} of "${short_id}" v${n} failed${requeued ? " again on a re-queued attempt" : ""}${why} — the page may still be fine; open ${url} to check. ` +
               // Only the current version re-renders: the worker discards a job for a
               // superseded one, so promising a retry here would be advice that silently
               // does nothing. Say what actually works instead.
-              (n === a.current_version
-                ? "Reading again re-queues a fresh render."
-                : `This is an old version, and only v${a.current_version} re-renders — read it without \`version\` to retry.`),
+              (r.public
+                ? "It is not re-rendered for a reader without a seat in its workspace."
+                : n === a.current_version
+                  ? "Reading again re-queues a fresh render."
+                  : `This is an old version, and only v${a.current_version} re-renders — read it without \`version\` to retry.`),
           )
         if (requeued)
           return err(
-            `The render:${render} of "${short_id}" v${n} had failed (${variant.error ?? "transient error"}) — a fresh render was just re-queued. Call read again with \`wait\` (seconds, max 30) to collect it.`,
+            `The render:${render} of "${short_id}" v${n} had failed${why} — a fresh render was just re-queued. Call read again with \`wait\` (seconds, max 30) to collect it.`,
           )
         return err(
-          `The render:${render} of "${short_id}" v${n} isn't ready yet — screenshots are computed a few seconds after publish. Try again shortly, or pass \`wait\` (seconds, max 30) to block for it.`,
+          `The render:${render} of "${short_id}" v${n} isn't ready yet — screenshots are computed a few seconds after publish. Try again shortly${r.public ? "" : ", or pass `wait` (seconds, max 30) to block for it"}.`,
         )
       }
       // The data rung: a version's structured facts, queried instead of re-parsed. A
@@ -707,6 +723,8 @@ export function registerReadTool(tc: ToolContext): void {
             return err(
               `Bad \`versions\` "${versions}" for "${short_id}" (it has 1..${a.current_version}) — use "1-30", "12", "20-", or "all".`,
             )
+          // The same clamp the raw series route applies to anonymous readers.
+          if (r.public && !a.public_history) range.from = range.to = a.current_version
           const rows = await ctx.meta.getVersionDataSeries(
             a.id,
             data,
@@ -770,9 +788,14 @@ export function registerReadTool(tc: ToolContext): void {
         // the corpus's $links) recomputes from the version's own bytes: one blob, one
         // pass, value returned now, rows persisted off the response. Series reads and the
         // raw routes serve stored rows only — a 200-version series must never become 200
-        // blob reads in one request, and anonymous traffic must not command compute.
+        // blob reads in one request, and anonymous traffic must not command compute. The
+        // world link over MCP is anonymous traffic: stored rows only, nothing persisted.
         let lazyFilled = false
-        if (isDerivedFactName(data) && (!rows[0] || rows[0].gen !== derivedGen(data))) {
+        if (
+          !r.public &&
+          isDerivedFactName(data) &&
+          (!rows[0] || rows[0].gen !== derivedGen(data))
+        ) {
           const fresh = await lazyDeriveVersion(ctx, a.id, v, n)
           if (fresh) {
             rows = fresh.filter((r) => r.slot === data)
@@ -781,6 +804,10 @@ export function registerReadTool(tc: ToolContext): void {
         }
         const row = rows[0]
         if (!row) {
+          if (r.public && isDerivedFactName(data))
+            return err(
+              `"${short_id}" v${n} has no stored "${data}". Derived facts are computed for readers with a seat in its workspace; the world link serves only what is stored.`,
+            )
           const all = await ctx.meta.getVersionData(a.id, n)
           return err(
             absenceNote(

--- a/apps/api/src/mcp-util.ts
+++ b/apps/api/src/mcp-util.ts
@@ -240,6 +240,14 @@ export const parseLineRange = (
   return { from, to: Math.min(to, total) }
 }
 
+/** On the world link only the current version is readable, unless the owner opened the history. */
+export const versionOpenToWorld = (a: ArtifactRecord, n: number): boolean =>
+  n === a.current_version || !!a.public_history
+export const historyNotPublic = (shortId: string, a: ArtifactRecord) =>
+  err(
+    `"${shortId}" is readable here only at its current version (${a.current_version}); its history is not public.`,
+  )
+
 export const summarizeArtifact = (a: ArtifactRecord) => ({
   short_id: a.short_id,
   title: a.title,

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -1,7 +1,12 @@
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import type { BlobStore, MetaStore, SearchIndex } from "@derive/core"
+import {
+  type BlobStore,
+  type MetaStore,
+  publish as publishVersion,
+  type SearchIndex,
+} from "@derive/core"
 import { SqliteMetaStore } from "@derive/db/sqlite"
 import { FsBlobStore } from "@derive/storage/fs"
 import Database from "better-sqlite3"
@@ -1220,6 +1225,165 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(col?.count).toBe(2)
     const inspect = JSON.parse(toolText(await call(app, token, "organize", { short_ids: [a] })))
     expect(inspect.artifacts[0].collections).toContain(col.id)
+  })
+
+  it("reaches a public artifact outside the grant at viewer: read and lineage only", async () => {
+    const { app, token, meta, blobs } = appWithGrant(
+      dir,
+      "public-reach",
+      "openid derive:read derive:comment derive:publish",
+      // Previews on, so the render rung below reaches the self-heal it must not trigger.
+      { renderPreviews: true },
+    )
+    const home = JSON.parse(toolText(await call(app, token, "list_workspaces"))) as {
+      workspaces: { id: string; default: boolean }[]
+    }
+    const homeWorkspace = home.workspaces.find((w) => w.default)?.id
+    if (!homeWorkspace) throw new Error("the grant has no default workspace")
+    // A workspace the granting user does not belong to, with one public and one private
+    // artifact. Silent breakage here is a cross-tenant leak, so it goes through the tools.
+    await meta.setWorkspace("ws_far", "Far workspace")
+    const farBody = (title: string, usd: number) =>
+      `<!doctype html><html><body><h1>${title}</h1><p>from far away</p>` +
+      `<script type="application/derive-facts" data-fact="usd">{"usd":${usd}}</script></body></html>`
+    const far = async (title: string, linkRole: "viewer" | "none", listed: "public" | "none") =>
+      (
+        await publishVersion(meta, blobs, {
+          bytes: new TextEncoder().encode(farBody(title, 1)),
+          filename: "doc.html",
+          isBundle: false,
+          title,
+          author: "Far owner",
+          authorId: "u_far",
+          orgId: "ws_far",
+          workspaceAccess: "member",
+          linkRole,
+          listed,
+        })
+      ).artifact
+    const open = await far("Far public template", "viewer", "public")
+    const linkOnly = await far("Far link-only", "viewer", "none")
+    const closed = await far("Far private", "none", "none")
+    await meta.setArtifactTags(open.id, ["template"])
+    // Facts rows as the publish chain would store them (the core publish helper alone
+    // does not extract them), one per version, so the series has a history to clamp.
+    const usdFact = (n: number) => [
+      { id: `vd_far_usd_${n}`, slot: "usd", json: `{"usd":${n}}`, size_bytes: 9, gen: 0 },
+    ]
+    await meta.setVersionData(open.id, 1, usdFact(1))
+    // A password on the world link suspends it, for anonymous readers and here alike.
+    const locked = await meta.createArtifact({
+      id: "a_far_locked",
+      short_id: "farlockd",
+      org_id: "ws_far",
+      slug: "locked",
+      title: "Far locked",
+      workspace_access: "member",
+      link_role: "viewer",
+      listed: "public",
+      password_hash: "not-a-real-hash",
+      kind: "file",
+      spa: 0,
+    })
+
+    // The world link is what reaches it: public or link-only read; private and locked do not.
+    expect(toolText(await call(app, token, "read", { short_id: open.short_id }))).toContain(
+      "from far away",
+    )
+    expect(toolText(await call(app, token, "read", { short_id: linkOnly.short_id }))).toContain(
+      "from far away",
+    )
+    for (const unreachable of [closed.short_id, locked.short_id])
+      expect(toolText(await call(app, token, "read", { short_id: unreachable }))).toMatch(
+        /No artifact/,
+      )
+    // The shelf lists it as public, and grep within it works.
+    const shelf = JSON.parse(toolText(await call(app, token, "find", { templates: true }))) as {
+      results: { uri: string; source: string }[]
+    }
+    expect(shelf.results).toContainEqual(
+      expect.objectContaining({ uri: open.short_id, source: "public" }),
+    )
+    expect(
+      toolText(await call(app, token, "find", { short_id: open.short_id, query: "far away" })),
+    ).toContain("far away")
+
+    // Lineage: the copy lands in the caller's own workspace, pointing at the far source.
+    const adopted = JSON.parse(
+      toolText(
+        await call(app, token, "publish", {
+          title: "Ours, from far",
+          content: "# Ours\n\nadapted",
+          derived_from: open.short_id,
+        }),
+      ),
+    ) as { short_id: string }
+    const adoptedRow = await meta.getByShortId(adopted.short_id)
+    expect(adoptedRow?.derived_from).toBe(open.id)
+    expect(adoptedRow?.org_id).not.toBe("ws_far")
+
+    // Read-only. The write and collaboration tools never opt into the public branch, so
+    // to them the artifact does not exist: no revision, no comment, no review state.
+    expect(
+      toolText(
+        await call(app, token, "publish", { short_id: open.short_id, content: "# Overwrite" }),
+      ),
+    ).toMatch(/No artifact/)
+    expect((await meta.getByShortId(open.short_id))?.current_version).toBe(1)
+    expect(
+      toolText(await call(app, token, "comment", { short_id: open.short_id, body: "hi" })),
+    ).toMatch(/No artifact/)
+    expect(toolText(await call(app, token, "catch_up", { short_id: open.short_id }))).toMatch(
+      /No artifact/,
+    )
+    await publishVersion(
+      meta,
+      blobs,
+      {
+        bytes: new TextEncoder().encode(farBody("Far public template, revised", 2)),
+        filename: "doc.html",
+        isBundle: false,
+        author: "Far owner",
+        authorId: "u_far",
+        orgId: "ws_far",
+      },
+      open.short_id,
+    )
+    await meta.setVersionData(open.id, 2, usdFact(2))
+    expect(
+      toolText(await call(app, token, "read", { short_id: open.short_id, version: 1 })),
+    ).toMatch(/history is not public/)
+    expect(toolText(await call(app, token, "read", { short_id: open.short_id }))).toContain(
+      "revised",
+    )
+    // The facts series is clamped to the current version, like the raw series route.
+    const series = JSON.parse(
+      toolText(
+        await call(app, token, "read", { short_id: open.short_id, data: "usd", versions: "all" }),
+      ),
+    ) as { series: { n: number; data: { usd: number } }[] }
+    expect(series.series.map((row) => row.n)).toEqual([2])
+    // Nothing is persisted on the far tenant's behalf: a derived slot is served from what
+    // is stored, never computed and written by an outsider's read.
+    await call(app, token, "read", { short_id: open.short_id, data: "$stats" })
+    expect(await meta.getVersionData(open.id, 2, "$stats")).toHaveLength(0)
+    // And a failed render stays failed, with the renderer's own error kept to itself.
+    await meta.setVersionPreview(open.id, 2, {
+      preview_status: "failed",
+      preview_error: "chromium OOM at an internal bucket",
+    })
+    const failed = toolText(
+      await call(app, token, "read", { short_id: open.short_id, render: "top" }),
+    )
+    expect(failed).toMatch(/failed/)
+    expect(failed).not.toContain("internal bucket")
+    expect((await meta.getVersion(open.id, 2))?.preview_status).toBe("failed")
+    // Naming the caller's own workspace (as the Templates handoff does) still reaches it.
+    expect(
+      toolText(
+        await call(app, token, "read", { short_id: open.short_id, workspace: homeWorkspace }),
+      ),
+    ).toContain("revised")
   })
 
   it("organize never folds a roaming artifact into the default workspace's collection", async () => {

--- a/apps/web/src/pages/templates/agent-handoff.ts
+++ b/apps/web/src/pages/templates/agent-handoff.ts
@@ -8,9 +8,6 @@ export type AgentTemplateTarget = {
   outcome?: string
   sections?: ReadonlyArray<string>
   inputs?: ReadonlyArray<{ name: string; description: string; required?: boolean }>
-  /** A public artifact from another workspace. The agent's grant may not reach it by
-   *  short id, so the handoff references the page URL and records no lineage. */
-  publicUrl?: string
 }
 
 export type AgentHandoffWorkspace = { id: string; name: string }
@@ -47,24 +44,17 @@ Use the template as a reference, then make the decisions this brief needs:
 4. Publish the adapted manifest as a new artifact with \`derived_from: "${target.uri}"\`, then use automate with create_context once the setup is clear.
 5. Return the new shareable Derive URL and briefly explain the important adaptations.`
 
-  const viaUrl = !!target.publicUrl
-  const inspect = viaUrl
-    ? "Fetch the exact reference URL (it serves markdown to agents) before creating anything; it is outside this workspace, so Derive's read tool may not reach it."
-    : "Use Derive's read tool to inspect the exact reference before creating anything."
-  const publish = viaUrl
-    ? "Leave the original unchanged and publish a new artifact. Do not set derived_from: lineage to an artifact outside this workspace is not recorded yet."
-    : `Leave the original unchanged and publish a new artifact with \`derived_from: "${target.uri}"\` so Derive records the exact reference.`
-  return `Use this Derive ${viaUrl ? "public artifact" : "template"} as a strong reference and make a new artifact for me.
+  return `Use this Derive template as a strong reference and make a new artifact for me.
 
 Template: ${target.title}
-Exact reference: ${target.publicUrl ?? target.uri}
+Exact reference: ${target.uri}
 ${destination}What I need:
 ${request}
 
 Use the template as a reference, then make the decisions this brief needs:
-1. ${confirmWorkspace} ${inspect}
+1. ${confirmWorkspace} Use Derive's read tool to inspect the exact reference before creating anything.
 2. Keep the useful structure, visual language, interactions, and narrative rhythm. Adapt the content and other decisions to my brief. Use find when workspace evidence would improve the result.
-3. ${publish}
+3. Leave the original unchanged and publish a new artifact with \`derived_from: "${target.uri}"\` so Derive records the exact reference.
 4. Render and visually inspect the finished result before reporting success. Revise it if the rendered result is weak.
 5. Return the new shareable Derive URL and briefly explain the important adaptations.`
 }

--- a/apps/web/src/pages/templates/index.tsx
+++ b/apps/web/src/pages/templates/index.tsx
@@ -107,13 +107,7 @@ export function Templates() {
               template={template}
               copying={copyMut.isPendingFor(template.short_id)}
               onCopy={() => copyMut.mutate(template.short_id)}
-              onAsk={() =>
-                setAgentTarget(
-                  targetFromArtifact(template, {
-                    publicUrl: template.shelf === "public" ? template.url : undefined,
-                  }),
-                )
-              }
+              onAsk={() => setAgentTarget(targetFromArtifact(template))}
             />
           ))}
         </CardGrid>

--- a/apps/web/src/pages/templates/template-target.ts
+++ b/apps/web/src/pages/templates/template-target.ts
@@ -7,14 +7,12 @@ const artifactCategory = (artifact: Pick<Artifact, "current_content_type">): str
 
 export const targetFromArtifact = (
   artifact: Pick<Artifact, "short_id" | "title" | "current_content_type">,
-  opts?: { publicUrl?: string },
 ): AgentTemplateTarget => ({
   uri: artifact.short_id,
   title: artifact.title || "Untitled artifact",
   description: "A new, agent-authored result grounded in this artifact.",
   kind: "artifact",
   category: artifactCategory(artifact),
-  ...(opts?.publicUrl ? { publicUrl: opts.publicUrl } : {}),
 })
 
 export const targetFromLibraryEntry = (


### PR DESCRIPTION
## Why

The template shelf (#794) lists public templates from any workspace, but over MCP an agent could not do anything with one from outside its grant: `reach` had no public branch, so `read` answered "no artifact you can reach" and `publish … derived_from` refused the lineage. The shelf told agents about templates they could not start from. The web handoff had to special-case those rows with a URL and no lineage.

## What

`reach` gains an opt-in `public` option. When no seat reaches an artifact (outside the grant, or `workspace_access: none` with no membership), and the caller opted in, the artifact comes back at **viewer** with `public: true` if its world link is open, using the same rule the anonymous web viewer uses (`effectiveRole({ kind: "anon" }, …)`, and no password on the link). Only three call sites opt in, and all three are reads:

- `read` (content, sections, map, render, facts), with the gates the anonymous raw routes already apply: a non-current `version` is refused unless the artifact's history is public; the facts series is clamped to the current version on the same condition; a derived (`$`) slot is served as stored, never computed and persisted on the reader's behalf; a failed render is not re-queued and `wait` does not long-poll. An expired draft is unreachable, as the page serves it as gone.
- `find` with `short_id` (grep within one artifact), same version gate.
- `publish`'s `derived_from` lookup, which records the lineage id; the copy itself lands in the caller's workspace at the caller's role.

Every other tool calls `reach` without the option and keeps seeing "no artifact you can reach": comment, catch_up, checkpoint, organize, stage, and `publish` with a `short_id` (a revision). So the world link grants reading and nothing else.

On the web, the handoff no longer needs a public-row branch: "Ask your agent" hands over the short id for every shelf row, and the `publicUrl` plumbing from #794 is gone. The `find templates:true` `next` text stops warning about unreachable public rows.

The guarantee this is meant to hold: an agent reaches exactly what an anonymous holder of the artifact's URL can read, and can never write through it. Every public-branch read logs `mcp.reach.public` with the artifact, its workspace, and the agent, so a cross-tenant scrape is tellable from ordinary use.

Registered agent tokens and run tokens (no granting user) get the same anonymous-level read; they could not roam before. That is within the guarantee and is noted here on purpose.

## Verified

- `pnpm verify` green (guardrails 33/33, typecheck, every package's tests).
- New case in `mcp.test.ts`, watched failing with the public branch disabled and again with the read gates removed: a workspace the grant's owner does not belong to holds a public, a link-only, a private, and a password-locked artifact. Public and link-only `read`; private and locked do not. The public one appears on the shelf as `public`, greps, and records lineage into the caller's own workspace. A revision, a comment, and `catch_up` on it all answer "no artifact you can reach". After a revision: version 1 is refused (history not public), the current version reads, the facts series returns the current version only, a derived-slot read persists nothing, and a failed render stays failed.
- Playwright locally: `templates.smoke.spec.ts` (the handoff still names the short id).
- Two adversarial review rounds framed as a control review (the guarantee above, against every tool that calls `reach`). Round one confirmed the gate itself (no workspace escalation through `workspace`, no role or target-workspace laundering through `derived_from`, one not-found message for nonexistent, private, and locked ids) and found three lower `read` rungs leaking past the anonymous page (facts history, lazy derivation writes, render re-queue); all three are gated and pinned. Round two found that passing a `workspace` argument (which the Templates handoff prompt encourages) skipped the public branch entirely, that the render assertion was vacuous with previews off in the harness, and that the failed-render message handed a seatless reader the renderer's internal error text; fixed, with the test now built with previews on, asserting the error text is withheld and that naming the caller's own workspace still reaches the public artifact.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/796"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789948518&installation_model_id=428097&pr_number=796&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F796&signature=94c317cf16b864f078d8c428c632b68fe835c1a0f920869b0f2dbe37e57f1ca2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->