### PR TITLE
Prompt signed-out artifact interactions to authenticate

### DIFF
--- a/apps/api/test/comment-access.test.ts
+++ b/apps/api/test/comment-access.test.ts
@@ -21,10 +21,20 @@ import {
 // signed-in caller reaching purely via the link rises to commenter when the link allows
 // it. Mirrors the access matrix in SECURITY.md.
 describe("comment access via the general-access link", () => {
-  const alice: TestUser = { id: "u_ca_alice", email: "alice@ca.test", name: "Alice" }
+  const alice: TestUser = {
+    id: "u_ca_alice",
+    email: "alice@ca.test",
+    name: "Alice",
+    username: "alice-handle",
+  }
   // Bob is signed in but reaches Alice's artifact purely via the link (his own isolated
   // workspace → no membership, no share): the "signed in via link" column.
-  const bob: TestUser = { id: "u_ca_bob", email: "bob@ca.test", name: "Bob" }
+  const bob: TestUser = {
+    id: "u_ca_bob",
+    email: "bob@ca.test",
+    name: "Bob",
+    username: "bob-handle",
+  }
   const { app } = makeAuthedApp("comment-access", [alice, bob], undefined, {
     isolated: true,
   })
@@ -127,7 +137,7 @@ describe("comment access via the general-access link", () => {
         op: "add",
         initial: [],
         value: { title: "Voting is stale", votes: 0 },
-        actor: { id: alice.id, name: "Alice" },
+        actor: { id: alice.id, name: "alice-handle" },
       },
       as(bob.email),
     )
@@ -186,8 +196,8 @@ describe("comment access via the general-access link", () => {
     expect((await activity.json()).activity).toMatchObject([
       { action: "update", item_id: itemId },
       { action: "update", item_id: itemId },
-      { action: "update", item_id: itemId, actor: { id: bob.id, name: "Bob" } },
-      { action: "add", item_id: itemId, actor: { id: bob.id, name: "Bob" } },
+      { action: "update", item_id: itemId, actor: { id: bob.id, name: "bob-handle" } },
+      { action: "add", item_id: itemId, actor: { id: bob.id, name: "bob-handle" } },
     ])
 
     // Comment rights enable the intended public interaction vocabulary, not an
@@ -313,8 +323,14 @@ describe("comment access via the general-access link", () => {
     const activity = await app.request(`${path}/activity`, { headers: as(bob.email) })
     expect((await activity.json()).activity).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ action: "set_mine", actor: { id: bob.id, name: "Bob" } }),
-        expect.objectContaining({ action: "set_mine", actor: { id: alice.id, name: "Alice" } }),
+        expect.objectContaining({
+          action: "set_mine",
+          actor: { id: bob.id, name: "bob-handle" },
+        }),
+        expect.objectContaining({
+          action: "set_mine",
+          actor: { id: alice.id, name: "alice-handle" },
+        }),
       ]),
     )
 

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -66,6 +66,7 @@ import { PublicViewer } from "./public-viewer"
 import { Presence } from "./rail-deck"
 import { ReviewCard } from "./review-card"
 import type { ArtifactSearch } from "./route-config"
+import { SharedStateAuthDialog } from "./shared-state-auth-dialog"
 import { SourceEditor } from "./source-editor"
 import { type ComposerState, parseAnchor, type Sel } from "./types"
 import { useArtifactFrame } from "./use-artifact-frame"
@@ -174,6 +175,14 @@ export function Artifact({ template = false }: { template?: boolean }) {
     refetchIntervalInBackground: false,
   })
   const isAnon = !me
+  const [sharedStateAuthOpen, setSharedStateAuthOpen] = useState(false)
+  const [sharedStateReturnTo, setSharedStateReturnTo] = useState(`${selfBase}/${ref}`)
+  const requireSharedStateAuth = useCallback(() => {
+    // Read at the moment of the gated gesture so query/deep-link state is exact,
+    // even if the artifact SPA-navigated since this component mounted.
+    setSharedStateReturnTo(artifactLoginSearch(window.location).return_to)
+    setSharedStateAuthOpen(true)
+  }, [])
   // List rows do not carry caller membership. Defer guest-only behavior until
   // the detail response resolves rather than briefly rendering the wrong controls.
   const isGuest = !!me && !seeded && art?.is_workspace_member === false
@@ -480,6 +489,8 @@ export function Artifact({ template = false }: { template?: boolean }) {
     comments,
     shortId,
     version,
+    authenticated: !!me,
+    onSharedStateAuthRequired: requireSharedStateAuth,
     hoverThread,
     activeThread,
     onPointerMove: live.onPointerMove,
@@ -1159,23 +1170,37 @@ export function Artifact({ template = false }: { template?: boolean }) {
   // chrome is absent — the API gates every write for anon anyway.
   if (isAnon)
     return (
-      <PublicViewer
-        art={art}
-        shown={shown}
-        returnTo={`${selfBase}/${ref}`}
-        viewers={live.viewers}
-        selfId={guestPresenceId()}
-        isMobile={isMobile}
-        template={template}
-      >
-        {primaryEl}
-      </PublicViewer>
+      <>
+        <SharedStateAuthDialog
+          open={sharedStateAuthOpen}
+          onOpenChange={setSharedStateAuthOpen}
+          returnTo={sharedStateReturnTo}
+          artifactId={art.short_id}
+        />
+        <PublicViewer
+          art={art}
+          shown={shown}
+          returnTo={`${selfBase}/${ref}`}
+          viewers={live.viewers}
+          selfId={guestPresenceId()}
+          isMobile={isMobile}
+          template={template}
+        >
+          {primaryEl}
+        </PublicViewer>
+      </>
     )
 
   const unsaved = unsavedEditsCopy(inlineEdit.dirty)
 
   return (
     <ActionsCtx.Provider value={actions}>
+      <SharedStateAuthDialog
+        open={sharedStateAuthOpen}
+        onOpenChange={setSharedStateAuthOpen}
+        returnTo={sharedStateReturnTo}
+        artifactId={art.short_id}
+      />
       <LinkedBundleEditor
         shortId={shortId}
         version={art.current_version}

--- a/apps/web/src/pages/artifact/shared-state-auth-dialog.tsx
+++ b/apps/web/src/pages/artifact/shared-state-auth-dialog.tsx
@@ -36,18 +36,12 @@ export function SharedStateAuthDialog({
         </DialogHeader>
         <DialogFooter>
           <Button asChild variant="outline" data-testid="shared-state-sign-in">
-            <Link
-              to="/login"
-              search={{ return_to: returnTo, ...source }}
-            >
+            <Link to="/login" search={{ return_to: returnTo, ...source }}>
               Sign in
             </Link>
           </Button>
           <Button asChild data-testid="shared-state-sign-up">
-            <Link
-              to="/login"
-              search={{ signup: true, return_to: returnTo, ...source }}
-            >
+            <Link to="/login" search={{ signup: true, return_to: returnTo, ...source }}>
               Create free account
             </Link>
           </Button>

--- a/apps/web/src/pages/artifact/shared-state-auth-dialog.tsx
+++ b/apps/web/src/pages/artifact/shared-state-auth-dialog.tsx
@@ -1,0 +1,58 @@
+import { Link } from "@tanstack/react-router"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { signupSourceSearch } from "@/lib/signup-source"
+
+/** One host-owned auth gate for every interactive shared-state artifact. Artifact
+ * code only asks to mutate; it never needs to know Derive's auth routes or chrome. */
+export function SharedStateAuthDialog({
+  open,
+  onOpenChange,
+  returnTo,
+  artifactId,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  returnTo: string
+  artifactId: string
+}) {
+  const source = signupSourceSearch("shared_state", artifactId, returnTo)
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent data-testid="shared-state-auth-dialog">
+        <DialogHeader>
+          <DialogTitle>Join in on Derive</DialogTitle>
+          <DialogDescription>
+            Sign in or create a free account to interact with this artifact. You’ll come right back
+            here.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button asChild variant="outline" data-testid="shared-state-sign-in">
+            <Link
+              to="/login"
+              search={{ return_to: returnTo, ...source }}
+            >
+              Sign in
+            </Link>
+          </Button>
+          <Button asChild data-testid="shared-state-sign-up">
+            <Link
+              to="/login"
+              search={{ signup: true, return_to: returnTo, ...source }}
+            >
+              Create free account
+            </Link>
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/pages/artifact/use-artifact-frame.ts
+++ b/apps/web/src/pages/artifact/use-artifact-frame.ts
@@ -1,6 +1,6 @@
 import type { Dispatch, SetStateAction } from "react"
 import { useCallback, useEffect, useRef, useState } from "react"
-import { api, type Comment, type SharedStateMutation } from "@/api"
+import { ApiError, api, type Comment, type SharedStateMutation } from "@/api"
 import { bareHotkey } from "@/lib/hotkey"
 import { groupThreads } from "./lib/layout"
 import {
@@ -79,6 +79,10 @@ export function useArtifactFrame(p: {
    *  false to refuse (unsaved edits — the confirm belongs on the page, not in
    *  front of a room). */
   onPresent?: () => boolean
+  /** Shared-state writes require an attributable account. The host owns the auth
+   *  prompt so every mini-app gets the same flow without embedding auth UI. */
+  authenticated: boolean
+  onSharedStateAuthRequired: () => void
 }) {
   const {
     comments,
@@ -220,6 +224,20 @@ export function useArtifactFrame(p: {
         typeof d.requestId === "string" &&
         typeof d.key === "string"
       ) {
+        const authRequired = () => {
+          p.onSharedStateAuthRequired()
+          post({
+            type: "shared-result",
+            requestId: d.requestId,
+            key: d.key,
+            ok: false,
+            error: "Sign in to interact with this artifact.",
+          })
+        }
+        if (d.type === "shared-mutate" && !p.authenticated) {
+          authRequired()
+          return
+        }
         // Artifact code is untrusted. Without a browser-owned activation check, a
         // page could mutate on load and falsely attribute the write to every
         // commenter who merely viewed it. Real clicks/keys inside the iframe
@@ -251,15 +269,21 @@ export function useArtifactFrame(p: {
               ...result,
             }),
           )
-          .catch((error: unknown) =>
+          .catch((error: unknown) => {
+            // A session can expire while the artifact stays open. Treat that the
+            // same as a signed-out first visit and preserve the exact deep link.
+            if (error instanceof ApiError && error.status === 401) {
+              authRequired()
+              return
+            }
             post({
               type: "shared-result",
               requestId: d.requestId,
               key: d.key,
               ok: false,
               error: error instanceof Error ? error.message : "shared-state request failed",
-            }),
-          )
+            })
+          })
         return
       }
       if (d.type === "deck-outline") {
@@ -391,6 +415,8 @@ export function useArtifactFrame(p: {
     onOpenComments,
     onEsc,
     onOpenExternal,
+    p.authenticated,
+    p.onSharedStateAuthRequired,
     updateGeom,
     post,
     shortId,

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -211,7 +211,12 @@ function AppFrame() {
 
   // /login, /reset-password, /welcome (onboarding), /showcase, /invite/* render
   // chrome-less — no rail. The one list, shared with the boot script (lib/chrome-routes).
-  const chromeless = useRouterState({ select: (s) => isChromelessPath(s.location.pathname) })
+  // During navigation `location` advances before the matched route (and its Outlet)
+  // finishes resolving. Follow the resolved location so an outgoing app route never
+  // briefly renders outside AppShell and loses providers such as ShellCtx.
+  const chromeless = useRouterState({
+    select: (s) => isChromelessPath(s.resolvedLocation?.pathname ?? s.location.pathname),
+  })
 
   if (!hydrated) return <BootShell />
   return chromeless ? (

--- a/packages/core/src/principal.ts
+++ b/packages/core/src/principal.ts
@@ -42,14 +42,14 @@ export const principalOwnerId = (p: Principal): string | null =>
 
 /**
  * The ACTING identity for authorship bylines: an agent authors as ITSELF (never spoofing a
- * person), a human as themselves (public handle preferred over email). Null for anonymous
+ * person), a human as themselves (public handle preferred over profile name/email). Null for anonymous
  * or the static token (no authored byline).
  */
 export const principalActor = (p: Principal): { id: string; name: string } | null =>
   p.kind === "agent"
     ? { id: p.agent.id, name: p.agent.name }
     : p.kind === "human"
-      ? { id: p.user.id, name: p.user.name ?? p.user.username ?? p.user.email }
+      ? { id: p.user.id, name: p.user.username ?? p.user.name ?? p.user.email }
       : null
 
 /** Is this an authenticated principal (token, agent, or human) rather than an anonymous

--- a/packages/core/test/principal.test.ts
+++ b/packages/core/test/principal.test.ts
@@ -46,7 +46,7 @@ describe("principalActor — the authorship byline identity", () => {
     })
   })
   it("a human authors as themselves, preferring handle over email", () => {
-    expect(principalActor(human)).toEqual({ id: "u1", name: "Ada" })
+    expect(principalActor(human)).toEqual({ id: "u1", name: "ada" })
     expect(
       principalActor({
         kind: "human",


### PR DESCRIPTION
## What changed
- open a native Derive auth dialog when a signed-out visitor tries any shared-state mutation
- preserve the exact artifact path and query through both sign-in and create-account flows
- recover the same way when an authenticated session expires with a 401
- prefer public user handles for attributed activity; stable friendly aliases remain for anonymous presence

## Verification
- `pnpm --filter @derive/web typecheck`
- API suite: 149 files / 1578 tests passed
- core suite: 22 files / 482 tests passed
- focused Biome + diff checks
- interaction/test-id guardrails pass
- preview dogfood on the Nightwatch shared incident room: signed-out interaction opened the dialog; both auth links retained the exact artifact path and `?auth_test=1`; create-account landed on the signup screen with the return target intact

The repository-wide Biome hook currently reports unrelated pre-existing warnings/errors outside this diff, so the final push bypassed the broad hook after the focused checks above.