### PR TITLE
Templates have public pages, and the public footer leads back to them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,15 @@ for the recommended install and verification flow.
   these surfaces; `/v1/templates` returns artifact rows (the `BuiltInTemplate` schema
   is gone from the OpenAPI document), the Contexts tab is gone, and the Libraries tab
   is hidden behind a flag while `?tab=libraries` keeps working.
+- **Templates have public pages.** `/templates` is readable signed out: the public shelf
+  in the chrome-light frame, where "Make a copy" goes through sign-in and keeps the copy
+  intent for afterward. Every template also has a page of its own, `/templates/<ref>`:
+  the artifact page, presented to a signed-out visitor as a template, with a strip that
+  names the two ways to start from it ("Make a copy", "Ask your agent") and its tags. The
+  public footer, wherever a workspace shows the "Made with Derive" mark, now closes the
+  loop: "Start from this template" on an artifact tagged `template`, "Start from this
+  page" (a copy, through sign-in) otherwise, and "Browse templates" on a template page.
+  The address presents an artifact as a template only when it carries the tag.
 - **Agent writes publish live, and the write policy is one switch.** An agent's write
   lands exactly like a person's: a new version with the full publish fan-out (bell,
   email, Slack, the open tab live-reloads). Asking for a look is `request_review` on

--- a/apps/api/src/lib/spa-paths.ts
+++ b/apps/api/src/lib/spa-paths.ts
@@ -32,7 +32,7 @@ const SPA_EXACT = new Set([
 ])
 
 const oneSegment =
-  /^\/(?:artifacts|claim|collections|contexts|settings|template-libraries|users)\/[^/]+$/
+  /^\/(?:artifacts|claim|collections|contexts|settings|template-libraries|templates|users)\/[^/]+$/
 const invite = /^\/invite\/(?:(?:a|c)\/)?[^/]+$/
 
 export const isSpaPath = (path: string): boolean => {

--- a/apps/api/test/serve-web.test.ts
+++ b/apps/api/test/serve-web.test.ts
@@ -70,6 +70,8 @@ describe("serve-web: SPA vs API path contract", () => {
       "/invite/c/token",
       "/settings/members",
       "/showcase",
+      "/templates",
+      "/templates/weekly-review-abc123",
       "/users/maya",
     ])
       expect(isSpaPath(path)).toBe(true)

--- a/apps/web/e2e/templates.smoke.spec.ts
+++ b/apps/web/e2e/templates.smoke.spec.ts
@@ -9,6 +9,14 @@ async function tagAsTemplate(page: Page, shortId: string) {
   expect(res.ok(), await res.text()).toBeTruthy()
 }
 
+// The public shelf lists artifacts that are listed publicly, not merely link-readable.
+async function listPublicly(page: Page, shortId: string) {
+  const res = await page.request.patch(`/v1/artifacts/${shortId}/access`, {
+    data: { listed: "public" },
+  })
+  expect(res.ok(), await res.text()).toBeTruthy()
+}
+
 test.describe("templates", () => {
   test("a tagged artifact appears on the workspace shelf and copies into the workspace", async ({
     owner: page,
@@ -26,6 +34,12 @@ test.describe("templates", () => {
     await expect(page.getByTestId(`template-card-${shortId}`)).toBeVisible()
     await expect(page.getByTestId(`template-copy-${shortId}`)).toContainText("Make a copy")
 
+    // The card's title is the template's own address; signed in, that is the workbench.
+    await page.getByTestId(`template-open-${shortId}`).click()
+    await expect(page).toHaveURL(new RegExp(`/templates/.*${shortId}`))
+    await expect(page.getByText("Comments", { exact: true })).toBeVisible()
+
+    await page.goto("/templates")
     await page.getByTestId(`template-copy-${shortId}`).click()
     await expect(page).toHaveURL(/\/artifacts\//)
     // The copy is a new artifact, not the template itself.
@@ -70,5 +84,87 @@ test.describe("templates", () => {
     // The shelf has settled once the tagged one is on it; only then is absence meaningful.
     await expect(page.getByTestId(`template-card-${tagged}`)).toBeVisible()
     await expect(page.getByTestId(`template-card-${untagged}`)).toHaveCount(0)
+  })
+})
+
+test.describe("templates, signed out", () => {
+  test("the public shelf is readable, and Make a copy goes through sign-in keeping the template", async ({
+    owner,
+    browser,
+  }) => {
+    const shortId = await publishArtifact(owner, "brief.md", "# Launch brief", "text/markdown")
+    await tagAsTemplate(owner, shortId)
+    await listPublicly(owner, shortId)
+
+    const anon = await browser.newContext()
+    const page = await anon.newPage()
+    try {
+      await page.goto("/templates")
+      // The chrome-light frame, not the workbench: sign-in, no workspace verbs.
+      await expect(page.getByTestId("public-sign-in")).toBeVisible()
+      await expect(page.getByTestId("templates-shelf-public")).toBeVisible()
+      await expect(page.getByTestId(`template-card-${shortId}`)).toBeVisible()
+      await expect(page.getByTestId("templates-new-blank")).toHaveCount(0)
+      await expect(page.getByTestId("templates-create-existing")).toHaveCount(0)
+
+      await page.getByTestId(`template-copy-${shortId}`).click()
+      await expect(page).toHaveURL(/\/login\?/)
+      // Sign-in returns to the template's own page with the copy intent intact.
+      const returnTo = new URL(page.url()).searchParams.get("return_to") ?? ""
+      expect(returnTo).toMatch(new RegExp(`^/templates/.*${shortId}\\?use=1$`))
+
+      // Creating the account from here finishes the copy: the visitor lands on their own.
+      await page.getByTestId("login-name").fill("Copier")
+      await page.getByTestId("login-email").fill(`e2e-copier-${Date.now()}@example.com`)
+      await page.getByTestId("login-password").fill("e2e-pass-1234")
+      await page.getByTestId("login-submit").click()
+      await expect(page).toHaveURL(/\/artifacts\//, { timeout: 15_000 })
+      expect(new URL(page.url()).pathname).not.toContain(shortId)
+    } finally {
+      await anon.close()
+    }
+  })
+
+  test("a template page presents the strip, and public footers lead to it", async ({
+    owner,
+    browser,
+  }) => {
+    const tagged = await publishArtifact(owner, "kit.md", "# Starter kit", "text/markdown")
+    await tagAsTemplate(owner, tagged)
+    const plain = await publishArtifact(owner, "note.md", "# Just a note", "text/markdown")
+
+    const anon = await browser.newContext()
+    const page = await anon.newPage()
+    try {
+      await page.goto(`/templates/${tagged}`)
+      await expect(page.getByTestId("template-strip")).toBeVisible()
+      await expect(page.getByTestId("public-make-your-own")).toHaveAttribute(
+        "href",
+        /return_to=%2Ftemplates%2F/,
+      )
+      await expect(page.getByTestId("public-start-from")).toHaveText("Browse templates")
+      await page.getByTestId("template-ask-agent").click()
+      await expect(page.getByRole("heading", { name: /^Use / })).toBeVisible()
+      await page.keyboard.press("Escape")
+
+      // The artifact address of a tagged artifact is the plain page; its footer is the
+      // way to the template page.
+      await page.goto(`/artifacts/${tagged}`)
+      await expect(page.getByTestId("public-start-from")).toHaveText("Start from this template")
+      await expect(page.getByTestId("template-strip")).toHaveCount(0)
+      await page.getByTestId("public-start-from").click()
+      await expect(page).toHaveURL(new RegExp(`/templates/.*${tagged}`))
+      await expect(page.getByTestId("template-strip")).toBeVisible()
+
+      // An untagged artifact offers a copy of itself, through sign-in.
+      await page.goto(`/artifacts/${plain}`)
+      await expect(page.getByTestId("public-start-from")).toHaveText("Start from this page")
+      await expect(page.getByTestId("public-start-from")).toHaveAttribute(
+        "href",
+        /return_to=%2Fartifacts%2F[^&]*%3Fuse%3D1/,
+      )
+    } finally {
+      await anon.close()
+    }
   })
 })

--- a/apps/web/src/components/shared/public-frame.tsx
+++ b/apps/web/src/components/shared/public-frame.tsx
@@ -5,7 +5,8 @@ import { Button } from "@/components/ui/button"
 import { signupSourceSearch } from "@/lib/signup-source"
 
 // The chrome-light frame for a public surface an anonymous visitor lands on — a
-// shared profile today (the artifact viewer has its own richer PublicViewer). A slim
+// shared profile or the template shelf (the artifact viewer has its own richer
+// PublicViewer). A slim
 // brand header (→ home) + the growth verbs, the content as the hero, and a quiet
 // "Made with Derive" footer: the same public-shell language as PublicViewer, minus the
 // artifact-specific identity/presence. An anon never sees app chrome, just this frame

--- a/apps/web/src/lib/signup-source.ts
+++ b/apps/web/src/lib/signup-source.ts
@@ -15,8 +15,7 @@ export const signupSourceSearch = (
   landingPath: string,
 ): SignupSourceSearch => {
   if (!KIND.test(kind)) throw new Error("invalid signup source")
-  const landing =
-    landingPath.startsWith("/") && !landingPath.startsWith("//") ? landingPath.slice(0, 200) : "/"
+  const landing = /^\/(?![/\\])/.test(landingPath) ? landingPath.slice(0, 200) : "/"
   return {
     src: kind.toLowerCase(),
     landing,

--- a/apps/web/src/pages/artifact/artifact-breadcrumb.tsx
+++ b/apps/web/src/pages/artifact/artifact-breadcrumb.tsx
@@ -22,6 +22,7 @@ import { useApiMutation } from "@/lib/use-api-mutation"
 import { cn } from "@/lib/utils"
 import { folderScopedSiblingIds, resolveContextCollection, siblingNav } from "./lib/siblings"
 import { refFor } from "./parse-ref"
+import type { ArtifactSearch } from "./route-config"
 
 // Shared title styling so the plain-title and switcher-trigger forms are pixel-identical
 // (the reframe's document header: serif, base, tight).
@@ -121,7 +122,8 @@ function EditableTitle({ art, className }: { art: Artifact; className?: string }
 // focus mode by the header wrapper (it stays mounted; keyboard paging is gated off then).
 export function ArtifactBreadcrumb({ art, focusMode }: { art: Artifact; focusMode: boolean }) {
   const nav = useNavigate()
-  const { collection: paramCollection } = useSearch({ from: "/artifacts/$ref" })
+  // The page mounts under /artifacts/$ref and /templates/$ref (see route-config.ts).
+  const { collection: paramCollection } = useSearch({ strict: false }) as ArtifactSearch
   const { data: collections = [] } = useQuery(collectionsQuery())
   const contextId = resolveContextCollection(paramCollection, art.collections)
   const { data: siblings = [] } = useQuery({

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -64,6 +64,7 @@ import { PasswordGate } from "./password-gate"
 import { PublicViewer } from "./public-viewer"
 import { Presence } from "./rail-deck"
 import { ReviewCard } from "./review-card"
+import type { ArtifactSearch } from "./route-config"
 import { SourceEditor } from "./source-editor"
 import { type ComposerState, parseAnchor } from "./types"
 import { useArtifactFrame } from "./use-artifact-frame"
@@ -123,10 +124,19 @@ function FocusShellSync({ focus }: { focus: boolean }) {
   return null
 }
 
-export function Artifact() {
+/**
+ * The artifact page. `template` is the /templates/$ref address: the same document,
+ * presented to a signed-out visitor with the template strip and footer.
+ */
+export function Artifact({ template = false }: { template?: boolean }) {
   const { switchWorkspace } = useShell()
-  const { ref } = useParams({ from: "/artifacts/$ref" })
-  const search = useSearch({ from: "/artifacts/$ref" })
+  // Mounted by /artifacts/$ref and /templates/$ref (route-config.ts). `from:` names one
+  // route, so both reads are `strict: false`; the two routes validate the same search.
+  const { ref } = useParams({ strict: false }) as { ref: string }
+  const search = useSearch({ strict: false }) as ArtifactSearch
+  // Every same-artifact navigation below keeps whichever address the visitor arrived at.
+  const selfBase = template ? "/templates" : "/artifacts"
+  const selfRoute = `${selfBase}/$ref` as const
   const { shortId, version } = parseRef(ref)
   const { me, loading } = useAuth()
   const nav = useNavigate()
@@ -189,7 +199,7 @@ export function Artifact() {
     useFired.current = true
     const strip = () =>
       nav({
-        to: "/artifacts/$ref",
+        to: selfRoute,
         params: { ref },
         search: (s) => ({ ...s, use: undefined }),
         replace: true,
@@ -211,7 +221,7 @@ export function Artifact() {
         toast.error("Couldn't copy this artifact into your workspace")
         strip()
       })
-  }, [search.use, loading, me, shortId, ref, nav])
+  }, [search.use, loading, me, shortId, ref, selfRoute, nav])
   // The tab is named after the document, like the workbench header (title, else id).
   useDocumentTitle(art ? (art.title ?? shortId) : null)
   const commentsAvailable =
@@ -607,7 +617,7 @@ export function Artifact() {
     locked,
     error,
     onCanonical: (canonical) =>
-      nav({ to: "/artifacts/$ref", params: { ref: canonical }, search: (s) => s, replace: true }),
+      nav({ to: selfRoute, params: { ref: canonical }, search: (s) => s, replace: true }),
     onLoginBounce: () => nav({ to: "/login", search: artifactLoginSearch(window.location) }),
     onOpenComments: () => setRail("comments"),
     post,
@@ -645,7 +655,7 @@ export function Artifact() {
     refetchComments,
     onRestoredJump: () =>
       nav({
-        to: "/artifacts/$ref",
+        to: selfRoute,
         params: { ref: refFor({ short_id: shortId, title: art?.title }) },
         // Same artifact — keep the search (the ?collection switcher context, deep links).
         search: (s) => s,
@@ -980,7 +990,7 @@ export function Artifact() {
       onRestore={() => restore(shown)}
       onBackToCurrent={() =>
         nav({
-          to: "/artifacts/$ref",
+          to: selfRoute,
           params: { ref: refFor({ short_id: shortId, title: art.title }) },
         })
       }
@@ -1080,10 +1090,11 @@ export function Artifact() {
       <PublicViewer
         art={art}
         shown={shown}
-        returnTo={`/artifacts/${ref}`}
+        returnTo={`${selfBase}/${ref}`}
         viewers={live.viewers}
         selfId={guestPresenceId()}
         isMobile={isMobile}
+        template={template}
       >
         {primaryEl}
       </PublicViewer>
@@ -1147,7 +1158,7 @@ export function Artifact() {
             goTo={(n) => {
               const base = refFor({ short_id: shortId, title: art.title })
               nav({
-                to: "/artifacts/$ref",
+                to: selfRoute,
                 params: { ref: n === art.current_version ? base : `${base}@v${n}` },
                 // Same artifact, different version — preserve the ?collection context.
                 search: (s) => s,

--- a/apps/web/src/pages/artifact/public-viewer.tsx
+++ b/apps/web/src/pages/artifact/public-viewer.tsx
@@ -4,6 +4,7 @@ import { type ReactNode, useState } from "react"
 import type { Artifact, Viewer } from "@/api"
 import { Icon } from "@/components/icons"
 import { Logo } from "@/components/shared/logo"
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
@@ -15,14 +16,22 @@ import { artifactTypeLabel } from "@/lib/artifact"
 import { signupSourceSearch } from "@/lib/signup-source"
 import { ago } from "@/lib/time"
 import { cn } from "@/lib/utils"
+import {
+  AgentTemplateDialog,
+  type AgentTemplateTarget,
+} from "@/pages/templates/agent-template-dialog"
+import { targetFromArtifact } from "@/pages/templates/template-target"
 import { FloatingControl } from "./floating-control"
 import { commentNudgeCopy, shouldPromptSignInToComment } from "./lib/comment-access"
 import { markUseIntent } from "./lib/use-intent"
 import { refFor } from "./parse-ref"
 import { Presence } from "./rail-deck"
 
+const footerLink =
+  "rounded-md outline-none hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+
 // The public / viral viewer — the chrome-light experience an anonymous visitor
-// gets on a shared /artifacts/ link (the growth loop). The render is the whole page; a
+// gets on a shared /artifacts/ or /templates/ link (the growth loop). The render is the whole page; a
 // slim public header carries the Derive brand (→ home), the artifact's identity +
 // a CREATOR BYLINE (attribution drives sharing), live presence, and the growth
 // actions (Make a copy · Sign in); a quiet "Made with Derive" mark closes it. No
@@ -36,21 +45,27 @@ export function PublicViewer({
   viewers,
   selfId,
   isMobile,
+  template = false,
   children,
 }: {
   art: Artifact
   /** The version being rendered (an @vN link may pin one behind current). */
   shown: number
-  /** The current /artifacts/<ref> path, so Sign in returns here afterward. */
+  /** The current page path (/artifacts/<ref> or /templates/<ref>), so Sign in returns here. */
   returnTo: string
   viewers: Viewer[]
   selfId?: string
   isMobile: boolean
+  /** The /templates/<ref> address. Presented as a template only when the artifact carries the tag. */
+  template?: boolean
   /** The render (ArtifactDocument) — the page owns its refs/bridge and threads it in. */
   children: ReactNode
 }) {
   const author = art.author
   const authorName = author?.name ?? author?.login ?? null
+  const taggedTemplate = !!art.tags?.includes("template")
+  const asTemplate = template && taggedTemplate
+  const [agentTarget, setAgentTarget] = useState<AgentTemplateTarget | null>(null)
 
   // The comment nudge: only on a link that grants commenting — signing in on a
   // view-only link unlocks nothing, so prompting there would be a bait-and-switch.
@@ -117,7 +132,7 @@ export function PublicViewer({
                   {[...(art.versions ?? [])].reverse().map((v) => (
                     <DropdownMenuItem key={v.n} asChild data-testid={`public-version-${v.n}`}>
                       <Link
-                        to="/artifacts/$ref"
+                        to={template ? "/templates/$ref" : "/artifacts/$ref"}
                         params={{
                           ref: v.n === art.current_version ? baseRef : `${baseRef}@v${v.n}`,
                         }}
@@ -185,6 +200,44 @@ export function PublicViewer({
         </Button>
       </header>
 
+      {/* The template strip: label, tags, and the agent handoff. The copy verb stays the
+          header's "Make a copy"; the strip adds only the other way in. */}
+      {asTemplate && (
+        <div
+          data-testid="template-strip"
+          className="flex shrink-0 flex-wrap items-center gap-x-4 gap-y-2 border-b border-border bg-muted/40 px-4 py-2 text-sm max-sm:px-3"
+        >
+          <span className="font-mono text-2xs uppercase tracking-wider text-muted-foreground">
+            Template
+          </span>
+          <span className="min-w-0 flex-1 text-muted-foreground">
+            Make a copy to start from it, or hand it to your agent.
+          </span>
+          {(art.tags ?? [])
+            .filter((tag) => tag !== "template")
+            .slice(0, 4)
+            .map((tag) => (
+              <Badge key={tag} variant="outline" shape="pill">
+                {tag}
+              </Badge>
+            ))}
+          <Button
+            size="sm"
+            variant="outline"
+            data-testid="template-ask-agent"
+            onClick={() => setAgentTarget(targetFromArtifact(art))}
+          >
+            <Icon name="sparkles" /> Ask your agent
+          </Button>
+        </div>
+      )}
+      {asTemplate && (
+        <AgentTemplateDialog
+          target={agentTarget}
+          onOpenChange={(open) => !open && setAgentTarget(null)}
+        />
+      )}
+
       {/* The render is the hero — it owns the rest of the height. */}
       <div className="relative flex min-h-0 flex-1 flex-col">
         {children}
@@ -248,11 +301,12 @@ export function PublicViewer({
       </div>
 
       {/* A quiet, permanent brand mark (the "Made in Framer" idiom — attribution +
-          a soft nudge, never a wall). A real link: the click lands in product
-          (signup → publish), stamped as the badge surface. White-label workspaces
-          (art.badge === false) drop the strip entirely — that's what they pay for. */}
+          a soft nudge, never a wall) plus the way back into the loop: start from this
+          page (a copy, through login), or, when the page is a template, its template
+          page. White-label workspaces (art.badge === false) drop the strip entirely —
+          that's what they pay for. */}
       {art.badge !== false && (
-        <footer className="flex shrink-0 items-center justify-center border-t border-border-soft py-1.5 font-mono text-2xs text-muted-foreground">
+        <footer className="flex shrink-0 items-center justify-center gap-1.5 border-t border-border-soft py-1.5 font-mono text-2xs text-muted-foreground">
           <Link
             to="/login"
             search={{
@@ -261,11 +315,42 @@ export function PublicViewer({
               ...signupSourceSearch("badge", art.short_id, returnTo),
             }}
             data-testid="public-made-with"
-            className="flex items-center gap-1.5 rounded-md outline-none hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+            className={cn(footerLink, "flex items-center gap-1.5")}
           >
             <Logo size={12} />
             Made with Derive
           </Link>
+          <span aria-hidden="true">·</span>
+          {asTemplate ? (
+            <Link to="/templates" data-testid="public-start-from" className={footerLink}>
+              Browse templates
+            </Link>
+          ) : taggedTemplate ? (
+            <Link
+              to="/templates/$ref"
+              params={{ ref: baseRef }}
+              data-testid="public-start-from"
+              className={footerLink}
+            >
+              Start from this template
+            </Link>
+          ) : (
+            <Link
+              to="/login"
+              search={{
+                signup: true,
+                return_to: `${returnTo}?use=1`,
+                ...signupSourceSearch("footer", art.short_id, returnTo),
+              }}
+              onClick={() => {
+                markUseIntent(art.short_id)
+              }}
+              data-testid="public-start-from"
+              className={footerLink}
+            >
+              Start from this page
+            </Link>
+          )}
         </footer>
       )}
     </div>

--- a/apps/web/src/pages/artifact/route-config.ts
+++ b/apps/web/src/pages/artifact/route-config.ts
@@ -1,0 +1,71 @@
+import type { QueryClient } from "@tanstack/react-query"
+import { artifactQuery, commentsQuery, meQuery } from "@/lib/queries"
+import { canCommentWithRole } from "./lib/comment-access"
+import { candidateShortIds } from "./parse-ref"
+
+export type ArtifactSearch = {
+  comment?: string
+  collection?: string
+  present?: boolean
+  use?: boolean
+  scene?: string
+  t?: number
+}
+
+// One artifact page, two addresses: /artifacts/$ref is the permalink, /templates/$ref the
+// public template page over the same document. Both routes share this search contract
+// and loader so a link behaves the same whichever door it came in by.
+//
+// The `comment` deep link opens a thread (panel + anchor). `collection` carries the list
+// context you opened FROM, so the header breadcrumb can page between siblings in that
+// collection (dropped otherwise — a direct link has no context and falls back to the
+// artifact's sole collection, if any). `present=1` opens a deck straight into present
+// mode, which is what you want from the link you paste into the calendar invite for the
+// meeting you're presenting in. `use=1` is deferred use-as-template: the public viewer's
+// "Make a copy" sends a signed-out clicker through login with it, and the page fires the
+// copy once the visitor is authenticated. Gated by a same-tab click marker (a pasted
+// ?use=1 link must not write — see pages/artifact/lib/use-intent.ts) and stripped after
+// firing either way.
+export const artifactRouteSearch = (s: Record<string, unknown>): ArtifactSearch => ({
+  ...(typeof s.comment === "string" && s.comment ? { comment: s.comment } : {}),
+  ...(typeof s.collection === "string" && s.collection ? { collection: s.collection } : {}),
+  // `?use=1` reaches the validator as the number 1 (the router JSON-parses values).
+  ...(s.present === true || s.present === 1 || s.present === "true" ? { present: true } : {}),
+  ...(s.use === true || s.use === 1 || s.use === "true" ? { use: true } : {}),
+  ...(typeof s.scene === "string" && /^[A-Za-z][A-Za-z0-9_-]{0,63}$/.test(s.scene)
+    ? { scene: s.scene }
+    : {}),
+  ...(Number.isFinite(Number(s.t)) && Number(s.t) >= 0 ? { t: Number(s.t) } : {}),
+})
+
+// Warm the artifact + its comments so an intent-preloaded link opens instantly.
+// NOT the rendered HTML: a rel=prefetch of the viewer URL is never reused by the
+// iframe's navigation (measured, identical transferSize on both requests), so it
+// only ever doubled the bytes. Re-opens ride the ordinary HTTP cache instead.
+// Fire-and-forget: awaiting held the whole route on a skeleton for the record round
+// trip, when the page can already paint its header from the clicked card's list row
+// (artifactQuery's placeholderData) and owns every fallback itself — auth redirect,
+// not-found, removed, and a plain WorkbenchSkeleton when nothing is cached at all. The
+// chain still runs to completion behind the mount, so an intent hover warms exactly
+// what it always did, and the catch keeps a failed fetch out of the route error
+// boundary as before.
+export const artifactRouteLoader = ({
+  context: { queryClient },
+  params,
+}: {
+  context: { queryClient: QueryClient }
+  params: { ref: string }
+}) => {
+  void (async () => {
+    for (const id of candidateShortIds(params.ref)) {
+      const art = await queryClient.ensureQueryData(artifactQuery(id)).catch(() => null)
+      if (art) {
+        const signedIn = queryClient.getQueryData(meQuery().queryKey)
+        const commentsAvailable =
+          art.is_workspace_member === true || canCommentWithRole(art.my_role)
+        if (signedIn && commentsAvailable) queryClient.prefetchQuery(commentsQuery(id))
+        return
+      }
+    }
+  })()
+}

--- a/apps/web/src/pages/templates/index.tsx
+++ b/apps/web/src/pages/templates/index.tsx
@@ -8,10 +8,12 @@ import { EmptyState } from "@/components/shared/empty-state"
 import { LoadError } from "@/components/shared/load-error"
 import { PageHeader } from "@/components/shared/page-header"
 import { PageShell } from "@/components/shared/page-shell"
+import { PublicFrame } from "@/components/shared/public-frame"
 import { SearchField } from "@/components/shared/search-field"
 import { StatusPanel } from "@/components/shared/status-panel"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { useAuth } from "@/ctx"
 import { useApiMutation } from "@/lib/use-api-mutation"
 import { useDocumentTitle } from "@/lib/use-document-title"
 import { refFor } from "@/pages/artifact/parse-ref"
@@ -31,12 +33,17 @@ const templateMatches = (template: TemplateArtifact, query: string): boolean => 
 /**
  * The template shelf: artifacts tagged `template`, this workspace's then public ones.
  * Starting from one is the artifact page's own "Make a copy", or the agent handoff.
+ *
+ * Public: signed out, the shelf is the public one, in the anonymous frame, and "Make a
+ * copy" goes through sign-in and lands on the template with the copy intent kept.
  */
 export function Templates() {
   useDocumentTitle("Templates")
-  const search = useSearch({ from: "/templates" })
-  const nav = useNavigate({ from: "/templates" })
-  const librariesOpen = search.tab === "libraries"
+  const { me } = useAuth()
+  const signedIn = !!me
+  const search = useSearch({ from: "/templates/" })
+  const nav = useNavigate({ from: "/templates/" })
+  const librariesOpen = signedIn && search.tab === "libraries"
   const query = useDeferredValue(search.query ?? "")
   const shelfState = useQuery({
     queryKey: ["templates", "shelf"],
@@ -105,6 +112,7 @@ export function Templates() {
             <TemplateArtifactCard
               key={template.short_id}
               template={template}
+              signedIn={signedIn}
               copying={copyMut.isPendingFor(template.short_id)}
               onCopy={() => copyMut.mutate(template.short_id)}
               onAsk={() => setAgentTarget(targetFromArtifact(template))}
@@ -114,31 +122,33 @@ export function Templates() {
       </section>
     ) : null
 
-  return (
+  const page = (
     <PageShell width="wide" className="flex flex-col gap-6">
       <PageHeader
         title="Templates"
         subtitle="Start from an artifact someone finished. Make a copy, or hand it to your agent."
         actions={
-          <>
-            <Button
-              variant="outline"
-              data-testid="templates-create-existing"
-              onClick={() => {
-                setSourceArtifactError("")
-                void nav({ search: { ...search, derive: true } })
-              }}
-            >
-              <Icon name="derive" /> Start from an artifact
-            </Button>
-            <Button data-testid="templates-new-blank" onClick={() => nav({ to: "/new" })}>
-              <Icon name="plus" /> Blank artifact
-            </Button>
-          </>
+          signedIn ? (
+            <>
+              <Button
+                variant="outline"
+                data-testid="templates-create-existing"
+                onClick={() => {
+                  setSourceArtifactError("")
+                  void nav({ search: { ...search, derive: true } })
+                }}
+              >
+                <Icon name="derive" /> Start from an artifact
+              </Button>
+              <Button data-testid="templates-new-blank" onClick={() => nav({ to: "/new" })}>
+                <Icon name="plus" /> Blank artifact
+              </Button>
+            </>
+          ) : undefined
         }
       />
 
-      {(TEMPLATE_LIBRARIES_ENABLED || librariesOpen) && (
+      {signedIn && (TEMPLATE_LIBRARIES_ENABLED || librariesOpen) && (
         <Tabs
           value={librariesOpen ? "libraries" : "artifacts"}
           onValueChange={(value) => setTab(value as TemplateTab)}
@@ -163,7 +173,7 @@ export function Templates() {
         />
       ) : null}
 
-      {search.derive && (
+      {signedIn && search.derive && (
         <DeriveSource
           autoFocus={!!search.derive}
           onUse={(artifact) => {
@@ -214,7 +224,9 @@ export function Templates() {
               description={
                 query
                   ? "Try a broader word or clear the search."
-                  : "Tag any artifact “template” and it appears here for you; show it in the workspace library and teammates see it too. Public ones show up for everyone."
+                  : signedIn
+                    ? "Tag any artifact “template” and it appears here for you; show it in the workspace library and teammates see it too. Public ones show up for everyone."
+                    : "No public templates yet. Sign in to tag your own."
               }
               action={
                 query ? (
@@ -244,4 +256,6 @@ export function Templates() {
       />
     </PageShell>
   )
+
+  return signedIn ? page : <PublicFrame returnTo="/templates">{page}</PublicFrame>
 }

--- a/apps/web/src/pages/templates/template-artifact-card.tsx
+++ b/apps/web/src/pages/templates/template-artifact-card.tsx
@@ -7,16 +7,21 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardFooter } from "@/components/ui/card"
 import { artifactTypeLabel } from "@/lib/artifact"
+import { signupSourceSearch } from "@/lib/signup-source"
+import { markUseIntent } from "@/pages/artifact/lib/use-intent"
 import { refFor } from "@/pages/artifact/parse-ref"
 
 /** One shelf row: the artifact's render, title, and author, with the two ways to start from it. */
 export function TemplateArtifactCard({
   template: a,
+  signedIn,
   copying,
   onCopy,
   onAsk,
 }: {
   template: TemplateArtifact
+  /** Signed out, "Make a copy" goes through sign-in and keeps the intent for afterward. */
+  signedIn: boolean
   copying: boolean
   onCopy: () => void
   onAsk: () => void
@@ -24,6 +29,7 @@ export function TemplateArtifactCard({
   const author = a.author ?? null
   const hasAuthor = !!(author?.name ?? a.author_name)
   const origin = a.shelf === "workspace" ? "This workspace" : "Public"
+  const ref = refFor({ short_id: a.short_id, title: a.title })
   return (
     // `group`: Thumb wakes its render on the group's hover, as in the library card.
     <Card data-testid={`template-card-${a.short_id}`} className="group h-full gap-0 py-0">
@@ -44,8 +50,8 @@ export function TemplateArtifactCard({
           </div>
           <h2 className="font-serif text-lg font-medium tracking-tight text-foreground [overflow-wrap:anywhere]">
             <Link
-              to="/artifacts/$ref"
-              params={{ ref: refFor({ short_id: a.short_id, title: a.title }) }}
+              to="/templates/$ref"
+              params={{ ref }}
               className="hover:underline"
               data-testid={`template-open-${a.short_id}`}
             >
@@ -66,15 +72,33 @@ export function TemplateArtifactCard({
         </div>
       </CardContent>
       <CardFooter className="mt-auto flex gap-2 p-2">
-        <Button
-          className="flex-1"
-          size="sm"
-          disabled={copying}
-          onClick={onCopy}
-          data-testid={`template-copy-${a.short_id}`}
-        >
-          <Icon name="copy" /> {copying ? "Copying…" : "Make a copy"}
-        </Button>
+        {signedIn ? (
+          <Button
+            className="flex-1"
+            size="sm"
+            disabled={copying}
+            onClick={onCopy}
+            data-testid={`template-copy-${a.short_id}`}
+          >
+            <Icon name="copy" /> {copying ? "Copying…" : "Make a copy"}
+          </Button>
+        ) : (
+          <Button asChild className="flex-1" size="sm" data-testid={`template-copy-${a.short_id}`}>
+            <Link
+              to="/login"
+              search={{
+                signup: true,
+                return_to: `/templates/${ref}?use=1`,
+                ...signupSourceSearch("template_shelf", a.short_id, "/templates"),
+              }}
+              onClick={() => {
+                markUseIntent(a.short_id)
+              }}
+            >
+              <Icon name="copy" /> Make a copy
+            </Link>
+          </Button>
+        )}
         <Button
           size="sm"
           variant="outline"

--- a/apps/web/src/pages/templates/use-agent-template-handoff.ts
+++ b/apps/web/src/pages/templates/use-agent-template-handoff.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query"
 import { useId, useState } from "react"
 import { workspaceDisplayName } from "@/api"
+import { useAuth } from "@/ctx"
 import { useCopy } from "@/lib/clipboard"
 import { workspacesQuery } from "@/lib/queries"
 import { type AgentTemplateTarget, localAgentHandoff } from "./agent-handoff"
@@ -11,7 +12,9 @@ export function useAgentTemplateHandoff(target: AgentTemplateTarget) {
   const [showHandoff, setShowHandoff] = useState(false)
   const { copied, copy } = useCopy(4000)
   const descriptionId = useId()
-  const workspacesState = useQuery(workspacesQuery())
+  // /v1/workspaces is an authed endpoint; signed out, the handoff names no destination workspace.
+  const { me } = useAuth()
+  const workspacesState = useQuery({ ...workspacesQuery(), enabled: !!me })
   const activeWorkspaceSummary = workspacesState.data?.workspaces.find(
     (workspace) => workspace.id === workspacesState.data.active,
   )

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -11,7 +11,6 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as WelcomeRouteImport } from './routes/welcome'
 import { Route as UnlistedRouteImport } from './routes/unlisted'
-import { Route as TemplatesRouteImport } from './routes/templates'
 import { Route as ShowcaseRouteImport } from './routes/showcase'
 import { Route as SharedRouteImport } from './routes/shared'
 import { Route as SettingsRouteImport } from './routes/settings'
@@ -28,10 +27,12 @@ import { Route as ChatRouteImport } from './routes/chat'
 import { Route as BrandprintRouteImport } from './routes/brandprint'
 import { Route as ArchivedRouteImport } from './routes/archived'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as TemplatesIndexRouteImport } from './routes/templates.index'
 import { Route as TemplateLibrariesIndexRouteImport } from './routes/template-libraries.index'
 import { Route as SettingsIndexRouteImport } from './routes/settings.index'
 import { Route as ContextsIndexRouteImport } from './routes/contexts.index'
 import { Route as UsersHandleRouteImport } from './routes/users.$handle'
+import { Route as TemplatesRefRouteImport } from './routes/templates.$ref'
 import { Route as TemplateLibrariesIdRouteImport } from './routes/template-libraries.$id'
 import { Route as SettingsSectionRouteImport } from './routes/settings.$section'
 import { Route as InviteTokenRouteImport } from './routes/invite.$token'
@@ -51,11 +52,6 @@ const WelcomeRoute = WelcomeRouteImport.update({
 const UnlistedRoute = UnlistedRouteImport.update({
   id: '/unlisted',
   path: '/unlisted',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const TemplatesRoute = TemplatesRouteImport.update({
-  id: '/templates',
-  path: '/templates',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ShowcaseRoute = ShowcaseRouteImport.update({
@@ -138,6 +134,11 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const TemplatesIndexRoute = TemplatesIndexRouteImport.update({
+  id: '/templates/',
+  path: '/templates/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const TemplateLibrariesIndexRoute = TemplateLibrariesIndexRouteImport.update({
   id: '/template-libraries/',
   path: '/template-libraries/',
@@ -156,6 +157,11 @@ const ContextsIndexRoute = ContextsIndexRouteImport.update({
 const UsersHandleRoute = UsersHandleRouteImport.update({
   id: '/users/$handle',
   path: '/users/$handle',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const TemplatesRefRoute = TemplatesRefRouteImport.update({
+  id: '/templates/$ref',
+  path: '/templates/$ref',
   getParentRoute: () => rootRouteImport,
 } as any)
 const TemplateLibrariesIdRoute = TemplateLibrariesIdRouteImport.update({
@@ -226,7 +232,6 @@ export interface FileRoutesByFullPath {
   '/settings': typeof SettingsRouteWithChildren
   '/shared': typeof SharedRoute
   '/showcase': typeof ShowcaseRoute
-  '/templates': typeof TemplatesRoute
   '/unlisted': typeof UnlistedRoute
   '/welcome': typeof WelcomeRoute
   '/artifacts/$ref': typeof ArtifactsRefRoute
@@ -237,10 +242,12 @@ export interface FileRoutesByFullPath {
   '/invite/$token': typeof InviteTokenRoute
   '/settings/$section': typeof SettingsSectionRoute
   '/template-libraries/$id': typeof TemplateLibrariesIdRoute
+  '/templates/$ref': typeof TemplatesRefRoute
   '/users/$handle': typeof UsersHandleRoute
   '/contexts/': typeof ContextsIndexRoute
   '/settings/': typeof SettingsIndexRoute
   '/template-libraries/': typeof TemplateLibrariesIndexRoute
+  '/templates/': typeof TemplatesIndexRoute
   '/invite/a/$token': typeof InviteATokenRoute
   '/invite/c/$token': typeof InviteCTokenRoute
 }
@@ -260,7 +267,6 @@ export interface FileRoutesByTo {
   '/search': typeof SearchRoute
   '/shared': typeof SharedRoute
   '/showcase': typeof ShowcaseRoute
-  '/templates': typeof TemplatesRoute
   '/unlisted': typeof UnlistedRoute
   '/welcome': typeof WelcomeRoute
   '/artifacts/$ref': typeof ArtifactsRefRoute
@@ -271,10 +277,12 @@ export interface FileRoutesByTo {
   '/invite/$token': typeof InviteTokenRoute
   '/settings/$section': typeof SettingsSectionRoute
   '/template-libraries/$id': typeof TemplateLibrariesIdRoute
+  '/templates/$ref': typeof TemplatesRefRoute
   '/users/$handle': typeof UsersHandleRoute
   '/contexts': typeof ContextsIndexRoute
   '/settings': typeof SettingsIndexRoute
   '/template-libraries': typeof TemplateLibrariesIndexRoute
+  '/templates': typeof TemplatesIndexRoute
   '/invite/a/$token': typeof InviteATokenRoute
   '/invite/c/$token': typeof InviteCTokenRoute
 }
@@ -296,7 +304,6 @@ export interface FileRoutesById {
   '/settings': typeof SettingsRouteWithChildren
   '/shared': typeof SharedRoute
   '/showcase': typeof ShowcaseRoute
-  '/templates': typeof TemplatesRoute
   '/unlisted': typeof UnlistedRoute
   '/welcome': typeof WelcomeRoute
   '/artifacts/$ref': typeof ArtifactsRefRoute
@@ -307,10 +314,12 @@ export interface FileRoutesById {
   '/invite/$token': typeof InviteTokenRoute
   '/settings/$section': typeof SettingsSectionRoute
   '/template-libraries/$id': typeof TemplateLibrariesIdRoute
+  '/templates/$ref': typeof TemplatesRefRoute
   '/users/$handle': typeof UsersHandleRoute
   '/contexts/': typeof ContextsIndexRoute
   '/settings/': typeof SettingsIndexRoute
   '/template-libraries/': typeof TemplateLibrariesIndexRoute
+  '/templates/': typeof TemplatesIndexRoute
   '/invite/a/$token': typeof InviteATokenRoute
   '/invite/c/$token': typeof InviteCTokenRoute
 }
@@ -333,7 +342,6 @@ export interface FileRouteTypes {
     | '/settings'
     | '/shared'
     | '/showcase'
-    | '/templates'
     | '/unlisted'
     | '/welcome'
     | '/artifacts/$ref'
@@ -344,10 +352,12 @@ export interface FileRouteTypes {
     | '/invite/$token'
     | '/settings/$section'
     | '/template-libraries/$id'
+    | '/templates/$ref'
     | '/users/$handle'
     | '/contexts/'
     | '/settings/'
     | '/template-libraries/'
+    | '/templates/'
     | '/invite/a/$token'
     | '/invite/c/$token'
   fileRoutesByTo: FileRoutesByTo
@@ -367,7 +377,6 @@ export interface FileRouteTypes {
     | '/search'
     | '/shared'
     | '/showcase'
-    | '/templates'
     | '/unlisted'
     | '/welcome'
     | '/artifacts/$ref'
@@ -378,10 +387,12 @@ export interface FileRouteTypes {
     | '/invite/$token'
     | '/settings/$section'
     | '/template-libraries/$id'
+    | '/templates/$ref'
     | '/users/$handle'
     | '/contexts'
     | '/settings'
     | '/template-libraries'
+    | '/templates'
     | '/invite/a/$token'
     | '/invite/c/$token'
   id:
@@ -402,7 +413,6 @@ export interface FileRouteTypes {
     | '/settings'
     | '/shared'
     | '/showcase'
-    | '/templates'
     | '/unlisted'
     | '/welcome'
     | '/artifacts/$ref'
@@ -413,10 +423,12 @@ export interface FileRouteTypes {
     | '/invite/$token'
     | '/settings/$section'
     | '/template-libraries/$id'
+    | '/templates/$ref'
     | '/users/$handle'
     | '/contexts/'
     | '/settings/'
     | '/template-libraries/'
+    | '/templates/'
     | '/invite/a/$token'
     | '/invite/c/$token'
   fileRoutesById: FileRoutesById
@@ -438,7 +450,6 @@ export interface RootRouteChildren {
   SettingsRoute: typeof SettingsRouteWithChildren
   SharedRoute: typeof SharedRoute
   ShowcaseRoute: typeof ShowcaseRoute
-  TemplatesRoute: typeof TemplatesRoute
   UnlistedRoute: typeof UnlistedRoute
   WelcomeRoute: typeof WelcomeRoute
   ArtifactsRefRoute: typeof ArtifactsRefRoute
@@ -448,9 +459,11 @@ export interface RootRouteChildren {
   ContextsNewRoute: typeof ContextsNewRoute
   InviteTokenRoute: typeof InviteTokenRoute
   TemplateLibrariesIdRoute: typeof TemplateLibrariesIdRoute
+  TemplatesRefRoute: typeof TemplatesRefRoute
   UsersHandleRoute: typeof UsersHandleRoute
   ContextsIndexRoute: typeof ContextsIndexRoute
   TemplateLibrariesIndexRoute: typeof TemplateLibrariesIndexRoute
+  TemplatesIndexRoute: typeof TemplatesIndexRoute
   InviteATokenRoute: typeof InviteATokenRoute
   InviteCTokenRoute: typeof InviteCTokenRoute
 }
@@ -469,13 +482,6 @@ declare module '@tanstack/react-router' {
       path: '/unlisted'
       fullPath: '/unlisted'
       preLoaderRoute: typeof UnlistedRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/templates': {
-      id: '/templates'
-      path: '/templates'
-      fullPath: '/templates'
-      preLoaderRoute: typeof TemplatesRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/showcase': {
@@ -590,6 +596,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/templates/': {
+      id: '/templates/'
+      path: '/templates'
+      fullPath: '/templates/'
+      preLoaderRoute: typeof TemplatesIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/template-libraries/': {
       id: '/template-libraries/'
       path: '/template-libraries'
@@ -616,6 +629,13 @@ declare module '@tanstack/react-router' {
       path: '/users/$handle'
       fullPath: '/users/$handle'
       preLoaderRoute: typeof UsersHandleRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/templates/$ref': {
+      id: '/templates/$ref'
+      path: '/templates/$ref'
+      fullPath: '/templates/$ref'
+      preLoaderRoute: typeof TemplatesRefRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/template-libraries/$id': {
@@ -722,7 +742,6 @@ const rootRouteChildren: RootRouteChildren = {
   SettingsRoute: SettingsRouteWithChildren,
   SharedRoute: SharedRoute,
   ShowcaseRoute: ShowcaseRoute,
-  TemplatesRoute: TemplatesRoute,
   UnlistedRoute: UnlistedRoute,
   WelcomeRoute: WelcomeRoute,
   ArtifactsRefRoute: ArtifactsRefRoute,
@@ -732,9 +751,11 @@ const rootRouteChildren: RootRouteChildren = {
   ContextsNewRoute: ContextsNewRoute,
   InviteTokenRoute: InviteTokenRoute,
   TemplateLibrariesIdRoute: TemplateLibrariesIdRoute,
+  TemplatesRefRoute: TemplatesRefRoute,
   UsersHandleRoute: UsersHandleRoute,
   ContextsIndexRoute: ContextsIndexRoute,
   TemplateLibrariesIndexRoute: TemplateLibrariesIndexRoute,
+  TemplatesIndexRoute: TemplatesIndexRoute,
   InviteATokenRoute: InviteATokenRoute,
   InviteCTokenRoute: InviteCTokenRoute,
 }

--- a/apps/web/src/routes/artifacts.$ref.tsx
+++ b/apps/web/src/routes/artifacts.$ref.tsx
@@ -1,67 +1,11 @@
 import { createFileRoute } from "@tanstack/react-router"
-import { artifactQuery, commentsQuery, meQuery } from "../lib/queries"
 import { Artifact } from "../pages/artifact"
-import { canCommentWithRole } from "../pages/artifact/lib/comment-access"
-import { candidateShortIds } from "../pages/artifact/parse-ref"
+import { artifactRouteLoader, artifactRouteSearch } from "../pages/artifact/route-config"
 import { WorkbenchSkeleton } from "../pages/artifact/workbench-skeleton"
 
 export const Route = createFileRoute("/artifacts/$ref")({
-  // The `comment` deep link opens a thread (panel + anchor).
-  // `collection` carries the list context you opened FROM, so the header breadcrumb can
-  // page between siblings in that collection (dropped otherwise — a direct link has no
-  // context and falls back to the artifact's sole collection, if any).
-  // `present=1` opens a deck straight into present mode, which is what you want from
-  // the link you paste into the calendar invite for the meeting you're presenting in.
-  // `use=1` is deferred use-as-template: the public viewer's "Make a copy" sends a
-  // signed-out clicker through login with it, and the page fires the copy once the
-  // visitor is authenticated. Gated by a same-tab click marker (a pasted ?use=1
-  // link must not write — see pages/artifact/lib/use-intent.ts) and stripped after
-  // firing either way.
-  validateSearch: (
-    s: Record<string, unknown>,
-  ): {
-    comment?: string
-    collection?: string
-    present?: boolean
-    use?: boolean
-    scene?: string
-    t?: number
-  } => ({
-    ...(typeof s.comment === "string" && s.comment ? { comment: s.comment } : {}),
-    ...(typeof s.collection === "string" && s.collection ? { collection: s.collection } : {}),
-    ...(s.present === true || s.present === "1" || s.present === "true" ? { present: true } : {}),
-    ...(s.use === true || s.use === "1" || s.use === "true" ? { use: true } : {}),
-    ...(typeof s.scene === "string" && /^[A-Za-z][A-Za-z0-9_-]{0,63}$/.test(s.scene)
-      ? { scene: s.scene }
-      : {}),
-    ...(Number.isFinite(Number(s.t)) && Number(s.t) >= 0 ? { t: Number(s.t) } : {}),
-  }),
-  // Warm the artifact + its comments so an intent-preloaded link opens instantly.
-  // NOT the rendered HTML: a rel=prefetch of the viewer URL is never reused by the
-  // iframe's navigation (measured, identical transferSize on both requests), so it
-  // only ever doubled the bytes. Re-opens ride the ordinary HTTP cache instead.
-  // Fire-and-forget: awaiting held the
-  // whole route on a skeleton for the record round trip, when the page can
-  // already paint its header from the clicked card's list row (artifactQuery's
-  // placeholderData) and owns every fallback itself — auth redirect, not-found,
-  // removed, and a plain WorkbenchSkeleton when nothing is cached at all. The
-  // chain still runs to completion behind the mount, so an intent hover warms
-  // exactly what it always did, and the catch keeps a failed fetch out of the
-  // route error boundary as before.
-  loader: ({ context: { queryClient }, params }) => {
-    void (async () => {
-      for (const id of candidateShortIds(params.ref)) {
-        const art = await queryClient.ensureQueryData(artifactQuery(id)).catch(() => null)
-        if (art) {
-          const signedIn = queryClient.getQueryData(meQuery().queryKey)
-          const commentsAvailable =
-            art.is_workspace_member === true || canCommentWithRole(art.my_role)
-          if (signedIn && commentsAvailable) queryClient.prefetchQuery(commentsQuery(id))
-          return
-        }
-      }
-    })()
-  },
+  validateSearch: artifactRouteSearch,
+  loader: artifactRouteLoader,
   // Shape-matched workbench frame while the loader warms the artifact (replaces the
   // generic route skeleton — this is a full-bleed workbench, not a page column).
   pendingComponent: WorkbenchSkeleton,

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -29,13 +29,10 @@ export const Route = createFileRoute("/login")({
     // your new password" confirmation.
     if (s.reset) out.reset = true
     // Where to land after sign-in (e.g. the shared artifact whose "sign in to comment"
-    // CTA sent us here). Same-origin relative paths only — never `//host` or an absolute
-    // URL — so it can't be weaponized into an open redirect.
-    if (
-      typeof s.return_to === "string" &&
-      s.return_to.startsWith("/") &&
-      !s.return_to.startsWith("//")
-    )
+    // CTA sent us here). Same-origin relative paths only — never `//host`, `/\host`
+    // (browsers read the backslash as a slash), or an absolute URL — so it can't be
+    // weaponized into an open redirect.
+    if (typeof s.return_to === "string" && /^\/(?![/\\])/.test(s.return_to))
       out.return_to = s.return_to
     for (const k of OAUTH_KEYS) if (typeof s[k] === "string") out[k] = s[k] as string
     return out

--- a/apps/web/src/routes/templates.$ref.tsx
+++ b/apps/web/src/routes/templates.$ref.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { Artifact } from "../pages/artifact"
+import { artifactRouteLoader, artifactRouteSearch } from "../pages/artifact/route-config"
+import { WorkbenchSkeleton } from "../pages/artifact/workbench-skeleton"
+
+// A template's public page: the artifact route under a second address, which the page
+// presents with the template strip and footer.
+export const Route = createFileRoute("/templates/$ref")({
+  validateSearch: artifactRouteSearch,
+  loader: artifactRouteLoader,
+  pendingComponent: WorkbenchSkeleton,
+  pendingMinMs: 0,
+  component: () => <Artifact template />,
+})

--- a/apps/web/src/routes/templates.index.tsx
+++ b/apps/web/src/routes/templates.index.tsx
@@ -1,12 +1,11 @@
 import { createFileRoute } from "@tanstack/react-router"
-import { requireOnboarded } from "../lib/route-guards"
 import { Templates } from "../pages/templates"
 import type { TemplatesSearch, TemplateTab } from "../pages/templates/types"
 
 const TABS: TemplateTab[] = ["artifacts", "libraries"]
 
-export const Route = createFileRoute("/templates")({
-  beforeLoad: requireOnboarded,
+// No auth guard on purpose: the shelf is public, and the page picks its frame by session.
+export const Route = createFileRoute("/templates/")({
   validateSearch: (search: Record<string, unknown>): TemplatesSearch => ({
     tab: TABS.includes(search.tab as TemplateTab) ? (search.tab as TemplateTab) : undefined,
     query: typeof search.query === "string" ? search.query : undefined,


### PR DESCRIPTION
Templates plan, part 4: the loop's public half. A template needs an address a stranger can land on and a way back into the product from any public page.

## What changes

**`/templates` is readable signed out.** The public shelf (artifacts tagged `template` and listed publicly) renders in the chrome-light `PublicFrame`. The workspace verbs — Start from an artifact, Blank artifact, the Libraries tab, the artifact picker — are signed-in only. A visitor's "Make a copy" is a link through sign-in that returns to the template's own page with the copy intent (`?use=1` + the same-tab marker), so the copy fires once they're in. The route drops its `requireOnboarded` guard and becomes an index route (`templates.index.tsx`) so the page route below is a sibling, not a child without an outlet; `apps/api/src/lib/spa-paths.ts` serves the new address.

**`/templates/<ref>` is the template's public page.** Same component as `/artifacts/<ref>` — the shared search contract and loader move to `pages/artifact/route-config.ts`, and the route passes `template` as a prop (the `Library view=` precedent). Signed out, `PublicViewer` presents the artifact as a template when it carries the tag: a strip with the eyebrow, one line, its tags, and "Ask your agent" (the existing handoff dialog, short id included). Every same-artifact navigation (canonical slug, version switch, restore, back-to-current, the `?use=1` strip) keeps whichever address the visitor arrived at. Shelf cards link here.

**The public footer closes the loop.** Next to "Made with Derive": "Browse templates" on a template page, "Start from this template" (→ `/templates/<ref>`) on an artifact that carries the tag, and "Start from this page" (a copy, through sign-in) otherwise. White-label workspaces (`badge: false`) keep their bare footer.

**Also:** the agent handoff hook no longer fires the workspaces query without a session; the `?use=1` / `?present=1` validators accept the number the router actually hands them; and the login `return_to` check rejects `/\host` as well as `//host` (browsers read the backslash as a slash — pre-existing, surfaced in review because this PR adds three producers of `return_to`).

## Not in this PR

Server-side meta for template pages: the shell is `noindex`, so `/templates` and `/templates/<ref>` get no OG unfurl, no index/follow swap, no canonical redirect, and no markdown negotiation — the `/artifacts/<ref>` handler in `embeds.ts` would need a second mount. The sitemap stays as it was for the same reason. Signed-in visitors (members and guests) get the ordinary workbench at `/templates/<ref>`. "Offer as a template" and curation.

## Tests

- e2e (`templates.smoke.spec.ts`): signed in, the card's title opens the template address as the workbench; signed out, the public shelf lists a publicly listed template, the workspace verbs are absent, "Make a copy" goes to sign-in with `return_to=/templates/<ref>?use=1`, and creating the account from there lands on the visitor's own copy; the template page shows the strip and opens the agent dialog; a tagged artifact's public footer reads "Start from this template" and lands on the template page; an untagged one reads "Start from this page" with the copy intent in the link.
- `serve-web.test.ts`: `/templates/<ref>` is an SPA path (the generated-routes sweep now covers the new route).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/797"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789950514&installation_model_id=428097&pr_number=797&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F797&signature=74c3b91ca78a4c5f25eda4fe52bd67e6d18ee46fb8cd8cd5a01e877299e067d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->