### PR TITLE
Rich review notifications for Slack and email

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -2130,6 +2130,10 @@
             "type": "boolean",
             "description": "The caller's \"DM me for interrupts\" preference (mentions, review requests, shares)"
           },
+          "review_email": {
+            "type": "boolean",
+            "description": "The caller's opt-in preference for review-request email (default false)"
+          },
           "linked": {
             "type": "boolean",
             "description": "Whether the caller has linked their Slack identity for the connected team"
@@ -2141,6 +2145,7 @@
           "team_name",
           "needs_reauth",
           "slack_dm",
+          "review_email",
           "linked"
         ]
       },

--- a/apps/api/src/lib/email.ts
+++ b/apps/api/src/lib/email.ts
@@ -5,10 +5,11 @@
 // pre-rendered at enqueue time (the drainer has no request context) and this sender
 // just transports the finished message.
 
-import { type ArtifactRecord, type DeliveryRecord, escapeHtml } from "@derive/core"
+import { type ArtifactRecord, artifactUrl, type DeliveryRecord, escapeHtml } from "@derive/core"
 import { log } from "../log"
 import type { ChannelSendResult } from "../webhooks"
 import { commentDeepLink } from "./comments"
+import { type ReviewChange, type ReviewSummary, reviewDeltaLabel } from "./review-summary"
 import { truncate } from "./text"
 
 /** A finished message, ready to transport. `from` is filled by the sender's config. */
@@ -183,23 +184,73 @@ export const buildArtifactInviteEmail = buildShareInviteEmail
 export const buildReviewEmail = (
   baseUrl: string,
   artifact: ArtifactRecord,
-  input: { requestedBy: string; version: number; note?: string | null },
+  input: {
+    requestedBy: string
+    version: number
+    note?: string | null
+    summary?: ReviewSummary
+  },
 ): { subject: string; html: string; text: string } => {
   const title = artifact.title ?? artifact.short_id
-  const link = `${baseUrl.replace(/\/$/, "")}/artifacts/${artifact.short_id}`
-  const subject = `${input.requestedBy} requested your review of ${title}`
-  const note = input.note ? truncate(input.note, 600) : null
-  const html = `<!doctype html><html><body style="font-family:-apple-system,Segoe UI,Roboto,sans-serif;color:#1a1a1a;line-height:1.5">
-  <p><strong>${escapeHtml(input.requestedBy)}</strong> requested your review of <a href="${escapeHtml(link)}">${escapeHtml(title)}</a> (v${input.version}).</p>
-  ${note ? `<p style="white-space:pre-wrap">${escapeHtml(note)}</p>` : ""}
-  <p><a href="${escapeHtml(link)}" style="display:inline-block;background:#111;color:#fff;padding:8px 16px;border-radius:6px;text-decoration:none">Review in Derive</a></p>
+  const link = artifactUrl(baseUrl.replace(/\/$/, ""), artifact)
+  const summary = input.summary
+  const delta = summary ? reviewDeltaLabel(summary) : null
+  const subject = summary
+    ? `${input.requestedBy} updated ${title} · ${delta}`
+    : `${input.requestedBy} updated ${title}`
+  const note = input.note ? truncate(input.note, 600) : (summary?.note ?? null)
+  const highlights = summary?.highlights ?? []
+  const changes = summary?.changes ?? []
+  const remaining = Math.max(0, (summary?.totalChanges ?? changes.length) - changes.length)
+  const changeHtml = (change: ReviewChange): string => {
+    const palette = {
+      added: { label: "ADDED", color: "#137333", bg: "#e9f5ec" },
+      updated: { label: "UPDATED", color: "#7a4f01", bg: "#fff4d6" },
+      removed: { label: "REMOVED", color: "#a50e0e", bg: "#fce8e6" },
+    }[change.kind]
+    const renamed = change.previousTitle
+      ? `<div style="color:#777;font-size:12px;margin-top:3px">${escapeHtml(change.previousTitle)} → ${escapeHtml(change.title)}</div>`
+      : ""
+    const before = change.before
+      ? `<div style="color:#777;font-size:14px;margin-top:9px"><span style="font-size:11px;font-weight:700;letter-spacing:.04em">BEFORE</span><br/><span style="text-decoration:line-through">${escapeHtml(change.before)}</span></div>`
+      : ""
+    const after = change.after
+      ? `<div style="color:#1a1a1a;font-size:14px;margin-top:9px"><span style="font-size:11px;font-weight:700;letter-spacing:.04em">${change.kind === "added" ? "NEW" : "NOW"}</span><br/>${escapeHtml(change.after)}</div>`
+      : ""
+    return `<div style="border:1px solid #e6e6e6;border-left:4px solid ${palette.color};border-radius:9px;padding:12px 14px;margin:10px 0">
+      <span style="display:inline-block;background:${palette.bg};color:${palette.color};font-size:10px;font-weight:700;letter-spacing:.06em;border-radius:999px;padding:3px 7px">${palette.label}</span>
+      <strong style="margin-left:7px">${escapeHtml(change.title)}</strong>${renamed}${before}${after}
+    </div>`
+  }
+  const html = `<!doctype html><html><head><meta charset="utf-8"/></head><body style="margin:0;background:#fff;font-family:-apple-system,Segoe UI,Roboto,sans-serif;color:#1a1a1a;line-height:1.5"><div style="max-width:640px;margin:0 auto;padding:24px 16px">
+  <p style="font-size:18px;margin:0 0 6px"><strong>${escapeHtml(input.requestedBy)} updated ${escapeHtml(title)}</strong></p>
+  <p style="color:#666;margin:0 0 18px">${summary?.fromVersion ? `v${summary.fromVersion} → ` : ""}v${input.version}${delta ? ` · ${escapeHtml(delta)}` : ""}</p>
+  ${note ? `<p style="white-space:pre-wrap;background:#f6f6f6;border-radius:8px;padding:12px 14px">${escapeHtml(note)}</p>` : ""}
+  <p><a href="${escapeHtml(link)}" style="display:inline-block;background:#111;color:#fff;padding:10px 18px;border-radius:7px;text-decoration:none">Open the work</a></p>
+  ${changes.length ? `<div style="margin:18px 0"><strong>What changed</strong>${changes.map(changeHtml).join("")}${remaining ? `<div style="color:#666;font-size:13px;font-weight:600;text-align:center;margin:12px 0 2px">+ ${remaining} more ${remaining === 1 ? "change" : "changes"} in the full work</div>` : ""}</div>` : highlights.length ? `<div style="border:1px solid #e6e6e6;border-radius:10px;padding:14px 16px;margin:18px 0"><strong>What changed</strong><ul style="padding-left:20px;margin:8px 0 0">${highlights.map((line) => `<li>${escapeHtml(line)}</li>`).join("")}</ul></div>` : ""}
+  <p><a href="${escapeHtml(link)}" style="display:inline-block;background:#111;color:#fff;padding:10px 18px;border-radius:7px;text-decoration:none">Open the work</a></p>
   <hr style="border:none;border-top:1px solid #eee;margin:24px 0"/>
-  <p style="color:#999;font-size:12px">You're receiving this because the revision is waiting on your review.</p>
-  </body></html>`
+  <p style="color:#999;font-size:12px">This version is waiting for your feedback in Derive.</p>
+  </div></body></html>`
   const text = [
-    `${input.requestedBy} requested your review of ${title} (v${input.version}).`,
+    `${input.requestedBy} updated ${title} (v${input.version}${delta ? ` · ${delta}` : ""}).`,
     note ? `\n${note}` : "",
-    `\nReview in Derive: ${link}`,
+    changes.length
+      ? `\nWhat changed:\n${changes
+          .map((change) => {
+            const lines = [`- ${change.kind.toUpperCase()} · ${change.title}`]
+            if (change.before) lines.push(`  Before: ${change.before}`)
+            if (change.after)
+              lines.push(`  ${change.kind === "added" ? "New" : "Now"}: ${change.after}`)
+            return lines.join("\n")
+          })
+          .join(
+            "\n",
+          )}${remaining ? `\n+ ${remaining} more ${remaining === 1 ? "change" : "changes"} in the full work` : ""}`
+      : highlights.length
+        ? `\nWhat changed:\n${highlights.map((line) => `- ${line}`).join("\n")}`
+        : "",
+    `\nOpen the work: ${link}`,
   ]
     .filter(Boolean)
     .join("\n")

--- a/apps/api/src/lib/review-request.ts
+++ b/apps/api/src/lib/review-request.ts
@@ -12,18 +12,28 @@
 // (`agentPushFanout`) is shared for the same reason: one row per push, a review ask beats a
 // plain publish, and the delivery receipt becomes `opened_in_tab`.
 
-import { type ArtifactRecord, artifactUrl, type MetaStore, newId } from "@derive/core"
+import {
+  type ArtifactRecord,
+  artifactUrl,
+  type BlobStore,
+  type MetaStore,
+  newId,
+} from "@derive/core"
 import type { Backplane } from "../bus"
 import type { WebhookEvent } from "../events"
+import { log } from "../log"
 import { enqueueChannelDelivery } from "../webhooks"
 import { buildReviewEmail } from "./email"
-import { enqueueSlackReviewRequestedDm } from "./slack-dm"
+import { buildReviewSummary, type ReviewSummary } from "./review-summary"
+import { enqueueSlackReviewRequestedDm, wantsReviewEmail } from "./slack-dm"
 
 export interface ReviewRequestDeps {
   meta: MetaStore
+  blobs: BlobStore
   bus: Backplane
   baseUrl: string
   notify: (a: ArtifactRecord, event: WebhookEvent, data: Record<string, unknown>) => Promise<void>
+  pokeWebhooks?: () => void
 }
 
 export interface ReviewRequestInput {
@@ -42,11 +52,6 @@ export interface ReviewRequestInput {
    *  acting, else the acting user; null when neither is known. The card's `author` is
    *  always `requestedByName`. */
   actorId: string | null
-  /** Suppress the reviewer's email/DM when they ARE this user — nobody needs an interrupt
-   *  about a request that is their own action. Attended surfaces pass the acting human's id
-   *  (their click or their conversational edit); a detached executor passes null, because
-   *  interrupting the human it acts for is the point. */
-  selfId?: string | null
 }
 
 /** Open the round and run the whole reviewer fan-out. Returns the round id. */
@@ -70,31 +75,66 @@ export const openReviewRound = async (
     author: input.requestedByName,
     actor_id: input.actorId,
   })
-  // The review request is the one event that earns an interrupt: the loop is blocked on the
-  // reviewer, who may have no tab open. Never for your own request on yourself.
-  if (input.reviewer !== input.selfId) {
-    if ((await deps.meta.getOrgSettings(artifact.org_id)).emailNotifications) {
-      const [r] = await deps.meta.getUsers([input.reviewer])
-      if (r?.email)
-        await enqueueChannelDelivery(deps.meta, "email", "review.requested", {
-          to: r.email,
-          toName: r.name ?? undefined,
-          ...buildReviewEmail(deps.baseUrl, artifact, {
-            requestedBy: input.requestedByName,
-            version: input.version,
-            note: input.note ?? null,
-          }),
-        })
-    }
-    // Same interrupt, mirrored to Slack (independent of the email gate above — gated on
-    // the reviewer's own Slack-DM preference instead).
-    await enqueueSlackReviewRequestedDm(
-      { meta: deps.meta, baseUrl: deps.baseUrl },
-      artifact,
-      { requestedBy: input.requestedByName, version: input.version, note: input.note ?? null },
-      input.reviewer,
+  let summary: ReviewSummary
+  try {
+    summary = await buildReviewSummary(
+      deps.meta,
+      deps.blobs,
+      artifact.id,
+      input.version,
+      input.note,
     )
+  } catch (err) {
+    log.warn("review summary could not be built; sending the review request without a diff", {
+      artifact: artifact.id,
+      version: input.version,
+      error: err instanceof Error ? err.message : String(err),
+    })
+    summary = {
+      fromVersion: input.version > 1 ? input.version - 1 : null,
+      toVersion: input.version,
+      added: 0,
+      removed: 0,
+      changes: [],
+      totalChanges: 0,
+      highlights: [],
+      note: input.note ?? null,
+    }
   }
+  const [reviewer, pref, orgSettings] = await Promise.all([
+    deps.meta.getUsers([input.reviewer]).then(([user]) => user),
+    deps.meta.getUserNotificationPref(artifact.org_id, input.reviewer),
+    deps.meta.getOrgSettings(artifact.org_id),
+  ])
+  // Slack is the default review surface, including attended Derive sessions. It now carries
+  // enough of the diff to be useful rather than merely echoing that a request exists.
+  await enqueueSlackReviewRequestedDm(
+    { meta: deps.meta, baseUrl: deps.baseUrl },
+    artifact,
+    {
+      requestedBy: input.requestedByName,
+      roundId: round.id,
+      version: input.version,
+      note: input.note ?? null,
+      summary,
+    },
+    input.reviewer,
+  )
+  // Review email requires both the workspace master gate and an explicit personal opt-in.
+  if (orgSettings.emailNotifications && wantsReviewEmail(pref?.prefs) && reviewer?.email)
+    await enqueueChannelDelivery(deps.meta, "email", "review.requested", {
+      to: reviewer.email,
+      toName: reviewer.name ?? undefined,
+      ...buildReviewEmail(deps.baseUrl, artifact, {
+        requestedBy: input.requestedByName,
+        version: input.version,
+        note: input.note ?? null,
+        summary,
+      }),
+    })
+  // notify() poked before these direct outbox rows existed. Wake the drainer again so Slack
+  // arrives immediately instead of waiting for the next hosted cron tick.
+  deps.pokeWebhooks?.()
   return round.id
 }
 

--- a/apps/api/src/lib/review-summary.ts
+++ b/apps/api/src/lib/review-summary.ts
@@ -1,0 +1,362 @@
+import {
+  type BlobStore,
+  type DiffOp,
+  diffLines,
+  type MetaStore,
+  toMarkdown,
+  type VersionRecord,
+} from "@derive/core"
+import { pageTextResolver } from "./bundle"
+import { truncate } from "./text"
+
+export type ReviewChangeKind = "added" | "updated" | "removed"
+
+export interface ReviewChange {
+  kind: ReviewChangeKind
+  title: string
+  previousTitle?: string
+  added: number
+  removed: number
+  before?: string
+  after?: string
+}
+
+export interface ReviewSummary {
+  fromVersion: number | null
+  toVersion: number
+  added: number
+  removed: number
+  /** Ranked structural changes. Always populated by production; optional for old payloads. */
+  changes?: ReviewChange[]
+  /** All detected structural changes, including cards omitted from the compact preview. */
+  totalChanges?: number
+  /** Plain-text fallback used by older consumers and notification payloads. */
+  highlights: string[]
+  note: string | null
+}
+
+interface DocSection {
+  key: string
+  title: string
+  level: number
+  lines: string[]
+  order: number
+}
+
+const readableText = async (blobs: BlobStore, version: VersionRecord): Promise<string> => {
+  const resolve = await pageTextResolver(blobs, version)
+  const source = (await resolve(null)) ?? ""
+  const type = /^\s*<(?:!doctype|html|head|body|main|section)\b/i.test(source)
+    ? "text/html"
+    : version.content_type
+  return toMarkdown(source, type)
+}
+
+const diagramNode = (raw: string): string =>
+  raw
+    .trim()
+    .replace(/^[A-Za-z0-9_-]+\s*(?:\[|\(|\{|>)(.+?)(?:\]|\)|\}|])$/, "$1")
+    .replace(/^['"]|['"]$/g, "")
+    .trim()
+
+const humanizeDiagramLine = (line: string): string => {
+  const edge = /^\s*([^\n]+?)\s*--(?:>|[^>|]*\|([^|]+)\|\s*>)\s*([^\n]+?)\s*$/.exec(line)
+  if (!edge?.[1] || !edge[3]) return line
+  const from = diagramNode(edge[1])
+  const to = diagramNode(edge[3])
+  return edge[2] ? `${from} → ${edge[2].trim()} → ${to}` : `${from} → ${to}`
+}
+
+const cleanLine = (line: string, max = 220): string =>
+  truncate(
+    humanizeDiagramLine(line)
+      .replace(/^\s{0,3}(?:#{1,6}|[-*+] |\d+\. )\s*/, "")
+      .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
+      .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+      .replace(/[*_`>#~]/g, "")
+      .replace(/\s+/g, " ")
+      .trim(),
+    max,
+  )
+
+const meaningful = (line: string): boolean => {
+  const clean = cleanLine(line)
+  return clean.length >= 8 && /[A-Za-z0-9]/.test(clean) && !/^[-=]{3,}$/.test(clean)
+}
+
+const normalizedTitle = (title: string): string =>
+  title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+
+const documentSections = (markdown: string): DocSection[] => {
+  const sections: DocSection[] = []
+  const seen = new Map<string, number>()
+  let current: DocSection = {
+    key: "__overview__:1",
+    title: "Overview",
+    level: 1,
+    lines: [],
+    order: 0,
+  }
+  sections.push(current)
+  for (const raw of markdown.split("\n")) {
+    const heading = /^\s{0,3}(#{1,6})\s+(.+?)\s*#*\s*$/.exec(raw)
+    if (heading?.[1] && heading[2]) {
+      const title = cleanLine(heading[2], 100) || "Untitled section"
+      const normalized = normalizedTitle(title) || "untitled"
+      const occurrence = (seen.get(normalized) ?? 0) + 1
+      seen.set(normalized, occurrence)
+      current = {
+        key: `${normalized}:${occurrence}`,
+        title,
+        level: heading[1].length,
+        lines: [],
+        order: sections.length,
+      }
+      sections.push(current)
+      continue
+    }
+    if (meaningful(raw)) current.lines.push(raw.trim())
+  }
+  return sections.filter((section, index) => index > 0 || section.lines.length > 0)
+}
+
+const tokens = (section: DocSection): Set<string> =>
+  new Set(
+    `${section.title} ${section.lines.join(" ")}`
+      .toLowerCase()
+      .match(/[a-z0-9]{3,}/g)
+      ?.filter((token) => !STOP_WORDS.has(token)) ?? [],
+  )
+
+const STOP_WORDS = new Set([
+  "and",
+  "are",
+  "but",
+  "for",
+  "from",
+  "have",
+  "into",
+  "not",
+  "that",
+  "the",
+  "their",
+  "this",
+  "was",
+  "were",
+  "with",
+  "you",
+  "your",
+])
+
+const similarity = (a: DocSection, b: DocSection): number => {
+  const left = tokens(a)
+  const right = tokens(b)
+  if (!left.size || !right.size) return 0
+  let intersection = 0
+  for (const token of left) if (right.has(token)) intersection++
+  return intersection / (left.size + right.size - intersection)
+}
+
+const diffFor = (before: string[], after: string[]): DiffOp[] => {
+  if (before.length * after.length <= 80_000) return diffLines(before.join("\n"), after.join("\n"))
+  const beforeSet = new Set(before)
+  const afterSet = new Set(after)
+  return [
+    ...before.filter((line) => !afterSet.has(line)).map((line) => ({ t: "del" as const, line })),
+    ...after.filter((line) => !beforeSet.has(line)).map((line) => ({ t: "add" as const, line })),
+  ]
+}
+
+const bestExcerpt = (lines: string[]): string | undefined => {
+  const scored = lines
+    .map((line, index) => {
+      const clean = cleanLine(line)
+      const words = clean.split(/\s+/).filter(Boolean).length
+      const score = Math.min(words, 18) + (/[.!?]$/.test(clean) ? 2 : 0) - index * 0.02
+      return { clean, score }
+    })
+    .filter(({ clean }) => meaningful(clean))
+    .sort((a, b) => b.score - a.score)
+  return scored[0]?.clean
+}
+
+const changedSection = (before: DocSection, after: DocSection): ReviewChange | null => {
+  const ops = diffFor(before.lines, after.lines)
+  const addedLines = ops.filter((op) => op.t === "add" && meaningful(op.line)).map((op) => op.line)
+  const removedLines = ops
+    .filter((op) => op.t === "del" && meaningful(op.line))
+    .map((op) => op.line)
+  const renamed = normalizedTitle(before.title) !== normalizedTitle(after.title)
+  if (!renamed && addedLines.length === 0 && removedLines.length === 0) return null
+  return {
+    kind: "updated",
+    title: after.title,
+    ...(renamed ? { previousTitle: before.title } : {}),
+    added: addedLines.length,
+    removed: removedLines.length,
+    before: bestExcerpt(removedLines),
+    after: bestExcerpt(addedLines),
+  }
+}
+
+const newSection = (section: DocSection): ReviewChange => ({
+  kind: "added",
+  title: section.title,
+  added: section.lines.filter(meaningful).length,
+  removed: 0,
+  after: bestExcerpt(section.lines),
+})
+
+const removedSection = (section: DocSection): ReviewChange => ({
+  kind: "removed",
+  title: section.title,
+  added: 0,
+  removed: section.lines.filter(meaningful).length,
+  before: bestExcerpt(section.lines),
+})
+
+const rank = (change: ReviewChange, section: DocSection): number => {
+  const magnitude = Math.min(change.added + change.removed, 20)
+  const paired = change.before && change.after ? 8 : 0
+  const structural = change.kind === "updated" ? 4 : 6
+  const heading = Math.max(0, 5 - section.level)
+  return magnitude + paired + structural + heading - section.order * 0.01
+}
+
+const structuralChanges = (
+  before: string,
+  after: string,
+): { changes: ReviewChange[]; total: number } => {
+  const oldSections = documentSections(before)
+  const newSections = documentSections(after)
+  const oldByKey = new Map(oldSections.map((section) => [section.key, section]))
+  const matchedOld = new Set<string>()
+  const candidates: Array<{ change: ReviewChange; section: DocSection; score: number }> = []
+
+  // Exact heading matches preserve a stable section identity even when its body is rewritten.
+  for (const section of newSections) {
+    const old = oldByKey.get(section.key)
+    if (!old) continue
+    matchedOld.add(old.key)
+    const change = changedSection(old, section)
+    if (change) candidates.push({ change, section, score: rank(change, section) })
+  }
+
+  // Pair renamed/moved sections by content similarity before calling them add/remove.
+  const unmatchedOld = oldSections.filter((section) => !matchedOld.has(section.key))
+  for (const section of newSections.filter((candidate) => !oldByKey.has(candidate.key))) {
+    let best: DocSection | undefined
+    let bestScore = 0
+    for (const old of unmatchedOld) {
+      if (matchedOld.has(old.key)) continue
+      const score = similarity(old, section)
+      if (score > bestScore) {
+        best = old
+        bestScore = score
+      }
+    }
+    if (best && bestScore >= 0.42) {
+      matchedOld.add(best.key)
+      const change = changedSection(best, section)
+      if (change) candidates.push({ change, section, score: rank(change, section) + bestScore * 5 })
+    } else {
+      const change = newSection(section)
+      candidates.push({ change, section, score: rank(change, section) })
+    }
+  }
+
+  for (const section of oldSections) {
+    if (matchedOld.has(section.key)) continue
+    const change = removedSection(section)
+    candidates.push({ change, section, score: rank(change, section) })
+  }
+
+  const ranked = candidates
+    .filter(({ change }) => change.added > 0 || change.removed > 0 || !!change.previousTitle)
+    .sort((a, b) => b.score - a.score)
+  return {
+    changes: ranked.slice(0, 3).map(({ change }) => change),
+    total: ranked.length,
+  }
+}
+
+const globalDelta = (before: string, after: string): { added: number; removed: number } => {
+  const ops = diffFor(before.split("\n"), after.split("\n"))
+  return {
+    added: ops.filter((op) => op.t === "add" && meaningful(op.line)).length,
+    removed: ops.filter((op) => op.t === "del" && meaningful(op.line)).length,
+  }
+}
+
+/** Pure structural summarizer, exported so the algorithm can be tested without storage. */
+export const summarizeReviewDocuments = (input: {
+  before: string
+  after: string
+  beforeContentType?: string
+  afterContentType?: string
+  fromVersion: number | null
+  toVersion: number
+  note?: string | null
+}): ReviewSummary => {
+  const before = toMarkdown(input.before, input.beforeContentType ?? "text/markdown")
+  const after = toMarkdown(input.after, input.afterContentType ?? "text/markdown")
+  const delta = globalDelta(before, after)
+  const structural = structuralChanges(before, after)
+  const changes = structural.changes
+  return {
+    fromVersion: input.fromVersion,
+    toVersion: input.toVersion,
+    ...delta,
+    changes,
+    totalChanges: structural.total,
+    highlights: changes
+      .map((change) => change.after ?? change.before)
+      .filter((line): line is string => !!line),
+    note: input.note ? truncate(input.note, 600) : null,
+  }
+}
+
+/** Build the compact, channel-neutral change story used by Slack and email. */
+export const buildReviewSummary = async (
+  meta: MetaStore,
+  blobs: BlobStore,
+  artifactId: string,
+  version: number,
+  note?: string | null,
+): Promise<ReviewSummary> => {
+  const current = await meta.getVersion(artifactId, version)
+  const previous = version > 1 ? await meta.getVersion(artifactId, version - 1) : null
+  if (!current)
+    return {
+      fromVersion: previous?.n ?? null,
+      toVersion: version,
+      added: 0,
+      removed: 0,
+      changes: [],
+      totalChanges: 0,
+      highlights: [],
+      note: note ? truncate(note, 600) : null,
+    }
+  const [before, after] = await Promise.all([
+    previous ? readableText(blobs, previous) : Promise.resolve(""),
+    readableText(blobs, current),
+  ])
+  return summarizeReviewDocuments({
+    before,
+    after,
+    fromVersion: previous?.n ?? null,
+    toVersion: version,
+    note: note ?? current.message,
+  })
+}
+
+export const reviewDeltaLabel = (summary: ReviewSummary): string => {
+  if (summary.added === 0 && summary.removed === 0) return "No text changes detected"
+  const parts = []
+  if (summary.added) parts.push(`${summary.added} added`)
+  if (summary.removed) parts.push(`${summary.removed} removed`)
+  return parts.join(" · ")
+}

--- a/apps/api/src/lib/slack-dm.ts
+++ b/apps/api/src/lib/slack-dm.ts
@@ -22,10 +22,16 @@ import {
 import type { ChannelSendResult } from "../webhooks"
 import { enqueueChannelDelivery } from "../webhooks"
 import { commentDeepLink, type Mention, previewOf } from "./comments"
+import { type ReviewSummary, reviewDeltaLabel } from "./review-summary"
 import { openSlackDm, resolveSlackUserIdByEmail } from "./slack"
 import { actionButton, actions, mrkdwnBody, mrkdwnLabel, openButton, section } from "./slack-cards"
 import { postWithRecovery, resolveBotToken, slackFailure } from "./slack-delivery"
-import { commentThreadEntity, encodeReviewAction, SLACK_REVIEW_ACTION } from "./slack-work-object"
+import {
+  commentThreadEntity,
+  encodeReviewAction,
+  reviewNotificationEntity,
+  SLACK_REVIEW_ACTION,
+} from "./slack-work-object"
 
 /** The self-contained payload a slack_dm delivery carries. */
 interface SlackDmPayload {
@@ -33,6 +39,8 @@ interface SlackDmPayload {
   userId: string
   text: string
   blocks: unknown[]
+  /** Native Slack Work Object metadata. Blocks remain the graceful fallback. */
+  metadata?: Record<string, unknown>
   /** Present only for an @mention. It gives the delivery worker enough durable context to make
    *  the first DM a Work Object and to thread every later ping under that one root. */
   mention?: {
@@ -57,6 +65,17 @@ export const wantsSlackDm = (prefsJson: string | undefined): boolean => {
     return (JSON.parse(prefsJson) as { slackDm?: boolean }).slackDm !== false
   } catch {
     return true
+  }
+}
+
+/** Review email is deliberately opt-in. Workspace email remains the administrator's master
+ * gate, but an absent or malformed personal preference must never create inbox noise. */
+export const wantsReviewEmail = (prefsJson: string | undefined): boolean => {
+  if (!prefsJson) return false
+  try {
+    return (JSON.parse(prefsJson) as { reviewEmail?: boolean }).reviewEmail === true
+  } catch {
+    return false
   }
 }
 
@@ -150,13 +169,18 @@ export const enqueueSlackArtifactMentionDms = async (
   }
 }
 
-/** DM the human a review is blocked on — the one event that most deserves to interrupt
- *  (same rationale as buildReviewEmail): the loop is waiting on them and they may have no
- *  tab open. Never for your own request on yourself; caller already enforces that. */
+/** DM the human a review is blocked on. Slack defaults on because the message explains the
+ * change itself instead of merely announcing that a review exists. */
 export const enqueueSlackReviewRequestedDm = async (
   deps: { meta: MetaStore; baseUrl: string },
   artifact: ArtifactRecord,
-  round: { requestedBy: string; version: number; note?: string | null },
+  round: {
+    requestedBy: string
+    roundId: string
+    version: number
+    note?: string | null
+    summary: ReviewSummary
+  },
   reviewerId: string,
 ): Promise<void> => {
   const { meta, baseUrl } = deps
@@ -166,16 +190,31 @@ export const enqueueSlackReviewRequestedDm = async (
   if (!wantsSlackDm(pref?.prefs)) return
   const link = artifactUrl(baseUrl, artifact)
   const t = title(artifact)
+  const changes = round.summary.changes ?? []
+  const remaining = Math.max(0, (round.summary.totalChanges ?? changes.length) - changes.length)
+  const changeBlocks = changes.map((change) => {
+    const label =
+      change.kind === "added" ? "ADDED" : change.kind === "removed" ? "REMOVED" : "UPDATED"
+    const details = [
+      `*${label} · ${mrkdwnLabel(change.title)}*`,
+      change.before ? `~Before: ${mrkdwnBody(change.before, 350)}~` : null,
+      change.after
+        ? `${change.kind === "added" ? "New" : "Now"}: ${mrkdwnBody(change.after, 350)}`
+        : null,
+    ]
+      .filter(Boolean)
+      .join("\n")
+    return section(details)
+  })
   const blocks = [
     section(
-      `:mag: *${mrkdwnLabel(round.requestedBy)}* requested your review of <${link}|${mrkdwnLabel(t)}> (v${round.version}).`,
+      `:mag: *${mrkdwnLabel(round.requestedBy)} updated <${link}|${mrkdwnLabel(t)}>*\n${round.summary.fromVersion ? `v${round.summary.fromVersion} → ` : ""}v${round.version} · ${reviewDeltaLabel(round.summary)}`,
     ),
     ...(round.note ? [section(`> ${mrkdwnBody(round.note, 600)}`)] : []),
-    // Settle it HERE. This DM is the one moment the loop is blocked on a named person, and it
-    // is addressed to exactly them — so the two answers the agent is waiting for belong on it,
-    // with "Review in Derive" kept for everything a button cannot express. Sending them to a
-    // browser to press the same button is the difference between a notification and a
-    // place to work.
+    ...(changeBlocks.length ? [section("*What changed*"), ...changeBlocks] : []),
+    ...(remaining
+      ? [section(`_${remaining} more ${remaining === 1 ? "change" : "changes"} in the full work_`)]
+      : []),
     actions([
       actionButton(
         SLACK_REVIEW_ACTION.sendBack,
@@ -183,14 +222,26 @@ export const enqueueSlackReviewRequestedDm = async (
         encodeReviewAction(artifact.id),
         "primary",
       ),
-      openButton(link, "Review in Derive"),
+      openButton(link, "Open & comment"),
     ]),
   ]
   await enqueueChannelDelivery(meta, "slack_dm", "review.requested", {
     orgId: artifact.org_id,
     userId: reviewerId,
-    text: `${mrkdwnLabel(round.requestedBy)} requested your review of ${mrkdwnLabel(t)} (v${round.version})`,
+    text: `${mrkdwnLabel(round.requestedBy)} updated ${mrkdwnLabel(t)} (v${round.version} · ${reviewDeltaLabel(round.summary)})`,
     blocks,
+    metadata: {
+      entities: [
+        reviewNotificationEntity({
+          baseUrl,
+          artifact,
+          roundId: round.roundId,
+          requestedBy: round.requestedBy,
+          summary: round.summary,
+          iconUrl: new URL("/icon.png", link).toString(),
+        }),
+      ],
+    },
   } satisfies SlackDmPayload)
 }
 
@@ -321,7 +372,7 @@ export const makeSlackDmSender =
               }),
             ],
           }
-        : undefined
+        : p.metadata
     const res = await postWithRecovery(
       meta,
       p.orgId,

--- a/apps/api/src/lib/slack-work-object.ts
+++ b/apps/api/src/lib/slack-work-object.ts
@@ -20,9 +20,10 @@
 // stable short id and never a slug.
 
 import type { ArtifactRecord, CommentRecord, UnfurlInfo } from "@derive/core"
-import { unfurlDescription } from "@derive/core"
+import { artifactUrl, unfurlDescription } from "@derive/core"
 import { type ArtifactStatus, agoLabel, statusPhrase } from "./artifact-status"
 import { commentDeepLink } from "./comments"
+import { type ReviewSummary, reviewDeltaLabel } from "./review-summary"
 import { mrkdwnBody } from "./slack-cards"
 import { encodeQuestionReply, SLACK_QUESTION_REPLY_ACTION } from "./slack-question"
 
@@ -57,6 +58,7 @@ export const DERIVE_ENTITY_TYPE = "artifact"
  * namespace: a Slack DM about one question should aggregate its replies, not every discussion
  * that happens to reference the artifact. */
 export const DERIVE_COMMENT_THREAD_ENTITY_TYPE = "comment_thread"
+export const DERIVE_REVIEW_REQUEST_ENTITY_TYPE = "review_request"
 
 /** Work Object metadata for one open Derive conversation. Used on the first personal mention
  * DM and for a pasted deep link to an exact question. Subsequent activity is a normal Slack
@@ -156,6 +158,59 @@ const reviewActions = (artifactId: string) => ({
     },
   ],
 })
+
+/** A personal review request as a native Slack Work Object. The structural diff is short on
+ * purpose: Slack remains a useful place to decide, while the canonical work stays in Derive. */
+export const reviewNotificationEntity = (args: {
+  baseUrl: string
+  artifact: ArtifactRecord
+  roundId: string
+  requestedBy: string
+  summary: ReviewSummary
+  iconUrl: string
+}): Record<string, unknown> => {
+  const link = artifactUrl(args.baseUrl, args.artifact)
+  const shown = args.summary.changes ?? []
+  const remaining = Math.max(0, (args.summary.totalChanges ?? shown.length) - shown.length)
+  const lines = shown.slice(0, 2).map((change) => {
+    const marker = change.kind === "added" ? "+" : change.kind === "removed" ? "−" : "~"
+    const detail = change.after ?? change.before
+    return `*${marker} ${mrkdwnBody(change.title, 100)}*${detail ? ` — ${mrkdwnBody(detail, 180)}` : ""}`
+  })
+  if (remaining > 0) lines.push(`_${remaining} more ${remaining === 1 ? "change" : "changes"}_`)
+  const description = [
+    `*${mrkdwnBody(args.requestedBy, 100)} updated this work*`,
+    reviewDeltaLabel(args.summary),
+    args.summary.note ? `> ${mrkdwnBody(args.summary.note, 400)}` : null,
+    ...lines,
+  ]
+    .filter(Boolean)
+    .join("\n")
+  return {
+    url: link,
+    external_ref: { id: args.roundId, type: DERIVE_REVIEW_REQUEST_ENTITY_TYPE },
+    entity_type: "slack#/entities/content_item",
+    entity_payload: {
+      actions: reviewActions(args.artifact.id),
+      attributes: {
+        title: { text: args.artifact.title ?? args.artifact.short_id },
+        display_type: "Review",
+        product_name: "Derive",
+        product_icon: { url: args.iconUrl, alt_text: "Derive" },
+      },
+      fields: { description: { value: description, format: "markdown" } },
+      custom_fields: [
+        { key: "version", label: "Version", value: `v${args.summary.toVersion}`, type: "string" },
+        {
+          key: "changes",
+          label: "Changes",
+          value: reviewDeltaLabel(args.summary),
+          type: "string",
+        },
+      ],
+    },
+  }
+}
 
 export interface WorkObjectArgs {
   /** The URL exactly as pasted — Slack matches the unfurl back to the message by this, so it is

--- a/apps/api/src/mcp-tools/publish.ts
+++ b/apps/api/src/mcp-tools/publish.ts
@@ -790,7 +790,14 @@ export function registerPublishTool(tc: ToolContext): void {
         const reviewFor = actingFor?.id ?? (profileAskReview ? profileReviewer : null)
         if ((request_review || profileAskReview) && reviewFor) {
           review_round = await openReviewRound(
-            { meta: ctx.meta, bus: ctx.bus, baseUrl: ctx.deps.baseUrl, notify: ctx.notify },
+            {
+              meta: ctx.meta,
+              blobs: ctx.blobs,
+              bus: ctx.bus,
+              baseUrl: ctx.deps.baseUrl,
+              notify: ctx.notify,
+              pokeWebhooks: ctx.deps.pokeWebhooks,
+            },
             artifact,
             {
               reviewer: reviewFor,
@@ -798,10 +805,6 @@ export function registerPublishTool(tc: ToolContext): void {
               requestedByName: agent.name,
               version: version.n,
               actorId: agent.id,
-              // A detached executor's request interrupts the human it acts for — that is
-              // the point. An attended surface's request is the person's own conversational
-              // edit: the round is the record, and emailing them about it would be noise.
-              selfId: attended ? reviewFor : null,
             },
           )
         }

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -949,15 +949,18 @@ export const artifactRoutes = (ctx: AppContext) => {
           (await meta.listMemberships(org)).find((m) => m.role === "owner")?.user_id ??
           null
         if (reviewer) {
-          await openReviewRound({ meta, bus, baseUrl: deps.baseUrl, notify }, artifact, {
-            reviewer,
-            requestedById: actor?.id ?? "agent",
-            requestedByName: actor?.name ?? "An agent",
-            version: version.n,
-            note: str(body["review_note"]) ?? null,
-            actorId: agentPrincipal?.id ?? actor?.id ?? null,
-            selfId: actor?.id ?? null,
-          })
+          await openReviewRound(
+            { meta, blobs, bus, baseUrl: deps.baseUrl, notify, pokeWebhooks: deps.pokeWebhooks },
+            artifact,
+            {
+              reviewer,
+              requestedById: actor?.id ?? "agent",
+              requestedByName: actor?.name ?? "An agent",
+              version: version.n,
+              note: str(body["review_note"]) ?? null,
+              actorId: agentPrincipal?.id ?? actor?.id ?? null,
+            },
+          )
           roundCreated = true
         }
       }
@@ -972,14 +975,17 @@ export const artifactRoutes = (ctx: AppContext) => {
         onBehalf &&
         agentSettings?.brandprint?.profileId === artifact.short_id
       ) {
-        await openReviewRound({ meta, bus, baseUrl: deps.baseUrl, notify }, artifact, {
-          reviewer: onBehalf,
-          requestedById: agentPrincipal.id,
-          requestedByName: agentPrincipal.name,
-          version: version.n,
-          actorId: agentPrincipal.id,
-          selfId: null,
-        })
+        await openReviewRound(
+          { meta, blobs, bus, baseUrl: deps.baseUrl, notify, pokeWebhooks: deps.pokeWebhooks },
+          artifact,
+          {
+            reviewer: onBehalf,
+            requestedById: agentPrincipal.id,
+            requestedByName: agentPrincipal.name,
+            version: version.n,
+            actorId: agentPrincipal.id,
+          },
+        )
         roundCreated = true
       }
       // The MCP loop over HTTP: an AGENT-credentialed publish (a registered

--- a/apps/api/src/routes/slack.ts
+++ b/apps/api/src/routes/slack.ts
@@ -63,7 +63,7 @@ import {
   threadStateBlocks,
 } from "../lib/slack-comments"
 import { flagSlackReauth, resolveBotToken } from "../lib/slack-delivery"
-import { enqueueSlackDm, wantsSlackDm } from "../lib/slack-dm"
+import { enqueueSlackDm, wantsReviewEmail, wantsSlackDm } from "../lib/slack-dm"
 import { isVerifiedLink, linkToActMessage } from "../lib/slack-identity"
 import { handleSlackMention } from "../lib/slack-mention"
 import {
@@ -552,6 +552,9 @@ export const slackRoutes = (ctx: AppContext) => {
         .describe(
           'The caller\'s "DM me for interrupts" preference (mentions, review requests, shares)',
         ),
+      review_email: z
+        .boolean()
+        .describe("The caller's opt-in preference for review-request email (default false)"),
       linked: z
         .boolean()
         .describe("Whether the caller has linked their Slack identity for the connected team"),
@@ -1624,16 +1627,23 @@ export const slackRoutes = (ctx: AppContext) => {
         team_name: install?.team_name ?? null,
         needs_reauth: install?.needs_reauth === 1,
         slack_dm: wantsSlackDm(pref?.prefs),
+        review_email: wantsReviewEmail(pref?.prefs),
         linked,
       })
     },
   )
 
-  // Toggle the caller's "DM me for interrupts" preference.
+  // Update the caller's personal delivery preferences. Slack defaults on; review email
+  // defaults off and still sits behind the workspace-wide email master switch.
   app.patch("/v1/slack/prefs", async (c) => {
     const me = await requireUser(c)
     if (me instanceof Response) return me
-    const b = await readJson(c, z.object({ slack_dm: z.boolean() }))
+    const b = await readJson(
+      c,
+      z
+        .object({ slack_dm: z.boolean().optional(), review_email: z.boolean().optional() })
+        .refine((value) => value.slack_dm !== undefined || value.review_email !== undefined),
+    )
     if (b instanceof Response) return b
     const org = await activeWorkspace(c)
     const cur = await meta.getUserNotificationPref(org, me.id)
@@ -1641,7 +1651,11 @@ export const slackRoutes = (ctx: AppContext) => {
     try {
       if (cur) existing = JSON.parse(cur.prefs) as Record<string, unknown>
     } catch {}
-    const prefs = { ...existing, slackDm: b.slack_dm }
+    const prefs = {
+      ...existing,
+      ...(b.slack_dm !== undefined ? { slackDm: b.slack_dm } : {}),
+      ...(b.review_email !== undefined ? { reviewEmail: b.review_email } : {}),
+    }
     await meta.setUserNotificationPref({
       id: cur?.id ?? newId("unp"),
       org_id: org,
@@ -1649,7 +1663,10 @@ export const slackRoutes = (ctx: AppContext) => {
       prefs: JSON.stringify(prefs),
       created_at: cur?.created_at ?? new Date().toISOString(),
     })
-    return c.json({ slack_dm: b.slack_dm })
+    return c.json({
+      slack_dm: wantsSlackDm(JSON.stringify(prefs)),
+      review_email: wantsReviewEmail(JSON.stringify(prefs)),
+    })
   })
 
   // Send the caller a test DM (verifies their account email matches a Slack account +

--- a/apps/api/test/agents-hosted.test.ts
+++ b/apps/api/test/agents-hosted.test.ts
@@ -94,6 +94,13 @@ describe("hostable agents + workspace agent settings", () => {
       ...(await meta.getOrgSettings("default")),
       brandprint: { collectionId: "col_bp", profileId: short_id },
     })
+    await meta.setUserNotificationPref({
+      id: "unp-brand-review-email",
+      org_id: "default",
+      user_id: owner.id,
+      prefs: JSON.stringify({ reviewEmail: true }),
+      created_at: new Date().toISOString(),
+    })
     const agent = await createAgent("Stylist", "editor")
     const wrote = await publishAs(app, "<h1>new voice</h1>", {}, bearer(agent.token), short_id)
     expect(wrote.status).toBeLessThan(300)
@@ -102,8 +109,7 @@ describe("hostable agents + workspace agent settings", () => {
     const pending = rounds.find((r) => r.state === "pending")
     expect(pending).toBeTruthy()
     expect(pending?.requested_for).toBe(owner.id)
-    // A DETACHED request interrupts the human it acts for — the positive twin of the
-    // attended lane's no-self-email rule: the review email is enqueued here.
+    // The reviewer explicitly opted into email above, so this review request uses it.
     const far = new Date(Date.now() + 10_000_000).toISOString()
     const due = await meta.claimDueDeliveries(far, 50, far)
     expect(due.some((d) => d.kind === "email" && d.event_type === "review.requested")).toBe(true)

--- a/apps/api/test/comment-fanout.test.ts
+++ b/apps/api/test/comment-fanout.test.ts
@@ -380,8 +380,15 @@ describe("connected-channel event cards (publishes)", () => {
 })
 
 describe("review-request + share emails", () => {
-  it("an agent's review request emails the human it acts for", async () => {
+  it("emails an opted-in human when an agent requests their review", async () => {
     const { app, meta } = makeAuthedApp("fanout-review", [owner, editor], "editor")
+    await meta.setUserNotificationPref({
+      id: "unp-review-email",
+      org_id: "default",
+      user_id: owner.id,
+      prefs: JSON.stringify({ reviewEmail: true }),
+      created_at: new Date().toISOString(),
+    })
     const reg = await (
       await app.request("/v1/agents", jsonAs(as(owner.email), { name: "Scribe", role: "editor" }))
     ).json()
@@ -392,10 +399,10 @@ describe("review-request + share emails", () => {
     const emails = (await claim(meta)).filter((d) => d.kind === "email")
     expect(emails).toHaveLength(1)
     expect(emails[0]?.payload).toContain(owner.email)
-    expect(emails[0]?.payload).toContain("requested your review")
+    expect(emails[0]?.payload).toContain("updated")
   })
 
-  it("a human's own request_review never emails themselves", async () => {
+  it("does not email a reviewer who has not opted in", async () => {
     const { app, meta } = makeAuthedApp("fanout-review-self", [owner], "editor")
     const res = await pub(
       app,

--- a/apps/api/test/slack-dm.test.ts
+++ b/apps/api/test/slack-dm.test.ts
@@ -6,6 +6,8 @@ import {
   newId,
 } from "@derive/core"
 import { afterEach, describe, expect, it, vi } from "vitest"
+import { buildReviewEmail } from "../src/lib/email"
+import { summarizeReviewDocuments } from "../src/lib/review-summary"
 import { postWithRecovery } from "../src/lib/slack-delivery"
 import {
   enqueueSlackArtifactMentionDms,
@@ -13,6 +15,8 @@ import {
   enqueueSlackReviewRequestedDm,
   enqueueSlackShareDm,
   makeSlackDmSender,
+  wantsReviewEmail,
+  wantsSlackDm,
 } from "../src/lib/slack-dm"
 import { quotaApp, type TestUser } from "./helpers"
 
@@ -215,23 +219,115 @@ describe("enqueueSlackReviewRequestedDm (gate)", () => {
     await enqueueSlackReviewRequestedDm(
       { meta, baseUrl },
       artifact,
-      { requestedBy: "Ada", version: 3, note: "please check the intro" },
+      {
+        requestedBy: "Ada",
+        roundId: "rr-review-1",
+        version: 3,
+        note: "please check the intro",
+        summary: {
+          fromVersion: 2,
+          toVersion: 3,
+          added: 4,
+          removed: 1,
+          changes: [
+            {
+              kind: "updated",
+              title: "Approval flow",
+              added: 4,
+              removed: 1,
+              before: "Publish immediately after approval.",
+              after: "Open the work and leave contextual feedback.",
+            },
+          ],
+          totalChanges: 4,
+          highlights: [],
+          note: "please check the intro",
+        },
+      },
       linked.id,
     )
     const dms = (await claim(meta)).filter((d) => d.kind === "slack_dm")
     expect(dms).toHaveLength(1)
     const payload = JSON.parse(dms[0]?.payload ?? "{}")
     expect(payload.userId).toBe(linked.id)
-    expect(payload.text).toContain("Ada requested your review")
+    expect(payload.text).toContain("Ada updated")
+    expect(JSON.stringify(payload.blocks)).toContain("Approval flow")
+    expect(JSON.stringify(payload.blocks)).toContain("3 more changes")
+    expect(payload.metadata.entities[0].entity_payload.attributes.display_type).toBe("Review")
+    expect(payload.metadata.entities[0].external_ref).toEqual({
+      id: "rr-review-1",
+      type: "review_request",
+    })
 
     await optOut(meta, optout.id)
     await enqueueSlackReviewRequestedDm(
       { meta, baseUrl },
       artifact,
-      { requestedBy: "Ada", version: 3 },
+      {
+        requestedBy: "Ada",
+        roundId: "rr-review-2",
+        version: 3,
+        summary: {
+          fromVersion: 2,
+          toVersion: 3,
+          added: 0,
+          removed: 0,
+          highlights: [],
+          note: null,
+        },
+      },
       optout.id,
     )
     expect((await claim(meta)).filter((d) => d.kind === "slack_dm")).toHaveLength(0)
+  })
+})
+
+describe("notification preferences", () => {
+  it("defaults Slack on and review email off", () => {
+    expect(wantsSlackDm(undefined)).toBe(true)
+    expect(wantsReviewEmail(undefined)).toBe(false)
+    expect(wantsReviewEmail("not-json")).toBe(false)
+    expect(wantsReviewEmail(JSON.stringify({ reviewEmail: true }))).toBe(true)
+  })
+})
+
+describe("review summary", () => {
+  it("turns HTML and Mermaid changes into ranked, bounded structural cards", () => {
+    const summary = summarizeReviewDocuments({
+      before: `<h1>Checkout</h1><h2>Flow</h2><pre class="mermaid">graph LR\nCart-->|Pay|Receipt</pre><h2>Legacy</h2><p>Publish immediately after approval.</p>`,
+      after: `<h1>Checkout</h1><h2>Flow</h2><pre class="mermaid">graph LR\nCart-->|Review|Approval\nApproval-->|Pay|Receipt</pre><h2>Review controls</h2><p>Open the work and leave contextual feedback.</p><h2>Audit trail</h2><p>Every decision records its author and time.</p>`,
+      beforeContentType: "text/html",
+      afterContentType: "text/html",
+      fromVersion: 6,
+      toVersion: 7,
+    })
+    expect(summary.added).toBeGreaterThan(0)
+    expect(summary.removed).toBeGreaterThan(0)
+    expect(summary.changes?.length).toBeLessThanOrEqual(3)
+    expect(summary.totalChanges).toBeGreaterThanOrEqual(summary.changes?.length ?? 0)
+    expect(JSON.stringify(summary)).toContain("Review controls")
+    expect(JSON.stringify(summary)).not.toContain("<h2>")
+  })
+
+  it("keeps the email compact and puts the open action above and below the diff", async () => {
+    const meta = make("review-email-render")
+    const artifact = await makeArtifact(meta)
+    const summary = summarizeReviewDocuments({
+      before: "# Intro\nOld introduction.\n# Flow\nOld flow.\n# Legacy\nRemove this.\n",
+      after:
+        "# Intro\nNew introduction.\n# Flow\nNew flow.\n# Diagram\nDraft → Review → Done.\n# Audit\nEvery choice is recorded.\n",
+      fromVersion: 2,
+      toVersion: 3,
+    })
+    const email = buildReviewEmail(baseUrl, artifact, {
+      requestedBy: "Ada",
+      version: 3,
+      summary: { ...summary, totalChanges: 6 },
+    })
+    expect(email.subject).toContain("updated Doc")
+    expect(email.html).toContain('<meta charset="utf-8"')
+    expect(email.html.match(/>Open the work</g)).toHaveLength(2)
+    expect(email.html).toContain("+ 3 more changes")
   })
 })
 

--- a/apps/api/test/slack-routes.test.ts
+++ b/apps/api/test/slack-routes.test.ts
@@ -129,6 +129,28 @@ const addV = async (m: MetaStore, artifactId: string): Promise<number> => {
 }
 
 describe("slack status + admin routes", () => {
+  it("defaults Slack review DMs on, review email off, and lets each change independently", async () => {
+    const { app } = make("slack-personal-prefs")
+    const initial = await (await app.request("/v1/slack", { headers: as(owner.email) })).json()
+    expect(initial).toMatchObject({ slack_dm: true, review_email: false })
+
+    const emailOn = await (
+      await app.request("/v1/slack/prefs", {
+        ...jsonAs(as(owner.email), { review_email: true }),
+        method: "PATCH",
+      })
+    ).json()
+    expect(emailOn).toMatchObject({ slack_dm: true, review_email: true })
+
+    const slackOff = await (
+      await app.request("/v1/slack/prefs", {
+        ...jsonAs(as(owner.email), { slack_dm: false }),
+        method: "PATCH",
+      })
+    ).json()
+    expect(slackOff).toMatchObject({ slack_dm: false, review_email: true })
+  })
+
   it("persists an OAuth install and returns an explicit success handoff", async () => {
     const { app, meta } = make("slack-oauth-success")
     const start = await app.request("/v1/slack/install", { headers: as(owner.email) })

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -7413,6 +7413,8 @@ export interface components {
             needs_reauth: boolean;
             /** @description The caller's "DM me for interrupts" preference (mentions, review requests, shares) */
             slack_dm: boolean;
+            /** @description The caller's opt-in preference for review-request email (default false) */
+            review_email: boolean;
             /** @description Whether the caller has linked their Slack identity for the connected team */
             linked: boolean;
         };

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1296,6 +1296,8 @@ export const api = {
     f("/v1/slack", { method: "DELETE", credentials: "include" }).then(() => undefined),
   setSlackDm: (slack_dm: boolean): Promise<{ slack_dm: boolean }> =>
     f("/v1/slack/prefs", { ...opts({ slack_dm }), method: "PATCH" }).then(j),
+  setReviewEmail: (review_email: boolean): Promise<{ slack_dm: boolean; review_email: boolean }> =>
+    f("/v1/slack/prefs", { ...opts({ review_email }), method: "PATCH" }).then(j),
   sendSlackTestDm: (): Promise<{ ok: boolean }> =>
     f("/v1/slack/test-dm", { ...opts({}), method: "POST" }).then(j),
   // Link is a redirect to /v1/slack/link (full-page navigation); only unlink is a fetch.

--- a/apps/web/src/pages/settings/notifications-section.tsx
+++ b/apps/web/src/pages/settings/notifications-section.tsx
@@ -48,6 +48,15 @@ export function NotificationsSection() {
       return rollback
     },
   })
+  const reviewEmail = useApiMutation({
+    mutationFn: (next: boolean) => api.setReviewEmail(next),
+    optimistic: (next, client) => {
+      const qk = slackQuery().queryKey
+      const rollback = snapshot(client, qk)
+      client.setQueryData(qk, (prev) => (prev ? { ...prev, review_email: next } : prev))
+      return rollback
+    },
+  })
   const testDm = useApiMutation({
     mutationFn: () => api.sendSlackTestDm(),
     success: "Test DM sent",
@@ -190,6 +199,27 @@ export function NotificationsSection() {
               </SettingRow>
             )}
           </>
+        )}
+      </SettingsGroup>
+
+      <SettingsGroup title="Email">
+        {!slack ? (
+          <div>
+            <SettingsListSkeleton rows={1} />
+          </div>
+        ) : (
+          <SettingRow
+            htmlFor="toggle-review-email"
+            label="Email me review requests"
+            description="Off by default. Turn this on when you also want review requests in your inbox. A workspace admin must keep email delivery enabled."
+          >
+            <Switch
+              id="toggle-review-email"
+              data-testid="toggle-review-email"
+              checked={slack.review_email ?? false}
+              onCheckedChange={(next) => reviewEmail.mutate(next)}
+            />
+          </SettingRow>
         )}
       </SettingsGroup>
 


### PR DESCRIPTION
## What changed

- builds a shared structural review summary from Markdown or HTML version pairs, including section changes and compact diagram text
- sends rich Slack review DMs by default, including attended Derive sessions, with native Work Object metadata plus Block Kit fallback
- makes review email a personal opt-in while preserving the workspace email master switch
- adds personal controls for Slack DMs and review email, and immediately wakes the delivery outbox after enqueue
- redesigns email around what changed, with Open the work actions above and below a maximum of three change cards

## Validation

- `pnpm verify` (33/33 guardrails, all workspace typechecks, 2,627 tests passed)
- responsive Chromium QA at 1280px and 390px; no mobile horizontal overflow
- focused notification suite: 113 tests passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790010225&installation_model_id=428097&pr_number=800&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F800&signature=ba8c33ee582314ce197bedac1e244f6b74c5b35d7bd04868545bf5640df81f2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->