### PR TITLE
Show recent workflow run status

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -7722,6 +7722,194 @@
         }
       }
     },
+    "/v1/artifacts/{shortId}/workflow-runs": {
+      "get": {
+        "tags": [
+          "Artifacts"
+        ],
+        "summary": "List recent runs and materialized step attempts for a workflow artifact.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "shortId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": false,
+            "name": "diagram",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 20
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Recent version-pinned workflow runs, newest first.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "runs": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "diagramId": {
+                            "type": "string"
+                          },
+                          "workflowVersion": {
+                            "type": "integer"
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "queued",
+                              "running",
+                              "waiting",
+                              "succeeded",
+                              "failed",
+                              "cancelled"
+                            ]
+                          },
+                          "reason": {
+                            "type": "string"
+                          },
+                          "requestedExecution": {
+                            "type": "string",
+                            "enum": [
+                              "any",
+                              "local",
+                              "hosted"
+                            ]
+                          },
+                          "actualExecution": {
+                            "type": "string",
+                            "nullable": true,
+                            "enum": [
+                              "local",
+                              "hosted",
+                              null
+                            ]
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "startedAt": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "finishedAt": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "attempts": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string"
+                                },
+                                "nodeId": {
+                                  "type": "string"
+                                },
+                                "attempt": {
+                                  "type": "integer"
+                                },
+                                "kind": {
+                                  "type": "string",
+                                  "enum": [
+                                    "context",
+                                    "human",
+                                    "terminal"
+                                  ]
+                                },
+                                "status": {
+                                  "type": "string",
+                                  "enum": [
+                                    "queued",
+                                    "running",
+                                    "waiting",
+                                    "succeeded",
+                                    "failed",
+                                    "cancelled"
+                                  ]
+                                },
+                                "resultArtifactId": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "createdAt": {
+                                  "type": "string"
+                                },
+                                "startedAt": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "finishedAt": {
+                                  "type": "string",
+                                  "nullable": true
+                                }
+                              },
+                              "required": [
+                                "id",
+                                "nodeId",
+                                "attempt",
+                                "kind",
+                                "status",
+                                "resultArtifactId",
+                                "createdAt",
+                                "startedAt",
+                                "finishedAt"
+                              ]
+                            }
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "diagramId",
+                          "workflowVersion",
+                          "status",
+                          "reason",
+                          "requestedExecution",
+                          "actualExecution",
+                          "createdAt",
+                          "startedAt",
+                          "finishedAt",
+                          "attempts"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "runs"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/artifacts/{shortId}/rework": {
       "post": {
         "tags": [

--- a/apps/api/src/routes/rework.ts
+++ b/apps/api/src/routes/rework.ts
@@ -165,6 +165,31 @@ export const reworkRoutes = (ctx: AppContext) => {
     return diagram
   }
 
+  const workflowAttemptSummary = z.object({
+    id: z.string(),
+    nodeId: z.string(),
+    attempt: z.number().int(),
+    kind: z.enum(["context", "human", "terminal"]),
+    status: z.enum(["queued", "running", "waiting", "succeeded", "failed", "cancelled"]),
+    resultArtifactId: z.string().nullable(),
+    createdAt: z.string(),
+    startedAt: z.string().nullable(),
+    finishedAt: z.string().nullable(),
+  })
+  const workflowRunSummary = z.object({
+    id: z.string(),
+    diagramId: z.string(),
+    workflowVersion: z.number().int(),
+    status: z.enum(["queued", "running", "waiting", "succeeded", "failed", "cancelled"]),
+    reason: z.string(),
+    requestedExecution: z.enum(["any", "local", "hosted"]),
+    actualExecution: z.enum(["local", "hosted"]).nullable(),
+    createdAt: z.string(),
+    startedAt: z.string().nullable(),
+    finishedAt: z.string().nullable(),
+    attempts: z.array(workflowAttemptSummary),
+  })
+
   // Pick the addressee: the named agent, else the workspace's sole one.
   const pickAgent = (
     c: Context,
@@ -279,6 +304,71 @@ export const reworkRoutes = (ctx: AppContext) => {
       return c.json({
         prompt: `Workflow ${artifact.short_id}@v${artifact.current_version}, diagram "${ready.id}", is Ready to run. Starting it creates a fresh run record and version-pinned instruction.`,
         diagram: { id: ready.id, title: ready.title },
+      })
+    },
+  )
+
+  app.openapi(
+    createRoute({
+      method: "get",
+      path: "/v1/artifacts/{shortId}/workflow-runs",
+      tags: ["Artifacts"],
+      summary: "List recent runs and materialized step attempts for a workflow artifact.",
+      request: {
+        params: z.object({ shortId: z.string() }),
+        query: z.object({
+          diagram: z.string().min(1).optional(),
+          limit: z.coerce.number().int().min(1).max(20).optional(),
+        }),
+      },
+      responses: {
+        200: {
+          description: "Recent version-pinned workflow runs, newest first.",
+          content: {
+            "application/json": {
+              schema: z.object({ runs: z.array(workflowRunSummary) }),
+            },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const artifact = await requireArtifact(c, "comment", { split: true })
+      if (artifact instanceof Response) return bail(artifact)
+      if (artifact.current_version === 0) return bail(fail(c, 404, "not found"))
+      if (!(await actingUser(c))) return bail(fail(c, 401, "sign in to view workflow runs"))
+      const query = c.req.valid("query")
+      const runs = await meta.listWorkflowRuns(artifact.id, artifact.org_id, {
+        diagramId: query.diagram,
+        limit: query.limit ?? 10,
+      })
+      const attempts = await Promise.all(
+        runs.map((run) => meta.listWorkflowStepAttempts(run.id, artifact.org_id)),
+      )
+      return c.json({
+        runs: runs.map((run, index) => ({
+          id: run.id,
+          diagramId: run.diagram_id,
+          workflowVersion: run.workflow_version,
+          status: run.status,
+          reason: run.reason,
+          requestedExecution: run.requested_execution,
+          actualExecution: run.actual_execution,
+          createdAt: run.created_at,
+          startedAt: run.started_at,
+          finishedAt: run.finished_at,
+          attempts: (attempts[index] ?? []).map((attempt) => ({
+            id: attempt.id,
+            nodeId: attempt.node_id,
+            attempt: attempt.attempt,
+            kind: attempt.kind,
+            status: attempt.status,
+            resultArtifactId: attempt.result_artifact_id,
+            createdAt: attempt.created_at,
+            startedAt: attempt.started_at,
+            finishedAt: attempt.finished_at,
+          })),
+        })),
       })
     },
   )

--- a/apps/api/test/rework.test.ts
+++ b/apps/api/test/rework.test.ts
@@ -319,6 +319,59 @@ describe("workflow run: explicit local-agent handoff", () => {
       status: "queued",
     })
     expect(run?.reason).toBe("agent-request")
+
+    const running = await meta.transitionWorkflowRun(
+      started.runId,
+      artifact?.org_id ?? "",
+      { status: "queued", stateRevision: 0 },
+      {
+        status: "running",
+        at: "2026-08-26T18:00:00.000Z",
+        actualExecution: "local",
+        executorId: agent.id,
+      },
+    )
+    expect(running).not.toBeNull()
+    const waiting = await meta.createWorkflowStepAttempt(artifact?.org_id ?? "", {
+      id: "wfsa_visible_human",
+      workflow_run_id: started.runId,
+      node_id: "review",
+      attempt: 1,
+      kind: "human",
+    })
+    await meta.transitionWorkflowStepAttempt(
+      waiting.id,
+      started.runId,
+      artifact?.org_id ?? "",
+      { status: "queued", stateRevision: 0 },
+      { status: "waiting", at: "2026-08-26T18:01:00.000Z" },
+    )
+
+    const historyRes = await app.request(
+      `/v1/artifacts/${published.short_id}/workflow-runs?diagram=brief`,
+      { headers: as(editor.email) },
+    )
+    expect(historyRes.status).toBe(200)
+    expect(await historyRes.json()).toMatchObject({
+      runs: [
+        {
+          id: started.runId,
+          diagramId: "brief",
+          workflowVersion: 1,
+          status: "running",
+          requestedExecution: "local",
+          actualExecution: "local",
+          attempts: [
+            {
+              nodeId: "review",
+              attempt: 1,
+              kind: "human",
+              status: "waiting",
+            },
+          ],
+        },
+      ],
+    })
   })
 
   it("copy starts a distinct pinned run without requiring a registered agent", async () => {

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -41,6 +41,82 @@ test("publish, comment, resolve, and find it in the library", async ({ owner }) 
   await expect(owner.getByTestId(`artifact-card-open-${shortId}`)).toBeVisible()
 })
 
+test("starting a workflow creates a visible, version-pinned run", async ({ owner }) => {
+  const manifest = {
+    schema: "derive.linked-bundle/v1",
+    purpose: "Keep internal docs aligned with code changes.",
+    members: [],
+    diagrams: [
+      {
+        id: "docs-update",
+        title: "Update internal docs",
+        type: "graph",
+        nodes: [
+          {
+            id: "update-docs",
+            label: "Update docs",
+            state: "pending",
+            note: "Inspect the code change and publish the necessary documentation update.",
+          },
+        ],
+        edges: [],
+      },
+    ],
+  }
+  const workflow = {
+    schema: "derive.workflow/v1",
+    purpose: manifest.purpose,
+    diagrams: [
+      {
+        id: "docs-update",
+        entry: "update-docs",
+        nodes: [
+          {
+            id: "update-docs",
+            kind: "context",
+            context_ref: "docs-updater",
+            instruction: "Inspect the supplied code change and update the affected internal docs.",
+            result: "A published documentation update grounded in the code change",
+            terminal: true,
+          },
+        ],
+        routes: [],
+        scenarios: [
+          {
+            id: "expected",
+            kind: "expected",
+            path: ["update-docs"],
+            outcome: "The internal docs reflect the code change",
+          },
+          {
+            id: "failure",
+            kind: "failure",
+            path: ["update-docs"],
+            outcome: "The failed attempt remains visible without changing the docs",
+          },
+        ],
+      },
+    ],
+  }
+  const html =
+    `<!doctype html><html><body><h1>Internal docs update</h1>` +
+    `<script type="application/derive-facts" data-fact="bundle-manifest">${JSON.stringify(manifest)}</script>` +
+    `<script type="application/derive-facts" data-fact="workflow-definition">${JSON.stringify(workflow)}</script>` +
+    `</body></html>`
+  const shortId = await publishArtifact(owner, "workflow.html", html, "text/html")
+
+  await owner.goto(`/artifacts/${shortId}`)
+  await expect(owner.getByTestId("workflow-preview")).toBeVisible()
+  await expect(owner.getByText("No runs yet.", { exact: false })).toBeVisible()
+  await owner.getByTestId("workflow-run-docs-update").click()
+  await owner.getByTestId("workflow-run-copy").click()
+
+  const runs = owner.getByTestId("workflow-runs")
+  await expect(runs.getByText("Queued", { exact: true })).toBeVisible()
+  await expect(runs.getByText("v1 · local copy", { exact: false })).toBeVisible()
+  await expect(runs.getByText("Waiting for an agent to claim this run.")).toBeVisible()
+})
+
 test("a cached screenshot still becomes a visible library thumbnail", async ({ owner }) => {
   const shortId = await publishArtifact(owner, "cached-thumb.md", "# Cached thumbnail")
 

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -4129,6 +4129,76 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/artifacts/{shortId}/workflow-runs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List recent runs and materialized step attempts for a workflow artifact. */
+        get: {
+            parameters: {
+                query?: {
+                    diagram?: string;
+                    limit?: number;
+                };
+                header?: never;
+                path: {
+                    shortId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Recent version-pinned workflow runs, newest first. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            runs: {
+                                id: string;
+                                diagramId: string;
+                                workflowVersion: number;
+                                /** @enum {string} */
+                                status: "queued" | "running" | "waiting" | "succeeded" | "failed" | "cancelled";
+                                reason: string;
+                                /** @enum {string} */
+                                requestedExecution: "any" | "local" | "hosted";
+                                /** @enum {string|null} */
+                                actualExecution: "local" | "hosted" | null;
+                                createdAt: string;
+                                startedAt: string | null;
+                                finishedAt: string | null;
+                                attempts: {
+                                    id: string;
+                                    nodeId: string;
+                                    attempt: number;
+                                    /** @enum {string} */
+                                    kind: "context" | "human" | "terminal";
+                                    /** @enum {string} */
+                                    status: "queued" | "running" | "waiting" | "succeeded" | "failed" | "cancelled";
+                                    resultArtifactId: string | null;
+                                    createdAt: string;
+                                    startedAt: string | null;
+                                    finishedAt: string | null;
+                                }[];
+                            }[];
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/artifacts/{shortId}/rework": {
         parameters: {
             query?: never;

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -89,6 +89,8 @@ export type VersionSession = components["schemas"]["VersionSession"]
  *  from the OpenAPI spec (apps/api/openapi.json). `my_role` is `Role | null`;
  *  workspace_access/link_role/listed are the v2 access enums (see access-model.md). */
 export type Artifact = components["schemas"]["Artifact"]
+export type WorkflowRunSummary =
+  paths["/v1/artifacts/{shortId}/workflow-runs"]["get"]["responses"][200]["content"]["application/json"]["runs"][number]
 /** An abuse report against an artifact. Generated from the OpenAPI spec. */
 export type Report = components["schemas"]["Report"]
 /** A collection: a shareable group of artifacts, tagged with its item count and origin
@@ -1550,6 +1552,15 @@ export const api = {
     body: { agentId?: string; diagramId: string; delivery?: "agent" | "copy" },
   ): Promise<{ runId: string; prompt: string; requestId?: string }> =>
     f(`/v1/artifacts/${shortId}/workflow-run`, opts(body)).then(j),
+  workflowRuns: (
+    shortId: string,
+    diagramId: string,
+    limit = 3,
+  ): Promise<{ runs: WorkflowRunSummary[] }> =>
+    f(
+      `/v1/artifacts/${shortId}/workflow-runs?diagram=${encodeURIComponent(diagramId)}&limit=${limit}`,
+      opts(),
+    ).then(j),
   // Ask a registered agent to build the workspace's brand profile (shortId must be the
   // profile artifact). Same queue mechanics as reworkArtifact, different canned brief.
   generateProfile: (shortId: string, agentId?: string): Promise<{ requestId: string }> =>

--- a/apps/web/src/pages/artifact/linked-bundle-workspace.tsx
+++ b/apps/web/src/pages/artifact/linked-bundle-workspace.tsx
@@ -1117,7 +1117,9 @@ export function LinkedBundleWorkspace({
         <main className="min-w-0">
           {view === "preview" && workflowPreview ? (
             <WorkflowPreview
+              shortId={shortId}
               preview={workflowPreview}
+              showRuns={canComment}
               onRun={canComment ? setRunDiagram : undefined}
             />
           ) : view === "now" ? (

--- a/apps/web/src/pages/artifact/workflow-preview.tsx
+++ b/apps/web/src/pages/artifact/workflow-preview.tsx
@@ -1,6 +1,7 @@
 import type { Artifact } from "@/api"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
+import { WorkflowRunHistory } from "./workflow-run-history"
 
 type WorkflowPreviewValue = NonNullable<Artifact["workflow_preview"]>
 type PreviewDiagram = WorkflowPreviewValue["diagrams"][number]
@@ -147,10 +148,14 @@ const ScenarioChecks = ({ scenarios }: { scenarios: PreviewDiagram["scenarios"] 
 }
 
 const DiagramPreview = ({
+  shortId,
   diagram,
+  showRuns,
   onRun,
 }: {
+  shortId: string
   diagram: PreviewDiagram
+  showRuns: boolean
   onRun?: (diagramId: string) => void
 }) => (
   <article
@@ -179,6 +184,7 @@ const DiagramPreview = ({
       <RunConsiderations diagram={diagram} />
     </div>
     <ScenarioChecks scenarios={diagram.scenarios} />
+    {showRuns ? <WorkflowRunHistory shortId={shortId} diagramId={diagram.id} /> : null}
   </article>
 )
 
@@ -186,10 +192,14 @@ const DiagramPreview = ({
  * than a configuration form: a teammate can understand the workflow cold, then
  * inspect live state or the exact graph only when they need to. */
 export function WorkflowPreview({
+  shortId,
   preview,
+  showRuns,
   onRun,
 }: {
+  shortId: string
   preview: WorkflowPreviewValue
+  showRuns: boolean
   onRun?: (diagramId: string) => void
 }) {
   const ready = preview.status === "ready"
@@ -273,7 +283,13 @@ export function WorkflowPreview({
       </section>
 
       {preview.diagrams.map((diagram) => (
-        <DiagramPreview key={diagram.id} diagram={diagram} onRun={ready ? onRun : undefined} />
+        <DiagramPreview
+          key={diagram.id}
+          shortId={shortId}
+          diagram={diagram}
+          showRuns={showRuns}
+          onRun={ready ? onRun : undefined}
+        />
       ))}
 
       {preview.cannot_do.length ? (

--- a/apps/web/src/pages/artifact/workflow-run-dialog.tsx
+++ b/apps/web/src/pages/artifact/workflow-run-dialog.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { ApiError, api, type DirUser } from "@/api"
 import { Eyebrow } from "@/components/shared/section-eyebrow"
 import { Button } from "@/components/ui/button"
@@ -30,6 +30,7 @@ export function WorkflowRunDialog({
   open: boolean
   onOpenChange: (open: boolean) => void
 }) {
+  const queryClient = useQueryClient()
   const { data, error, isError, refetch } = useQuery({
     queryKey: ["workflow-run-prompt", shortId, diagramId] as const,
     queryFn: () => api.workflowRunPrompt(shortId, diagramId),
@@ -39,7 +40,10 @@ export function WorkflowRunDialog({
   const handoffReady = !!data && !isError
   const run = useApiMutation<{ runId: string; prompt: string; requestId?: string }, AgentTarget>({
     mutationFn: (agent) => api.runWorkflow(shortId, { agentId: agent.id, diagramId }),
-    success: (_result, agent) => queuedFor("Workflow", agent.name),
+    success: (_result, agent) => {
+      void queryClient.invalidateQueries({ queryKey: ["workflow-runs", shortId, diagramId] })
+      queuedFor("Workflow", agent.name)
+    },
     errorToast: false,
     onError: (error) => {
       if (error instanceof ApiError && error.code === "alreadyQueued") toast(ALREADY_QUEUED)
@@ -52,6 +56,7 @@ export function WorkflowRunDialog({
   const copyRun = useApiMutation<{ runId: string; prompt: string }, void>({
     mutationFn: () => api.runWorkflow(shortId, { diagramId, delivery: "copy" }),
     success: (result) => {
+      void queryClient.invalidateQueries({ queryKey: ["workflow-runs", shortId, diagramId] })
       void copyText(result.prompt, { success: "Prompt copied. Paste it into your agent." })
     },
     errorToast: false,

--- a/apps/web/src/pages/artifact/workflow-run-history.tsx
+++ b/apps/web/src/pages/artifact/workflow-run-history.tsx
@@ -1,0 +1,118 @@
+import { useQuery } from "@tanstack/react-query"
+import { api, type WorkflowRunSummary } from "@/api"
+import { ago } from "@/lib/time"
+import { cn } from "@/lib/utils"
+
+const terminal = new Set<WorkflowRunSummary["status"]>(["succeeded", "failed", "cancelled"])
+
+const statusTone = (status: WorkflowRunSummary["status"]): string => {
+  if (status === "succeeded") return "bg-success"
+  if (status === "failed" || status === "cancelled") return "bg-destructive"
+  if (status === "waiting") return "bg-warning"
+  if (status === "running") return "bg-insights"
+  return "bg-muted-foreground"
+}
+
+const statusLabel = (status: WorkflowRunSummary["status"]): string =>
+  status.charAt(0).toUpperCase() + status.slice(1)
+
+const deliveryLabel = (run: WorkflowRunSummary): string => {
+  if (run.actualExecution) return run.actualExecution
+  if (run.reason === "agent-request") return "assigned agent"
+  if (run.reason === "manual:copy") return "local copy"
+  return run.requestedExecution
+}
+
+const runDetail = (run: WorkflowRunSummary): string => {
+  const waiting = run.attempts.find((attempt) => attempt.status === "waiting")
+  if (waiting) return `${waiting.nodeId} is waiting.`
+  const active = run.attempts.find((attempt) => attempt.status === "running")
+  if (active) return `${active.nodeId} is running.`
+  if (run.status === "queued") return "Waiting for an agent to claim this run."
+  if (run.status === "running" && run.attempts.length === 0)
+    return "The agent claimed this run; no step receipt has arrived yet."
+  if (run.status === "succeeded") return "The workflow finished successfully."
+  if (run.status === "failed") return "The workflow stopped after a failure."
+  if (run.status === "cancelled") return "The workflow was cancelled."
+  return `${run.attempts.length} materialized attempt${run.attempts.length === 1 ? "" : "s"}.`
+}
+
+export function WorkflowRunHistory({ shortId, diagramId }: { shortId: string; diagramId: string }) {
+  const query = useQuery({
+    queryKey: ["workflow-runs", shortId, diagramId] as const,
+    queryFn: () => api.workflowRuns(shortId, diagramId),
+    refetchInterval: (current) =>
+      current.state.data?.runs.some((run) => !terminal.has(run.status)) ? 5000 : false,
+  })
+
+  if (query.isPending) {
+    return (
+      <div className="border-t border-border-soft px-4 py-3 text-xs text-muted-foreground sm:px-5">
+        Checking recent runs…
+      </div>
+    )
+  }
+  if (query.isError) {
+    return (
+      <div className="border-t border-border-soft px-4 py-3 text-xs text-destructive sm:px-5">
+        Couldn’t load recent runs.
+      </div>
+    )
+  }
+  if (query.data.runs.length === 0) {
+    return (
+      <div className="border-t border-border-soft px-4 py-3 text-xs text-muted-foreground sm:px-5">
+        No runs yet. Starting this workflow creates a separate, version-pinned run.
+      </div>
+    )
+  }
+
+  return (
+    <section className="border-t border-border-soft px-4 py-3 sm:px-5" data-testid="workflow-runs">
+      <div className="font-mono text-2xs uppercase tracking-[0.12em] text-muted-foreground">
+        Recent runs
+      </div>
+      <div className="mt-2 grid gap-2">
+        {query.data.runs.map((run, index) => (
+          <article
+            key={run.id}
+            className={cn(
+              "rounded-lg border border-border-soft px-3 py-2.5",
+              index === 0 && "bg-muted/20",
+            )}
+          >
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div className="flex min-w-0 items-center gap-2 text-xs font-medium text-foreground">
+                <span className={cn("size-1.5 shrink-0 rounded-full", statusTone(run.status))} />
+                <span>{statusLabel(run.status)}</span>
+                <span className="font-mono text-2xs font-normal text-muted-foreground">
+                  {run.id.slice(-8)}
+                </span>
+              </div>
+              <span className="font-mono text-2xs text-muted-foreground">
+                v{run.workflowVersion} · {deliveryLabel(run)} · {ago(run.createdAt)}
+              </span>
+            </div>
+            {index === 0 ? (
+              <div className="mt-2 grid gap-2">
+                <p className="text-xs text-muted-foreground">{runDetail(run)}</p>
+                {run.attempts.length > 0 ? (
+                  <div className="flex flex-wrap gap-1.5">
+                    {run.attempts.map((attempt) => (
+                      <span
+                        key={attempt.id}
+                        className="rounded-md border border-border bg-background px-2 py-1 font-mono text-2xs text-muted-foreground"
+                      >
+                        {attempt.nodeId} · {statusLabel(attempt.status)}
+                      </span>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+          </article>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -2164,6 +2164,11 @@ export interface AgentStore {
 export interface WorkflowRunStore {
   createWorkflowRun(run: NewWorkflowRun): Promise<WorkflowRunRecord>
   getWorkflowRun(id: string, orgId: string): Promise<WorkflowRunRecord | null>
+  listWorkflowRuns(
+    workflowArtifactId: string,
+    orgId: string,
+    opts?: { diagramId?: string; limit?: number },
+  ): Promise<WorkflowRunRecord[]>
   transitionWorkflowRun(
     id: string,
     orgId: string,

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -5277,6 +5277,25 @@ export class PgMetaStore implements MetaStore {
       .limit(1)
     return rows[0] ?? null
   }
+  async listWorkflowRuns(
+    workflowArtifactId: string,
+    orgId: string,
+    opts: { diagramId?: string; limit?: number } = {},
+  ): Promise<WorkflowRunRecord[]> {
+    const limit = Math.max(1, Math.min(opts.limit ?? 20, 100))
+    return this.db
+      .select()
+      .from(workflowRun)
+      .where(
+        and(
+          eq(workflowRun.workflow_artifact_id, workflowArtifactId),
+          eq(workflowRun.org_id, orgId),
+          opts.diagramId ? eq(workflowRun.diagram_id, opts.diagramId) : undefined,
+        ),
+      )
+      .orderBy(desc(workflowRun.created_at), desc(workflowRun.id))
+      .limit(limit)
+  }
   async transitionWorkflowRun(
     id: string,
     orgId: string,

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -4248,6 +4248,26 @@ export function makeRepos(db: SqliteDb) {
       .from(workflowRun)
       .where(and(eq(workflowRun.id, id), eq(workflowRun.org_id, orgId)))
       .get()) as WorkflowRunRecord | undefined) ?? null
+  const listWorkflowRuns = async (
+    workflowArtifactId: string,
+    orgId: string,
+    opts: { diagramId?: string; limit?: number } = {},
+  ): Promise<WorkflowRunRecord[]> => {
+    const limit = Math.max(1, Math.min(opts.limit ?? 20, 100))
+    return (await db
+      .select()
+      .from(workflowRun)
+      .where(
+        and(
+          eq(workflowRun.workflow_artifact_id, workflowArtifactId),
+          eq(workflowRun.org_id, orgId),
+          opts.diagramId ? eq(workflowRun.diagram_id, opts.diagramId) : undefined,
+        ),
+      )
+      .orderBy(desc(workflowRun.created_at), desc(workflowRun.id))
+      .limit(limit)
+      .all()) as WorkflowRunRecord[]
+  }
   const transitionWorkflowRun = async (
     id: string,
     orgId: string,
@@ -5541,6 +5561,7 @@ export function makeRepos(db: SqliteDb) {
     appendRunPayload,
     createWorkflowRun,
     getWorkflowRun,
+    listWorkflowRuns,
     transitionWorkflowRun,
     createWorkflowStepAttempt,
     getWorkflowStepAttemptBySession,

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -4,6 +4,7 @@ import type {
   NewArtifact,
   NewRun,
   NewVersion,
+  NewWorkflowRun,
   NewWorkflowStepAttempt,
   SortMode,
   SubscriptionRecord,
@@ -4741,6 +4742,46 @@ export function runStoreContract(
           reason: "manual:u1",
         }),
       ).rejects.toThrow("complete version pin")
+    })
+
+    it("lists workflow runs newest first, scoped to the artifact, workspace, and diagram", async () => {
+      const artifactId = `art_${uuid()}`
+      const create = (id: string, createdAt: string, over: Partial<NewWorkflowRun> = {}) =>
+        store.createWorkflowRun({
+          id,
+          org_id: ORG,
+          workflow_artifact_id: artifactId,
+          workflow_version: 2,
+          workflow_blob_key: `blob_${uuid()}`,
+          workflow_content_type: "text/html",
+          diagram_id: "brief",
+          reason: "manual:copy",
+          created_at: createdAt,
+          ...over,
+        })
+      const older = await create(`wfr_${uuid()}`, "2026-08-25T20:00:00.000Z")
+      const newer = await create(`wfr_${uuid()}`, "2026-08-25T20:02:00.000Z")
+      const otherDiagram = await create(`wfr_${uuid()}`, "2026-08-25T20:03:00.000Z", {
+        diagram_id: "release",
+      })
+      await create(`wfr_${uuid()}`, "2026-08-25T20:04:00.000Z", {
+        workflow_artifact_id: `art_${uuid()}`,
+      })
+      await create(`wfr_${uuid()}`, "2026-08-25T20:05:00.000Z", {
+        org_id: `org_${uuid()}`,
+      })
+
+      expect((await store.listWorkflowRuns(artifactId, ORG)).map((run) => run.id)).toEqual([
+        otherDiagram.id,
+        newer.id,
+        older.id,
+      ])
+      expect(
+        (await store.listWorkflowRuns(artifactId, ORG, { diagramId: "brief", limit: 1 })).map(
+          (run) => run.id,
+        ),
+      ).toEqual([newer.id])
+      expect(await store.listWorkflowRuns(artifactId, `org_${uuid()}`)).toEqual([])
     })
 
     it("workflow step attempts keep context pins, human decisions, and route receipts", async () => {


### PR DESCRIPTION
Stacked on #825; merge that foundation first.\n\nSummary:\n- Add an artifact-, workspace-, and diagram-scoped read contract for recent workflow runs in SQLite, Postgres, and the API.\n- Show each run's pinned workflow version, execution lane, durable status, and materialized step attempts in Preview.\n- Refresh after a start and poll only while a returned run is active. Executor error text stays server-side.\n\nVerification:\n- pnpm verify\n- API workflow route test\n- SQLite store contract\n- Focused Playwright docs-update workflow\n\nThe full local smoke run also passed the new workflow scenario; unrelated deck and inline-editor tests timed out under the three-worker dev-server run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790360483&installation_model_id=428097&pr_number=827&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F827&signature=98d914f1a462ef416488f33b9495024a9ac27c8471ead6ea6dc6ea87a3685dfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->