### PR TITLE
Stop linking the site repo 

### DIFF
--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -351,7 +351,7 @@ export interface AppDeps {
   pokeRun?: (runId: string) => void
   /**
    * derive.to's public site (the front door): the marketing pages, the blog, and
-   * the trust files, served by their own Worker (github.com/derive-to/site). A
+   * the trust files, served by their own Worker (the derive-to/site repo, private). A
    * function from request to response because it is the SITE service binding on
    * the edge and an origin proxy (DERIVE_SITE_ORIGIN) on Node. When set, `/`
    * serves the site's landing page to signed-out visitors (signed-in ones keep

--- a/apps/api/src/routes/site.ts
+++ b/apps/api/src/routes/site.ts
@@ -5,7 +5,7 @@ import { SESSION_COOKIE_NAMES } from "../lib/http"
 
 /**
  * The front door. derive.to's public site (the marketing pages, the blog, the
- * trust files) lives in its own Worker — github.com/derive-to/site — reached
+ * trust files) lives in its own Worker — the derive-to/site repo, private — reached
  * through `deps.site`: the SITE service binding on the edge, DERIVE_SITE_ORIGIN
  * on Node. The app itself owns exactly two paths here:
  *

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -100,7 +100,7 @@ export interface Env {
    *  a hand-run deploy, which then reports "dev" — honest rather than wrong. */
   BUILD_SHA?: string
   BUCKET: R2Bucket
-  // The public site (github.com/derive-to/site): derive.to's marketing pages,
+  // The public site (the derive-to/site repo, private): derive.to's marketing pages,
   // blog and trust files, on their own Worker. Bound only on the hosted deploy;
   // absent ⇒ the application owns the front door (every self-host, previews).
   SITE?: Fetcher

--- a/apps/docs/content/self-hosting/configuration.md
+++ b/apps/docs/content/self-hosting/configuration.md
@@ -119,9 +119,8 @@ migrates an already-verified legacy account to the user-id record; it never admi
 
 Your instance is the application, not a copy of derive.to. Signed-out visitors land on
 the sign-in page; there is no marketing site, pricing page, or blog, because those pages
-belong to derive.to and live in their own repository
-([derive-to/site](https://github.com/derive-to/site)), reached only by derive.to's own
-deployment. The same applies to `sitemap.xml`, the security pages, and the `.well-known`
+belong to derive.to and live in their own private repository, reached only by
+derive.to's own deployment. The same applies to `sitemap.xml`, the security pages, and the `.well-known`
 verification files. Every build does serve a `robots.txt` that keeps crawlers out of the
 API and settings paths. To put your own front door on the instance, serve it from your
 reverse proxy at `/` and let Derive keep the application paths.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -5,8 +5,8 @@ The Derive web application and public website, built with TanStack Start and Vit
 The application contains the signed-in library, artifact viewer, collaboration and review
 surfaces, workspace settings, and onboarding. Static assets every deployment ships live in
 `public/`. The public site (derive.to's marketing pages, blog and trust files) is its own
-repository and Worker, [derive-to/site](https://github.com/derive-to/site), which the API
-reaches over a service binding; nothing of it ships in this build. In local development,
+repository and Worker (derive-to/site, private), which the API reaches over a service
+binding; nothing of it ships in this build. In local development,
 Vite serves the application on port 3090 and proxies the API on port 8090.
 
 From the repository root:


### PR DESCRIPTION


- [x] `pnpm run ci` passes (docs build included); the pre-push hook ran the affected verify.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/810"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790167810&installation_model_id=428097&pr_number=810&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F810&signature=aba2176bed270715b26d8e724f1047ab65a34b61c701f2395d9d41bef3352afa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->