### PR TITLE
Fix/confirmed reads

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -3216,6 +3216,10 @@
             "type": "number",
             "description": "How many of the unique viewers are anonymous"
           },
+          "reads": {
+            "type": "number",
+            "description": "Unique viewers who stayed, not just fetched (link previews do not count)"
+          },
           "perVersion": {
             "type": "array",
             "items": {
@@ -3295,6 +3299,7 @@
           "last24h",
           "unique",
           "anonViewers",
+          "reads",
           "perVersion",
           "daily",
           "recent"

--- a/apps/api/src/bus.ts
+++ b/apps/api/src/bus.ts
@@ -59,6 +59,13 @@ export interface Viewer {
 // open) is counted gone this long after its last beat. Shared with the edge DO.
 export const PRESENCE_TTL_MS = 45_000
 
+// How long a viewer must stay before a view counts as a read. The web client beats on
+// mount and every 20s, so the second beat is the first that can clear this; sitting just
+// under 20s means a slightly late beat still lands. Link-preview crawlers (LinkedIn,
+// Slack, iMessage) render with a real browser and do execute recordView, but tear the
+// context down in seconds — long enough to log a view, never long enough to beat twice.
+export const CONFIRM_READ_MS = 15_000
+
 /** Ephemeral presence per artifact. A viewer is present while they hold ≥1 open SSE
  *  stream — join on connect, leave the instant that stream closes, so a departure
  *  (tab-close or crash) reflects in ~a second, not after the heartbeat TTL. The TTL

--- a/apps/api/src/routes/analytics.ts
+++ b/apps/api/src/routes/analytics.ts
@@ -22,6 +22,9 @@ export const analyticsRoutes = (ctx: AppContext) => {
         .number()
         .describe("Distinct viewers; a signed-in person or anon cookie counts once"),
       anonViewers: z.number().describe("How many of the unique viewers are anonymous"),
+      reads: z
+        .number()
+        .describe("Unique viewers who stayed, not just fetched (link previews do not count)"),
       perVersion: z.array(
         z.object({
           version: z.number(),

--- a/apps/api/src/routes/realtime.ts
+++ b/apps/api/src/routes/realtime.ts
@@ -3,7 +3,7 @@ import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import type { Context } from "hono"
 import { streamSSE } from "hono/streaming"
 import type { BlankEnv } from "hono/types"
-import type { Viewer } from "../bus"
+import { CONFIRM_READ_MS, type Viewer } from "../bus"
 import type { AppContext } from "../context"
 import { anonName, bail, readJson } from "../lib/http"
 
@@ -141,6 +141,11 @@ export const realtimeRoutes = (ctx: AppContext) => {
       if (artifact instanceof Response) return bail(artifact)
       const viewer = await deriveViewer(c, artifact)
       const viewers = await presence.heartbeat(artifact.id, viewer, Date.now())
+      // A beat this long after the view means a reader, not a fetch (see CONFIRM_READ_MS).
+      // Fire-and-forget: presence must never fail on an analytics write.
+      void meta
+        .confirmRead(artifact.id, viewer.id, new Date(Date.now() - CONFIRM_READ_MS).toISOString())
+        .catch(() => {})
       bus.publish(artifact.id, { type: "presence", viewers })
       return c.json({ viewers })
     },

--- a/apps/api/test/analytics.test.ts
+++ b/apps/api/test/analytics.test.ts
@@ -65,6 +65,33 @@ describe("view analytics", () => {
     const row = list.artifacts.find((x: { short_id: string }) => x.short_id === short_id)
     expect(row.views).toBe(3)
   })
+
+  it("counts a read only once the viewer is still present after the delay", async () => {
+    const { short_id } = await (await upload("r.md", "# R", { visibility: "public" })).json()
+
+    // A link-preview crawler's whole footprint: fetch the page, run its scripts, leave.
+    const opened = await anonApp.request(`/v1/artifacts/${short_id}/view`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ version: 1 }),
+    })
+    const cookie = (opened.headers.get("set-cookie") ?? "").split(";")[0] ?? ""
+    const stats = async () =>
+      (await (await app.request(`/v1/artifacts/${short_id}/analytics`)).json()) as {
+        total: number
+        reads: number
+      }
+    expect((await stats()).total).toBe(1)
+    expect((await stats()).reads).toBe(0)
+
+    // The client beats on mount too, and that first beat is inside the window, so it
+    // must not promote the view. This is the case that separates a reader from a fetch.
+    await anonApp.request(`/v1/artifacts/${short_id}/presence`, {
+      method: "POST",
+      headers: { "content-type": "application/json", ...(cookie ? { cookie } : {}) },
+    })
+    expect((await stats()).reads).toBe(0)
+  })
 })
 
 describe("live stream (SSE)", () => {

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -7494,6 +7494,8 @@ export interface components {
             unique: number;
             /** @description How many of the unique viewers are anonymous */
             anonViewers: number;
+            /** @description Unique viewers who stayed, not just fetched (link previews do not count) */
+            reads: number;
             perVersion: {
                 version: number;
                 /** @description Views recorded for that version */

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -681,6 +681,13 @@ CREATE TABLE IF NOT EXISTS view (
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
   );
 
+CREATE TABLE IF NOT EXISTS view_read (
+    artifact_id TEXT NOT NULL REFERENCES artifact(id),
+    viewer TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    PRIMARY KEY (artifact_id, viewer)
+  );
+
 CREATE INDEX IF NOT EXISTS invitation_org_email ON invitation (org_id, email);
 
 CREATE INDEX IF NOT EXISTS artifact_invite_artifact_email ON artifact_invite (artifact_id, email);

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -856,6 +856,11 @@ export interface ArtifactQueryStore {
 
   /** Append a view event. */
   recordView(v: NewView): Promise<void>
+  /** Promote this viewer's view to a confirmed read, if it landed before
+   *  `viewedBeforeIso`. Idempotent: at most one read per (artifact, viewer), and a
+   *  no-op when they have no view row yet. Driven by the presence heartbeat, so
+   *  surviving the delay is what separates a reader from a one-shot fetch. */
+  confirmRead(artifactId: string, viewer: string, viewedBeforeIso: string): Promise<void>
   /** Has this viewer already seen this version since `sinceIso`? (open de-dup) */
   viewedSince(
     artifactId: string,
@@ -3682,6 +3687,9 @@ export interface ViewStats {
   unique: number
   /** Distinct anonymous viewers (the rest of `unique` are named users). */
   anonViewers: number
+  /** Distinct viewers confirmed to have stayed, not just fetched (see `confirmRead`).
+   *  Always <= unique. */
+  reads: number
   perVersion: { version: number; count: number }[]
   /** Daily counts over the trailing window, oldest first. */
   daily: { day: string; count: number }[]

--- a/packages/db/src/d1.ts
+++ b/packages/db/src/d1.ts
@@ -83,6 +83,21 @@ export function createD1Store(d1: D1Database): MetaStore {
         sql`UPDATE artifact SET first_foreign_view_at = ${new Date().toISOString()} WHERE id = ${v.artifact_id} AND first_foreign_view_at IS NULL`,
       )
     },
+    // See MetaStore.confirmRead. One idempotent statement, so the repeat heartbeats
+    // that follow cost a single indexed probe.
+    confirmRead: async (
+      artifactId: string,
+      viewer: string,
+      viewedBeforeIso: string,
+    ): Promise<void> => {
+      await db.run(
+        sql`INSERT OR IGNORE INTO view_read (artifact_id, viewer)
+            SELECT ${artifactId}, ${viewer}
+             WHERE EXISTS (
+               SELECT 1 FROM view WHERE artifact_id=${artifactId} AND viewer=${viewer} AND created_at<=${viewedBeforeIso}
+             )`,
+      )
+    },
     viewedSince: async (
       artifactId: string,
       viewer: string,
@@ -95,6 +110,9 @@ export function createD1Store(d1: D1Database): MetaStore {
       return !!row
     },
     pruneViews: async (cutoffIso: string): Promise<number> => {
+      // Reads ride the same retention: leaving them behind would let `reads` outlive the
+      // views it is derived from, and outgrow `unique`.
+      await db.run(sql`DELETE FROM view_read WHERE created_at < ${cutoffIso}`)
       const res = await db.run(sql`DELETE FROM view WHERE created_at < ${cutoffIso}`)
       return res.meta.changes ?? 0
     },
@@ -104,6 +122,9 @@ export function createD1Store(d1: D1Database): MetaStore {
         viewers.map((v) => sql`${v}`),
         sql`, `,
       )
+      // Their reads go too, or an owner stays counted as a reader after the self-view
+      // rows they came from are gone.
+      await db.run(sql`DELETE FROM view_read WHERE viewer IN (${list})`)
       const res = await db.run(
         sql`DELETE FROM view WHERE viewer_kind='user' AND viewer IN (${list})`,
       )
@@ -124,6 +145,9 @@ export function createD1Store(d1: D1Database): MetaStore {
       const anon = (await db.get(
         sql`SELECT count(DISTINCT viewer) n FROM view WHERE artifact_id=${artifactId} AND viewer_kind='anon'`,
       )) as { n: number }
+      const reads = (await db.get(
+        sql`SELECT count(*) n FROM view_read WHERE artifact_id=${artifactId}`,
+      )) as { n: number }
       const perVersion = (await db.all(
         sql`SELECT version, count(*) count FROM view WHERE artifact_id=${artifactId} GROUP BY version ORDER BY version`,
       )) as { version: number; count: number }[]
@@ -138,6 +162,7 @@ export function createD1Store(d1: D1Database): MetaStore {
         last24h: day.n,
         unique: uni.n,
         anonViewers: anon.n,
+        reads: reads.n,
         perVersion,
         daily,
         recent,

--- a/packages/db/src/ddl.ts
+++ b/packages/db/src/ddl.ts
@@ -133,6 +133,17 @@ export const placeholderTables = (iso: string): string[] => [
     viewer_kind TEXT NOT NULL DEFAULT 'anon',
     created_at TEXT NOT NULL DEFAULT ${iso}
   )`,
+  // A confirmed read: this viewer was still present, beating, CONFIRM_READ_MS after
+  // their view landed (see confirmRead). Its own table rather than a column on `view`
+  // because `view` has no drizzle def and so gets no automatic ADD COLUMN migration,
+  // and SQLite has no ADD COLUMN IF NOT EXISTS — a new table is forward-only on all
+  // three dialects. Keyed on (artifact, viewer): a read is a fact, not a counter.
+  `CREATE TABLE IF NOT EXISTS view_read (
+    artifact_id TEXT NOT NULL REFERENCES artifact(id),
+    viewer TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT ${iso},
+    PRIMARY KEY (artifact_id, viewer)
+  )`,
 ]
 
 /** Performance indexes (identical SQL across dialects; the unique ones are inline

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -2007,6 +2007,20 @@ export class PgMetaStore implements MetaStore {
     )
   }
 
+  async confirmRead(artifactId: string, viewer: string, viewedBeforeIso: string): Promise<void> {
+    // EXISTS rather than a join: the read is anchored to a view row old enough to rule
+    // out a one-shot fetch, and ON CONFLICT makes every later heartbeat a cheap no-op.
+    await this.pool.query(
+      `INSERT INTO view_read (artifact_id, viewer)
+       SELECT $1, $2
+        WHERE EXISTS (
+          SELECT 1 FROM view WHERE artifact_id=$1 AND viewer=$2 AND created_at<=$3
+        )
+       ON CONFLICT (artifact_id, viewer) DO NOTHING`,
+      [artifactId, viewer, viewedBeforeIso],
+    )
+  }
+
   async viewedSince(
     artifactId: string,
     viewer: string,
@@ -2021,6 +2035,9 @@ export class PgMetaStore implements MetaStore {
   }
 
   async pruneViews(cutoffIso: string): Promise<number> {
+    // Reads ride the same retention: leaving them behind would let `reads` outlive the
+    // views it is derived from, and outgrow `unique`.
+    await this.pool.query(`DELETE FROM view_read WHERE created_at < $1`, [cutoffIso])
     const res = await this.pool.query(`DELETE FROM view WHERE created_at < $1`, [cutoffIso])
     return res.rowCount ?? 0
   }
@@ -2028,6 +2045,9 @@ export class PgMetaStore implements MetaStore {
   async pruneViewsByViewers(viewers: string[]): Promise<number> {
     if (viewers.length === 0) return 0
     const ph = viewers.map((_, i) => `$${i + 1}`).join(",")
+    // Their reads go too, or an owner stays counted as a reader after the self-view
+    // rows they came from are gone.
+    await this.pool.query(`DELETE FROM view_read WHERE viewer IN (${ph})`, viewers)
     const res = await this.pool.query(
       `DELETE FROM view WHERE viewer_kind='user' AND viewer IN (${ph})`,
       viewers,
@@ -2038,7 +2058,7 @@ export class PgMetaStore implements MetaStore {
   async viewStats(artifactId: string): Promise<ViewStats> {
     const cutoff = new Date(Date.now() - VIEW_WINDOW_MS).toISOString()
     const dayAgo = new Date(Date.now() - LAST_24H_MS).toISOString()
-    const [tot, day, uni, anon, perV, daily, recent] = await Promise.all([
+    const [tot, day, uni, anon, reads, perV, daily, recent] = await Promise.all([
       this.pool.query(`SELECT count(*)::int n FROM view WHERE artifact_id=$1`, [artifactId]),
       this.pool.query(`SELECT count(*)::int n FROM view WHERE artifact_id=$1 AND created_at>=$2`, [
         artifactId,
@@ -2051,6 +2071,7 @@ export class PgMetaStore implements MetaStore {
         `SELECT count(DISTINCT viewer)::int n FROM view WHERE artifact_id=$1 AND viewer_kind='anon'`,
         [artifactId],
       ),
+      this.pool.query(`SELECT count(*)::int n FROM view_read WHERE artifact_id=$1`, [artifactId]),
       this.pool.query(
         `SELECT version, count(*)::int c FROM view WHERE artifact_id=$1 GROUP BY version ORDER BY version`,
         [artifactId],
@@ -2069,6 +2090,7 @@ export class PgMetaStore implements MetaStore {
       last24h: day.rows[0].n,
       unique: uni.rows[0].n,
       anonViewers: anon.rows[0].n,
+      reads: reads.rows[0].n,
       perVersion: perV.rows.map((r) => ({ version: r.version, count: r.c })),
       daily: daily.rows.map((r) => ({ day: r.day, count: r.c })),
       recent: recent.rows.map((r) => ({ viewer: r.viewer, kind: r.viewer_kind, at: r.at })),
@@ -5752,6 +5774,7 @@ export class PgMetaStore implements MetaStore {
       // so deleting any artifact that had ever logged a view rolled the whole
       // transaction back (a production 500 the embedded suite could not reproduce:
       // better-sqlite3 runs with FK enforcement off). Raw SQL, matching the writes.
+      await tx.execute(sql`DELETE FROM view_read WHERE artifact_id = ${id}`)
       await tx.execute(sql`DELETE FROM view WHERE artifact_id = ${id}`)
       await tx.delete(artifact).where(eq(artifact.id, id))
     })

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -4825,8 +4825,10 @@ export function makeRepos(db: SqliteDb) {
     await db.delete(notification).where(eq(notification.artifact_id, id)).run()
     await db.delete(agentMention).where(eq(agentMention.artifact_id, id)).run()
     await db.delete(slackThreadLink).where(eq(slackThreadLink.artifact_id, id)).run()
-    // The view ledger is raw DDL (no drizzle model) with an FK to artifact(id) —
-    // invisible to check-delete-cascade and enforced on Postgres. See pg.ts.
+    // The view ledger and its reads are raw DDL (no drizzle model) with an FK to
+    // artifact(id) — invisible to check-delete-cascade, and enforced on Postgres and
+    // D1 but not by better-sqlite3. See pg.ts.
+    await db.run(sql`DELETE FROM view_read WHERE artifact_id = ${id}`)
     await db.run(sql`DELETE FROM view WHERE artifact_id = ${id}`)
     await db.delete(artifact).where(eq(artifact.id, id)).run()
     // Drop the search-index row too. Contentless FTS/tsvector rows aren't drizzle

--- a/packages/db/src/sqlite.ts
+++ b/packages/db/src/sqlite.ts
@@ -320,6 +320,7 @@ export function createSqliteStore(path: string): MetaStore & { close(): void } {
         db.delete(slackThreadLink).where(eq(slackThreadLink.artifact_id, id)).run()
         // The view ledger is raw DDL (no drizzle model) with an FK to artifact(id) —
         // invisible to check-delete-cascade and enforced on Postgres. See pg.ts.
+        raw.prepare(`DELETE FROM view_read WHERE artifact_id = ?`).run(id)
         raw.prepare(`DELETE FROM view WHERE artifact_id = ?`).run(id)
         db.delete(artifact).where(eq(artifact.id, id)).run()
       })()
@@ -386,6 +387,19 @@ export function createSqliteStore(path: string): MetaStore & { close(): void } {
         )
         .run(new Date().toISOString(), v.artifact_id)
     },
+    // See MetaStore.confirmRead. One idempotent statement, so the repeat heartbeats
+    // that follow cost a single indexed probe.
+    confirmRead: async (artifactId, viewer, viewedBeforeIso): Promise<void> => {
+      raw
+        .prepare(
+          `INSERT OR IGNORE INTO view_read (artifact_id, viewer)
+           SELECT ?, ?
+            WHERE EXISTS (
+              SELECT 1 FROM view WHERE artifact_id=? AND viewer=? AND created_at<=?
+            )`,
+        )
+        .run(artifactId, viewer, artifactId, viewer, viewedBeforeIso)
+    },
     viewedSince: async (artifactId, viewer, version, sinceIso): Promise<boolean> => {
       const row = raw
         .prepare(
@@ -394,11 +408,18 @@ export function createSqliteStore(path: string): MetaStore & { close(): void } {
         .get(artifactId, viewer, version, sinceIso)
       return !!row
     },
-    pruneViews: async (cutoffIso): Promise<number> =>
-      raw.prepare(`DELETE FROM view WHERE created_at < ?`).run(cutoffIso).changes,
+    pruneViews: async (cutoffIso): Promise<number> => {
+      // Reads ride the same retention: leaving them behind would let `reads` outlive the
+      // views it is derived from, and outgrow `unique`.
+      raw.prepare(`DELETE FROM view_read WHERE created_at < ?`).run(cutoffIso)
+      return raw.prepare(`DELETE FROM view WHERE created_at < ?`).run(cutoffIso).changes
+    },
     pruneViewsByViewers: async (viewers): Promise<number> => {
       if (viewers.length === 0) return 0
       const ph = viewers.map(() => "?").join(",")
+      // Their reads go too, or an owner stays counted as a reader after the self-view
+      // rows they came from are gone.
+      raw.prepare(`DELETE FROM view_read WHERE viewer IN (${ph})`).run(...viewers)
       return raw
         .prepare(`DELETE FROM view WHERE viewer_kind='user' AND viewer IN (${ph})`)
         .run(...viewers).changes
@@ -419,6 +440,7 @@ export function createSqliteStore(path: string): MetaStore & { close(): void } {
           `SELECT count(DISTINCT viewer) n FROM view WHERE artifact_id=? AND viewer_kind='anon'`,
           artifactId,
         ),
+        reads: n(`SELECT count(*) n FROM view_read WHERE artifact_id=?`, artifactId),
         perVersion: raw
           .prepare(
             `SELECT version, count(*) count FROM view WHERE artifact_id=? GROUP BY version ORDER BY version`,

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -1720,6 +1720,8 @@ export function runStoreContract(
       expect(stats.total).toBe(2)
       expect(stats.unique).toBe(2)
       expect(stats.anonViewers).toBe(1)
+      // A view alone is not a read: link-preview crawlers fetch and execute the page.
+      expect(stats.reads).toBe(0)
       // The rolling 24h window powers the Insights "24h" tile. Both rows were just
       // recorded, so all of them fall inside it.
       expect(stats.last24h).toBe(2)
@@ -1728,6 +1730,37 @@ export function runStoreContract(
       // Cleanup helpers.
       expect(await store.pruneViewsByViewers(["amy"])).toBeGreaterThanOrEqual(1)
       expect(await store.pruneViews("2999-01-01T00:00:00.000Z")).toBeGreaterThanOrEqual(1)
+    })
+
+    it("confirms a read only for a viewer who stayed, and counts it once", async () => {
+      const a = await store.createArtifact(newArtifact())
+      await store.recordView({
+        id: uuid(),
+        artifact_id: a.id,
+        version: 1,
+        viewer: "anon_reader",
+        viewer_kind: "anon",
+      })
+      const future = new Date(Date.now() + 60_000).toISOString()
+      const past = new Date(Date.now() - 60_000).toISOString()
+
+      // Too soon: the view landed after the cutoff, which is the crawler's signature.
+      await store.confirmRead(a.id, "anon_reader", past)
+      expect((await store.viewStats(a.id)).reads).toBe(0)
+
+      // A viewer with no view row at all can never be promoted.
+      await store.confirmRead(a.id, "anon_ghost", future)
+      expect((await store.viewStats(a.id)).reads).toBe(0)
+
+      // Still present after the delay: a reader.
+      await store.confirmRead(a.id, "anon_reader", future)
+      expect((await store.viewStats(a.id)).reads).toBe(1)
+
+      // Idempotent: every later heartbeat is a no-op, not another read.
+      await store.confirmRead(a.id, "anon_reader", future)
+      await store.confirmRead(a.id, "anon_reader", future)
+      expect((await store.viewStats(a.id)).reads).toBe(1)
+      expect((await store.viewStats(a.id)).total).toBe(1)
     })
 
     it("stamps first_foreign_view_at on the first view only (the activation moment)", async () => {
@@ -3223,6 +3256,18 @@ export function runStoreContract(
       const a = await store.createArtifact(newArtifact())
       const thread = uuid()
       const dv = await store.addVersion(a.id, newVersion())
+      // Same trap for the view ledger and its reads: both carry a NOT NULL FK to
+      // artifact(id), and neither is a drizzle model, so check-delete-cascade.mjs cannot
+      // see them. Postgres enforces the FK; better-sqlite3 does not, so only a live
+      // delete catches a miss here.
+      await store.recordView({
+        id: uuid(),
+        artifact_id: a.id,
+        version: 1,
+        viewer: "anon_reader",
+        viewer_kind: "anon",
+      })
+      await store.confirmRead(a.id, "anon_reader", new Date(Date.now() + 60_000).toISOString())
       // Facts hang off the version by artifact_id — a delete that doesn't clear them
       // first hits a FOREIGN KEY constraint (found by deleting a fact-bearing artifact live).
       await store.setVersionData(a.id, dv.n, [


### PR DESCRIPTION
A view row only proves a page was fetched. Link-preview crawlers (LinkedIn, Slack, iMessage) render with a real browser and execute the client's recordView, so sharing a link registers a view and a fresh unique viewer even when nobody opens it.

Measured, not assumed. I published a control artifact, sent the link in a LinkedIn DM, and deliberately never opened it: one view, 1.9 minutes after publish. Every outreach page we've sent shows the same signature, exactly one view shortly after the send, and companion pages that are only reachable by clicking a link inside the page have zero views across all of them. We were reporting a 100% open rate on pages that may never have been read.

This adds a confirmed read: the viewer was still present, heartbeating, at least CONFIRM_READ_MS (15s) after their view landed. The client beats on mount and every 20s, so the second beat is the earliest that can clear the window, while a crawler tears its context down on a timeout measured in seconds and never sends one. viewStats.reads is therefore a count of people, and is always <= unique.

total and unique are unchanged, so no existing number moves. Historical views can't be reclassified, since the evidence never existed; every artifact starts from zero reads.

Design notes:

view_read is its own table rather than a column on view. view is a placeholder table with no drizzle definition, so it gets no automatic ADD COLUMN migration, and SQLite has no ADD COLUMN IF NOT EXISTS. A new CREATE TABLE IF NOT EXISTS is forward-only and identical across all three dialects.

The write is idempotent (INSERT..SELECT behind an EXISTS gate, ON CONFLICT DO NOTHING) and fire-and-forget, so repeat heartbeats cost one indexed probe and presence never fails on an analytics write.

Two generated artifacts needed regenerating and are included: deploy/d1-schema.sql for the new table, and apps/api/openapi.json for the new response field. Both are only checked by the full suite, and the D1 one would have shipped a Cloudflare deployment missing the table, failing silently behind the fire-and-forget catch.

Testing: typecheck clean repo-wide, CI lint gate green, all three dialect stores green. New coverage for the crawler case, the too-soon case, a viewer with no view row, and idempotency, plus a route-level test that the first heartbeat on mount does not promote a view.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/817"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790214145&installation_model_id=428097&pr_number=817&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F817&signature=d18e42ff0521a2f515f5c159c8d26cb5f0d4946e7fa8e2aa39b00e2d412652a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->