### PR TITLE
/?home shows the landing page to a signed-in visitor

### DIFF
--- a/apps/api/src/routes/site.ts
+++ b/apps/api/src/routes/site.ts
@@ -12,6 +12,8 @@ import { SESSION_COOKIE_NAMES } from "../lib/http"
  *   GET /            the shared URL. Signed-OUT visitors get the site's landing
  *                    page; a session cookie (or the app.* alias host) gets the
  *                    SPA shell, so the app keeps owning `/` for its users.
+ *                    `/?home` overrides the check, for looking at the landing
+ *                    page while signed in.
  *   GET /robots.txt  crawler policy is the app's on every deployment (the
  *                    Disallow lines guard its own private paths); the Sitemap
  *                    line exists only where a site does.
@@ -66,9 +68,14 @@ export const siteRoutes = (ctx: AppContext) => {
   const hasSession = (c: Context): boolean => SESSION_COOKIE_NAMES.some((n) => !!getCookie(c, n))
 
   app.get("/", async (c) => {
+    // ?home is the one way a signed-in person can see the landing page: the
+    // session check is presence-only, so without it the brochure is unreachable
+    // from a logged-in browser. Nothing links to it; the response below is
+    // already never shared-cacheable, so the parameter changes nothing else.
+    const wantsHome = c.req.query("home") !== undefined
     // app.* is the app alias: its visitors chose the app, never the brochure.
     const host = (c.req.header("host") ?? "").toLowerCase()
-    if (host.startsWith("app.") || hasSession(c)) return shellOr404(c)
+    if (!wantsHome && (host.startsWith("app.") || hasSession(c))) return shellOr404(c)
     const page = await site(c.req.raw)
     // A broken or empty site deploy must never 404 the front door.
     if (!page.ok) return shellOr404(c)

--- a/apps/api/test/site.test.ts
+++ b/apps/api/test/site.test.ts
@@ -48,6 +48,15 @@ describe("the front door (worker-first `/` and `/robots.txt`)", () => {
     }
   })
 
+  it("shows the landing page to a signed-in visitor who asks with ?home", async () => {
+    const app = workerApp(SITE)
+    const res = await app.request("/?home", {
+      headers: { cookie: "better-auth.session_token=abc" },
+    })
+    expect(await res.text()).toBe("SITE HOME")
+    expect(res.headers.get("cache-control")).toBe("private, max-age=0, must-revalidate")
+  })
+
   it("serves the SPA shell on the app.* alias host", async () => {
     const res = await workerApp(SITE).request("/", { headers: { host: "app.derive.test" } })
     expect(await res.text()).toContain("id=root")


### PR DESCRIPTION
## What & why

The session check on `/` is presence-only, so a signed-in browser has no way to see the public landing page short of a private window. `derive.to/?home` now overrides the check for that one request.

## Changes

- `routes/site.ts`: `?home` skips the cookie/alias-host branch; the route's doc comment names it. The response keeps `private, max-age=0, must-revalidate`, and nothing emits the parameter, so links stay clean.
- `site.test.ts`: a signed-in `/?home` gets the landing page with the private cache header.

## Testing

- [x] `pnpm run ci` (all 33 checks) and the front-door suite pass; the pre-push hook ran the affected verify.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790113255&installation_model_id=428097&pr_number=806&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F806&signature=4858d425fab983c870264a8c5c4fb9f839898ad84bd2a6e82d5f5b7554210a15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->