### PR TITLE
Slack: notify owners when agent work completes

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -2194,7 +2194,7 @@
           },
           "slack_dm": {
             "type": "boolean",
-            "description": "The caller's \"DM me for interrupts\" preference (mentions, review requests, shares)"
+            "description": "The caller's \"DM me for important updates\" preference (agent completions, mentions, review requests, shares)"
           },
           "review_email": {
             "type": "boolean",

--- a/apps/api/src/lib/review-request.ts
+++ b/apps/api/src/lib/review-request.ts
@@ -8,7 +8,7 @@
 // keep only what genuinely differs: who the reviewer is, and what the channel card should
 // attribute.
 //
-// The bell + auto-open push an agent-credentialed publish owes the human behind the grant
+// The Slack completion, bell + auto-open push an agent-credentialed publish owes the human behind the grant
 // (`agentPushFanout`) is shared for the same reason: one row per push, a review ask beats a
 // plain publish, and the delivery receipt becomes `opened_in_tab`.
 
@@ -25,7 +25,11 @@ import { log } from "../log"
 import { enqueueChannelDelivery } from "../webhooks"
 import { buildReviewEmail } from "./email"
 import { buildReviewSummary, type ReviewSummary } from "./review-summary"
-import { enqueueSlackReviewRequestedDm, wantsReviewEmail } from "./slack-dm"
+import {
+  enqueueSlackArtifactCompletedDm,
+  enqueueSlackReviewRequestedDm,
+  wantsReviewEmail,
+} from "./slack-dm"
 
 export interface ReviewRequestDeps {
   meta: MetaStore
@@ -149,18 +153,51 @@ export interface AgentPushInput {
   reviewRound: boolean
   /** A create pushes even without a round; a plain revision does not. */
   isNew: boolean
+  /** Whether this surface should try to auto-open the artifact in a live Derive tab. */
+  notifyBrowser?: boolean
 }
 
 /**
- * The bell + auto-open an agent-credentialed publish owes the human behind the grant, so a
- * push reaches them even with no tab open. Returns whether an open tab caught the push
+ * The Slack completion, bell + auto-open an agent-credentialed publish owes the human behind
+ * the grant, so a push reaches them even with no tab open. Returns whether an open tab caught the push
  * (`opened_in_tab`), so the agent knows whether to open the URL itself.
  */
 export const agentPushFanout = async (
-  deps: Pick<ReviewRequestDeps, "meta" | "bus" | "baseUrl">,
+  deps: Pick<ReviewRequestDeps, "meta" | "blobs" | "bus" | "baseUrl" | "pokeWebhooks">,
   artifact: ArtifactRecord,
   input: AgentPushInput,
 ): Promise<boolean> => {
+  // A successful agent publish is the reliable completion boundary shared by every client.
+  // Review asks already enqueue a richer actionable DM, so one version never produces both.
+  if (!input.reviewRound) {
+    let summary: ReviewSummary
+    try {
+      summary = await buildReviewSummary(deps.meta, deps.blobs, artifact.id, input.version)
+    } catch (err) {
+      log.warn("completion summary could not be built; sending completion without a diff", {
+        artifact: artifact.id,
+        version: input.version,
+        error: err instanceof Error ? err.message : String(err),
+      })
+      summary = {
+        fromVersion: input.version > 1 ? input.version - 1 : null,
+        toVersion: input.version,
+        added: 0,
+        removed: 0,
+        changes: [],
+        totalChanges: 0,
+        highlights: [],
+        note: null,
+      }
+    }
+    await enqueueSlackArtifactCompletedDm(
+      { meta: deps.meta, baseUrl: deps.baseUrl },
+      artifact,
+      { agentName: input.agentName, version: input.version, summary },
+      input.user,
+    )
+    deps.pokeWebhooks?.()
+  }
   // One bell row per push that warrants one: a review ask beats a plain "published".
   if (input.reviewRound || input.isNew) {
     const row = {
@@ -183,6 +220,8 @@ export const agentPushFanout = async (
       notification: { ...row, read: 0, created_at: new Date().toISOString() },
     })
   }
+  if (input.notifyBrowser === false) return false
+
   // A context-bound agent is an askable service: its publishes are routinely OTHER
   // people's asks riding this owner's grant, so the push must not commandeer the owner's
   // browser. Flag it — the client downgrades auto-open to a toast (the bell row still

--- a/apps/api/src/lib/slack-cards.ts
+++ b/apps/api/src/lib/slack-cards.ts
@@ -1,5 +1,5 @@
 // Block Kit primitives for the connected Slack App's messages: the comment thread mirror,
-// channel event cards, and per-user DMs (mentions, review requests, shares). Pure functions
+// channel event cards, and per-user DMs (agent completions, mentions, review requests, shares). Pure functions
 // (no I/O). Slack renders mrkdwn, never HTML, and there are two kinds of untrusted text with
 // two different treatments:
 //   - short identity fields (author, title, a Slack display name) → `escapeMrkdwn`; they are

--- a/apps/api/src/lib/slack-dm.ts
+++ b/apps/api/src/lib/slack-dm.ts
@@ -1,5 +1,5 @@
 // Per-user Slack DMs: the same "email is for interrupts" policy as notify-email.ts
-// (mentions, review requests, shares — see that file's header), mirrored onto Slack.
+// (agent completions, mentions, review requests, shares — see that file's header), mirrored onto Slack.
 // The Slack user is resolved from the account link when the recipient has one, and only
 // falls back to guessing by their Derive account email via users.lookupByEmail (see
 // lib/slack.ts resolveSlackUserIdByEmail) when they haven't linked. That fallback is
@@ -27,6 +27,7 @@ import { openSlackDm, resolveSlackUserIdByEmail } from "./slack"
 import { actionButton, actions, mrkdwnBody, mrkdwnLabel, openButton, section } from "./slack-cards"
 import { postWithRecovery, resolveBotToken, slackFailure } from "./slack-delivery"
 import {
+  artifactCompletionEntity,
   commentThreadEntity,
   encodeReviewAction,
   reviewNotificationEntity,
@@ -56,7 +57,8 @@ interface SlackDmPayload {
   }
 }
 
-/** Whether a user wants Slack DMs for interrupts (mentions, review requests, shares —
+/** Whether a user wants Slack DMs for important updates (agent completions, mentions,
+ *  review requests, shares —
  *  default on). Stored in their per-workspace notification prefs so a user can turn it
  *  off, independent of the workspace-level `emailNotifications` gate email uses. */
 export const wantsSlackDm = (prefsJson: string | undefined): boolean => {
@@ -80,6 +82,61 @@ export const wantsReviewEmail = (prefsJson: string | undefined): boolean => {
 }
 
 const title = (a: ArtifactRecord) => a.title ?? a.short_id
+
+/** Tell the human behind an agent grant that a successful publish finished. Review requests
+ * use their own actionable DM instead, so callers must not enqueue both for one version. */
+export const enqueueSlackArtifactCompletedDm = async (
+  deps: { meta: MetaStore; baseUrl: string },
+  artifact: ArtifactRecord,
+  input: { agentName: string; version: number; summary: ReviewSummary },
+  recipientId: string,
+): Promise<void> => {
+  const { meta, baseUrl } = deps
+  const install = await meta.getSlackInstall(artifact.org_id)
+  if (!install) return
+  const pref = await meta.getUserNotificationPref(artifact.org_id, recipientId)
+  if (!wantsSlackDm(pref?.prefs)) return
+  const link = artifactUrl(baseUrl, artifact)
+  const t = title(artifact)
+  const changes = input.summary.changes ?? []
+  const remaining = Math.max(0, (input.summary.totalChanges ?? changes.length) - changes.length)
+  const action = input.summary.fromVersion ? "updated" : "finished"
+  const changeBlocks = changes.slice(0, 3).map((change) => {
+    const label =
+      change.kind === "added" ? "ADDED" : change.kind === "removed" ? "REMOVED" : "UPDATED"
+    const detail = change.after ?? change.before
+    return section(
+      `*${label} · ${mrkdwnLabel(change.title)}*${detail ? `\n${mrkdwnBody(detail, 350)}` : ""}`,
+    )
+  })
+  const blocks = [
+    section(
+      `:white_check_mark: *${mrkdwnLabel(input.agentName)} ${action} <${link}|${mrkdwnLabel(t)}>*\n${input.summary.fromVersion ? `v${input.summary.fromVersion} → ` : ""}v${input.version} · ${reviewDeltaLabel(input.summary)}`,
+    ),
+    ...(changeBlocks.length ? [section("*What changed*"), ...changeBlocks] : []),
+    ...(remaining
+      ? [section(`_${remaining} more ${remaining === 1 ? "change" : "changes"} in the full work_`)]
+      : []),
+    actions([openButton(link, "Open & comment")]),
+  ]
+  await enqueueChannelDelivery(meta, "slack_dm", "artifact.completed", {
+    orgId: artifact.org_id,
+    userId: recipientId,
+    text: `${mrkdwnLabel(input.agentName)} ${action} ${mrkdwnLabel(t)} (v${input.version} · ${reviewDeltaLabel(input.summary)})`,
+    blocks,
+    metadata: {
+      entities: [
+        artifactCompletionEntity({
+          baseUrl,
+          artifact,
+          agentName: input.agentName,
+          summary: input.summary,
+          iconUrl: new URL("/icon.png", link).toString(),
+        }),
+      ],
+    },
+  } satisfies SlackDmPayload)
+}
 
 /** Enqueue a DM to each mentioned Derive user who's still a member of the workspace and
  *  hasn't turned Slack DMs off. Resolution to a Slack account happens later, at delivery

--- a/apps/api/src/lib/slack-work-object.ts
+++ b/apps/api/src/lib/slack-work-object.ts
@@ -59,6 +59,7 @@ export const DERIVE_ENTITY_TYPE = "artifact"
  * that happens to reference the artifact. */
 export const DERIVE_COMMENT_THREAD_ENTITY_TYPE = "comment_thread"
 export const DERIVE_REVIEW_REQUEST_ENTITY_TYPE = "review_request"
+export const DERIVE_ARTIFACT_COMPLETION_ENTITY_TYPE = "artifact_completion"
 
 /** Work Object metadata for one open Derive conversation. Used on the first personal mention
  * DM and for a pasted deep link to an exact question. Subsequent activity is a normal Slack
@@ -195,6 +196,61 @@ export const reviewNotificationEntity = (args: {
       attributes: {
         title: { text: args.artifact.title ?? args.artifact.short_id },
         display_type: "Review",
+        product_name: "Derive",
+        product_icon: { url: args.iconUrl, alt_text: "Derive" },
+      },
+      fields: { description: { value: description, format: "markdown" } },
+      custom_fields: [
+        { key: "version", label: "Version", value: `v${args.summary.toVersion}`, type: "string" },
+        {
+          key: "changes",
+          label: "Changes",
+          value: reviewDeltaLabel(args.summary),
+          type: "string",
+        },
+      ],
+    },
+  }
+}
+
+/** A successful agent publish as a native Slack Work Object. This is intentionally a
+ * read/comment surface, not a second review request: when a review round exists the richer
+ * review entity is sent instead. */
+export const artifactCompletionEntity = (args: {
+  baseUrl: string
+  artifact: ArtifactRecord
+  agentName: string
+  summary: ReviewSummary
+  iconUrl: string
+}): Record<string, unknown> => {
+  const link = artifactUrl(args.baseUrl, args.artifact)
+  const shown = args.summary.changes ?? []
+  const remaining = Math.max(0, (args.summary.totalChanges ?? shown.length) - shown.length)
+  const lines = shown.slice(0, 3).map((change) => {
+    const marker = change.kind === "added" ? "+" : change.kind === "removed" ? "−" : "~"
+    const detail = change.after ?? change.before
+    return `*${marker} ${mrkdwnBody(change.title, 100)}*${detail ? ` — ${mrkdwnBody(detail, 180)}` : ""}`
+  })
+  if (remaining > 0) lines.push(`_${remaining} more ${remaining === 1 ? "change" : "changes"}_`)
+  const action = args.summary.fromVersion ? "updated" : "finished"
+  const description = [
+    `*${mrkdwnBody(args.agentName, 100)} ${action} this work*`,
+    reviewDeltaLabel(args.summary),
+    ...lines,
+  ]
+    .filter(Boolean)
+    .join("\n")
+  return {
+    url: link,
+    external_ref: {
+      id: `${args.artifact.id}:v${args.summary.toVersion}`,
+      type: DERIVE_ARTIFACT_COMPLETION_ENTITY_TYPE,
+    },
+    entity_type: "slack#/entities/content_item",
+    entity_payload: {
+      attributes: {
+        title: { text: args.artifact.title ?? args.artifact.short_id },
+        display_type: "Work completed",
         product_name: "Derive",
         product_icon: { url: args.iconUrl, alt_text: "Derive" },
       },

--- a/apps/api/src/mcp-tools/publish.ts
+++ b/apps/api/src/mcp-tools/publish.ts
@@ -809,15 +809,20 @@ export function registerPublishTool(tc: ToolContext): void {
           )
         }
         const url = artifactUrl(ctx.deps.baseUrl, artifact)
-        // Bell + auto-open for the human behind the grant — the shared fan-out the HTTP
-        // route runs. The delivery receipt becomes `opened_in_tab`, so the agent knows
-        // whether to open the URL locally. An attended surface pushes only for a CREATE
-        // (auto-opening the new page is the point); its edits happen in front of the
-        // person, whose tab live-reloads — a bell about their own edit is noise.
+        // Slack completion + bell + auto-open for the human behind the grant — the shared
+        // fan-out the HTTP route runs. The delivery receipt becomes `opened_in_tab`, so the
+        // agent knows whether to open the URL locally. An attended revision still gets the
+        // completion DM, but does not commandeer the person's browser; their live tab reloads.
         let openedInTab = false
-        if (actingFor && (!attended || !short_id)) {
+        if (actingFor) {
           openedInTab = await agentPushFanout(
-            { meta: ctx.meta, bus: ctx.bus, baseUrl: ctx.deps.baseUrl },
+            {
+              meta: ctx.meta,
+              blobs: ctx.blobs,
+              bus: ctx.bus,
+              baseUrl: ctx.deps.baseUrl,
+              pokeWebhooks: ctx.deps.pokeWebhooks,
+            },
             artifact,
             {
               user: actingFor.id,
@@ -826,6 +831,7 @@ export function registerPublishTool(tc: ToolContext): void {
               version: version.n,
               reviewRound: !!review_round,
               isNew: !short_id,
+              notifyBrowser: !attended || !short_id,
             },
           )
         }

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -376,7 +376,7 @@ const channelSenders: ChannelSenders = {
   github_review_comment: makeGithubCommentSender(meta, authSecret),
   github_issue_comment: makeGithubCommentSender(meta, authSecret),
   // Slack App posting (bot token decrypted with the auth secret per delivery): the
-  // comment thread mirror and per-user DMs (mentions, review requests, shares).
+  // comment thread mirror and per-user DMs (agent completions, mentions, review requests, shares).
   slack_app: makeSlackSender(meta, authSecret),
   slack_dm: makeSlackDmSender(meta, authSecret),
   // Inbound: a Slack thread reply the events endpoint deferred — resolve the author and

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -995,14 +995,18 @@ export const artifactRoutes = (ctx: AppContext) => {
       // already looking at it.
       let openedInTab: boolean | null = null
       if (agentPrincipal && onBehalf) {
-        openedInTab = await agentPushFanout({ meta, bus, baseUrl: deps.baseUrl }, artifact, {
-          user: onBehalf,
-          agentId: agentPrincipal.id,
-          agentName: agentPrincipal.name,
-          version: version.n,
-          reviewRound: roundCreated,
-          isNew: !shortId,
-        })
+        openedInTab = await agentPushFanout(
+          { meta, blobs, bus, baseUrl: deps.baseUrl, pokeWebhooks: deps.pokeWebhooks },
+          artifact,
+          {
+            user: onBehalf,
+            agentId: agentPrincipal.id,
+            agentName: agentPrincipal.name,
+            version: version.n,
+            reviewRound: roundCreated,
+            isNew: !shortId,
+          },
+        )
       }
       const versions = await meta.listVersions(artifact.id)
       // Advisories over what was just stored (missing viewport meta, oversized

--- a/apps/api/src/routes/slack.ts
+++ b/apps/api/src/routes/slack.ts
@@ -550,7 +550,7 @@ export const slackRoutes = (ctx: AppContext) => {
       slack_dm: z
         .boolean()
         .describe(
-          'The caller\'s "DM me for interrupts" preference (mentions, review requests, shares)',
+          'The caller\'s "DM me for important updates" preference (agent completions, mentions, review requests, shares)',
         ),
       review_email: z
         .boolean()

--- a/apps/api/test/mcp-loop.test.ts
+++ b/apps/api/test/mcp-loop.test.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import type { DeliveryRecord } from "@derive/core"
 import { SqliteMetaStore } from "@derive/db/sqlite"
 import { FsBlobStore } from "@derive/storage/fs"
 import Database from "better-sqlite3"
@@ -21,7 +22,7 @@ afterAll(() => rmSync(dir, { recursive: true, force: true }))
 
 // Same harness as mcp.test.ts (OAuth grant seeded straight into the provider
 // tables), plus an injected in-process backplane the test can observe.
-function loopApp(name: string) {
+function loopApp(name: string, clientId = "cli") {
   const path = join(dir, `${name}.db`)
   const meta = new SqliteMetaStore(path)
   const db = new Database(path)
@@ -33,12 +34,15 @@ function loopApp(name: string) {
   db.prepare(
     `INSERT OR IGNORE INTO "user"(id,email,name) VALUES('u_o','owner@x.test','Owner')`,
   ).run()
-  db.prepare(`INSERT OR IGNORE INTO "oauthClient"(clientId,name) VALUES('cli','Claude')`).run()
+  db.prepare(`INSERT OR IGNORE INTO "oauthClient"(clientId,name) VALUES(?,?)`).run(
+    clientId,
+    clientId === "chat" ? "ChatGPT" : "Claude",
+  )
   db.prepare(
     `INSERT INTO "oauthAccessToken"(token,clientId,userId,scopes,expiresAt) VALUES(?,?,?,?,?)`,
   ).run(
     sha256(`tok_${name}`),
-    "cli",
+    clientId,
     "u_o",
     JSON.stringify(["openid", "derive:read", "derive:publish"]),
     new Date(Date.now() + 3_600_000).toISOString(),
@@ -97,9 +101,27 @@ const record = (bp: Backplane, channel: string): DeriveEvent[] => {
   return seen
 }
 
+const connectSlack = (meta: SqliteMetaStore, orgId = "ws_p_u_o") =>
+  meta.setSlackInstall({
+    org_id: orgId,
+    team_id: "T1",
+    team_name: "Derive",
+    bot_token: "xoxb-test",
+    bot_user_id: "UBOT",
+    created_at: new Date().toISOString(),
+  })
+
+const claim = (meta: SqliteMetaStore): Promise<DeliveryRecord[]> =>
+  meta.claimDueDeliveries(
+    new Date(Date.now() + 60_000).toISOString(),
+    100,
+    new Date(Date.now() + 120_000).toISOString(),
+  )
+
 describe("MCP publish reaches the human (event parity + auto-open)", () => {
   it("emits version.published + artifact.pushed, writes a bell row, and reports opened_in_tab", async () => {
     const { app, meta, backplane, token } = loopApp("push")
+    await connectSlack(meta)
     // An "open tab": a live subscriber on the user channel (what the bell SSE holds).
     const userEvents = record(backplane, "u:u_o")
 
@@ -139,10 +161,16 @@ describe("MCP publish reaches the human (event parity + auto-open)", () => {
     // Revisions don't add bell rows (only creates and review asks do).
     const after = await meta.listNotifications("u_o", 10)
     expect(after.filter((r) => r.artifact_short_id === created.short_id)).toHaveLength(1)
+    const completions = (await claim(meta)).filter(
+      (d) => d.kind === "slack_dm" && d.event_type === "artifact.completed",
+    )
+    expect(completions).toHaveLength(2)
+    expect(JSON.parse(completions[1]?.payload ?? "{}").text).toContain("Claude updated Loop Draft")
   })
 
   it("request_review writes ONE bell row (review beats publish) and notifies live", async () => {
     const { app, meta, backplane, token } = loopApp("ask")
+    await connectSlack(meta)
     const userEvents = record(backplane, "u:u_o")
     const created = await call(app, token, "publish", {
       content: "<h1>Plan</h1>",
@@ -157,6 +185,29 @@ describe("MCP publish reaches the human (event parity + auto-open)", () => {
     expect(mine[0]?.preview).toContain("review")
     const pushed = userEvents.find((e) => e.type === "artifact.pushed")
     expect(pushed?.review_requested).toBe(true)
+    const dms = (await claim(meta)).filter((d) => d.kind === "slack_dm")
+    expect(dms.map((d) => d.event_type)).toEqual(["review.requested"])
+  })
+
+  it("still sends Slack completion for an attended revision without auto-opening it", async () => {
+    const { app, meta, backplane, token } = loopApp("attended-completion", "chat")
+    await connectSlack(meta)
+    const userEvents = record(backplane, "u:u_o")
+    const created = await call(app, token, "publish", {
+      content: "<h1>Draft</h1>",
+      title: "Attended work",
+    })
+    const revised = await call(app, token, "publish", {
+      content: "<h1>Finished</h1><h2>Decision</h2><p>Ship it.</p>",
+      short_id: created.short_id,
+    })
+    expect(revised.opened_in_tab).toBe(false)
+    expect(userEvents.some((e) => e.type === "artifact.pushed" && e.kind === "revised")).toBe(false)
+    const completions = (await claim(meta)).filter(
+      (d) => d.kind === "slack_dm" && d.event_type === "artifact.completed",
+    )
+    expect(completions).toHaveLength(2)
+    expect(JSON.stringify(JSON.parse(completions[1]?.payload ?? "{}").blocks)).toContain("Decision")
   })
 })
 

--- a/apps/api/test/slack-dm.test.ts
+++ b/apps/api/test/slack-dm.test.ts
@@ -10,6 +10,7 @@ import { buildReviewEmail } from "../src/lib/email"
 import { summarizeReviewDocuments } from "../src/lib/review-summary"
 import { postWithRecovery } from "../src/lib/slack-delivery"
 import {
+  enqueueSlackArtifactCompletedDm,
   enqueueSlackArtifactMentionDms,
   enqueueSlackMentionDms,
   enqueueSlackReviewRequestedDm,
@@ -272,6 +273,96 @@ describe("enqueueSlackReviewRequestedDm (gate)", () => {
           toVersion: 3,
           added: 0,
           removed: 0,
+          highlights: [],
+          note: null,
+        },
+      },
+      optout.id,
+    )
+    expect((await claim(meta)).filter((d) => d.kind === "slack_dm")).toHaveLength(0)
+  })
+})
+
+describe("enqueueSlackArtifactCompletedDm", () => {
+  it("defaults on and renders a bounded visual diff with an open-and-comment action", async () => {
+    const meta = make("slack-dm-completed")
+    await connect(meta)
+    const artifact = await makeArtifact(meta)
+    await enqueueSlackArtifactCompletedDm(
+      { meta, baseUrl },
+      artifact,
+      {
+        agentName: "Codex",
+        version: 8,
+        summary: {
+          fromVersion: 7,
+          toVersion: 8,
+          added: 12,
+          removed: 3,
+          changes: [
+            {
+              kind: "updated",
+              title: "Review flow",
+              added: 4,
+              removed: 1,
+              after: "Comment inline.",
+            },
+            {
+              kind: "added",
+              title: "Diagram",
+              added: 5,
+              removed: 0,
+              after: "Draft → Review → Done.",
+            },
+            {
+              kind: "removed",
+              title: "Publish step",
+              added: 0,
+              removed: 2,
+              before: "Publish manually.",
+            },
+          ],
+          totalChanges: 6,
+          highlights: [],
+          note: null,
+        },
+      },
+      linked.id,
+    )
+    const dms = (await claim(meta)).filter((d) => d.kind === "slack_dm")
+    expect(dms).toHaveLength(1)
+    expect(dms[0]?.event_type).toBe("artifact.completed")
+    const payload = JSON.parse(dms[0]?.payload ?? "{}")
+    expect(payload.text).toContain("Codex updated Doc")
+    expect(JSON.stringify(payload.blocks)).toContain("Open & comment")
+    expect(JSON.stringify(payload.blocks)).toContain("3 more changes")
+    expect(payload.metadata.entities[0].entity_payload.attributes.display_type).toBe(
+      "Work completed",
+    )
+    expect(payload.metadata.entities[0].external_ref).toEqual({
+      id: `${artifact.id}:v8`,
+      type: "artifact_completion",
+    })
+  })
+
+  it("does not enqueue after the user turns Slack updates off", async () => {
+    const meta = make("slack-dm-completed-optout")
+    await connect(meta)
+    await optOut(meta, optout.id)
+    const artifact = await makeArtifact(meta)
+    await enqueueSlackArtifactCompletedDm(
+      { meta, baseUrl },
+      artifact,
+      {
+        agentName: "Codex",
+        version: 1,
+        summary: {
+          fromVersion: null,
+          toVersion: 1,
+          added: 0,
+          removed: 0,
+          changes: [],
+          totalChanges: 0,
           highlights: [],
           note: null,
         },

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -7435,7 +7435,7 @@ export interface components {
             team_name: string | null;
             /** @description Whether the stored bot token needs a re-auth — a failed auth/scope call, or Slack reporting the app uninstalled or its token revoked */
             needs_reauth: boolean;
-            /** @description The caller's "DM me for interrupts" preference (mentions, review requests, shares) */
+            /** @description The caller's "DM me for important updates" preference (agent completions, mentions, review requests, shares) */
             slack_dm: boolean;
             /** @description The caller's opt-in preference for review-request email (default false) */
             review_email: boolean;

--- a/apps/web/src/pages/settings/notifications-section.tsx
+++ b/apps/web/src/pages/settings/notifications-section.tsx
@@ -127,8 +127,8 @@ export function NotificationsSection() {
               label="Send important updates in Slack"
               description={
                 connected
-                  ? "Get a Slack direct message when someone mentions you, requests your review, or shares a document with you. Link your Slack account below so Derive knows where to send it."
-                  : "A Slack direct message when someone @mentions you, requests your review, or shares a doc with you. Takes effect once an admin connects Slack under Integrations."
+                  ? "Get a Slack direct message when an agent finishes work, someone mentions you, requests your review, or shares a document with you. Link your Slack account below so Derive knows where to send it."
+                  : "A Slack direct message when an agent finishes work, someone @mentions you, requests your review, or shares a doc with you. Takes effect once an admin connects Slack under Integrations."
               }
             >
               <div className="flex items-center gap-2">


### PR DESCRIPTION
## What changed
- send a default-on Slack DM after every successful agent publish without a review request
- show a bounded top-three Markdown/HTML structural diff with an Open & comment action and native Slack Work Object metadata
- preserve the review request DM as the single message when review is requested
- keep completion email off; the existing personal Slack preference opts out
- cover creates, revisions, attended sessions, review deduplication, and preference gating

## Validation
- `pnpm verify`
- 33/33 guardrails
- all workspace typechecks
- 2,607 tests passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/802"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790034621&installation_model_id=428097&pr_number=802&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F802&signature=33451fbdcee83f2761e6f6b64fa2feb738fcc31a6d0a1ca84d3b174ca6582df3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->