### PR TITLE
Make artifact viewer startup failures phase-aware

### DIFF
--- a/apps/web/e2e/render-fidelity/fixtures/startup-aria-hidden-ancestor.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-aria-hidden-ancestor.html
@@ -1,0 +1,4 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>ARIA-hidden ancestor</title></head><body>
+<main aria-hidden="true"><table><tbody><tr><td>Inaccessible table</td></tr></tbody></table></main>
+<script>throw new Error("bootstrap failed before accessible content")</script>
+</body></html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-attribute-visible-after-timeout.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-attribute-visible-after-timeout.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Attribute-only late visibility</title></head>
+<body>
+  <main id="app" style="opacity:0">
+    <h1>Attribute-only recovery reached Ready</h1>
+    <table><tbody><tr><td>Late visible row</td><td>Ready</td></tr></tbody></table>
+    <button id="control" type="button">Working control · <span id="count">0</span></button>
+  </main>
+  <script>
+    const app = document.querySelector("#app")
+    app.querySelector("#control").addEventListener("click", () => {
+      const count = app.querySelector("#count")
+      count.textContent = String(Number(count.textContent) + 1)
+    })
+    setTimeout(() => { app.style.opacity = "1" }, 16500)
+  </script>
+</body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-blocked.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-blocked.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Startup blocked</title>
+    <script>
+      throw new Error("intentional pre-content bootstrap failure")
+    </script>
+  </head>
+  <body>
+    <main>Loading…</main>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-broken-sized-image.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-broken-sized-image.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Broken sized image</title></head>
+<body>
+  <img width="320" height="180" alt="Unavailable chart" src="/missing-sized-chart.png">
+  <script>throw new Error("bootstrap failed before media loaded")</script>
+</body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-clipped-rich-content.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-clipped-rich-content.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Clipped rich content is not ready</title></head>
+<body>
+  <div style="width:0;height:0;overflow:hidden">
+    <table style="width:240px"><tbody><tr><td>Fully clipped table</td></tr></tbody></table>
+  </div>
+  <script>throw new Error("bootstrap failed before anything visible")</script>
+</body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-collapsed-details.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-collapsed-details.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Collapsed details is not ready</title></head>
+<body>
+  <details><summary>Closed</summary><table><tbody><tr><td>Hidden until opened</td></tr></tbody></table></details>
+  <script>throw new Error("bootstrap failed before details opened")</script>
+</body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-delayed-ready.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-delayed-ready.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Delayed meaningful paint</title>
+    <style>
+      body { margin: 0; padding: 24px; font: 16px/1.5 system-ui, sans-serif; }
+      main { max-width: 720px; margin: auto; }
+      table { width: 100%; border-collapse: collapse; }
+      td { border-bottom: 1px solid #ddd; padding: 6px; }
+      button { margin-top: 16px; padding: 8px 12px; }
+    </style>
+  </head>
+  <body>
+    <main id="app">Loading…<img src="/missing-optional-startup-logo.png" alt="" /></main>
+    <script>
+      setTimeout(() => {
+        const app = document.querySelector("#app")
+        app.innerHTML = `
+          <h1>Delayed content is usable</h1>
+          <p>The iframe loaded before this meaningful table appeared.</p>
+          <table><tbody id="rows"></tbody></table>
+          <button id="control" type="button">Working control · <span id="count">0</span></button>
+        `
+        const rows = app.querySelector("#rows")
+        for (let i = 1; i <= 30; i += 1) {
+          const row = document.createElement("tr")
+          row.innerHTML = `<td>Delayed row ${i}</td><td>Ready</td>`
+          rows.append(row)
+        }
+        let count = 0
+        app.querySelector("#control").addEventListener("click", () => {
+          count += 1
+          app.querySelector("#count").textContent = String(count)
+        })
+      }, 1500)
+    </script>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-display-none-ancestor.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-display-none-ancestor.html
@@ -1,0 +1,4 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Display-none ancestor</title></head><body>
+<main style="display:none"><table><tbody><tr><td>Unrendered table</td></tr></tbody></table></main>
+<script>throw new Error("bootstrap failed before rendered content")</script>
+</body></html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-fail-soft.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-fail-soft.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Startup fail-soft regression fixture</title>
+<style>
+  body { margin: 0; background: #f8f6f0; color: #18181b; font: 14px/1.45 system-ui, sans-serif; }
+  main { max-width: 720px; margin: 0 auto; padding: 28px 20px; }
+  h1 { margin: 0 0 6px; font-size: 24px; }
+  p { color: #666; }
+  table { width: 100%; border-collapse: collapse; background: white; }
+  td { border-top: 1px solid #e5e5e5; padding: 7px 9px; }
+  img { width: 22px; height: 22px; border-radius: 50%; }
+  button { margin-top: 16px; padding: 8px 12px; }
+</style>
+</head>
+<body>
+<main data-derive-ready>
+  <h1>Thirty usable advertiser rows</h1>
+  <p>The optional logo fails after the meaningful table has rendered.</p>
+  <table><tbody id="rows"></tbody></table>
+  <button id="control" type="button">Working control · <span id="count">0</span></button>
+</main>
+<script>
+  const rows = document.getElementById("rows");
+  for (let i = 1; i <= 30; i += 1) {
+    const row = document.createElement("tr");
+    row.innerHTML = `<td>Advertiser ${i}</td><td>Ready</td>`;
+    rows.appendChild(row);
+  }
+  document.getElementById("control").addEventListener("click", () => {
+    const count = document.getElementById("count");
+    count.textContent = String(Number(count.textContent) + 1);
+  });
+</script>
+<!-- Exact incident shape: the image is optional, but its fallback removes itself
+     before touching parentElement and throws after the table is already usable. -->
+<img
+  src="/missing-optional-logo.png"
+  alt=""
+  onerror="this.remove(); this.parentElement.textContent = 'AA'"
+/>
+</body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-hidden-loaded-image.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-hidden-loaded-image.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Hidden loaded image</title></head>
+<body>
+  <img hidden width="160" height="90" alt="Hidden gradient" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='90'%3E%3Crect width='160' height='90' fill='%235d4ac7'/%3E%3C/svg%3E">
+  <script>throw new Error("bootstrap failed before visible media")</script>
+</body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-hidden-marker.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-hidden-marker.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Hidden readiness marker</title>
+  </head>
+  <body>
+    <div data-derive-ready hidden></div>
+    <main>Loading…</main>
+    <script>
+      throw new Error("intentional failure after a hidden readiness marker")
+    </script>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-hidden-rich-content.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-hidden-rich-content.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Hidden rich content</title>
+  </head>
+  <body>
+    <table hidden>
+      <tbody>
+        <tr><td>This row is not rendered.</td></tr>
+      </tbody>
+    </table>
+    <main>Loading…</main>
+    <script>
+      throw new Error("intentional failure after a hidden table")
+    </script>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-hidden-shadow-host.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-hidden-shadow-host.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Hidden shadow host</title></head>
+<body>
+  <main id="host" style="opacity:0"></main>
+  <script>
+    const root = document.querySelector("#host").attachShadow({ mode: "open" })
+    root.innerHTML = `<table><tbody><tr><td>Invisible shadow row</td></tr></tbody></table>`
+    throw new Error("bootstrap failed behind hidden shadow host")
+  </script>
+</body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-loaded-image-ready.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-loaded-image-ready.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Loaded image readiness</title></head>
+<body>
+  <main>
+    <img id="proof" width="160" height="90" alt="Ready gradient" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='90'%3E%3Crect width='160' height='90' fill='%235d4ac7'/%3E%3C/svg%3E">
+    <button id="control" type="button">Use · <span id="count">0</span></button>
+  </main>
+  <script>
+    document.querySelector("#control").addEventListener("click", () => {
+      const count = document.querySelector("#count")
+      count.textContent = String(Number(count.textContent) + 1)
+    })
+  </script>
+</body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-nested-frame-spoof.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-nested-frame-spoof.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Nested frame protocol spoof</title>
+  </head>
+  <body>
+    <main data-derive-ready>
+      <h1>Direct artifact frame remains authoritative</h1>
+      <p>A nested child cannot forge a runtime failure in the surrounding Derive viewer.</p>
+      <button id="control" type="button">Working control · <span id="count">0</span></button>
+      <iframe
+        title="Untrusted nested child"
+        srcdoc="<script>setTimeout(function(){parent.parent.postMessage({source:'derive',type:'runtime-error',code:'script-error',phase:'loading'},'*')},400)<\/script>"
+      ></iframe>
+    </main>
+    <script>
+      document.getElementById("control").addEventListener("click", () => {
+        const count = document.getElementById("count")
+        count.textContent = String(Number(count.textContent) + 1)
+      })
+    </script>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-opacity-ancestor.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-opacity-ancestor.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Transparent ancestor is not ready</title></head>
+<body>
+  <div style="opacity:0">
+    <main data-derive-ready><table><tbody><tr><td>Invisible readiness</td></tr></tbody></table></main>
+  </div>
+  <script>throw new Error("bootstrap failed before anything visible")</script>
+</body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-open-details-ready.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-open-details-ready.html
@@ -1,0 +1,4 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Open details readiness</title></head><body>
+<details open><summary>Visible details</summary><table><tbody><tr><td>Open row</td><td>Ready</td></tr></tbody></table><button id="control" type="button">Working control · <span id="count">0</span></button></details>
+<script>document.querySelector("#control").addEventListener("click",()=>{const c=document.querySelector("#count");c.textContent=String(Number(c.textContent)+1)})</script>
+</body></html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-post-ready-actions.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-post-ready-actions.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Post-ready action failures</title>
+  </head>
+  <body>
+    <main data-derive-ready>
+      <h1>Useful controls reached Ready</h1>
+      <p>The document stays available when one later interaction fails.</p>
+      <button id="throw-control" type="button">Throw from click handler</button>
+      <button id="reject-control" type="button">Reject from click handler</button>
+      <button id="working-control" type="button">
+        Working control · <span id="count">0</span>
+      </button>
+    </main>
+    <script>
+      document.getElementById("throw-control").addEventListener("click", () => {
+        throw new Error("intentional post-ready click failure")
+      })
+      document.getElementById("reject-control").addEventListener("click", () => {
+        void Promise.reject(new Error("intentional post-ready rejection"))
+      })
+      document.getElementById("working-control").addEventListener("click", () => {
+        const count = document.getElementById("count")
+        count.textContent = String(Number(count.textContent) + 1)
+      })
+    </script>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-post-timeout-ready.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-post-timeout-ready.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Post-timeout readiness</title></head>
+<body>
+  <main id="app">Loading…</main>
+  <script>
+    setTimeout(() => {
+      const app = document.querySelector("#app")
+      app.innerHTML = `
+        <h1>Late content recovered automatically</h1>
+        <table><tbody><tr><td>Late row</td><td>Ready</td></tr></tbody></table>
+        <button id="control" type="button">Working control · <span id="count">0</span></button>
+      `
+      app.querySelector("#control").addEventListener("click", () => {
+        const count = app.querySelector("#count")
+        count.textContent = String(Number(count.textContent) + 1)
+      })
+    }, 16500)
+  </script>
+</body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-required-script-blocked.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-required-script-blocked.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Required script bootstrap failure</title>
+    <script src="/missing-required-bootstrap.js"></script>
+  </head>
+  <body>
+    <main>Loading…</main>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-script-source-only.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-script-source-only.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Script source is not content</title>
+  </head>
+  <body>
+    <script>
+      const sourceTextMustNeverCountAsVisibleContent =
+        "This deliberately long JavaScript source exceeds the visible-text readiness threshold while rendering absolutely nothing for the viewer."
+      throw new Error(sourceTextMustNeverCountAsVisibleContent)
+    </script>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-sequential-errors.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-sequential-errors.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Sequential post-ready failures</title>
+  </head>
+  <body>
+    <main data-derive-ready>
+      <h1>Useful content survives distinct failures</h1>
+      <p>The optional resource warning can be dismissed before a later script failure occurs.</p>
+      <button id="throw-control" type="button">Trigger distinct script failure</button>
+      <button id="working-control" type="button">
+        Working control · <span id="count">0</span>
+      </button>
+    </main>
+    <img src="/missing-sequential-optional.png" alt="" />
+    <script>
+      document.getElementById("throw-control").addEventListener("click", () => {
+        throw new Error("intentional second post-ready failure")
+      })
+      document.getElementById("working-control").addEventListener("click", () => {
+        const count = document.getElementById("count")
+        count.textContent = String(Number(count.textContent) + 1)
+      })
+    </script>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-shadow-image-ready.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-shadow-image-ready.html
@@ -1,0 +1,6 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Shadow image readiness</title></head><body>
+<main id="host"></main><script>
+const root=document.querySelector("#host").attachShadow({mode:"open"});
+root.innerHTML=`<img id="proof" width="160" height="90" alt="Shadow gradient" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='90'%3E%3Crect width='160' height='90' fill='%2323734b'/%3E%3C/svg%3E"><button id="control" type="button">Use · <span id="count">0</span></button>`;
+root.querySelector("#control").addEventListener("click",()=>{const c=root.querySelector("#count");c.textContent=String(Number(c.textContent)+1)});
+</script></body></html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-shadow-ready.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-shadow-ready.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Open shadow-root readiness</title></head>
+<body>
+  <main id="host"></main>
+  <script>
+    const root = document.querySelector("#host").attachShadow({ mode: "open" })
+    root.innerHTML = `
+      <style>table{border-collapse:collapse}td{padding:6px;border:1px solid #ddd}button{margin-top:12px}</style>
+      <h1>Shadow dashboard is ready</h1>
+      <table><tbody><tr><td>Visible shadow row</td><td>Ready</td></tr></tbody></table>
+      <button id="control" type="button">Working control · <span id="count">0</span></button>
+    `
+    root.querySelector("#control").addEventListener("click", () => {
+      const count = root.querySelector("#count")
+      count.textContent = String(Number(count.textContent) + 1)
+    })
+  </script>
+</body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-stale-loading-error.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-stale-loading-error.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Late legacy error</title>
+    <style>
+      body { margin: 0; padding: 24px; font: 16px/1.5 system-ui, sans-serif; }
+      main { max-width: 720px; margin: auto; }
+      button { padding: 8px 12px; }
+    </style>
+  </head>
+  <body>
+    <main data-derive-ready>
+      <h1>Useful content reached Ready</h1>
+      <p>The host must not return this frame to Blocked when an old runtime reports a late startup phase.</p>
+      <button id="control" type="button">Working control · <span id="count">0</span></button>
+    </main>
+    <script>
+      let count = 0
+      document.querySelector("#control").addEventListener("click", () => {
+        count += 1
+        document.querySelector("#count").textContent = String(count)
+      })
+      setTimeout(() => {
+        parent.postMessage({ source: "derive", type: "runtime-error", code: "script-error" }, "*")
+      }, 600)
+    </script>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-storage-blocked.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-storage-blocked.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Storage bootstrap failure</title>
+    <script>
+      localStorage.getItem("legacy-session")
+    </script>
+  </head>
+  <body>
+    <main>Loading…</main>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-threshold-79-error.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-threshold-79-error.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Below readiness threshold</title></head>
+<body>
+  <p>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA</p>
+  <script>throw new Error("bootstrap failed one character below readiness")</script>
+</body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-threshold-80.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-threshold-80.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Exact readiness threshold</title></head>
+<body>
+  <p id="copy">AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA</p>
+  <button id="control" type="button" aria-label="Increment" style="width:44px;height:44px"></button>
+  <script>
+    document.querySelector("#control").addEventListener("click", (event) => {
+      event.currentTarget.dataset.clicked = "true"
+    })
+  </script>
+</body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-visibility-hidden-ancestor.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-visibility-hidden-ancestor.html
@@ -1,0 +1,4 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Visibility-hidden ancestor</title></head><body>
+<main style="visibility:hidden"><table><tbody><tr><td>Invisible table</td></tr></tbody></table></main>
+<script>throw new Error("bootstrap failed before visible content")</script>
+</body></html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-visible-second-marker.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-visible-second-marker.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Visible second marker</title></head>
+<body>
+  <div data-derive-ready hidden>Hidden first marker</div>
+  <main data-derive-ready>
+    <button id="control" type="button">Working control · <span id="count">0</span></button>
+  </main>
+  <script>
+    document.querySelector("#control").addEventListener("click", () => {
+      const count = document.querySelector("#count")
+      count.textContent = String(Number(count.textContent) + 1)
+    })
+    throw new Error("post-ready script failure")
+  </script>
+</body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-zero-area-svg.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-zero-area-svg.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Zero-area SVG is not ready</title></head>
+<body>
+  <svg width="0" height="0" aria-label="Unpainted chart"><circle cx="0" cy="0" r="0"></circle></svg>
+  <script>throw new Error("bootstrap failed before any visible geometry")</script>
+</body>
+</html>

--- a/apps/web/e2e/render-fidelity/render-fidelity.spec.ts
+++ b/apps/web/e2e/render-fidelity/render-fidelity.spec.ts
@@ -35,6 +35,68 @@ async function withErrorCapture(page: Page, fn: () => Promise<void>): Promise<st
 }
 
 test.describe("render fidelity — pinning what the sandbox CSP permits", () => {
+  test("viewer fails closed when a script throws before meaningful content", async ({
+    browser,
+    owner: page,
+  }) => {
+    const html = readFileSync(join(FIXTURES, "startup-blocked.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+
+    await page.goto(`/artifacts/${shortId}`)
+    await expect(page.getByText("Artifact script stopped")).toBeVisible()
+    await expect(page.getByTestId("render-degraded")).toHaveCount(0)
+    await expect(page.getByTestId("render-retry")).toBeVisible()
+
+    const publicContext = await browser.newContext()
+    const publicPage = await publicContext.newPage()
+    try {
+      await publicPage.goto(`/artifacts/${shortId}`)
+      await expect(publicPage.getByText("This artifact couldn’t start")).toBeVisible()
+      await expect(publicPage.getByTestId("render-degraded")).toHaveCount(0)
+    } finally {
+      await publicContext.close()
+    }
+  })
+
+  test("viewer fails soft when an optional fallback throws after meaningful content", async ({
+    browser,
+    owner: page,
+  }) => {
+    const html = readFileSync(join(FIXTURES, "startup-fail-soft.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+
+    const wrapperErrors = await withErrorCapture(page, () => page.goto(`/artifacts/${shortId}`))
+    expect(wrapperErrors).toEqual([])
+    await expect(page.getByTestId("render-degraded")).toBeVisible()
+    await expect(page.getByText("This artifact couldn’t start")).toHaveCount(0)
+
+    const frame = page.locator('iframe[title="index"]')
+    await expect(frame).toBeVisible()
+    const artifact = page.frameLocator('iframe[title="index"]')
+    await expect(artifact.locator("#rows tr")).toHaveCount(30)
+    await artifact.locator("#control").click()
+    await expect(artifact.locator("#count")).toHaveText("1")
+    await page.getByTestId("render-degraded-dismiss").click()
+    await expect(page.getByTestId("render-degraded")).toHaveCount(0)
+    await expect(artifact.locator("#rows tr")).toHaveCount(30)
+
+    // The public wrapper has its own chrome/layout path. Exercise the same shared
+    // artifact anonymously so a workbench-only fix cannot masquerade as complete.
+    const publicContext = await browser.newContext({ viewport: { width: 390, height: 844 } })
+    const publicPage = await publicContext.newPage()
+    try {
+      await publicPage.goto(`/artifacts/${shortId}`)
+      await expect(publicPage.getByTestId("render-degraded")).toBeVisible()
+      await expect(publicPage.getByText("This artifact couldn’t start")).toHaveCount(0)
+      const publicArtifact = publicPage.frameLocator('iframe[title="index"]')
+      await expect(publicArtifact.locator("#rows tr")).toHaveCount(30)
+      await publicArtifact.locator("#control").click()
+      await expect(publicArtifact.locator("#count")).toHaveText("1")
+    } finally {
+      await publicContext.close()
+    }
+  })
+
   test("tier 1: a fully self-contained artifact renders with zero console errors, inline script executes", async ({
     owner: page,
   }) => {

--- a/apps/web/e2e/render-fidelity/render-fidelity.spec.ts
+++ b/apps/web/e2e/render-fidelity/render-fidelity.spec.ts
@@ -334,6 +334,45 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
     await expect(page.getByTestId("render-degraded")).toContainText("script-error")
   })
 
+  for (const scenario of [
+    { fixture: "startup-opacity-ancestor.html", label: "an opacity-zero ancestor" },
+    { fixture: "startup-clipped-rich-content.html", label: "a zero-area clipping ancestor" },
+    { fixture: "startup-collapsed-details.html", label: "collapsed details" },
+  ]) {
+    test(`${scenario.label} cannot expose hidden descendants as Ready`, async ({ owner: page }) => {
+      const html = readFileSync(join(FIXTURES, scenario.fixture), "utf8")
+      const shortId = await publishArtifact(page, "index.html", html, "text/html")
+
+      await page.goto(`/artifacts/${shortId}`)
+      await expect(page.getByText("Artifact script stopped")).toBeVisible()
+      await expect(page.getByTestId("render-degraded")).toHaveCount(0)
+      await expect(page.getByTestId("render-retry")).toHaveCount(1)
+    })
+  }
+
+  test("exactly 80 visible non-whitespace characters reaches Ready", async ({ owner: page }) => {
+    const html = readFileSync(join(FIXTURES, "startup-threshold-80.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+
+    await page.goto(`/artifacts/${shortId}`)
+    const artifact = page.frameLocator('iframe[title="index"]')
+    await artifact.locator("#control").click({ timeout: 5_000 })
+    await expect(artifact.locator("#control")).toHaveAttribute("data-clicked", "true")
+    await expect(page.getByTestId("render-retry")).toHaveCount(0)
+  })
+
+  test("79 visible non-whitespace characters plus an error stays Blocked", async ({
+    owner: page,
+  }) => {
+    const html = readFileSync(join(FIXTURES, "startup-threshold-79-error.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+
+    await page.goto(`/artifacts/${shortId}`)
+    await expect(page.getByText("Artifact script stopped")).toBeVisible()
+    await expect(page.getByTestId("render-degraded")).toHaveCount(0)
+    await expect(page.getByTestId("render-retry")).toHaveCount(1)
+  })
+
   test("tier 1: a fully self-contained artifact renders with zero console errors, inline script executes", async ({
     owner: page,
   }) => {

--- a/apps/web/e2e/render-fidelity/render-fidelity.spec.ts
+++ b/apps/web/e2e/render-fidelity/render-fidelity.spec.ts
@@ -97,6 +97,99 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
     }
   })
 
+  test("Ready never returns to Blocked for a late legacy loading-phase error", async ({
+    owner: page,
+  }) => {
+    const html = readFileSync(join(FIXTURES, "startup-stale-loading-error.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+
+    await page.goto(`/artifacts/${shortId}`)
+    await expect(page.getByTestId("render-degraded")).toBeVisible()
+    await expect(page.getByText("Artifact script stopped")).toHaveCount(0)
+    const artifact = page.frameLocator('iframe[title="index"]')
+    await expect(
+      artifact.getByRole("heading", { name: "Useful content reached Ready" }),
+    ).toBeVisible()
+    await artifact.locator("#control").click()
+    await expect(artifact.locator("#count")).toHaveText("1")
+  })
+
+  test("viewer waits through iframe load, then degrades after delayed meaningful paint", async ({
+    browser,
+    owner: page,
+  }) => {
+    const html = readFileSync(join(FIXTURES, "startup-delayed-ready.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+
+    await page.goto(`/artifacts/${shortId}`)
+    await expect(page.getByText("Loading preview…")).toBeVisible()
+    await expect(page.getByTestId("render-degraded")).toHaveCount(0)
+    await expect(page.getByTestId("render-degraded")).toBeVisible()
+    const artifact = page.frameLocator('iframe[title="index"]')
+    await expect(artifact.locator("#rows tr")).toHaveCount(30)
+    await artifact.locator("#control").click()
+    await expect(artifact.locator("#count")).toHaveText("1")
+
+    const publicContext = await browser.newContext({ viewport: { width: 390, height: 844 } })
+    const publicPage = await publicContext.newPage()
+    try {
+      await publicPage.goto(`/artifacts/${shortId}`)
+      await expect(publicPage.getByText("Loading preview…")).toBeVisible()
+      await expect(publicPage.getByTestId("render-degraded")).toBeVisible()
+      const publicArtifact = publicPage.frameLocator('iframe[title="index"]')
+      await expect(publicArtifact.locator("#rows tr")).toHaveCount(30)
+    } finally {
+      await publicContext.close()
+    }
+  })
+
+  for (const action of ["throw", "reject"] as const) {
+    test(`post-ready ${action} failure degrades without replacing useful controls`, async ({
+      owner: page,
+    }) => {
+      const html = readFileSync(join(FIXTURES, "startup-post-ready-actions.html"), "utf8")
+      const shortId = await publishArtifact(page, "index.html", html, "text/html")
+
+      await page.goto(`/artifacts/${shortId}`)
+      const artifact = page.frameLocator('iframe[title="index"]')
+      await expect(
+        artifact.getByRole("heading", { name: "Useful controls reached Ready" }),
+      ).toBeVisible()
+      await artifact.locator(`#${action}-control`).click()
+      await expect(page.getByTestId("render-degraded")).toBeVisible()
+      await expect(page.getByText("Artifact script stopped")).toHaveCount(0)
+      await artifact.locator("#working-control").click()
+      await expect(artifact.locator("#count")).toHaveText("1")
+    })
+  }
+
+  test("pre-content storage and required-script failures keep editor repair guidance", async ({
+    owner: page,
+  }) => {
+    const cases = [
+      {
+        fixture: "startup-storage-blocked.html",
+        title: "Browser storage isn’t available here",
+        repair: "derive.shared",
+      },
+      {
+        fixture: "startup-required-script-blocked.html",
+        title: "Artifact script stopped",
+        repair: "Check the source and republish",
+      },
+    ]
+
+    for (const scenario of cases) {
+      const html = readFileSync(join(FIXTURES, scenario.fixture), "utf8")
+      const shortId = await publishArtifact(page, "index.html", html, "text/html")
+      await page.goto(`/artifacts/${shortId}`)
+      await expect(page.getByText(scenario.title)).toBeVisible()
+      await expect(page.getByText(scenario.repair, { exact: false })).toBeVisible()
+      await expect(page.getByTestId("render-degraded")).toHaveCount(0)
+      await expect(page.getByTestId("render-retry")).toBeVisible()
+    }
+  })
+
   test("tier 1: a fully self-contained artifact renders with zero console errors, inline script executes", async ({
     owner: page,
   }) => {

--- a/apps/web/e2e/render-fidelity/render-fidelity.spec.ts
+++ b/apps/web/e2e/render-fidelity/render-fidelity.spec.ts
@@ -266,6 +266,74 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
     }
   })
 
+  test("visible meaningful content in an open shadow root reaches Ready", async ({
+    owner: page,
+  }) => {
+    const html = readFileSync(join(FIXTURES, "startup-shadow-ready.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+
+    await page.goto(`/artifacts/${shortId}`)
+    await expect(page.getByText("Loading preview…")).toHaveCount(0, { timeout: 5_000 })
+    const artifact = page.frameLocator('iframe[title="index"]')
+    await expect(artifact.locator("#host").locator("h1")).toHaveText("Shadow dashboard is ready")
+    await artifact.locator("#host").locator("#control").click()
+    await expect(artifact.locator("#host").locator("#count")).toHaveText("1")
+  })
+
+  test("a successfully loaded standalone image reaches Ready", async ({ owner: page }) => {
+    const html = readFileSync(join(FIXTURES, "startup-loaded-image-ready.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+
+    await page.goto(`/artifacts/${shortId}`)
+    await expect(page.getByText("Loading preview…")).toHaveCount(0, { timeout: 5_000 })
+    const artifact = page.frameLocator('iframe[title="index"]')
+    await expect(artifact.locator("#proof")).toBeVisible()
+    await artifact.locator("#control").click()
+    await expect(artifact.locator("#count")).toHaveText("1")
+  })
+
+  test("zero-area SVG cannot turn a bootstrap failure into Ready", async ({ owner: page }) => {
+    const html = readFileSync(join(FIXTURES, "startup-zero-area-svg.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+
+    await page.goto(`/artifacts/${shortId}`)
+    await expect(page.getByText("Artifact script stopped")).toBeVisible()
+    await expect(page.getByTestId("render-degraded")).toHaveCount(0)
+    await expect(page.getByTestId("render-retry")).toHaveCount(1)
+  })
+
+  test("meaningful paint after the generic timeout self-recovers to Ready", async ({
+    owner: page,
+  }) => {
+    const html = readFileSync(join(FIXTURES, "startup-post-timeout-ready.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+
+    await page.goto(`/artifacts/${shortId}`)
+    await expect(page.getByText("Preview didn’t load")).toBeVisible({ timeout: 16_000 })
+    const artifact = page.frameLocator('iframe[title="index"]')
+    await expect(
+      artifact.getByRole("heading", { name: "Late content recovered automatically" }),
+    ).toBeVisible({ timeout: 5_000 })
+    await expect(page.getByText("Preview didn’t load")).toHaveCount(0)
+    await artifact.locator("#control").click()
+    await expect(artifact.locator("#count")).toHaveText("1")
+  })
+
+  test("degraded dismissal is scoped to one artifact instance", async ({ owner: page }) => {
+    const html = readFileSync(join(FIXTURES, "startup-fail-soft.html"), "utf8")
+    const firstId = await publishArtifact(page, "index.html", html, "text/html")
+    const secondId = await publishArtifact(page, "index.html", html, "text/html")
+
+    await page.goto(`/artifacts/${firstId}`)
+    await expect(page.getByTestId("render-degraded")).toBeVisible()
+    await page.getByTestId("render-degraded-dismiss").click()
+    await expect(page.getByTestId("render-degraded")).toHaveCount(0)
+
+    await page.goto(`/artifacts/${secondId}`)
+    await expect(page.getByTestId("render-degraded")).toBeVisible()
+    await expect(page.getByTestId("render-degraded")).toContainText("script-error")
+  })
+
   test("tier 1: a fully self-contained artifact renders with zero console errors, inline script executes", async ({
     owner: page,
   }) => {

--- a/apps/web/e2e/render-fidelity/render-fidelity.spec.ts
+++ b/apps/web/e2e/render-fidelity/render-fidelity.spec.ts
@@ -373,6 +373,55 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
     await expect(page.getByTestId("render-retry")).toHaveCount(1)
   })
 
+  test("a visible second readiness marker wins over a hidden first marker", async ({
+    owner: page,
+  }) => {
+    const html = readFileSync(join(FIXTURES, "startup-visible-second-marker.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+
+    await page.goto(`/artifacts/${shortId}`)
+    await expect(page.getByTestId("render-degraded")).toBeVisible()
+    const artifact = page.frameLocator('iframe[title="index"]')
+    await artifact.locator("#control").click()
+    await expect(artifact.locator("#count")).toHaveText("1")
+  })
+
+  for (const scenario of [
+    { fixture: "startup-hidden-shadow-host.html", label: "an opacity-zero shadow host" },
+    { fixture: "startup-hidden-loaded-image.html", label: "a hidden loaded image" },
+    { fixture: "startup-broken-sized-image.html", label: "a broken image with layout dimensions" },
+  ]) {
+    test(`${scenario.label} cannot satisfy readiness`, async ({ owner: page }) => {
+      const html = readFileSync(join(FIXTURES, scenario.fixture), "utf8")
+      const shortId = await publishArtifact(page, "index.html", html, "text/html")
+
+      await page.goto(`/artifacts/${shortId}`)
+      await expect(page.getByText("Artifact script stopped")).toBeVisible()
+      await expect(page.getByTestId("render-degraded")).toHaveCount(0)
+      await expect(page.getByTestId("render-retry")).toHaveCount(1)
+    })
+  }
+
+  test("attribute-only visibility after timeout self-recovers to Ready", async ({
+    owner: page,
+  }) => {
+    const html = readFileSync(
+      join(FIXTURES, "startup-attribute-visible-after-timeout.html"),
+      "utf8",
+    )
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+
+    await page.goto(`/artifacts/${shortId}`)
+    await expect(page.getByText("Preview didn’t load")).toBeVisible({ timeout: 16_000 })
+    const artifact = page.frameLocator('iframe[title="index"]')
+    await expect(
+      artifact.getByRole("heading", { name: "Attribute-only recovery reached Ready" }),
+    ).toBeVisible({ timeout: 5_000 })
+    await expect(page.getByText("Preview didn’t load")).toHaveCount(0)
+    await artifact.locator("#control").click()
+    await expect(artifact.locator("#count")).toHaveText("1")
+  })
+
   test("tier 1: a fully self-contained artifact renders with zero console errors, inline script executes", async ({
     owner: page,
   }) => {

--- a/apps/web/e2e/render-fidelity/render-fidelity.spec.ts
+++ b/apps/web/e2e/render-fidelity/render-fidelity.spec.ts
@@ -45,7 +45,11 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
     await page.goto(`/artifacts/${shortId}`)
     await expect(page.getByText("Artifact script stopped")).toBeVisible()
     await expect(page.getByTestId("render-degraded")).toHaveCount(0)
-    await expect(page.getByTestId("render-retry")).toBeVisible()
+    // The generic 15s stuck-preview timer must not add an overlapping second
+    // recovery card after the specific runtime failure already owns this state.
+    await page.waitForTimeout(16_000)
+    await expect(page.getByText("Preview didn’t load")).toHaveCount(0)
+    await expect(page.getByTestId("render-retry")).toHaveCount(1)
 
     const publicContext = await browser.newContext()
     const publicPage = await publicContext.newPage()

--- a/apps/web/e2e/render-fidelity/render-fidelity.spec.ts
+++ b/apps/web/e2e/render-fidelity/render-fidelity.spec.ts
@@ -422,6 +422,42 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
     await expect(artifact.locator("#count")).toHaveText("1")
   })
 
+  for (const scenario of [
+    { fixture: "startup-aria-hidden-ancestor.html", label: "an aria-hidden ancestor" },
+    { fixture: "startup-visibility-hidden-ancestor.html", label: "a visibility-hidden ancestor" },
+    { fixture: "startup-display-none-ancestor.html", label: "a display-none ancestor" },
+  ]) {
+    test(`${scenario.label} keeps descendant rich content Blocked`, async ({ owner: page }) => {
+      const html = readFileSync(join(FIXTURES, scenario.fixture), "utf8")
+      const shortId = await publishArtifact(page, "index.html", html, "text/html")
+      await page.goto(`/artifacts/${shortId}`)
+      await expect(page.getByText("Artifact script stopped")).toBeVisible()
+      await expect(page.getByTestId("render-degraded")).toHaveCount(0)
+      await expect(page.getByTestId("render-retry")).toHaveCount(1)
+    })
+  }
+
+  test("an open details table reaches Ready and remains usable", async ({ owner: page }) => {
+    const html = readFileSync(join(FIXTURES, "startup-open-details-ready.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+    await page.goto(`/artifacts/${shortId}`)
+    const artifact = page.frameLocator('iframe[title="index"]')
+    await artifact.locator("#control").click({ timeout: 5_000 })
+    await expect(artifact.locator("#count")).toHaveText("1")
+    await expect(page.getByTestId("render-retry")).toHaveCount(0)
+  })
+
+  test("a loaded image inside an open shadow root reaches Ready", async ({ owner: page }) => {
+    const html = readFileSync(join(FIXTURES, "startup-shadow-image-ready.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+    await page.goto(`/artifacts/${shortId}`)
+    const artifact = page.frameLocator('iframe[title="index"]')
+    await expect(artifact.locator("#host").locator("#proof")).toBeVisible()
+    await artifact.locator("#host").locator("#control").click({ timeout: 5_000 })
+    await expect(artifact.locator("#host").locator("#count")).toHaveText("1")
+    await expect(page.getByTestId("render-retry")).toHaveCount(0)
+  })
+
   test("tier 1: a fully self-contained artifact renders with zero console errors, inline script executes", async ({
     owner: page,
   }) => {

--- a/apps/web/e2e/render-fidelity/render-fidelity.spec.ts
+++ b/apps/web/e2e/render-fidelity/render-fidelity.spec.ts
@@ -458,6 +458,96 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
     await expect(page.getByTestId("render-retry")).toHaveCount(0)
   })
 
+  test("a dismissed degraded warning returns after a full reload", async ({ owner: page }) => {
+    const html = readFileSync(join(FIXTURES, "startup-fail-soft.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+    await page.goto(`/artifacts/${shortId}`)
+    await expect(page.getByTestId("render-degraded")).toBeVisible()
+    await page.getByTestId("render-degraded-dismiss").click()
+    await expect(page.getByTestId("render-degraded")).toHaveCount(0)
+    await page.reload()
+    await expect(page.getByTestId("render-degraded")).toBeVisible()
+    await expect(page.frameLocator('iframe[title="index"]').locator("#rows tr")).toHaveCount(30)
+  })
+
+  test("Retry on a degraded artifact creates one fresh usable iframe", async ({ owner: page }) => {
+    const html = readFileSync(join(FIXTURES, "startup-fail-soft.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+    await page.goto(`/artifacts/${shortId}`)
+    const artifact = page.frameLocator('iframe[title="index"]')
+    await artifact.locator("#control").click()
+    await expect(artifact.locator("#count")).toHaveText("1")
+    await page.getByTestId("render-retry").click()
+    await expect(page.locator('iframe[title="index"]')).toHaveCount(1)
+    await expect(page.getByTestId("render-degraded")).toBeVisible()
+    await expect(artifact.locator("#count")).toHaveText("0")
+    await artifact.locator("#control").click()
+    await expect(artifact.locator("#count")).toHaveText("1")
+  })
+
+  test("two blocked Retry attempts never duplicate recovery or iframes", async ({
+    owner: page,
+  }) => {
+    const html = readFileSync(join(FIXTURES, "startup-blocked.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+    await page.goto(`/artifacts/${shortId}`)
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      await expect(page.getByText("Artifact script stopped")).toBeVisible()
+      await page.getByTestId("render-retry").click()
+      await expect(page.locator('iframe[title="index"]')).toHaveCount(1)
+      await expect(page.getByTestId("render-retry")).toHaveCount(1)
+      await expect(page.getByText("Preview didn’t load")).toHaveCount(0)
+    }
+  })
+
+  test("navigating from Blocked to a clean sibling clears blocking recovery", async ({
+    owner: page,
+  }) => {
+    const blocked = await publishArtifact(
+      page,
+      "index.html",
+      readFileSync(join(FIXTURES, "startup-blocked.html"), "utf8"),
+      "text/html",
+    )
+    const clean = await publishArtifact(
+      page,
+      "index.html",
+      readFileSync(join(FIXTURES, "startup-threshold-80.html"), "utf8"),
+      "text/html",
+    )
+    await page.goto(`/artifacts/${blocked}`)
+    await expect(page.getByText("Artifact script stopped")).toBeVisible()
+    await page.goto(`/artifacts/${clean}`)
+    await expect(page.getByTestId("render-retry")).toHaveCount(0)
+    const artifact = page.frameLocator('iframe[title="index"]')
+    await artifact.locator("#control").click({ timeout: 5_000 })
+    await expect(artifact.locator("#control")).toHaveAttribute("data-clicked", "true")
+  })
+
+  test("navigating from Degraded to a clean sibling clears the warning rail", async ({
+    owner: page,
+  }) => {
+    const degraded = await publishArtifact(
+      page,
+      "index.html",
+      readFileSync(join(FIXTURES, "startup-fail-soft.html"), "utf8"),
+      "text/html",
+    )
+    const clean = await publishArtifact(
+      page,
+      "index.html",
+      readFileSync(join(FIXTURES, "startup-open-details-ready.html"), "utf8"),
+      "text/html",
+    )
+    await page.goto(`/artifacts/${degraded}`)
+    await expect(page.getByTestId("render-degraded")).toBeVisible()
+    await page.goto(`/artifacts/${clean}`)
+    await expect(page.getByTestId("render-degraded")).toHaveCount(0)
+    const artifact = page.frameLocator('iframe[title="index"]')
+    await artifact.locator("#control").click({ timeout: 5_000 })
+    await expect(artifact.locator("#count")).toHaveText("1")
+  })
+
   test("tier 1: a fully self-contained artifact renders with zero console errors, inline script executes", async ({
     owner: page,
   }) => {

--- a/apps/web/e2e/render-fidelity/render-fidelity.spec.ts
+++ b/apps/web/e2e/render-fidelity/render-fidelity.spec.ts
@@ -194,6 +194,78 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
     }
   })
 
+  for (const scenario of [
+    { fixture: "startup-hidden-marker.html", label: "hidden readiness marker" },
+    { fixture: "startup-hidden-rich-content.html", label: "hidden rich content" },
+    { fixture: "startup-script-source-only.html", label: "script source text" },
+  ]) {
+    test(`${scenario.label} cannot turn a bootstrap failure into Ready`, async ({
+      owner: page,
+    }) => {
+      const html = readFileSync(join(FIXTURES, scenario.fixture), "utf8")
+      const shortId = await publishArtifact(page, "index.html", html, "text/html")
+
+      await page.goto(`/artifacts/${shortId}`)
+      await expect(page.getByText("Artifact script stopped")).toBeVisible()
+      await expect(page.getByTestId("render-degraded")).toHaveCount(0)
+      await expect(page.getByTestId("render-retry")).toHaveCount(1)
+    })
+  }
+
+  test("nested iframe cannot forge the direct artifact runtime protocol", async ({
+    owner: page,
+  }) => {
+    const html = readFileSync(join(FIXTURES, "startup-nested-frame-spoof.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+
+    await page.goto(`/artifacts/${shortId}`)
+    const artifact = page.frameLocator('iframe[title="index"]')
+    await expect(
+      artifact.getByRole("heading", { name: "Direct artifact frame remains authoritative" }),
+    ).toBeVisible()
+    await page.waitForTimeout(1_000)
+    await expect(page.getByTestId("render-degraded")).toHaveCount(0)
+    await expect(page.getByText("Artifact script stopped")).toHaveCount(0)
+    await artifact.locator("#control").click()
+    await expect(artifact.locator("#count")).toHaveText("1")
+  })
+
+  test("a distinct post-ready failure reopens recovery after dismissal", async ({
+    browser,
+    owner: page,
+  }) => {
+    const html = readFileSync(join(FIXTURES, "startup-sequential-errors.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+
+    await page.goto(`/artifacts/${shortId}`)
+    await expect(page.getByTestId("render-degraded")).toBeVisible()
+    await page.getByTestId("render-degraded-dismiss").click()
+    await expect(page.getByTestId("render-degraded")).toHaveCount(0)
+
+    const artifact = page.frameLocator('iframe[title="index"]')
+    await artifact.locator("#throw-control").click()
+    await expect(page.getByTestId("render-degraded")).toBeVisible()
+    await expect(
+      page.getByText("A script failed after meaningful content", { exact: false }),
+    ).toBeVisible()
+    await artifact.locator("#working-control").click()
+    await expect(artifact.locator("#count")).toHaveText("1")
+
+    const mobileContext = await browser.newContext({ viewport: { width: 390, height: 844 } })
+    const mobile = await mobileContext.newPage()
+    try {
+      await mobile.goto(`/artifacts/${shortId}`)
+      await expect(mobile.getByTestId("render-degraded")).toContainText("resource-error")
+      await mobile.getByTestId("render-degraded-dismiss").click()
+      const mobileArtifact = mobile.frameLocator('iframe[title="index"]')
+      await mobileArtifact.locator("#throw-control").click()
+      await expect(mobile.getByTestId("render-degraded")).toContainText("script-error")
+      await expect(mobile.getByTestId("render-degraded")).not.toContainText("resource-error")
+    } finally {
+      await mobileContext.close()
+    }
+  })
+
   test("tier 1: a fully self-contained artifact renders with zero console errors, inline script executes", async ({
     owner: page,
   }) => {

--- a/apps/web/src/lib/view-transition.ts
+++ b/apps/web/src/lib/view-transition.ts
@@ -1,0 +1,31 @@
+type ViewTransitionDocument = Document & {
+  __deriveHandlesSkippedViewTransitions?: true
+}
+
+const isExpectedCancellation = (error: unknown): boolean =>
+  error instanceof DOMException && error.name === "AbortError"
+
+/**
+ * Chromium rejects all three ViewTransition lifecycle promises when a newer
+ * navigation supersedes an in-flight transition. TanStack intentionally does not
+ * retain those promises, so the expected cancellation otherwise reaches the page
+ * as three unhandled AbortErrors. Observe the native promises without hiding an
+ * unexpected transition failure.
+ */
+export const installViewTransitionErrorHandling = (): void => {
+  if (typeof document === "undefined" || typeof document.startViewTransition !== "function") return
+  const doc = document as ViewTransitionDocument
+  if (doc.__deriveHandlesSkippedViewTransitions) return
+  doc.__deriveHandlesSkippedViewTransitions = true
+
+  const original = document.startViewTransition.bind(document)
+  document.startViewTransition = ((update: Parameters<typeof original>[0]) => {
+    const transition = original(update)
+    for (const outcome of [transition.ready, transition.updateCallbackDone, transition.finished]) {
+      void outcome.catch((error: unknown) => {
+        if (!isExpectedCancellation(error)) throw error
+      })
+    }
+    return transition
+  }) as typeof document.startViewTransition
+}

--- a/apps/web/src/pages/artifact/artifact-document.tsx
+++ b/apps/web/src/pages/artifact/artifact-document.tsx
@@ -34,6 +34,7 @@ export function ArtifactDocument({
   presentWrapRef,
   cursor,
   runtimeError,
+  runtimeReady = false,
   canFixRuntimeError = false,
   onScrollDoc,
   onFrameLoad,
@@ -79,6 +80,8 @@ export function ArtifactDocument({
   presentWrapRef: RefObject<HTMLDivElement | null>
   cursor: CursorLayerHandle
   runtimeError?: ArtifactRuntimeError | null
+  /** True only after the sandbox runtime observes meaningful rendered content. */
+  runtimeReady?: boolean
   canFixRuntimeError?: boolean
   onScrollDoc: (dy: number) => void
   onFrameLoad: () => void
@@ -172,6 +175,7 @@ export function ArtifactDocument({
           wrapRef={presentWrapRef}
           onFrameLoad={onFrameLoad}
           runtimeError={runtimeError}
+          runtimeReady={runtimeReady}
           canFixRuntimeError={canFixRuntimeError}
           overlay={presentOverlay}
           presenting={presenting}

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -475,6 +475,7 @@ export function Artifact({ template = false }: { template?: boolean }) {
     anchorTops,
     subscribeGeom,
     runtimeError,
+    runtimeReady,
   } = useArtifactFrame({
     // Paint the open thread anchors in the doc; a click focuses the thread.
     comments,
@@ -1037,6 +1038,7 @@ export function Artifact({ template = false }: { template?: boolean }) {
       presentWrapRef={presentWrap}
       cursor={live.cursor}
       runtimeError={runtimeError}
+      runtimeReady={runtimeReady}
       canFixRuntimeError={canPublish}
       onScrollDoc={scrollBy}
       // A frame (re)load while inline editing means the edit session's document is

--- a/apps/web/src/pages/artifact/render-stage.test.ts
+++ b/apps/web/src/pages/artifact/render-stage.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest"
-import { runtimeFailureCopy, type UpdateCueState, updateCue } from "./render-stage"
+import {
+  runtimeDisposition,
+  runtimeFailureCopy,
+  type UpdateCueState,
+  updateCue,
+} from "./render-stage"
+import { mergeRuntimeError } from "./types"
 
 // The soft "Updated · vN" cue's decision, pinned after it shipped a phantom: the render
 // stage stays mounted while the sibling switcher pages between artifacts, and a bare
@@ -55,17 +61,31 @@ describe("updateCue", () => {
 
 describe("runtimeFailureCopy", () => {
   it("gives editors the sandbox-storage repair without exposing exception details", () => {
-    const copy = runtimeFailureCopy("sandbox-storage", true)
+    const copy = runtimeFailureCopy("sandbox-storage", "blocked", true)
     expect(copy.title).toContain("Browser storage")
     expect(copy.description).toContain("derive.shared")
     expect(copy.description).not.toContain("SecurityError")
   })
 
   it("keeps reader-facing failures neutral", () => {
-    expect(runtimeFailureCopy("sandbox-storage", false)).toEqual({
+    expect(runtimeFailureCopy("sandbox-storage", "blocked", false)).toEqual({
       title: "This artifact couldn’t start",
       description: "Its author needs to update it for Derive’s secure sandbox.",
     })
-    expect(runtimeFailureCopy("script-error", false).description).not.toContain("stack")
+    expect(runtimeFailureCopy("script-error", "blocked", false).description).not.toContain("stack")
+  })
+
+  it("keeps optional and post-ready failures visible with neutral reader copy", () => {
+    expect(runtimeDisposition({ code: "resource-error", phase: "loading" })).toBe("degraded")
+    expect(runtimeDisposition({ code: "script-error", phase: "ready" })).toBe("degraded")
+    expect(runtimeDisposition({ code: "script-error", phase: "loading" })).toBe("blocked")
+    expect(runtimeFailureCopy("script-error", "degraded", false).title).toContain("unavailable")
+  })
+
+  it("never lets a queued optional warning downgrade a bootstrap failure", () => {
+    const blocked = { code: "script-error", phase: "loading" } as const
+    const optional = { code: "resource-error", phase: "ready" } as const
+    expect(mergeRuntimeError(blocked, optional)).toBe(blocked)
+    expect(mergeRuntimeError(optional, blocked)).toBe(blocked)
   })
 })

--- a/apps/web/src/pages/artifact/render-stage.test.ts
+++ b/apps/web/src/pages/artifact/render-stage.test.ts
@@ -5,7 +5,7 @@ import {
   type UpdateCueState,
   updateCue,
 } from "./render-stage"
-import { mergeRuntimeError } from "./types"
+import { isBlockingRuntimeError, mergeRuntimeError, normalizeRuntimeError } from "./types"
 
 // The soft "Updated · vN" cue's decision, pinned after it shipped a phantom: the render
 // stage stays mounted while the sibling switcher pages between artifacts, and a bare
@@ -87,5 +87,22 @@ describe("runtimeFailureCopy", () => {
     const optional = { code: "resource-error", phase: "ready" } as const
     expect(mergeRuntimeError(blocked, optional)).toBe(blocked)
     expect(mergeRuntimeError(optional, blocked)).toBe(blocked)
+  })
+
+  it("treats legacy errors as startup failures only before meaningful content", () => {
+    const beforeReady = normalizeRuntimeError("script-error", undefined, false)
+    expect(beforeReady.phase).toBe("loading")
+    expect(isBlockingRuntimeError(beforeReady)).toBe(true)
+
+    const afterReady = normalizeRuntimeError("script-error", undefined, true)
+    expect(afterReady.phase).toBe("ready")
+    expect(isBlockingRuntimeError(afterReady)).toBe(false)
+  })
+
+  it("makes the Ready boundary monotonic even for a stale explicit loading phase", () => {
+    expect(normalizeRuntimeError("script-error", "loading", true)).toEqual({
+      code: "script-error",
+      phase: "ready",
+    })
   })
 })

--- a/apps/web/src/pages/artifact/render-stage.tsx
+++ b/apps/web/src/pages/artifact/render-stage.tsx
@@ -172,10 +172,17 @@ export function RenderStage({
   // Arm the stuck-boot timeout while booting; clear it only after meaningful paint.
   // No src yet means no load in flight — don't count seed-wait time against the render.
   useEffect(() => {
-    if (phase !== "booting" || rawSrc == null) return
+    // A specific blocking runtime error already owns recovery. Do not let the
+    // generic timeout later mount a second, overlapping Try again control.
+    if (
+      phase !== "booting" ||
+      rawSrc == null ||
+      (runtimeError && isBlockingRuntimeError(runtimeError))
+    )
+      return
     const t = setTimeout(() => setPhase("failed"), BOOT_TIMEOUT_MS)
     return () => clearTimeout(t)
-  }, [phase, rawSrc])
+  }, [phase, rawSrc, runtimeError])
 
   const handleLoad = () => {
     onFrameLoad?.()
@@ -334,7 +341,7 @@ export function RenderStage({
         )}
 
         {/* Failure — an explicit terminal state with Retry, never a blank frame. */}
-        {phase === "failed" && (
+        {phase === "failed" && disposition !== "blocked" && (
           <div className="absolute inset-0 grid place-items-center bg-background p-6">
             <StatusPanel
               tone="danger"

--- a/apps/web/src/pages/artifact/render-stage.tsx
+++ b/apps/web/src/pages/artifact/render-stage.tsx
@@ -230,6 +230,7 @@ export function RenderStage({
       {/* A warning must never obscure authored content. Keep degraded recovery in
           the stage flow, outside the iframe/cursor coordinate system. */}
       {phase === "ready" &&
+        runtimeError &&
         runtimeFailure &&
         disposition === "degraded" &&
         incidentInstance !== dismissedIncident && (
@@ -245,8 +246,9 @@ export function RenderStage({
               <p className="hidden text-xs text-muted-foreground sm:block">
                 {runtimeFailure.description}
               </p>
-              <p className="mt-0.5 hidden font-mono text-3xs text-muted-foreground sm:block">
-                Reference: {incidentReference}
+              <p className="mt-0.5 truncate font-mono text-3xs text-muted-foreground">
+                {runtimeError.code}
+                <span className="hidden sm:inline"> · Reference: {incidentReference}</span>
               </p>
             </div>
             <div className="flex shrink-0 items-center gap-1">

--- a/apps/web/src/pages/artifact/render-stage.tsx
+++ b/apps/web/src/pages/artifact/render-stage.tsx
@@ -4,10 +4,14 @@ import { Spinner } from "@/components/shared/spinner"
 import { StatusPanel } from "@/components/shared/status-panel"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
-import type { ArtifactRuntimeError } from "./types"
+import {
+  type ArtifactRuntimeError,
+  type ArtifactRuntimeErrorCode,
+  isBlockingRuntimeError,
+} from "./types"
 
-// How long we wait for the sandboxed render to fire `load` before calling it a
-// failed boot. A cache-warm artifact paints in well under a second; this only
+// How long we wait for the sandboxed render to report meaningful content before
+// calling it a failed boot. A cache-warm artifact paints in well under a second; this only
 // catches a genuinely stuck/broken render so the viewer never stares at a blank
 // white frame (NN/g #1 — visibility of system status; the render's own failure
 // must be legible, not indistinguishable from "still loading").
@@ -53,11 +57,34 @@ export const updateCue = (
 
 /** Public copy stays source-free; editors get the one actionable repair for the
  * storage case. The runtime sends only this coarse code, never exception text. */
+export type RuntimeDisposition = "blocked" | "degraded"
+
+/** Resource failures are optional by default. Script/storage failures block only
+ * before meaningful content exists; after ready they degrade without replacing the
+ * last good frame. This is the viewer's small, explicit startup state machine. */
+export const runtimeDisposition = (error: ArtifactRuntimeError): RuntimeDisposition =>
+  isBlockingRuntimeError(error) ? "blocked" : "degraded"
+
 export const runtimeFailureCopy = (
-  error: ArtifactRuntimeError,
+  code: ArtifactRuntimeErrorCode,
+  disposition: RuntimeDisposition,
   canFix: boolean,
 ): { title: string; description: string } => {
-  if (error === "sandbox-storage")
+  if (disposition === "degraded")
+    return canFix
+      ? {
+          title: "Preview kept running after an artifact error",
+          description:
+            code === "resource-error"
+              ? "An optional image, font, or stylesheet failed to load. The rendered content is still available."
+              : "A script failed after meaningful content appeared. The rendered content is still available; check the source before republishing.",
+        }
+      : {
+          title: "Some preview features may be unavailable",
+          description:
+            "The artifact is still visible. You can retry if something looks incomplete.",
+        }
+  if (code === "sandbox-storage")
     return canFix
       ? {
           title: "Browser storage isn’t available here",
@@ -89,6 +116,7 @@ export function RenderStage({
   wrapRef,
   onFrameLoad,
   runtimeError,
+  runtimeReady = false,
   canFixRuntimeError = false,
   banner,
   overlays,
@@ -115,6 +143,8 @@ export function RenderStage({
   onFrameLoad?: () => void
   /** A source-free boot failure relayed by the first-injected sandbox runtime. */
   runtimeError?: ArtifactRuntimeError | null
+  /** The injected runtime found meaningful content, not merely an iframe load. */
+  runtimeReady?: boolean
   /** Editors get repair guidance; readers see a neutral failure. */
   canFixRuntimeError?: boolean
   /** A strip above the render (the past-version banner). */
@@ -130,11 +160,16 @@ export function RenderStage({
   // Boot/failure state is per-source: a new rawSrc (version swap, retry) resets it.
   const [phase, setPhase] = useState<"booting" | "ready" | "failed">("booting")
   const [attempt, setAttempt] = useState(0)
+  // biome-ignore lint/correctness/useExhaustiveDependencies: rawSrc identifies a new iframe document and intentionally resets its startup state.
   useEffect(() => {
     setPhase("booting")
-  }, [])
+  }, [rawSrc])
 
-  // Arm the stuck-boot timeout while booting; clear it the moment the frame loads.
+  useEffect(() => {
+    if (runtimeReady) setPhase("ready")
+  }, [runtimeReady])
+
+  // Arm the stuck-boot timeout while booting; clear it only after meaningful paint.
   // No src yet means no load in flight — don't count seed-wait time against the render.
   useEffect(() => {
     if (phase !== "booting" || rawSrc == null) return
@@ -143,14 +178,21 @@ export function RenderStage({
   }, [phase, rawSrc])
 
   const handleLoad = () => {
-    setPhase("ready")
     onFrameLoad?.()
   }
   const retry = () => {
     setPhase("booting")
     setAttempt((n) => n + 1)
   }
-  const runtimeFailure = runtimeError ? runtimeFailureCopy(runtimeError, canFixRuntimeError) : null
+  const disposition = runtimeError ? runtimeDisposition(runtimeError) : null
+  const runtimeFailure = runtimeError
+    ? runtimeFailureCopy(runtimeError.code, disposition ?? "blocked", canFixRuntimeError)
+    : null
+  const incidentReference = runtimeError
+    ? `${subject}${version == null ? "" : `-v${version}`}-${runtimeError.code}`
+    : null
+  const incidentInstance = incidentReference ? `${incidentReference}-${attempt}` : null
+  const [dismissedIncident, setDismissedIncident] = useState<string | null>(null)
 
   // "Updated" cue: when the shown version steps up IN PLACE (a peer published a new
   // version of the document being watched), flash a soft, non-blocking badge instead
@@ -178,6 +220,44 @@ export function RenderStage({
   return (
     <div className={cn("relative flex min-h-0 flex-1 flex-col", className)}>
       {banner}
+      {/* A warning must never obscure authored content. Keep degraded recovery in
+          the stage flow, outside the iframe/cursor coordinate system. */}
+      {phase === "ready" &&
+        runtimeFailure &&
+        disposition === "degraded" &&
+        incidentInstance !== dismissedIncident && (
+          <div
+            role="status"
+            aria-live="polite"
+            data-testid="render-degraded"
+            className="flex shrink-0 items-center gap-3 border-b border-warning/30 bg-card px-3 py-2"
+          >
+            <Icon name="report" className="size-4 shrink-0 text-warning" strokeWidth={1.75} />
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-medium text-foreground">{runtimeFailure.title}</p>
+              <p className="hidden text-xs text-muted-foreground sm:block">
+                {runtimeFailure.description}
+              </p>
+              <p className="mt-0.5 hidden font-mono text-3xs text-muted-foreground sm:block">
+                Reference: {incidentReference}
+              </p>
+            </div>
+            <div className="flex shrink-0 items-center gap-1">
+              <Button variant="outline" size="sm" data-testid="render-retry" onClick={retry}>
+                Try again
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                aria-label="Dismiss preview warning"
+                data-testid="render-degraded-dismiss"
+                onClick={() => setDismissedIncident(incidentInstance)}
+              >
+                <Icon name="close" size={14} />
+              </Button>
+            </div>
+          </div>
+        )}
       {/* The render fills edge-to-edge; the content card's rounded overflow-hidden
           clips it, and the header above carries its top edge. bg-background (the app
           canvas, NEVER bg-white) is the backdrop the boot state paints on — so a dark
@@ -274,7 +354,7 @@ export function RenderStage({
         {/* The iframe can load successfully while an authored script fails during
             first render. The early runtime relay makes that terminal state explicit
             instead of leaving the artifact's own loading copy on screen forever. */}
-        {phase === "ready" && runtimeFailure && (
+        {runtimeFailure && disposition === "blocked" && (
           <div className="absolute inset-0 z-20 grid place-items-center bg-background p-6">
             <StatusPanel
               tone="danger"

--- a/apps/web/src/pages/artifact/types.ts
+++ b/apps/web/src/pages/artifact/types.ts
@@ -75,7 +75,26 @@ export type FrameGeom = { scrollY: number; docH: number; viewH: number }
 /** A safe, deliberately coarse boot failure reported by the first-injected artifact
  * runtime. Never carries authored source, stack traces, or exception text across the
  * sandbox boundary. */
-export type ArtifactRuntimeError = "sandbox-storage" | "script-error"
+export type ArtifactRuntimeErrorCode = "resource-error" | "sandbox-storage" | "script-error"
+export type ArtifactRuntimePhase = "loading" | "ready"
+export type ArtifactRuntimeError = {
+  code: ArtifactRuntimeErrorCode
+  phase: ArtifactRuntimePhase
+}
+
+export const isBlockingRuntimeError = (error: ArtifactRuntimeError): boolean =>
+  error.code !== "resource-error" && error.phase === "loading"
+
+/** Errors can queue before the iframe handshake and flush together. Never let a
+ * later optional warning downgrade a bootstrap failure that already blocked. */
+export const mergeRuntimeError = (
+  current: ArtifactRuntimeError | null,
+  incoming: ArtifactRuntimeError,
+): ArtifactRuntimeError => {
+  if (current && isBlockingRuntimeError(current) && !isBlockingRuntimeError(incoming))
+    return current
+  return incoming
+}
 
 // The active text selection reported by the sandboxed artifact frame — the W3C
 // selector plus its geometry, used to place the new-comment composer and its

--- a/apps/web/src/pages/artifact/types.ts
+++ b/apps/web/src/pages/artifact/types.ts
@@ -82,6 +82,18 @@ export type ArtifactRuntimeError = {
   phase: ArtifactRuntimePhase
 }
 
+/** Normalize runtime messages from both current and immutable legacy artifacts.
+ * Once the host has observed meaningful content, a missing or stale loading phase
+ * can no longer describe a startup failure: Ready is monotonic for this document. */
+export const normalizeRuntimeError = (
+  code: ArtifactRuntimeErrorCode,
+  phase: unknown,
+  contentReady: boolean,
+): ArtifactRuntimeError => ({
+  code,
+  phase: contentReady || phase === "ready" ? "ready" : "loading",
+})
+
 export const isBlockingRuntimeError = (error: ArtifactRuntimeError): boolean =>
   error.code !== "resource-error" && error.phase === "loading"
 

--- a/apps/web/src/pages/artifact/use-artifact-frame.ts
+++ b/apps/web/src/pages/artifact/use-artifact-frame.ts
@@ -9,6 +9,7 @@ import {
   type Deck,
   type FrameGeom,
   mergeRuntimeError,
+  normalizeRuntimeError,
   type Panel,
   parseAnchor,
   type Selection,
@@ -98,6 +99,10 @@ export function useArtifactFrame(p: {
   const presentWrap = useRef<HTMLDivElement>(null)
   const [frameReady, setFrameReady] = useState(0)
   const [runtimeReady, setRuntimeReady] = useState(false)
+  // The message listener must make the blocking decision synchronously. React state
+  // is intentionally not in its closure, so keep the document's monotonic Ready
+  // boundary in a ref as well as exposing it for rendering.
+  const runtimeReadyRef = useRef(false)
   const [runtimeError, setRuntimeError] = useState<ArtifactRuntimeError | null>(null)
   const [sel, setSel] = useState<Selection>(null)
   const [inDoc, setInDoc] = useState<Record<string, boolean>>({})
@@ -209,6 +214,7 @@ export function useArtifactFrame(p: {
       }
       if (d.source !== "derive") return
       if (d.type === "runtime-ready") {
+        runtimeReadyRef.current = true
         setRuntimeReady(true)
         return
       }
@@ -216,12 +222,10 @@ export function useArtifactFrame(p: {
         d.type === "runtime-error" &&
         (d.code === "resource-error" || d.code === "sandbox-storage" || d.code === "script-error")
       ) {
-        const incoming: ArtifactRuntimeError = {
-          code: d.code,
-          // Older immutable artifact runtimes sent no phase. Preserve their
-          // fail-closed startup behavior instead of guessing that they were ready.
-          phase: d.phase === "ready" ? "ready" : "loading",
-        }
+        // Legacy runtimes omit phase and stale queued messages may still say
+        // loading. They fail closed before readiness, but can never revoke a Ready
+        // boundary the host has already observed for this document.
+        const incoming = normalizeRuntimeError(d.code, d.phase, runtimeReadyRef.current)
         setRuntimeError((current) => mergeRuntimeError(current, incoming))
         return
       }
@@ -478,6 +482,7 @@ export function useArtifactFrame(p: {
     setSel(null)
     setLandedSlides({})
     setAnchorConf({})
+    runtimeReadyRef.current = false
     setRuntimeReady(false)
     setRuntimeError(null)
   }, [shortId, version])
@@ -561,6 +566,7 @@ export function useArtifactFrame(p: {
     // (pins go unlocated/invisible until the new doc reports) instead of pinning
     // stale cards over the new document.
     onFrameLoad: () => {
+      runtimeReadyRef.current = false
       setRuntimeReady(false)
       setRuntimeError(null)
       updateGeom({ scrollY: 0, docH: 0, viewH: 0 })

--- a/apps/web/src/pages/artifact/use-artifact-frame.ts
+++ b/apps/web/src/pages/artifact/use-artifact-frame.ts
@@ -8,6 +8,7 @@ import {
   type ArtifactRuntimeError,
   type Deck,
   type FrameGeom,
+  mergeRuntimeError,
   type Panel,
   parseAnchor,
   type Selection,
@@ -96,6 +97,7 @@ export function useArtifactFrame(p: {
   onVisualPinRef.current = p.onVisualPin
   const presentWrap = useRef<HTMLDivElement>(null)
   const [frameReady, setFrameReady] = useState(0)
+  const [runtimeReady, setRuntimeReady] = useState(false)
   const [runtimeError, setRuntimeError] = useState<ArtifactRuntimeError | null>(null)
   const [sel, setSel] = useState<Selection>(null)
   const [inDoc, setInDoc] = useState<Record<string, boolean>>({})
@@ -206,11 +208,21 @@ export function useArtifactFrame(p: {
         return
       }
       if (d.source !== "derive") return
+      if (d.type === "runtime-ready") {
+        setRuntimeReady(true)
+        return
+      }
       if (
         d.type === "runtime-error" &&
-        (d.code === "sandbox-storage" || d.code === "script-error")
+        (d.code === "resource-error" || d.code === "sandbox-storage" || d.code === "script-error")
       ) {
-        setRuntimeError(d.code)
+        const incoming: ArtifactRuntimeError = {
+          code: d.code,
+          // Older immutable artifact runtimes sent no phase. Preserve their
+          // fail-closed startup behavior instead of guessing that they were ready.
+          phase: d.phase === "ready" ? "ready" : "loading",
+        }
+        setRuntimeError((current) => mergeRuntimeError(current, incoming))
         return
       }
       // The opaque-origin artifact cannot carry the viewer's cookies, so its tiny
@@ -466,6 +478,8 @@ export function useArtifactFrame(p: {
     setSel(null)
     setLandedSlides({})
     setAnchorConf({})
+    setRuntimeReady(false)
+    setRuntimeError(null)
   }, [shortId, version])
   // A slide flip toggles element visibility without a scroll or resize, so the
   // frame won't re-measure on its own — ping it to re-report highlight rects so the
@@ -547,6 +561,7 @@ export function useArtifactFrame(p: {
     // (pins go unlocated/invisible until the new doc reports) instead of pinning
     // stale cards over the new document.
     onFrameLoad: () => {
+      setRuntimeReady(false)
       setRuntimeError(null)
       updateGeom({ scrollY: 0, docH: 0, viewH: 0 })
       setAnchorTops({})
@@ -570,5 +585,6 @@ export function useArtifactFrame(p: {
     anchorTops,
     subscribeGeom,
     runtimeError,
+    runtimeReady,
   }
 }

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -3,11 +3,13 @@ import { AppBoot } from "./components/shared/app-boot"
 import { RouteError, RouteNotFound } from "./components/shared/route-error"
 import { PENDING } from "./lib/pending"
 import { queryClient } from "./lib/query-client"
+import { installViewTransitionErrorHandling } from "./lib/view-transition"
 import { routeTree } from "./routeTree.gen"
 
 // TanStack Start calls getRouter() to build the client router. Route tree is
 // generated from src/routes/* by the Start vite plugin.
 export function getRouter() {
+  installViewTransitionErrorHandling()
   return createRouter({
     routeTree,
     scrollRestoration: true,

--- a/packages/core/src/shared-state-client.ts
+++ b/packages/core/src/shared-state-client.ts
@@ -18,19 +18,44 @@ export const SHARED_STATE_CLIENT_JS = `(function () {
 
   // The load event is too late to be the only readiness signal. Image error handlers run
   // while the document is still loading, after an app may already have painted a
-  // complete table or dashboard. Treat an explicit author marker, a semantic root,
-  // or a non-trivial body as meaningful content so an optional failure cannot hide
-  // a usable artifact behind the host's startup card.
+  // complete table or dashboard. Treat an explicit author marker, visible rich content,
+  // or a non-trivial visible body as meaningful so an optional failure cannot hide a
+  // usable artifact behind the host's startup card. Hidden nodes and source text never
+  // count: they give the viewer nothing usable to preserve.
+  function isVisiblyRendered(element) {
+    if (!element || element.hidden) return false;
+    try {
+      if (element.getAttribute && element.getAttribute("aria-hidden") === "true") return false;
+      if (typeof window.getComputedStyle === "function") {
+        var style = window.getComputedStyle(element);
+        if (style && (
+          style.display === "none" ||
+          style.visibility === "hidden" ||
+          style.visibility === "collapse" ||
+          style.opacity === "0"
+        )) return false;
+      }
+      if (typeof element.getClientRects === "function" && element.getClientRects().length === 0)
+        return false;
+    } catch (_) { /* structural checks and visible text remain as fallbacks */ }
+    return true;
+  }
   function hasMeaningfulContent() {
     try {
       var doc = window.document, body = doc && doc.body;
       if (!body) return false;
-      if (body.querySelector && body.querySelector("[data-derive-ready]")) return true;
-      var richContent = body.querySelectorAll
-        ? body.querySelectorAll("table,canvas,svg,video").length
-        : 0;
-      var text = String(body.innerText || body.textContent || "").replace(/\\s+/g, "");
-      return Number(body.childElementCount || 0) > 0 && (richContent > 0 || text.length >= 80);
+      var marker = body.querySelector && body.querySelector("[data-derive-ready]");
+      if (isVisiblyRendered(marker)) return true;
+      var rich = body.querySelectorAll ? body.querySelectorAll("table,canvas,svg,video") : [];
+      var richContent = false;
+      for (var i = 0; i < Number(rich.length || 0); i += 1) {
+        if (isVisiblyRendered(rich[i])) { richContent = true; break; }
+      }
+      // innerText is layout-aware and omits script/style/hidden descendants. Falling
+      // back to textContent made a long inline script look like visible authored copy.
+      var visibleText = typeof body.innerText === "string" ? body.innerText : "";
+      var text = String(visibleText).replace(/\\s+/g, "");
+      return Number(body.childElementCount || 0) > 0 && (richContent || text.length >= 80);
     } catch (_) {
       return false;
     }

--- a/packages/core/src/shared-state-client.ts
+++ b/packages/core/src/shared-state-client.ts
@@ -35,21 +35,53 @@ export const SHARED_STATE_CLIENT_JS = `(function () {
           style.opacity === "0"
         )) return false;
       }
-      if (typeof element.getClientRects === "function" && element.getClientRects().length === 0)
-        return false;
+      if (typeof element.getClientRects === "function") {
+        var rects = element.getClientRects();
+        if (!rects.length) return false;
+        var hasArea = false;
+        for (var r = 0; r < rects.length; r += 1) {
+          if (Number(rects[r].width || 0) > 0 && Number(rects[r].height || 0) > 0) {
+            hasArea = true;
+            break;
+          }
+        }
+        if (!hasArea) return false;
+      }
+      if (String(element.tagName || "").toLowerCase() === "img" &&
+          (!element.complete || Number(element.naturalWidth || 0) <= 0 ||
+           Number(element.naturalHeight || 0) <= 0)) return false;
     } catch (_) { /* structural checks and visible text remain as fallbacks */ }
     return true;
+  }
+  function runtimeRoots(body) {
+    var roots = [body];
+    for (var at = 0; at < roots.length; at += 1) {
+      var root = roots[at];
+      var elements = root && root.querySelectorAll ? root.querySelectorAll("*") : [];
+      for (var i = 0; i < Number(elements.length || 0); i += 1) {
+        var shadow = elements[i] && elements[i].shadowRoot;
+        if (shadow && roots.indexOf(shadow) < 0) roots.push(shadow);
+      }
+    }
+    return roots;
   }
   function hasMeaningfulContent() {
     try {
       var doc = window.document, body = doc && doc.body;
       if (!body) return false;
-      var marker = body.querySelector && body.querySelector("[data-derive-ready]");
-      if (isVisiblyRendered(marker)) return true;
-      var rich = body.querySelectorAll ? body.querySelectorAll("table,canvas,svg,video") : [];
       var richContent = false;
-      for (var i = 0; i < Number(rich.length || 0); i += 1) {
-        if (isVisiblyRendered(rich[i])) { richContent = true; break; }
+      var roots = runtimeRoots(body);
+      for (var r = 0; r < roots.length && !richContent; r += 1) {
+        var markers = roots[r].querySelectorAll
+          ? roots[r].querySelectorAll("[data-derive-ready]") : [];
+        for (var m = 0; m < Number(markers.length || 0); m += 1) {
+          if (isVisiblyRendered(markers[m])) return true;
+        }
+        var rich = roots[r].querySelectorAll
+          ? roots[r].querySelectorAll("table,canvas,svg,video,img") : [];
+        for (var i = 0; i < Number(rich.length || 0); i += 1) {
+          if (isVisiblyRendered(rich[i])) { richContent = true; break; }
+        }
       }
       // innerText is layout-aware and omits script/style/hidden descendants. Falling
       // back to textContent made a long inline script look like visible authored copy.

--- a/packages/core/src/shared-state-client.ts
+++ b/packages/core/src/shared-state-client.ts
@@ -13,7 +13,28 @@ export const SHARED_STATE_CLIENT_JS = `(function () {
   var states = Object.create(null), pending = Object.create(null), queued = [], seq = 0;
   var keyPattern = new RegExp(${JSON.stringify(SHARED_STATE_KEY_PATTERN)});
   var ready = false;
-  var booting = true;
+  var contentReady = false;
+  var reported = Object.create(null);
+
+  // The load event is too late to be the only readiness signal. Image error handlers run
+  // while the document is still loading, after an app may already have painted a
+  // complete table or dashboard. Treat an explicit author marker, a semantic root,
+  // or a non-trivial body as meaningful content so an optional failure cannot hide
+  // a usable artifact behind the host's startup card.
+  function hasMeaningfulContent() {
+    try {
+      var doc = window.document, body = doc && doc.body;
+      if (!body) return false;
+      if (body.querySelector && body.querySelector("[data-derive-ready]")) return true;
+      var richContent = body.querySelectorAll
+        ? body.querySelectorAll("table,canvas,svg,video").length
+        : 0;
+      var text = String(body.innerText || body.textContent || "").replace(/\\s+/g, "");
+      return Number(body.childElementCount || 0) > 0 && (richContent > 0 || text.length >= 80);
+    } catch (_) {
+      return false;
+    }
+  }
 
   function runtimeErrorCode(error, message) {
     var text = String(message || (error && error.message) || "").toLowerCase();
@@ -21,17 +42,44 @@ export const SHARED_STATE_CLIENT_JS = `(function () {
       ? "sandbox-storage"
       : "script-error";
   }
-  function reportBootError(error, message) {
-    if (!booting) return;
-    send({ type: "runtime-error", code: runtimeErrorCode(error, message) });
+  function announceReady() {
+    if (contentReady || !hasMeaningfulContent()) return;
+    contentReady = true;
+    send({ type: "runtime-ready" });
+  }
+  function reportRuntimeError(error, message, target) {
+    var tag = target && typeof target.tagName === "string" ? target.tagName.toLowerCase() : "";
+    var resource = target && target !== window && !!tag;
+    // A required external script that never loaded is a bootstrap failure. Other
+    // resource failures are non-critical by default; if they truly prevent paint,
+    // the host's no-content timeout still supplies the blocking recovery state.
+    var code = resource
+      ? (tag === "script" ? "script-error" : "resource-error")
+      : runtimeErrorCode(error, message);
+    announceReady();
+    var phase = contentReady ? "ready" : "loading";
+    var key = code + ":" + phase;
+    if (reported[key]) return;
+    reported[key] = true;
+    send({ type: "runtime-error", code: code, phase: phase });
   }
   window.addEventListener("error", function (event) {
-    reportBootError(event.error, event.message);
-  });
+    reportRuntimeError(event.error, event.message, event.target);
+  }, true);
   window.addEventListener("unhandledrejection", function (event) {
-    reportBootError(event.reason, "");
+    reportRuntimeError(event.reason, "", null);
   });
-  window.addEventListener("load", function () { booting = false; });
+  window.addEventListener("DOMContentLoaded", announceReady);
+  window.addEventListener("load", announceReady);
+  try {
+    if (typeof MutationObserver === "function") {
+      var observer = new MutationObserver(function () {
+        announceReady();
+        if (contentReady) observer.disconnect();
+      });
+      observer.observe(window.document.documentElement, { childList: true, subtree: true });
+    }
+  } catch (_) { /* the lifecycle events remain as the compatibility path */ }
 
   function send(message) {
     message.source = "derive";

--- a/packages/core/src/shared-state-client.ts
+++ b/packages/core/src/shared-state-client.ts
@@ -25,15 +25,43 @@ export const SHARED_STATE_CLIENT_JS = `(function () {
   function isVisiblyRendered(element) {
     if (!element || element.hidden) return false;
     try {
-      if (element.getAttribute && element.getAttribute("aria-hidden") === "true") return false;
-      if (typeof window.getComputedStyle === "function") {
-        var style = window.getComputedStyle(element);
-        if (style && (
-          style.display === "none" ||
-          style.visibility === "hidden" ||
-          style.visibility === "collapse" ||
-          style.opacity === "0"
-        )) return false;
+      var elementRect = typeof element.getBoundingClientRect === "function"
+        ? element.getBoundingClientRect() : null;
+      var current = element;
+      while (current) {
+        if (current.hidden ||
+            (current.getAttribute && current.getAttribute("aria-hidden") === "true")) return false;
+        var tag = String(current.tagName || "").toLowerCase();
+        if (tag === "details" && !current.open) {
+          var summary = current.querySelector && current.querySelector(":scope > summary");
+          if (!summary || (element !== summary && !(summary.contains && summary.contains(element))))
+            return false;
+        }
+        if (typeof window.getComputedStyle === "function") {
+          var style = window.getComputedStyle(current);
+          if (style && (
+            style.display === "none" ||
+            style.visibility === "hidden" ||
+            style.visibility === "collapse" ||
+            Number(style.opacity) <= 0
+          )) return false;
+          var clips = style && /hidden|clip|scroll|auto/.test(
+            String(style.overflow || "") + " " +
+            String(style.overflowX || "") + " " + String(style.overflowY || "")
+          );
+          if (clips && typeof current.getBoundingClientRect === "function") {
+            var clipRect = current.getBoundingClientRect();
+            if (Number(clipRect.width || 0) <= 0 || Number(clipRect.height || 0) <= 0)
+              return false;
+            if (elementRect && (
+              elementRect.right <= clipRect.left || elementRect.left >= clipRect.right ||
+              elementRect.bottom <= clipRect.top || elementRect.top >= clipRect.bottom
+            )) return false;
+          }
+        }
+        var rootNode = !current.parentElement && current.getRootNode
+          ? current.getRootNode() : null;
+        current = current.parentElement || (rootNode && rootNode.host) || null;
       }
       if (typeof element.getClientRects === "function") {
         var rects = element.getClientRects();

--- a/packages/core/src/shared-state-client.ts
+++ b/packages/core/src/shared-state-client.ts
@@ -162,7 +162,12 @@ export const SHARED_STATE_CLIENT_JS = `(function () {
         announceReady();
         if (contentReady) observer.disconnect();
       });
-      observer.observe(window.document.documentElement, { childList: true, subtree: true });
+      observer.observe(window.document.documentElement, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ["style", "class", "hidden", "aria-hidden", "open"]
+      });
     }
   } catch (_) { /* the lifecycle events remain as the compatibility path */ }
 

--- a/packages/core/test/shared-state.test.ts
+++ b/packages/core/test/shared-state.test.ts
@@ -56,13 +56,16 @@ describe("shared-state contract", () => {
     expect(injected.indexOf(SHARED_STATE_SCRIPT)).toBeLessThan(injected.indexOf("boot()"))
   })
 
-  it("relays a source-free boot error before authored scripts can fail silently", () => {
+  it("keeps a source-free boot error blocking after iframe load without content", () => {
     type BrowserListener = (event: Record<string, unknown>) => void
     const sent: RuntimeMessage[] = []
     const listeners = new Map<string, BrowserListener>()
     const parent = { postMessage: (message: RuntimeMessage) => sent.push(message) }
     const frame = {
       derive: undefined as DeriveRuntime | undefined,
+      document: {
+        body: null,
+      },
       addEventListener: (type: string, listener: BrowserListener) => listeners.set(type, listener),
       dispatchEvent: () => true,
     }
@@ -86,11 +89,119 @@ describe("shared-state contract", () => {
       source: parent,
       data: { source: "derive-host", type: "shared-ready" },
     })
-    expect(sent).toEqual([{ source: "derive", type: "runtime-error", code: "sandbox-storage" }])
+    expect(sent).toEqual([
+      {
+        source: "derive",
+        type: "runtime-error",
+        code: "sandbox-storage",
+        phase: "loading",
+      },
+    ])
 
     listeners.get("load")?.({})
     listeners.get("error")?.({ error: { message: "late click handler failed" } })
-    expect(sent).toHaveLength(1) // only first-render failures replace the artifact
+    expect(sent.at(-1)).toMatchObject({
+      source: "derive",
+      type: "runtime-error",
+      code: "script-error",
+      phase: "loading",
+    })
+  })
+
+  it("classifies a fallback exception after meaningful paint as fail-soft", () => {
+    type BrowserListener = (event: Record<string, unknown>) => void
+    const sent: RuntimeMessage[] = []
+    const listeners = new Map<string, BrowserListener>()
+    const parent = { postMessage: (message: RuntimeMessage) => sent.push(message) }
+    const frame = {
+      derive: undefined as DeriveRuntime | undefined,
+      document: {
+        body: {
+          childElementCount: 1,
+          innerText:
+            "Thirty rendered rows remain useful even when an optional logo fallback fails. ".repeat(
+              2,
+            ),
+          querySelector: () => null,
+          querySelectorAll: () => ({ length: 1 }),
+        },
+      },
+      addEventListener: (type: string, listener: BrowserListener) => listeners.set(type, listener),
+      dispatchEvent: () => true,
+    }
+    const CustomEventStub = class {
+      constructor(
+        readonly type: string,
+        readonly init?: unknown,
+      ) {}
+    }
+    const load = Function("window", "parent", "CustomEvent", SHARED_STATE_CLIENT_JS) as (
+      frame: typeof frame,
+      parent: typeof parent,
+      event: typeof CustomEventStub,
+    ) => void
+    load(frame, parent, CustomEventStub)
+
+    listeners.get("error")?.({
+      error: { message: "Cannot set properties of null" },
+      message: "Cannot set properties of null",
+      target: frame,
+    })
+    listeners.get("message")?.({
+      source: parent,
+      data: { source: "derive-host", type: "shared-ready" },
+    })
+    expect(sent).toEqual([
+      {
+        source: "derive",
+        type: "runtime-ready",
+      },
+      {
+        source: "derive",
+        type: "runtime-error",
+        code: "script-error",
+        phase: "ready",
+      },
+    ])
+  })
+
+  it("does not mistake an empty semantic app shell for meaningful content", () => {
+    type BrowserListener = (event: Record<string, unknown>) => void
+    const sent: RuntimeMessage[] = []
+    const listeners = new Map<string, BrowserListener>()
+    const parent = { postMessage: (message: RuntimeMessage) => sent.push(message) }
+    const frame = {
+      derive: undefined as DeriveRuntime | undefined,
+      document: {
+        body: {
+          childElementCount: 1,
+          innerText: "Loading…",
+          querySelector: () => null,
+          querySelectorAll: () => ({ length: 0 }),
+        },
+      },
+      addEventListener: (type: string, listener: BrowserListener) => listeners.set(type, listener),
+      dispatchEvent: () => true,
+    }
+    const CustomEventStub = class {
+      constructor(
+        readonly type: string,
+        readonly init?: unknown,
+      ) {}
+    }
+    const load = Function("window", "parent", "CustomEvent", SHARED_STATE_CLIENT_JS) as (
+      frame: typeof frame,
+      parent: typeof parent,
+      event: typeof CustomEventStub,
+    ) => void
+    load(frame, parent, CustomEventStub)
+
+    listeners.get("error")?.({ error: { message: "boot failed" }, message: "boot failed" })
+    listeners.get("message")?.({
+      source: parent,
+      data: { source: "derive-host", type: "shared-ready" },
+    })
+    expect(sent.at(-1)).toMatchObject({ code: "script-error", phase: "loading" })
   })
 
   it("loads state, emits an atomic update, and applies the host result", async () => {
@@ -101,6 +212,9 @@ describe("shared-state contract", () => {
     const parent = { postMessage: (message: RuntimeMessage) => sent.push(message) }
     const frame = {
       derive: undefined as DeriveRuntime | undefined,
+      document: {
+        body: null,
+      },
       addEventListener: (type: string, listener: MessageListener) => {
         if (type === "message") receive = listener
       },

--- a/packages/core/test/shared-state.test.ts
+++ b/packages/core/test/shared-state.test.ts
@@ -204,6 +204,55 @@ describe("shared-state contract", () => {
     expect(sent.at(-1)).toMatchObject({ code: "script-error", phase: "loading" })
   })
 
+  it("excludes hidden markers, hidden rich nodes, and source text from readiness", () => {
+    type BrowserListener = (event: Record<string, unknown>) => void
+    const sent: RuntimeMessage[] = []
+    const listeners = new Map<string, BrowserListener>()
+    const parent = { postMessage: (message: RuntimeMessage) => sent.push(message) }
+    const hidden = { hidden: true }
+    const frame = {
+      derive: undefined as DeriveRuntime | undefined,
+      document: {
+        body: {
+          childElementCount: 3,
+          innerText: "Loading…",
+          textContent:
+            "A deliberately long inline script source that exceeds the old readiness threshold but renders nothing useful to a viewer.",
+          querySelector: () => hidden,
+          querySelectorAll: () => ({ 0: hidden, length: 1 }),
+        },
+      },
+      addEventListener: (type: string, listener: BrowserListener) => listeners.set(type, listener),
+      dispatchEvent: () => true,
+    }
+    const CustomEventStub = class {
+      constructor(
+        readonly type: string,
+        readonly init?: unknown,
+      ) {}
+    }
+    const load = Function("window", "parent", "CustomEvent", SHARED_STATE_CLIENT_JS) as (
+      frame: typeof frame,
+      parent: typeof parent,
+      event: typeof CustomEventStub,
+    ) => void
+    load(frame, parent, CustomEventStub)
+
+    listeners.get("error")?.({ error: { message: "boot failed" }, message: "boot failed" })
+    listeners.get("message")?.({
+      source: parent,
+      data: { source: "derive-host", type: "shared-ready" },
+    })
+    expect(sent).toEqual([
+      {
+        source: "derive",
+        type: "runtime-error",
+        code: "script-error",
+        phase: "loading",
+      },
+    ])
+  })
+
   it("loads state, emits an atomic update, and applies the host result", async () => {
     const sent: RuntimeMessage[] = []
     let receive: MessageListener = () => {


### PR DESCRIPTION
## Summary

- replace iframe-load readiness with a meaningful-content handshake and monotonic Loading → Ready/Degraded/Blocked state
- preserve usable frames for optional/post-ready failures while keeping bootstrap, storage, security, integrity, and authorization failures closed
- require genuinely visible content: no hidden/source-only/zero-area/clipped/failed-media false readiness; support open shadow roots and loaded images
- evaluate the full ancestor chain and visibility-relevant mutations, including automatic recovery after the generic timeout
- keep recovery singular and content-preserving across dismiss, reload, repeated Retry, mobile diagnostics, and cross-artifact navigation
- ignore nested-frame protocol spoofing and prevent stale/optional errors from downgrading fatal state or revoking Ready

## Self-learning loop

- exactly five fresh cases per iteration; any product finding reset the clean streak even after repair
- iterations 8–11 found and repaired visibility, geometry/media, mobile diagnostic, ancestor, and late-mutation gaps
- iterations 12 and 13 were consecutive clean five-case iterations: **2/2 stop condition met**
- accumulated startup contract: **44/44 cases passing**
- Luna real-Chrome dogfood: public wrapper, authenticated workbench, and recovery lanes across desktop + 390×844 mobile; zero final wrapper page errors

## Derive evidence

- [Incident and fix plan](https://derive.to/artifacts/derive-viewer-startup-resilience-incident-and-fi-y0ds8srs)
- [Completed self-learning loop](https://derive.to/artifacts/derive-viewer-startup-resilience-self-learning-l-t1jw0tzs)
- [Versioned QA run log](https://derive.to/artifacts/derive-viewer-startup-resilience-self-learning-r-9eqtax66)
- [Reusable 44-case QA procedure](https://derive.to/artifacts/derive-viewer-startup-resilience-self-learning-q-3aqrbnae)

## Verification

- `pnpm run ci` — 34/34 guardrails
- full workspace typecheck — pass
- unit tests — 2,517 passing
- render-fidelity E2E — 40/40 passing, including the complete expanded startup matrix and existing CSP tiers
- affected pre-push verification — pass on final commit `49974d97`
- GitHub CI, tests, DB, preview, accessibility, CodeQL, and image checks — green; render-fidelity final run pending/monitored

No merge or production deployment is included.
