### PR TITLE
Add capability tiers to linked graphs

### DIFF
--- a/packages/core/src/agent-routing.ts
+++ b/packages/core/src/agent-routing.ts
@@ -1,0 +1,38 @@
+/** Stable capability levels authored into graphs. Providers and model versions are runtime data. */
+export const AGENT_TIERS = ["utility", "fast", "balanced", "expert", "frontier"] as const
+
+export type AgentTier = (typeof AGENT_TIERS)[number]
+
+/**
+ * Versionless model-family handles understood by Derive's execution harnesses.
+ *
+ * The list includes Derive's native families plus every family represented in OpenRouter's
+ * trailing-30-day top ten on 2026-08-21. Two ranked DeepSeek Flash versions intentionally fold
+ * into one family: saved graphs should survive a provider's next model refresh.
+ *
+ * Source: OpenRouter (openrouter.ai/rankings), as of 2026-08-21.
+ */
+export const MODEL_FAMILY_TIERS = {
+  utility: "utility",
+  "deepseek-v4-flash": "fast",
+  mimo: "fast",
+  "nemotron-ultra": "fast",
+  luna: "balanced",
+  hy3: "balanced",
+  glm: "balanced",
+  terra: "expert",
+  sonnet: "expert",
+  "deepseek-v4-pro": "expert",
+  ox: "expert",
+  sol: "frontier",
+  fable: "frontier",
+  opus: "frontier",
+} as const satisfies Record<string, AgentTier>
+
+export type ModelFamily = keyof typeof MODEL_FAMILY_TIERS
+
+export const isAgentTier = (value: unknown): value is AgentTier =>
+  typeof value === "string" && AGENT_TIERS.includes(value as AgentTier)
+
+export const tierForModelFamily = (family: string): AgentTier | null =>
+  Object.hasOwn(MODEL_FAMILY_TIERS, family) ? MODEL_FAMILY_TIERS[family as ModelFamily] : null

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./advisories"
+export * from "./agent-routing"
 export * from "./anchor"
 export * from "./billing"
 export * from "./brandprint"

--- a/packages/core/src/linked-bundle.ts
+++ b/packages/core/src/linked-bundle.ts
@@ -1,3 +1,4 @@
+import { type AgentTier, isAgentTier } from "./agent-routing"
 import { LINKED_BUNDLE_HTML_CONTENT_TYPE } from "./content-types"
 import { artifactRefIn, artifactRefOf } from "./derived-facts"
 import { parseFacts } from "./facts"
@@ -31,6 +32,8 @@ export interface LinkedBundleNode {
   basis_version?: number
   /** Short human-readable context for the current state. */
   note?: string
+  /** Capability requested for this step. The execution harness resolves the concrete model. */
+  tier?: AgentTier
 }
 
 export interface LinkedBundleEdge {
@@ -46,6 +49,8 @@ export interface LinkedBundleDiagram {
   type: "loop" | "graph"
   nodes: LinkedBundleNode[]
   edges: LinkedBundleEdge[]
+  /** Default capability for nodes that do not carry a narrower override. */
+  tier?: AgentTier
   /** Descriptive, inspectable loop policy. Derive does not execute it. */
   goal?: string
   evaluate?: string
@@ -173,6 +178,7 @@ export const validateLinkedBundle = (value: unknown): LinkedBundleValidation => 
         Number.isInteger(nodeRaw.basis_version) && Number(nodeRaw.basis_version) > 0
           ? Number(nodeRaw.basis_version)
           : null
+      const tier = isAgentTier(nodeRaw.tier) ? nodeRaw.tier : null
       if (!nodeId) errors.push(`diagrams[${index}].nodes[${nodeIndex}].id is invalid`)
       else if (nodeIds.has(nodeId)) errors.push(`diagram "${id ?? index}" repeats node "${nodeId}"`)
       if (!nodeLabel) errors.push(`diagrams[${index}].nodes[${nodeIndex}].label is required`)
@@ -182,6 +188,10 @@ export const validateLinkedBundle = (value: unknown): LinkedBundleValidation => 
         )
       if (nodeRaw.basis_version !== undefined && !basisVersion)
         errors.push(`diagrams[${index}].nodes[${nodeIndex}].basis_version must be positive`)
+      if (nodeRaw.tier !== undefined && !tier)
+        errors.push(
+          `diagrams[${index}].nodes[${nodeIndex}].tier must be "utility", "fast", "balanced", "expert", or "frontier"`,
+        )
       if (member && !memberIds.has(member))
         errors.push(`diagram node "${nodeId ?? nodeIndex}" names unknown member "${member}"`)
       if (basisVersion && !member)
@@ -197,6 +207,7 @@ export const validateLinkedBundle = (value: unknown): LinkedBundleValidation => 
         ...(state ? { state } : {}),
         ...(basisVersion ? { basis_version: basisVersion } : {}),
         ...(text(nodeRaw.note) ? { note: text(nodeRaw.note) as string } : {}),
+        ...(tier ? { tier } : {}),
       })
     }
 
@@ -223,6 +234,11 @@ export const validateLinkedBundle = (value: unknown): LinkedBundleValidation => 
     const goal = text(raw.goal)
     const evaluate = text(raw.evaluate)
     const stop = text(raw.stop)
+    const tier = isAgentTier(raw.tier) ? raw.tier : null
+    if (raw.tier !== undefined && !tier)
+      errors.push(
+        `diagrams[${index}].tier must be "utility", "fast", "balanced", "expert", or "frontier"`,
+      )
     if (type === "loop") {
       if (!goal) warnings.push(`loop "${id ?? index}" has no stated goal`)
       if (!evaluate) warnings.push(`loop "${id ?? index}" has no evaluation condition`)
@@ -239,6 +255,7 @@ export const validateLinkedBundle = (value: unknown): LinkedBundleValidation => 
         type,
         nodes,
         edges,
+        ...(tier ? { tier } : {}),
         ...(goal ? { goal } : {}),
         ...(evaluate ? { evaluate } : {}),
         ...(stop ? { stop } : {}),

--- a/packages/core/test/publish.test.ts
+++ b/packages/core/test/publish.test.ts
@@ -1,6 +1,8 @@
 import { zipSync } from "fflate"
 import { describe, expect, it } from "vitest"
+import { MODEL_FAMILY_TIERS, tierForModelFamily } from "../src/agent-routing"
 import { sha256Hex } from "../src/hash"
+import { validateLinkedBundle } from "../src/linked-bundle"
 import type { ArtifactRecord, BlobStore, MetaStore, NewArtifact, NewVersion } from "../src/ports"
 import { artifactUrl, looksLikeHtmlDocument, type PublishInput, publish } from "../src/publish"
 
@@ -132,6 +134,86 @@ describe("publish: single file", () => {
     expect(artifact.link_role).toBe("viewer")
     expect(artifact.listed).toBe("public")
     expect(version.author).toBe("amy")
+  })
+})
+
+describe("linked bundle agent tiers", () => {
+  it("keeps a graph default and per-step tier without pinning a model version", () => {
+    const result = validateLinkedBundle({
+      schema: "derive.linked-bundle/v1",
+      purpose: "Regression improvement loop",
+      members: [{ id: "qa", ref: "abc12345", label: "QA evidence" }],
+      diagrams: [
+        {
+          id: "qa-loop",
+          title: "QA loop",
+          type: "loop",
+          tier: "balanced",
+          nodes: [
+            { id: "test", label: "Test", member: "qa", tier: "fast" },
+            { id: "judge", label: "Judge", tier: "frontier" },
+          ],
+          edges: [
+            { from: "test", to: "judge" },
+            { from: "judge", to: "test" },
+          ],
+          goal: "Improve confidence",
+          evaluate: "Compare against the previous run",
+          stop: "No material regression remains",
+        },
+      ],
+    })
+
+    expect(result.errors).toEqual([])
+    expect(result.manifest?.diagrams?.[0]).toMatchObject({
+      tier: "balanced",
+      nodes: [{ tier: "fast" }, { tier: "frontier" }],
+    })
+  })
+
+  it("rejects tiers outside the five-step contract", () => {
+    const result = validateLinkedBundle({
+      schema: "derive.linked-bundle/v1",
+      purpose: "Bad graph",
+      members: [{ id: "qa", ref: "abc12345", label: "QA" }],
+      diagrams: [
+        {
+          id: "bad",
+          title: "Bad",
+          type: "graph",
+          tier: "ultra",
+          nodes: [{ id: "test", label: "Test", tier: "cheap" }],
+          edges: [],
+        },
+      ],
+    })
+
+    expect(result.errors).toContain(
+      'diagrams[0].tier must be "utility", "fast", "balanced", "expert", or "frontier"',
+    )
+    expect(result.errors).toContain(
+      'diagrams[0].nodes[0].tier must be "utility", "fast", "balanced", "expert", or "frontier"',
+    )
+  })
+
+  it("maps stable model families to tiers and covers the monthly OpenRouter leaders", () => {
+    expect(MODEL_FAMILY_TIERS).toMatchObject({
+      "deepseek-v4-flash": "fast",
+      hy3: "balanced",
+      mimo: "fast",
+      luna: "balanced",
+      "nemotron-ultra": "fast",
+      glm: "balanced",
+      opus: "frontier",
+      ox: "expert",
+      "deepseek-v4-pro": "expert",
+      sonnet: "expert",
+      terra: "expert",
+      sol: "frontier",
+      fable: "frontier",
+    })
+    expect(tierForModelFamily("opus")).toBe("frontier")
+    expect(tierForModelFamily("opus-5-20260801")).toBeNull()
   })
 })
 


### PR DESCRIPTION
## Summary

- add a stable five-step capability contract: `utility`, `fast`, `balanced`, `expert`, `frontier`
- let linked graphs and loops set a default tier and override it per node
- keep provider model names and versions out of saved graph definitions; execution harnesses resolve tiers
- add a versionless model-family catalog covering Derive families and every family in OpenRouter’s trailing-30-day usage top ten

## Family mapping

- Utility: `utility`
- Fast: `deepseek-v4-flash`, `mimo`, `nemotron-ultra`
- Balanced: `luna`, `hy3`, `glm`
- Expert: `terra`, `sonnet`, `deepseek-v4-pro`, `ox`
- Frontier: `sol`, `fable`, `opus`

Two separately ranked DeepSeek Flash versions intentionally collapse into `deepseek-v4-flash`. Harnesses own concrete version resolution. Usage source: [OpenRouter rankings](https://openrouter.ai/rankings), as of 2026-08-21. Usage is coverage input, not the capability score.

## Verification

- `pnpm verify`
- 33/33 guardrails passed
- all workspace typechecks passed
- all tests passed (including 349 core and 1,581 API tests)

## Scope

This PR changes Derive only. Sift’s basic release automation remains separately scoped in Niftory/sift#6992.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/798"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789959654&installation_model_id=428097&pr_number=798&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F798&signature=d369960ef360dda0f65176d560f1c17bae0844cd92dc3b1878d3a56fd73620c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->