### PR TITLE
Project workflow step receipts

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -7727,7 +7727,7 @@
         "tags": [
           "Artifacts"
         ],
-        "summary": "List recent runs and materialized step attempts for a workflow artifact.",
+        "summary": "List recent runs and their durable step receipts for a workflow artifact.",
         "parameters": [
           {
             "schema": {
@@ -7854,6 +7854,17 @@
                                     "cancelled"
                                   ]
                                 },
+                                "selectedRoutes": {
+                                  "type": "array",
+                                  "nullable": true,
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "routeBasis": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
                                 "resultArtifactId": {
                                   "type": "string",
                                   "nullable": true
@@ -7876,6 +7887,8 @@
                                 "attempt",
                                 "kind",
                                 "status",
+                                "selectedRoutes",
+                                "routeBasis",
                                 "resultArtifactId",
                                 "createdAt",
                                 "startedAt",

--- a/apps/api/src/routes/rework.ts
+++ b/apps/api/src/routes/rework.ts
@@ -21,6 +21,18 @@ import { notifyMentions } from "../lib/mentions"
 import { notifyCommentBells } from "../lib/notify-comment"
 import { parseLinkedWorkflowFacts } from "../lib/workflow-facts"
 
+const parseWorkflowSelectedRoutes = (value: string | null): string[] | null => {
+  if (!value) return null
+  try {
+    const parsed: unknown = JSON.parse(value)
+    return Array.isArray(parsed) && parsed.every((route) => typeof route === "string")
+      ? parsed
+      : null
+  } catch {
+    return null
+  }
+}
+
 /** The canned agent-request endpoints — Rework, generate-profile, and the fill and
  *  save-as-skill pairs (each pair: a GET returning the instruction for copy-paste, a
  *  POST delivering it). Thin wrappers over the existing @mention-to-inbox path: each
@@ -171,6 +183,8 @@ export const reworkRoutes = (ctx: AppContext) => {
     attempt: z.number().int(),
     kind: z.enum(["context", "human", "terminal"]),
     status: z.enum(["queued", "running", "waiting", "succeeded", "failed", "cancelled"]),
+    selectedRoutes: z.array(z.string()).nullable(),
+    routeBasis: z.string().nullable(),
     resultArtifactId: z.string().nullable(),
     createdAt: z.string(),
     startedAt: z.string().nullable(),
@@ -313,7 +327,7 @@ export const reworkRoutes = (ctx: AppContext) => {
       method: "get",
       path: "/v1/artifacts/{shortId}/workflow-runs",
       tags: ["Artifacts"],
-      summary: "List recent runs and materialized step attempts for a workflow artifact.",
+      summary: "List recent runs and their durable step receipts for a workflow artifact.",
       request: {
         params: z.object({ shortId: z.string() }),
         query: z.object({
@@ -363,6 +377,8 @@ export const reworkRoutes = (ctx: AppContext) => {
             attempt: attempt.attempt,
             kind: attempt.kind,
             status: attempt.status,
+            selectedRoutes: parseWorkflowSelectedRoutes(attempt.selected_routes),
+            routeBasis: attempt.route_basis,
             resultArtifactId: attempt.result_artifact_id,
             createdAt: attempt.created_at,
             startedAt: attempt.started_at,

--- a/apps/api/test/rework.test.ts
+++ b/apps/api/test/rework.test.ts
@@ -346,6 +346,30 @@ describe("workflow run: explicit local-agent handoff", () => {
       { status: "queued", stateRevision: 0 },
       { status: "waiting", at: "2026-08-26T18:01:00.000Z" },
     )
+    const waitingHistoryRes = await app.request(
+      `/v1/artifacts/${published.short_id}/workflow-runs?diagram=brief`,
+      { headers: as(editor.email) },
+    )
+    expect(waitingHistoryRes.status).toBe(200)
+    expect(await waitingHistoryRes.json()).toMatchObject({
+      runs: [
+        {
+          attempts: [{ nodeId: "review", selectedRoutes: null, routeBasis: null }],
+        },
+      ],
+    })
+    await meta.transitionWorkflowStepAttempt(
+      waiting.id,
+      started.runId,
+      artifact?.org_id ?? "",
+      { status: "waiting", stateRevision: 1 },
+      {
+        status: "succeeded",
+        at: "2026-08-26T18:02:00.000Z",
+        selectedRoutes: JSON.stringify(["publish"]),
+        routeBasis: "The reviewer approved the draft.",
+      },
+    )
 
     const historyRes = await app.request(
       `/v1/artifacts/${published.short_id}/workflow-runs?diagram=brief`,
@@ -366,7 +390,9 @@ describe("workflow run: explicit local-agent handoff", () => {
               nodeId: "review",
               attempt: 1,
               kind: "human",
-              status: "waiting",
+              status: "succeeded",
+              selectedRoutes: ["publish"],
+              routeBasis: "The reviewer approved the draft.",
             },
           ],
         },

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -4136,7 +4136,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** List recent runs and materialized step attempts for a workflow artifact. */
+        /** List recent runs and their durable step receipts for a workflow artifact. */
         get: {
             parameters: {
                 query?: {
@@ -4180,6 +4180,8 @@ export interface paths {
                                     kind: "context" | "human" | "terminal";
                                     /** @enum {string} */
                                     status: "queued" | "running" | "waiting" | "succeeded" | "failed" | "cancelled";
+                                    selectedRoutes: string[] | null;
+                                    routeBasis: string | null;
                                     resultArtifactId: string | null;
                                     createdAt: string;
                                     startedAt: string | null;

--- a/apps/web/src/pages/artifact/workflow-preview.test.ts
+++ b/apps/web/src/pages/artifact/workflow-preview.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest"
+import type { WorkflowRunSummary } from "@/api"
 import { workflowTriggerLabel } from "./workflow-preview"
+import { workflowAttemptRoute } from "./workflow-run-history"
 
 describe("workflow Preview", () => {
   it("explains context triggers in plain run language", () => {
@@ -8,5 +10,33 @@ describe("workflow Preview", () => {
     expect(workflowTriggerLabel("Quality check returns ready")).toBe(
       "When Quality check returns ready",
     )
+  })
+
+  it("describes only routes recorded in a durable step receipt", () => {
+    const attempt: WorkflowRunSummary["attempts"][number] = {
+      id: "wsa_review",
+      nodeId: "review",
+      attempt: 1,
+      kind: "human",
+      status: "succeeded",
+      selectedRoutes: ["publish"],
+      routeBasis: "The reviewer approved the draft.",
+      resultArtifactId: null,
+      createdAt: "2026-08-26T18:00:00.000Z",
+      startedAt: "2026-08-26T18:00:00.000Z",
+      finishedAt: "2026-08-26T18:01:00.000Z",
+    }
+
+    expect(workflowAttemptRoute(attempt)).toBe("Next: publish")
+    expect(workflowAttemptRoute({ ...attempt, selectedRoutes: [] })).toBe("No next node selected")
+    expect(workflowAttemptRoute({ ...attempt, selectedRoutes: null })).toBeNull()
+    expect(
+      workflowAttemptRoute({
+        ...attempt,
+        status: "running",
+        selectedRoutes: [],
+        finishedAt: null,
+      }),
+    ).toBeNull()
   })
 })

--- a/apps/web/src/pages/artifact/workflow-run-history.tsx
+++ b/apps/web/src/pages/artifact/workflow-run-history.tsx
@@ -16,6 +16,21 @@ const statusTone = (status: WorkflowRunSummary["status"]): string => {
 const statusLabel = (status: WorkflowRunSummary["status"]): string =>
   status.charAt(0).toUpperCase() + status.slice(1)
 
+type WorkflowAttempt = WorkflowRunSummary["attempts"][number]
+
+const attemptKindLabel = (kind: WorkflowAttempt["kind"]): string => {
+  if (kind === "context") return "Context"
+  if (kind === "human") return "Human pause"
+  return "Terminal"
+}
+
+export const workflowAttemptRoute = (attempt: WorkflowAttempt): string | null => {
+  if (attempt.selectedRoutes === null) return null
+  if (attempt.selectedRoutes.length > 0) return `Next: ${attempt.selectedRoutes.join(", ")}`
+  if (attempt.status === "succeeded" && attempt.finishedAt) return "No next node selected"
+  return null
+}
+
 const deliveryLabel = (run: WorkflowRunSummary): string => {
   if (run.actualExecution) return run.actualExecution
   if (run.reason === "agent-request") return "assigned agent"
@@ -36,6 +51,57 @@ const runDetail = (run: WorkflowRunSummary): string => {
   if (run.status === "cancelled") return "The workflow was cancelled."
   return `${run.attempts.length} materialized attempt${run.attempts.length === 1 ? "" : "s"}.`
 }
+
+const WorkflowAttemptTimeline = ({ attempts }: { attempts: WorkflowAttempt[] }) => (
+  <ol className="grid gap-2" aria-label="Materialized workflow steps">
+    {attempts.map((attempt) => {
+      const route = workflowAttemptRoute(attempt)
+      return (
+        <li
+          key={attempt.id}
+          className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)] gap-2.5 rounded-lg border border-border-soft bg-background px-3 py-2.5"
+        >
+          <span
+            aria-hidden="true"
+            className={cn("mt-1 size-2 rounded-full", statusTone(attempt.status))}
+          />
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1">
+              <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+                <span className="break-all font-mono text-xs font-semibold text-foreground">
+                  {attempt.nodeId}
+                </span>
+                <span className="text-2xs text-muted-foreground">
+                  {attemptKindLabel(attempt.kind)} · attempt {attempt.attempt}
+                </span>
+              </div>
+              <span className="text-2xs font-medium text-muted-foreground">
+                {statusLabel(attempt.status)}
+              </span>
+            </div>
+            {route || attempt.routeBasis || attempt.resultArtifactId ? (
+              <div className="mt-1.5 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-2xs text-muted-foreground">
+                {route ? <span>{route}</span> : null}
+                {attempt.routeBasis ? (
+                  <span className="break-words">Because: {attempt.routeBasis}</span>
+                ) : null}
+                {attempt.resultArtifactId ? (
+                  <a
+                    className="font-medium text-primary hover:underline"
+                    href={`/artifacts/${attempt.resultArtifactId}`}
+                    aria-label={`Open result from ${attempt.nodeId}`}
+                  >
+                    Open result
+                  </a>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        </li>
+      )
+    })}
+  </ol>
+)
 
 export function WorkflowRunHistory({ shortId, diagramId }: { shortId: string; diagramId: string }) {
   const query = useQuery({
@@ -93,22 +159,22 @@ export function WorkflowRunHistory({ shortId, diagramId }: { shortId: string; di
                 v{run.workflowVersion} · {deliveryLabel(run)} · {ago(run.createdAt)}
               </span>
             </div>
-            {index === 0 ? (
+            {run.attempts.length > 0 && index === 0 ? (
               <div className="mt-2 grid gap-2">
                 <p className="text-xs text-muted-foreground">{runDetail(run)}</p>
-                {run.attempts.length > 0 ? (
-                  <div className="flex flex-wrap gap-1.5">
-                    {run.attempts.map((attempt) => (
-                      <span
-                        key={attempt.id}
-                        className="rounded-md border border-border bg-background px-2 py-1 font-mono text-2xs text-muted-foreground"
-                      >
-                        {attempt.nodeId} · {statusLabel(attempt.status)}
-                      </span>
-                    ))}
-                  </div>
-                ) : null}
+                <WorkflowAttemptTimeline attempts={run.attempts} />
               </div>
+            ) : run.attempts.length > 0 ? (
+              <details className="mt-2">
+                <summary className="cursor-pointer text-xs text-muted-foreground">
+                  {runDetail(run)}
+                </summary>
+                <div className="mt-2">
+                  <WorkflowAttemptTimeline attempts={run.attempts} />
+                </div>
+              </details>
+            ) : index === 0 ? (
+              <p className="mt-2 text-xs text-muted-foreground">{runDetail(run)}</p>
             ) : null}
           </article>
         ))}


### PR DESCRIPTION
## What this does

- extends recent workflow runs with the recorded next-node selection and route basis
- renders every materialized attempt as an expandable node timeline
- links context results without exposing raw executor errors or inferring absent branches
- keeps previous runs inspectable while opening the newest receipt by default

## Why

The durable ledger and recent-run status are live, but Preview currently compresses attempts into status chips. This turns the stored attempt rows into a truthful per-node receipt view without adding a scheduler, runner, or derived graph-progress state.

## Verification

- `pnpm verify`
- affected pre-push gate
- focused workflow browser smoke
- API contract covers selected routes and route basis
- UI contract covers recorded-route language and no-route behavior

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/828"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790362869&installation_model_id=428097&pr_number=828&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F828&signature=52501183cf436f1bb2b88919680817236325de38834079d68619ecf2291acc7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->