### PR TITLE
Fix false artifact runtime failures

### DIFF
--- a/apps/api/src/lib/serve-content.ts
+++ b/apps/api/src/lib/serve-content.ts
@@ -1,6 +1,7 @@
 import {
   type BlobStore,
   type BundleManifest,
+  injectArtifactRuntimeScripts,
   injectSharedStateScript,
   isBundleContentType,
   looksLikeHtmlDocument,
@@ -10,6 +11,7 @@ import {
   reflowHtml,
   renderMarkdown,
   SELECTION_SCRIPT,
+  SHARED_STATE_SCRIPT,
 } from "@derive/core"
 import type { Context } from "hono"
 import { IMMUTABLE_CACHE, RAW_HEADERS, rewriteAbsoluteUrls, toBody } from "./http"
@@ -43,7 +45,7 @@ export const serveContent = async (
    *  serve the document exactly as authored. Never applied to markdown-rendered output,
    *  which is already responsive. */
   reflow = true,
-  /** Append the anchor client (selection → comment, hover chips, live cursors).
+  /** Inject the anchor client (selection → comment, hover chips, live cursors).
    *  It only functions embedded in the app viewer — it talks to the host via
    *  parent.postMessage — so standalone serving (vanity/draft hosts, which are
    *  never iframed by the app) passes false: on a top-level page the client's
@@ -65,11 +67,16 @@ export const serveContent = async (
   // other read.
   const wantsMarks = ["1", "true"].includes(c.req.query("marks") ?? "")
   const marks = wantsMarks ? MARKS_SCRIPT : ""
-  const anchorClient = anchors ? SELECTION_SCRIPT : ""
+  const withRuntime = anchors
+    ? (doc: string) => injectArtifactRuntimeScripts(doc, SHARED_STATE_SCRIPT + SELECTION_SCRIPT)
+    : (doc: string) => doc
+  // renderMarkdown already carries SELECTION_SCRIPT in its generated shell, so it
+  // needs only the early shared-state runtime. Injecting the full pair would execute
+  // the anchor client twice.
   const withSharedState = anchors ? injectSharedStateScript : (doc: string) => doc
-  // Produce the final HTML body for a document: auto-reflow, then append the anchor
-  // client (for comment anchoring + live cursors) and, when asked, the marks overlay.
-  const htmlBody = (doc: string): string => withSharedState(rf(doc)) + anchorClient + marks + append
+  // Runtime scripts precede authored meta CSP and execute in parse-safe order. Marks and
+  // route-specific chrome remain appended because they are optional DOM enhancements.
+  const htmlBody = (doc: string): string => withRuntime(rf(doc)) + marks + append
   let path = rawPath
   if (isBundleContentType(content.content_type)) {
     const manifestBytes = await blobs.get(content.blob_key)
@@ -91,7 +98,7 @@ export const serveContent = async (
       const rewritten = rewriteAbsoluteUrls(new TextDecoder().decode(data), prefix.slice(0, -1))
       // Bundle pages get the anchor client too — comments stick everywhere.
       const out = entry.type.startsWith("text/html")
-        ? withSharedState(rf(rewritten)) + anchorClient + marks + append
+        ? withRuntime(rf(rewritten)) + marks + append
         : rewritten
       return c.body(out, 200, { ...headers, "Content-Type": entry.type })
     }

--- a/apps/api/test/serve-content.test.ts
+++ b/apps/api/test/serve-content.test.ts
@@ -40,7 +40,7 @@ const expectSandbox = (res: Response, cache: string = IMMUTABLE) => {
   expect(res.headers.get("cache-control")).toBe(cache)
 }
 
-const SCRIPT = "/raw/derive-client.js" // the appended anchor client (SELECTION_SCRIPT)
+const SCRIPT = "/raw/derive-client.js"
 const SHARED = "/raw/derive-shared.js"
 
 describe("serveContent — single-file artifacts", () => {
@@ -58,11 +58,31 @@ describe("serveContent — single-file artifacts", () => {
     const body = await res.text()
     expect(body).toContain("<h1>Hi</h1>")
     expect(body).toContain(SCRIPT)
-    // The shared-state API is available before any artifact-authored script runs;
-    // the DOM-dependent anchor client deliberately remains appended at the end.
+    // Both platform runtimes are available even when an authored meta CSP follows.
+    // The DOM-dependent client is deferred until parsing completes.
     expect(body).toContain(SHARED)
     expect(body.indexOf(SHARED)).toBeLessThan(body.indexOf("<h1>Hi</h1>"))
+    expect(body.indexOf(SCRIPT)).toBeLessThan(body.indexOf("<h1>Hi</h1>"))
+    expect(body).toContain('<script defer src="/raw/derive-client.js"></script>')
     expectSandbox(res)
+  })
+
+  it("loads Derive's runtimes before an authored meta CSP", async () => {
+    const authoredCsp = `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src https://unpkg.com">`
+    const res = await serveContent(
+      ctx(),
+      blobStore({
+        k: `<!doctype html><html><head>${authoredCsp}</head><body><h1>Visible</h1></body></html>`,
+      }),
+      { blob_key: "k", content_type: "text/html" },
+      "CSP document",
+      "/",
+      "",
+    )
+    const body = await res.text()
+    expect(body.indexOf("charset=utf-8")).toBeLessThan(body.indexOf(SHARED))
+    expect(body.indexOf(SHARED)).toBeLessThan(body.indexOf(authoredCsp))
+    expect(body.indexOf(SCRIPT)).toBeLessThan(body.indexOf(authoredCsp))
   })
 
   it("renders markdown to HTML", async () => {
@@ -78,6 +98,7 @@ describe("serveContent — single-file artifacts", () => {
     const body = await res.text()
     expect(body).toContain("<h1")
     expect(body).toContain(SCRIPT)
+    expect(body.match(/\/raw\/derive-client\.js/g)).toHaveLength(1)
     expect(body).toContain(SHARED)
   })
 

--- a/apps/web/e2e/render-fidelity/fixtures/startup-csp-visualization-shell.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-csp-visualization-shell.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'none'; script-src 'unsafe-inline' https://unpkg.com; style-src 'unsafe-inline'; frame-src 'self'; object-src 'none'; base-uri 'none'"
+    />
+    <title>Visualization shell with authored CSP</title>
+    <style>
+      html,
+      body,
+      iframe {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        border: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <iframe
+      sandbox="allow-scripts"
+      title="Generated visualization"
+      srcdoc="&lt;!doctype html&gt;&lt;html&gt;&lt;body&gt;&lt;h1&gt;Generated visualization remains visible&lt;/h1&gt;&lt;/body&gt;&lt;/html&gt;"
+    ></iframe>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/render-fidelity.spec.ts
+++ b/apps/web/e2e/render-fidelity/render-fidelity.spec.ts
@@ -35,6 +35,23 @@ async function withErrorCapture(page: Page, fn: () => Promise<void>): Promise<st
 }
 
 test.describe("render fidelity — pinning what the sandbox CSP permits", () => {
+  test("an iframe-based visualization with an authored CSP reaches Ready", async ({
+    owner: page,
+  }) => {
+    const html = readFileSync(join(FIXTURES, "startup-csp-visualization-shell.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+
+    const errors = await withErrorCapture(page, () => page.goto(`/artifacts/${shortId}`))
+    expect(errors).toEqual([])
+    await expect(page.getByTestId("render-degraded")).toHaveCount(0)
+    await expect(page.getByText("This artifact couldn’t start")).toHaveCount(0)
+    const artifact = page.frameLocator('iframe[title="index"]')
+    const generated = artifact.frameLocator('iframe[title="Generated visualization"]')
+    await expect(
+      generated.getByRole("heading", { name: "Generated visualization remains visible" }),
+    ).toBeVisible()
+  })
+
   test("viewer fails closed when a script throws before meaningful content", async ({
     browser,
     owner: page,

--- a/packages/core/src/anchor.ts
+++ b/packages/core/src/anchor.ts
@@ -435,8 +435,10 @@ export function mentionText(html: string): string {
 // scripts/build-anchor-client.mjs; CI keeps the generated file in sync (check-anchor-client).
 export { ANCHOR_CLIENT_JS } from "./anchor-client.gen"
 
-/** The tag appended to served artifact HTML; resolves on any host. */
-export const SELECTION_SCRIPT = `<script src="/raw/derive-client.js"></script>`
+/** The DOM-dependent artifact client. Full HTML artifacts inject this at the start of
+ * the document so an authored meta CSP cannot block Derive's own runtime; `defer` keeps
+ * execution after parsing. Generated markdown can safely leave the same tag in <body>. */
+export const SELECTION_SCRIPT = `<script defer src="/raw/derive-client.js"></script>`
 
 /**
  * Page content for anchor resolution. A bare string treats it as BOTH the markup

--- a/packages/core/src/shared-state-client.ts
+++ b/packages/core/src/shared-state-client.ts
@@ -106,7 +106,7 @@ export const SHARED_STATE_CLIENT_JS = `(function () {
           if (isVisiblyRendered(markers[m])) return true;
         }
         var rich = roots[r].querySelectorAll
-          ? roots[r].querySelectorAll("table,canvas,svg,video,img") : [];
+          ? roots[r].querySelectorAll("table,canvas,svg,video,img,iframe[src],iframe[srcdoc]") : [];
         for (var i = 0; i < Number(rich.length || 0); i += 1) {
           if (isVisiblyRendered(rich[i])) { richContent = true; break; }
         }
@@ -127,14 +127,29 @@ export const SHARED_STATE_CLIENT_JS = `(function () {
       ? "sandbox-storage"
       : "script-error";
   }
+  function isPlatformScript(source) {
+    var value = String(source || "");
+    var suffixAt = value.search(/[?#]/);
+    var bare = suffixAt < 0 ? value : value.slice(0, suffixAt);
+    var shared = "/raw/derive-shared.js";
+    var client = "/raw/derive-client.js";
+    var beacon = "https://static.cloudflareinsights.com/beacon.min.js";
+    return bare.slice(-shared.length) === shared || bare.slice(-client.length) === client ||
+      bare === beacon || bare.indexOf(beacon + "/") === 0;
+  }
   function announceReady() {
     if (contentReady || !hasMeaningfulContent()) return;
     contentReady = true;
     send({ type: "runtime-ready" });
   }
-  function reportRuntimeError(error, message, target) {
+  function reportRuntimeError(error, message, target, filename) {
     var tag = target && typeof target.tagName === "string" ? target.tagName.toLowerCase() : "";
     var resource = target && target !== window && !!tag;
+    // These scripts are injected by Derive or its hosting edge, not supplied by the
+    // artifact. Their failure may affect viewer chrome, but it is never an author error.
+    // In particular, do not put a healthy script-free document behind a repair banner.
+    var source = resource && target && typeof target.src === "string" ? target.src : filename;
+    if (isPlatformScript(source)) return;
     // A required external script that never loaded is a bootstrap failure. Other
     // resource failures are non-critical by default; if they truly prevent paint,
     // the host's no-content timeout still supplies the blocking recovery state.
@@ -149,7 +164,7 @@ export const SHARED_STATE_CLIENT_JS = `(function () {
     send({ type: "runtime-error", code: code, phase: phase });
   }
   window.addEventListener("error", function (event) {
-    reportRuntimeError(event.error, event.message, event.target);
+    reportRuntimeError(event.error, event.message, event.target, event.filename);
   }, true);
   window.addEventListener("unhandledrejection", function (event) {
     reportRuntimeError(event.reason, "", null);
@@ -346,8 +361,7 @@ export const SHARED_STATE_CLIENT_JS = `(function () {
  * this client uses a short cache so runtime fixes reach already-published work. */
 export const SHARED_STATE_SCRIPT = `<script src="/raw/derive-shared.js"></script>`
 
-/** Put the SDK before an artifact's own scripts without moving the existing
- * end-of-document anchor client (which needs the DOM to be fully parsed). */
+/** Find the end of an opening document tag without parsing untrusted HTML. */
 const openingTagEnd = (html: string, name: "head" | "html"): number => {
   const source = html.toLowerCase()
   const token = `<${name}`
@@ -362,6 +376,33 @@ const openingTagEnd = (html: string, name: "head" | "html"): number => {
   return -1
 }
 
+const runtimeInsertionPoint = (html: string): number => {
+  const head = openingTagEnd(html, "head")
+  if (head < 0) return openingTagEnd(html, "html")
+
+  // Preserve a leading charset declaration. Browsers only inspect the first 1024
+  // bytes for it, while a meta CSP must still follow the platform runtime tags.
+  let cursor = head
+  while (cursor < html.length) {
+    const whitespace = html.slice(cursor).match(/^\s+/)?.[0]
+    if (whitespace) {
+      cursor += whitespace.length
+      continue
+    }
+    if (html.startsWith("<!--", cursor)) {
+      const commentEnd = html.indexOf("-->", cursor + 4)
+      if (commentEnd < 0) break
+      cursor = commentEnd + 3
+      continue
+    }
+    break
+  }
+  if (html.slice(cursor, cursor + 5).toLowerCase() !== "<meta") return head
+  const metaEnd = html.indexOf(">", cursor + 5)
+  if (metaEnd < 0) return head
+  return /\bcharset\s*=/i.test(html.slice(cursor, metaEnd + 1)) ? metaEnd + 1 : head
+}
+
 const doctypeEnd = (html: string): number => {
   const token = "<!doctype"
   const start = html.toLowerCase().indexOf(token)
@@ -370,10 +411,14 @@ const doctypeEnd = (html: string): number => {
   return end < 0 ? -1 : end + 1
 }
 
-export const injectSharedStateScript = (html: string): string => {
-  const points = [openingTagEnd(html, "head"), openingTagEnd(html, "html"), doctypeEnd(html)]
+/** Insert platform runtime tags before any authored head content, including meta CSP. */
+export const injectArtifactRuntimeScripts = (html: string, scripts: string): string => {
+  const points = [runtimeInsertionPoint(html), doctypeEnd(html)]
   for (const at of points) {
-    if (at >= 0) return `${html.slice(0, at)}${SHARED_STATE_SCRIPT}${html.slice(at)}`
+    if (at >= 0) return `${html.slice(0, at)}${scripts}${html.slice(at)}`
   }
-  return SHARED_STATE_SCRIPT + html
+  return scripts + html
 }
+
+export const injectSharedStateScript = (html: string): string =>
+  injectArtifactRuntimeScripts(html, SHARED_STATE_SCRIPT)

--- a/packages/core/test/shared-state.test.ts
+++ b/packages/core/test/shared-state.test.ts
@@ -206,6 +206,110 @@ describe("shared-state contract", () => {
     expect(sent.at(-1)).toMatchObject({ code: "script-error", phase: "loading" })
   })
 
+  it("treats a visible embedded document as meaningful content", () => {
+    type BrowserListener = (event: Record<string, unknown>) => void
+    const sent: RuntimeMessage[] = []
+    const listeners = new Map<string, BrowserListener>()
+    const parent = { postMessage: (message: RuntimeMessage) => sent.push(message) }
+    const embedded = {
+      hidden: false,
+      tagName: "IFRAME",
+      parentElement: null,
+      getBoundingClientRect: () => ({
+        top: 0,
+        right: 800,
+        bottom: 600,
+        left: 0,
+        width: 800,
+        height: 600,
+      }),
+      getClientRects: () => ({ 0: { width: 800, height: 600 }, length: 1 }),
+      getAttribute: () => null,
+      getRootNode: () => null,
+    }
+    const frame = {
+      derive: undefined as DeriveRuntime | undefined,
+      getComputedStyle: () => ({ display: "block", visibility: "visible", opacity: "1" }),
+      document: {
+        body: {
+          childElementCount: 1,
+          innerText: "",
+          querySelectorAll: (selector: string) =>
+            selector.includes("iframe") ? { 0: embedded, length: 1 } : { length: 0 },
+        },
+      },
+      addEventListener: (type: string, listener: BrowserListener) => listeners.set(type, listener),
+      dispatchEvent: () => true,
+    }
+    const CustomEventStub = class {
+      constructor(
+        readonly type: string,
+        readonly init?: unknown,
+      ) {}
+    }
+    const load = Function("window", "parent", "CustomEvent", SHARED_STATE_CLIENT_JS) as (
+      frame: typeof frame,
+      parent: typeof parent,
+      event: typeof CustomEventStub,
+    ) => void
+    load(frame, parent, CustomEventStub)
+
+    listeners.get("load")?.({})
+    listeners.get("message")?.({
+      source: parent,
+      data: { source: "derive-host", type: "shared-ready" },
+    })
+    expect(sent).toEqual([{ source: "derive", type: "runtime-ready" }])
+  })
+
+  it("does not attribute platform script failures to the artifact author", () => {
+    type BrowserListener = (event: Record<string, unknown>) => void
+    const sent: RuntimeMessage[] = []
+    const listeners = new Map<string, BrowserListener>()
+    const parent = { postMessage: (message: RuntimeMessage) => sent.push(message) }
+    const frame = {
+      derive: undefined as DeriveRuntime | undefined,
+      document: { body: null },
+      addEventListener: (type: string, listener: BrowserListener) => listeners.set(type, listener),
+      dispatchEvent: () => true,
+    }
+    const CustomEventStub = class {
+      constructor(
+        readonly type: string,
+        readonly init?: unknown,
+      ) {}
+    }
+    const load = Function("window", "parent", "CustomEvent", SHARED_STATE_CLIENT_JS) as (
+      frame: typeof frame,
+      parent: typeof parent,
+      event: typeof CustomEventStub,
+    ) => void
+    load(frame, parent, CustomEventStub)
+
+    for (const src of [
+      "https://raw.derive.page/raw/derive-client.js",
+      "https://static.cloudflareinsights.com/beacon.min.js/v-test",
+    ]) {
+      listeners.get("error")?.({
+        error: null,
+        message: "Failed to load platform script",
+        target: { tagName: "SCRIPT", src },
+        filename: src,
+      })
+      listeners.get("error")?.({
+        error: { message: "Platform script threw" },
+        message: "Platform script threw",
+        target: frame,
+        filename: src,
+      })
+    }
+    listeners.get("message")?.({
+      source: parent,
+      data: { source: "derive-host", type: "shared-ready" },
+    })
+    expect(sent).toEqual([])
+  })
+
   it("excludes hidden markers, hidden rich nodes, and source text from readiness", () => {
     type BrowserListener = (event: Record<string, unknown>) => void
     const sent: RuntimeMessage[] = []


### PR DESCRIPTION
## Summary
- Inject Derive runtime scripts before authored meta CSP while preserving an early charset declaration\n- treat visible iframe and srcdoc shells as meaningful rendered content
- ignore failures from Derive-owned and Cloudflare-owned injected scripts while preserving authored-script failure handling

## Production cases
-  zhp4edr2: its generated visualization shell has an authored CSP that blocked the previously appended Derive client, and its top-level srcdoc iframe did not count as meaningful content
- ac7m218h: the stored artifact structure contains no authored JavaScript, confirming that its degraded script error came from platform-injected code

Existing artifacts do not need to be republished; the fix applies when their raw HTML is served after deployment.

## Verification
- pnpm verify
- full render-fidelity suite: 41 passed (one existing timing-sensitive test passed on automatic retry)
- production-shaped iframe/CSP regression test
- pre-push pnpm verify:affected
