### PR TITLE
Fix compact Slack notification cards

### DIFF
--- a/apps/api/src/lib/review-request.ts
+++ b/apps/api/src/lib/review-request.ts
@@ -196,7 +196,8 @@ export const agentPushFanout = async (
       { agentName: input.agentName, version: input.version, summary },
       input.user,
     )
-    deps.pokeWebhooks?.()
+    // Completion rows intentionally wait for the regular outbox tick, giving rapid publishes
+    // time to collapse into the latest card. Review requests still poke immediately above.
   }
   // One bell row per push that warrants one: a review ask beats a plain "published".
   if (input.reviewRound || input.isNew) {

--- a/apps/api/src/lib/slack-delivery.ts
+++ b/apps/api/src/lib/slack-delivery.ts
@@ -80,12 +80,15 @@ export const postWithRecovery = async (
     channel: string
     text: string
     blocks?: unknown
+    /** Expanded Block Kit used only when Slack rejects native Work Object metadata. */
+    fallbackBlocks?: unknown
     threadTs?: string
     metadata?: Record<string, unknown>
   },
   opts: { autoJoin?: boolean; textFallback?: boolean; metadataFallback?: boolean } = {},
 ): Promise<SlackDeliveryResult> => {
-  const post = (blocks: unknown) => postSlackMessage(token, { ...args, blocks })
+  const { fallbackBlocks, ...postArgs } = args
+  const post = (blocks: unknown) => postSlackMessage(token, { ...postArgs, blocks })
   const ok = (ts: string, channel: string, note = ""): SlackDeliveryResult => ({
     ok: true,
     status: `posted${note} ${ts}`,
@@ -116,7 +119,11 @@ export const postWithRecovery = async (
     // network ambiguity), avoiding duplicate DMs.
     if (opts.metadataFallback && args.metadata && WORK_OBJECT_METADATA_ERRORS.has(err.code)) {
       try {
-        const res = await postSlackMessage(token, { ...args, metadata: undefined })
+        const res = await postSlackMessage(token, {
+          ...postArgs,
+          blocks: fallbackBlocks ?? args.blocks,
+          metadata: undefined,
+        })
         return ok(res.ts, res.channel, " blocks-only")
       } catch (retryErr) {
         return slackFailure(meta, orgId, retryErr)

--- a/apps/api/src/lib/slack-dm.ts
+++ b/apps/api/src/lib/slack-dm.ts
@@ -20,7 +20,7 @@ import {
   type SlackThreadLinkRecord,
 } from "@derive/core"
 import type { ChannelSendResult } from "../webhooks"
-import { enqueueChannelDelivery } from "../webhooks"
+import { enqueueChannelDelivery, enqueueCoalescedChannelDelivery } from "../webhooks"
 import { commentDeepLink, type Mention, previewOf } from "./comments"
 import { type ReviewSummary, reviewDeltaLabel } from "./review-summary"
 import { openSlackDm, resolveSlackUserIdByEmail } from "./slack"
@@ -40,6 +40,8 @@ interface SlackDmPayload {
   userId: string
   text: string
   blocks: unknown[]
+  /** The larger Block Kit card is sent only when native Work Objects are unavailable. */
+  fallbackBlocks?: unknown[]
   /** Native Slack Work Object metadata. Blocks remain the graceful fallback. */
   metadata?: Record<string, unknown>
   /** Present only for an @mention. It gives the delivery worker enough durable context to make
@@ -119,23 +121,35 @@ export const enqueueSlackArtifactCompletedDm = async (
       : []),
     actions([openButton(link, "Open & comment")]),
   ]
-  await enqueueChannelDelivery(meta, "slack_dm", "artifact.completed", {
-    orgId: artifact.org_id,
-    userId: recipientId,
-    text: `${mrkdwnLabel(input.agentName)} ${action} ${mrkdwnLabel(t)} (v${input.version} · ${reviewDeltaLabel(input.summary)})`,
-    blocks,
-    metadata: {
-      entities: [
-        artifactCompletionEntity({
-          baseUrl,
-          artifact,
-          agentName: input.agentName,
-          summary: input.summary,
-          iconUrl: new URL("/icon.png", link).toString(),
-        }),
-      ],
-    },
-  } satisfies SlackDmPayload)
+  // At most one card per artifact/recipient in a ten-minute work window. Rapid agent saves
+  // replace the pending payload with the latest version; after delivery the bucket stays quiet.
+  const window = Math.floor(Date.now() / (10 * 60_000))
+  await enqueueCoalescedChannelDelivery(
+    meta,
+    `wd_ac_${artifact.id}_${recipientId}_${window}`,
+    "slack_dm",
+    "artifact.completed",
+    {
+      orgId: artifact.org_id,
+      userId: recipientId,
+      text: `${mrkdwnLabel(input.agentName)} ${action} ${mrkdwnLabel(t)} (v${input.version} · ${reviewDeltaLabel(input.summary)})`,
+      // Keep the successful native notification to one compact card. The longer blocks are
+      // retained solely for older Slack installs that reject Work Object metadata.
+      blocks: [],
+      fallbackBlocks: blocks,
+      metadata: {
+        entities: [
+          artifactCompletionEntity({
+            baseUrl,
+            artifact,
+            agentName: input.agentName,
+            summary: input.summary,
+            iconUrl: new URL("/icon.png", link).toString(),
+          }),
+        ],
+      },
+    } satisfies SlackDmPayload,
+  )
 }
 
 /** Enqueue a DM to each mentioned Derive user who's still a member of the workspace and
@@ -286,7 +300,8 @@ export const enqueueSlackReviewRequestedDm = async (
     orgId: artifact.org_id,
     userId: reviewerId,
     text: `${mrkdwnLabel(round.requestedBy)} updated ${mrkdwnLabel(t)} (v${round.version} · ${reviewDeltaLabel(round.summary)})`,
-    blocks,
+    blocks: [],
+    fallbackBlocks: blocks,
     metadata: {
       entities: [
         reviewNotificationEntity({
@@ -438,6 +453,7 @@ export const makeSlackDmSender =
         channel,
         text: p.text,
         blocks,
+        fallbackBlocks: p.fallbackBlocks,
         threadTs: existing?.message_ts,
         metadata,
       },

--- a/apps/api/src/lib/slack-work-object.ts
+++ b/apps/api/src/lib/slack-work-object.ts
@@ -173,7 +173,7 @@ export const reviewNotificationEntity = (args: {
   const link = artifactUrl(args.baseUrl, args.artifact)
   const shown = args.summary.changes ?? []
   const remaining = Math.max(0, (args.summary.totalChanges ?? shown.length) - shown.length)
-  const lines = shown.slice(0, 2).map((change) => {
+  const lines = shown.slice(0, 3).map((change) => {
     const marker = change.kind === "added" ? "+" : change.kind === "removed" ? "−" : "~"
     const detail = change.after ?? change.before
     return `*${marker} ${mrkdwnBody(change.title, 100)}*${detail ? ` — ${mrkdwnBody(detail, 180)}` : ""}`
@@ -189,7 +189,12 @@ export const reviewNotificationEntity = (args: {
     .join("\n")
   return {
     url: link,
-    external_ref: { id: args.roundId, type: DERIVE_REVIEW_REQUEST_ENTITY_TYPE },
+    // The artifact id makes entity_details_requested resolvable without a global review-round
+    // lookup; the round id keeps each request a distinct Slack entity.
+    external_ref: {
+      id: `${args.artifact.id}::${args.roundId}`,
+      type: DERIVE_REVIEW_REQUEST_ENTITY_TYPE,
+    },
     entity_type: "slack#/entities/content_item",
     entity_payload: {
       actions: reviewActions(args.artifact.id),
@@ -243,7 +248,7 @@ export const artifactCompletionEntity = (args: {
   return {
     url: link,
     external_ref: {
-      id: `${args.artifact.id}:v${args.summary.toVersion}`,
+      id: `${args.artifact.id}::v${args.summary.toVersion}`,
       type: DERIVE_ARTIFACT_COMPLETION_ENTITY_TYPE,
     },
     entity_type: "slack#/entities/content_item",

--- a/apps/api/src/routes/slack.ts
+++ b/apps/api/src/routes/slack.ts
@@ -94,8 +94,10 @@ import {
   artifactDetails,
   artifactEntity,
   commentThreadEntity,
+  DERIVE_ARTIFACT_COMPLETION_ENTITY_TYPE,
   DERIVE_COMMENT_THREAD_ENTITY_TYPE,
   DERIVE_ENTITY_TYPE,
+  DERIVE_REVIEW_REQUEST_ENTITY_TYPE,
   decodeReviewAction,
   SLACK_REVIEW_ACTION,
 } from "../lib/slack-work-object"
@@ -484,9 +486,21 @@ export const slackRoutes = (ctx: AppContext) => {
     }
 
     let artifact: ArtifactRecord | null = null
-    for (const id of candidateShortIds(ref)) {
-      artifact = await meta.getByShortId(id)
-      if (artifact) break
+    // Personal notification entities are version/round-specific, but their flexpane still
+    // describes the underlying artifact. The prefix is the stable artifact id; the suffix only
+    // keeps separate Slack cards from collapsing into one entity. Without this branch Slack
+    // treated the whole composite ref as a short id and showed a false "no longer exists" view.
+    if (
+      ev.external_ref?.type === DERIVE_ARTIFACT_COMPLETION_ENTITY_TYPE ||
+      ev.external_ref?.type === DERIVE_REVIEW_REQUEST_ENTITY_TYPE
+    ) {
+      const separator = ref.indexOf("::")
+      artifact = separator > 0 ? await meta.getArtifactById(ref.slice(0, separator)) : null
+    } else {
+      for (const id of candidateShortIds(ref)) {
+        artifact = await meta.getByShortId(id)
+        if (artifact) break
+      }
     }
     if (!artifact || artifact.removed_at || artifact.org_id !== install.org_id)
       return say(

--- a/apps/api/src/webhooks.ts
+++ b/apps/api/src/webhooks.ts
@@ -296,6 +296,26 @@ export async function enqueueChannelDelivery(
   })
 }
 
+/** A first-party delivery whose stable id lets rapid equivalent events collapse while pending.
+ * Once the row is delivered, later writes with the same id are intentionally ignored. */
+export async function enqueueCoalescedChannelDelivery(
+  meta: MetaStore,
+  id: string,
+  kind: Exclude<DeliveryKind, "generic" | "slack">,
+  event: string,
+  payload: unknown,
+): Promise<void> {
+  await meta.enqueueCoalescedDelivery({
+    id,
+    webhook_id: INTERNAL_DELIVERY,
+    url: "",
+    secret: "",
+    kind,
+    event_type: event,
+    payload: JSON.stringify(payload),
+  })
+}
+
 const backoff = (attempts: number) => Math.min(MAX_BACKOFF_MS, BASE_BACKOFF_MS * 2 ** attempts)
 
 /**

--- a/apps/api/test/mcp-loop.test.ts
+++ b/apps/api/test/mcp-loop.test.ts
@@ -164,8 +164,8 @@ describe("MCP publish reaches the human (event parity + auto-open)", () => {
     const completions = (await claim(meta)).filter(
       (d) => d.kind === "slack_dm" && d.event_type === "artifact.completed",
     )
-    expect(completions).toHaveLength(2)
-    expect(JSON.parse(completions[1]?.payload ?? "{}").text).toContain("Claude updated Loop Draft")
+    expect(completions).toHaveLength(1)
+    expect(JSON.parse(completions[0]?.payload ?? "{}").text).toContain("Claude updated Loop Draft")
   })
 
   it("request_review writes ONE bell row (review beats publish) and notifies live", async () => {
@@ -206,8 +206,10 @@ describe("MCP publish reaches the human (event parity + auto-open)", () => {
     const completions = (await claim(meta)).filter(
       (d) => d.kind === "slack_dm" && d.event_type === "artifact.completed",
     )
-    expect(completions).toHaveLength(2)
-    expect(JSON.stringify(JSON.parse(completions[1]?.payload ?? "{}").blocks)).toContain("Decision")
+    expect(completions).toHaveLength(1)
+    const payload = JSON.parse(completions[0]?.payload ?? "{}")
+    expect(payload.text).toContain("v2")
+    expect(JSON.stringify(payload.metadata)).toContain("Decision")
   })
 })
 

--- a/apps/api/test/slack-dm.test.ts
+++ b/apps/api/test/slack-dm.test.ts
@@ -252,11 +252,12 @@ describe("enqueueSlackReviewRequestedDm (gate)", () => {
     const payload = JSON.parse(dms[0]?.payload ?? "{}")
     expect(payload.userId).toBe(linked.id)
     expect(payload.text).toContain("Ada updated")
-    expect(JSON.stringify(payload.blocks)).toContain("Approval flow")
-    expect(JSON.stringify(payload.blocks)).toContain("3 more changes")
+    expect(payload.blocks).toEqual([])
+    expect(JSON.stringify(payload.fallbackBlocks)).toContain("Approval flow")
+    expect(JSON.stringify(payload.fallbackBlocks)).toContain("3 more changes")
     expect(payload.metadata.entities[0].entity_payload.attributes.display_type).toBe("Review")
     expect(payload.metadata.entities[0].external_ref).toEqual({
-      id: "rr-review-1",
+      id: `${artifact.id}::rr-review-1`,
       type: "review_request",
     })
 
@@ -334,15 +335,47 @@ describe("enqueueSlackArtifactCompletedDm", () => {
     expect(dms[0]?.event_type).toBe("artifact.completed")
     const payload = JSON.parse(dms[0]?.payload ?? "{}")
     expect(payload.text).toContain("Codex updated Doc")
-    expect(JSON.stringify(payload.blocks)).toContain("Open & comment")
-    expect(JSON.stringify(payload.blocks)).toContain("3 more changes")
+    expect(payload.blocks).toEqual([])
+    expect(JSON.stringify(payload.fallbackBlocks)).toContain("Open & comment")
+    expect(JSON.stringify(payload.fallbackBlocks)).toContain("3 more changes")
     expect(payload.metadata.entities[0].entity_payload.attributes.display_type).toBe(
       "Work completed",
     )
     expect(payload.metadata.entities[0].external_ref).toEqual({
-      id: `${artifact.id}:v8`,
+      id: `${artifact.id}::v8`,
       type: "artifact_completion",
     })
+  })
+
+  it("coalesces rapid publishes of one artifact into the latest pending card", async () => {
+    const meta = make("slack-dm-completed-coalesce")
+    await connect(meta)
+    const artifact = await makeArtifact(meta)
+    for (const version of [2, 3])
+      await enqueueSlackArtifactCompletedDm(
+        { meta, baseUrl },
+        artifact,
+        {
+          agentName: "Codex",
+          version,
+          summary: {
+            fromVersion: version - 1,
+            toVersion: version,
+            added: version,
+            removed: 0,
+            changes: [{ kind: "updated", title: `Version ${version}`, added: version, removed: 0 }],
+            totalChanges: 1,
+            highlights: [],
+            note: null,
+          },
+        },
+        linked.id,
+      )
+    const dms = (await claim(meta)).filter((d) => d.kind === "slack_dm")
+    expect(dms).toHaveLength(1)
+    const payload = JSON.parse(dms[0]?.payload ?? "{}")
+    expect(payload.text).toContain("v3")
+    expect(JSON.stringify(payload.metadata)).toContain("Version 3")
   })
 
   it("does not enqueue after the user turns Slack updates off", async () => {
@@ -607,7 +640,8 @@ describe("Slack Work Object recovery", () => {
       {
         channel: "D1",
         text: "A mention",
-        blocks: [{ type: "section" }],
+        blocks: [],
+        fallbackBlocks: [{ type: "section", block_id: "expanded-fallback" }],
         metadata: { entities: [{ external_ref: { id: "th_1" } }] },
       },
       { metadataFallback: true },
@@ -616,7 +650,9 @@ describe("Slack Work Object recovery", () => {
     expect(r).toMatchObject({ ok: true, status: expect.stringContaining("blocks-only") })
     expect(posted).toHaveLength(2)
     expect(posted[0]?.metadata).toBeTruthy()
+    expect(posted[0]?.blocks).toEqual([])
     expect(posted[1]?.metadata).toBeUndefined()
+    expect(JSON.stringify(posted[1]?.blocks)).toContain("expanded-fallback")
   })
 
   it("keeps entity metadata when only the Block Kit payload is invalid", async () => {

--- a/apps/api/test/slack-routes.test.ts
+++ b/apps/api/test/slack-routes.test.ts
@@ -2107,8 +2107,9 @@ describe("entity_details_requested (the flexpane)", () => {
 
   const clickAndCapture = async (
     app: ReturnType<typeof make>["app"],
-    shortId: string,
+    ref: string,
     user = "U1",
+    type = "artifact",
   ) => {
     const seen: Record<string, unknown>[] = []
     let fired: (v: unknown) => void = () => {}
@@ -2131,7 +2132,7 @@ describe("entity_details_requested (the flexpane)", () => {
           type: "entity_details_requested",
           user,
           trigger_id: "trig-1",
-          external_ref: { id: shortId, type: "artifact" },
+          external_ref: { id: ref, type },
         },
       }),
     )
@@ -2191,6 +2192,16 @@ describe("entity_details_requested (the flexpane)", () => {
   it("shows the real detail to a viewer who may read it", async () => {
     const { app, artifact } = await withInstall("flex-allowed")
     const body = await clickAndCapture(app, artifact.short_id)
+    expect(JSON.stringify(body.metadata)).toContain("Secret plan")
+    expect(body.error).toBeUndefined()
+  })
+
+  it.each([
+    ["artifact_completion", "v2"],
+    ["review_request", "rr-review-1"],
+  ])("resolves the artifact behind a %s notification entity", async (type, suffix) => {
+    const { app, artifact } = await withInstall(`flex-${type}`)
+    const body = await clickAndCapture(app, `${artifact.id}::${suffix}`, "U1", type)
     expect(JSON.stringify(body.metadata)).toContain("Secret plan")
     expect(body.error).toBeUndefined()
   })

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -897,6 +897,8 @@ export interface WebhookStore {
   activeWebhooks(artifactId: string, orgId: string): Promise<WebhookRecord[]>
   /** Enqueue a delivery into the outbox (target is denormalized for durability). */
   enqueueDelivery(d: NewDelivery): Promise<void>
+  /** Insert a delivery, or replace its payload only while the same id is still pending. */
+  enqueueCoalescedDelivery(d: NewDelivery): Promise<void>
   /** Enqueue the whole subscriber fan-out for one event in ONE insert. Empty ⇒ no-op.
    *  Use over a per-subscriber enqueueDelivery loop. */
   enqueueDeliveries(rows: NewDelivery[]): Promise<void>

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -2096,6 +2096,16 @@ export class PgMetaStore implements MetaStore {
   async enqueueDelivery(d: NewDelivery): Promise<void> {
     await this.db.insert(webhookDelivery).values(d)
   }
+  async enqueueCoalescedDelivery(d: NewDelivery): Promise<void> {
+    await this.db
+      .insert(webhookDelivery)
+      .values(d)
+      .onConflictDoUpdate({
+        target: webhookDelivery.id,
+        set: { payload: d.payload, event_type: d.event_type },
+        setWhere: eq(webhookDelivery.status, "pending"),
+      })
+  }
   async enqueueDeliveries(rows: NewDelivery[]): Promise<void> {
     if (rows.length === 0) return
     await this.db.insert(webhookDelivery).values(rows)

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -1497,6 +1497,17 @@ export function makeRepos(db: SqliteDb) {
   const enqueueDelivery = async (d: NewDelivery): Promise<void> => {
     await db.insert(webhookDelivery).values(d).run()
   }
+  const enqueueCoalescedDelivery = async (d: NewDelivery): Promise<void> => {
+    await db
+      .insert(webhookDelivery)
+      .values(d)
+      .onConflictDoUpdate({
+        target: webhookDelivery.id,
+        set: { payload: d.payload, event_type: d.event_type },
+        setWhere: eq(webhookDelivery.status, "pending"),
+      })
+      .run()
+  }
   const enqueueDeliveries = async (rows: NewDelivery[]): Promise<void> => {
     if (rows.length === 0) return
     await db.insert(webhookDelivery).values(rows).run()
@@ -5062,6 +5073,7 @@ export function makeRepos(db: SqliteDb) {
     deleteWebhook,
     activeWebhooks,
     enqueueDelivery,
+    enqueueCoalescedDelivery,
     enqueueDeliveries,
     claimDueDeliveries,
     updateDelivery,


### PR DESCRIPTION
## Summary
- resolve completion and review Work Objects correctly in Slack flexpanes
- put the change summary and actions inside one compact native card
- keep expanded Block Kit only as a compatibility fallback
- coalesce rapid publishes into the latest notification, capped at one per artifact/person/10-minute window

## Validation
- `pnpm verify` (33/33 guardrails, all typechecks, 2,607 tests passed)
- focused Slack delivery, route, and MCP integration coverage

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/803"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790036197&installation_model_id=428097&pr_number=803&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F803&signature=e4a2319567f4e9e8a360bc1c7d7dc4277404d0b9c7bfc933da66c1abe531a878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->