### PR TITLE
Harden iframe startup readiness

### DIFF
--- a/apps/web/e2e/render-fidelity/fixtures/startup-aria-hidden-srcdoc-frame.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-aria-hidden-srcdoc-frame.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>Aria-hidden srcdoc frame</title></head>
+  <body>
+    <iframe aria-hidden="true" title="Aria-hidden visualization" srcdoc="<!doctype html><h1>Hidden report</h1>"></iframe>
+    <script>throw new Error("bootstrap failed beside aria-hidden frame")</script>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-authored-aboutblank-iframe.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-authored-aboutblank-iframe.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>Authored about blank iframe</title></head>
+  <body>
+    <script>
+      const frame = document.createElement("iframe")
+      frame.title = "Authored in-memory visualization"
+      frame.src = "about:blank"
+      frame.style.cssText = "width: 800px; height: 600px"
+      frame.addEventListener("load", () => {
+        frame.contentDocument.body.innerHTML = "<h1>In-memory visualization remains visible</h1>"
+        throw new Error("optional enhancement failed after in-memory paint")
+      }, { once: true })
+      document.body.append(frame)
+    </script>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-blank-iframe.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-blank-iframe.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>Blank iframe</title></head>
+  <body>
+    <iframe
+      title="Blank generated visualization"
+      src="about:blank"
+      style="width: 800px; height: 600px; border: 0"
+    ></iframe>
+    <script>throw new Error("bootstrap failed beside blank iframe")</script>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-broken-iframe.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-broken-iframe.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>Broken iframe</title></head>
+  <body>
+    <iframe
+      title="Broken generated visualization"
+      src="/raw/definitely-missing-generated-visualization.html"
+      style="width: 800px; height: 600px; border: 0"
+    ></iframe>
+    <script>throw new Error("bootstrap failed beside broken iframe")</script>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-broken-image-srcdoc.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-broken-image-srcdoc.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>Broken image srcdoc</title></head>
+  <body>
+    <iframe
+      title="Broken image placeholder"
+      srcdoc="<!doctype html><img src='https://unreachable.invalid/missing.png' alt=''>"
+      style="width: 800px; height: 600px"
+    ></iframe>
+    <script>throw new Error("bootstrap failed beside broken image")</script>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-cleared-loaded-iframe.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-cleared-loaded-iframe.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>Cleared loaded iframe</title></head>
+  <body>
+    <iframe
+      id="generated"
+      title="Cleared visualization"
+      src="data:text/html,%3Ch1%3ETemporary%20visualization%3C%2Fh1%3E"
+      style="width: 800px; height: 600px; border: 0"
+    ></iframe>
+    <script>
+      document.getElementById("generated").addEventListener("load", () => {
+        document.getElementById("generated").removeAttribute("src")
+        setTimeout(() => { throw new Error("bootstrap failed after frame was cleared") }, 0)
+      }, { once: true })
+    </script>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-clipped-parent-iframe.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-clipped-parent-iframe.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>Clipped parent iframe</title></head>
+  <body>
+    <div style="width: 0; height: 0; overflow: hidden">
+      <iframe style="width: 800px; height: 600px" title="Clipped visualization" srcdoc="<!doctype html><h1>Clipped report</h1>"></iframe>
+    </div>
+    <script>throw new Error("bootstrap failed beside clipped frame")</script>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-closed-details-iframe.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-closed-details-iframe.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>Closed details iframe</title></head>
+  <body>
+    <details>
+      <summary>Optional report</summary>
+      <iframe title="Collapsed visualization" srcdoc="<!doctype html><h1>Collapsed report</h1>"></iframe>
+    </details>
+    <script>throw new Error("bootstrap failed beside collapsed frame")</script>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-cloudflare-host-spoof.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-cloudflare-host-spoof.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>Cloudflare host spoof</title></head>
+  <body>
+    <script src="https://static.cloudflareinsights.com.attacker.invalid/beacon.min.js"></script>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-cloudflare-path-spoof.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-cloudflare-path-spoof.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>Cloudflare path spoof</title></head>
+  <body><script src="https://static.cloudflareinsights.com/beacon.min.js.evil"></script></body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-cloudflare-scheme-spoof.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-cloudflare-scheme-spoof.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>Cloudflare scheme spoof</title></head>
+  <body><script src="http://static.cloudflareinsights.com/beacon.min.js"></script></body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-code-only-srcdoc-iframe.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-code-only-srcdoc-iframe.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>Code-only srcdoc iframe</title></head>
+  <body>
+    <iframe
+      title="Code-only generated visualization"
+      srcdoc="<!-- placeholder --><style>body { color: red }</style><script>window.placeholder = true</script>"
+      style="width: 800px; height: 600px; border: 0"
+    ></iframe>
+    <script>throw new Error("bootstrap failed beside code-only srcdoc")</script>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-delayed-hidden-reveal.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-delayed-hidden-reveal.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>Delayed hidden reveal</title></head>
+  <body>
+    <iframe id="generated" hidden title="Hidden then revealed visualization" srcdoc="<!doctype html><h1>Revealed visualization is ready</h1>"></iframe>
+    <script>setTimeout(() => { document.getElementById("generated").hidden = false }, 16000)</script>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-delayed-inserted-srcdoc-frame.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-delayed-inserted-srcdoc-frame.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>Delayed inserted srcdoc</title></head>
+  <body>
+    <script>
+      setTimeout(() => {
+        const frame = document.createElement("iframe")
+        frame.title = "Late inserted visualization"
+        frame.style.cssText = "width: 800px; height: 600px; border: 0"
+        frame.srcdoc = "<!doctype html><h1>Late inserted visualization is ready</h1>"
+        document.body.append(frame)
+      }, 16000)
+    </script>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-delayed-opacity-reveal.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-delayed-opacity-reveal.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>Delayed opacity reveal</title></head>
+  <body>
+    <iframe id="generated" style="opacity: 0" title="Transparent then revealed visualization" srcdoc="<!doctype html><h1>Opaque visualization is ready</h1>"></iframe>
+    <script>setTimeout(() => { document.getElementById("generated").style.opacity = "1" }, 16000)</script>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-delayed-src-frame.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-delayed-src-frame.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Delayed src frame</title>
+    <style>
+      html, body, iframe { width: 100%; height: 100%; margin: 0; border: 0 }
+    </style>
+  </head>
+  <body>
+    <iframe id="generated" title="Delayed URL visualization"></iframe>
+    <script>
+      setTimeout(() => {
+        document.getElementById("generated").src =
+          "data:text/html,%3C!doctype%20html%3E%3Ch1%3EDelayed%20URL%20visualization%20is%20ready%3C%2Fh1%3E"
+      }, 16000)
+    </script>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-delayed-srcdoc-frame.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-delayed-srcdoc-frame.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Delayed srcdoc frame</title>
+    <style>
+      html,
+      body,
+      iframe {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        border: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <iframe id="generated" title="Delayed generated visualization"></iframe>
+    <script>
+      setTimeout(() => {
+        document.getElementById("generated").srcdoc =
+          "<!doctype html><html><body><h1>Delayed visualization is ready</h1></body></html>"
+      }, 16000)
+    </script>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-delayed-srcdoc-replacement.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-delayed-srcdoc-replacement.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>Delayed srcdoc replacement</title></head>
+  <body>
+    <iframe
+      id="generated"
+      title="Replaced visualization"
+      srcdoc="<!doctype html><img src='https://unreachable.invalid/initial.png' alt=''>"
+      style="width: 640px; height: 360px"
+    ></iframe>
+    <script>
+      setTimeout(() => {
+        document.getElementById("generated").srcdoc =
+          "<!doctype html><h1>Replacement visualization is ready</h1>"
+      }, 16000)
+    </script>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-empty-srcdoc-iframe.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-empty-srcdoc-iframe.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>Empty srcdoc iframe</title></head>
+  <body>
+    <iframe
+      title="Empty generated visualization"
+      srcdoc=""
+      style="width: 800px; height: 600px; border: 0"
+    ></iframe>
+    <script>throw new Error("bootstrap failed beside empty srcdoc iframe")</script>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-empty-structure-srcdoc-iframe.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-empty-structure-srcdoc-iframe.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>Empty structural srcdoc iframe</title></head>
+  <body>
+    <iframe
+      title="Empty structural generated visualization"
+      srcdoc="<!doctype html><html><body><main><div><span></span></div></main></body></html>"
+      style="width: 800px; height: 600px; border: 0"
+    ></iframe>
+    <script>throw new Error("bootstrap failed beside empty structural srcdoc")</script>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-entity-space-srcdoc.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-entity-space-srcdoc.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>Entity-only srcdoc</title></head>
+  <body>
+    <iframe title="Entity placeholder" srcdoc="&#32;&#32;&#32;&#32;&#32;&#32;&#32;&#32;&#32;&#32;&#32;&#32;&#32;&#32;&#32;&#32;&#32;&#32;&#32;&#32;"></iframe>
+    <script>throw new Error("bootstrap failed beside entity-only placeholder")</script>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-hidden-srcdoc-frame.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-hidden-srcdoc-frame.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>Hidden srcdoc frame</title></head>
+  <body>
+    <iframe hidden title="Hidden visualization" srcdoc="<!doctype html><h1>Hidden report</h1>"></iframe>
+    <script>throw new Error("bootstrap failed beside hidden frame")</script>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-loaded-image-srcdoc.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-loaded-image-srcdoc.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>Loaded image srcdoc</title></head>
+  <body>
+    <iframe
+      title="Loaded image visualization"
+      srcdoc="<!doctype html><img width='320' height='180' alt='Blue visualization' src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%22320%22 height=%22180%22%3E%3Crect width=%22320%22 height=%22180%22 fill=%22%231d4ed8%22/%3E%3C/svg%3E'>"
+      style="width: 320px; height: 180px"
+    ></iframe>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-optimistic-broken-image.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-optimistic-broken-image.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Partial document with a broken image</title>
+  </head>
+  <body>
+    <main>
+      <h1>Available report content</h1>
+      <p>The chart image is optional; this copy and its control must remain usable.</p>
+      <button id="control" type="button" onclick="this.dataset.clicked='true'">Keep working</button>
+      <img src="https://unreachable.invalid/optional-chart.png" alt="Optional chart unavailable" />
+    </main>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-optimistic-broken-nested-frame.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-optimistic-broken-nested-frame.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>Broken nested frame with useful siblings</title></head>
+  <body>
+    <main>
+      <h1>Primary analysis remains usable</h1>
+      <p>The embedded appendix is optional.</p>
+      <iframe title="Optional appendix" src="https://unreachable.invalid/appendix"></iframe>
+      <button id="control" type="button">Continue</button>
+    </main>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-optimistic-canvas.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-optimistic-canvas.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>Empty optional canvas</title></head>
+  <body>
+    <main>
+      <h1>Controls survive an empty canvas</h1>
+      <canvas width="0" height="0" aria-label="Optional chart"></canvas>
+      <button id="control" type="button">Continue</button>
+    </main>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-optimistic-css-background.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-optimistic-css-background.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Missing CSS background asset</title>
+    <style>
+      main { background-image: url("https://unreachable.invalid/optional-background.png"); }
+    </style>
+  </head>
+  <body>
+    <main><h1>Report without its background</h1><button id="control" type="button">Continue</button></main>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-optimistic-empty.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-optimistic-empty.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Loaded empty document</title>
+  </head>
+  <body data-case="optimistic-empty"></body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-optimistic-font.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-optimistic-font.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Missing optional font</title>
+    <style>
+      @font-face { font-family: OptionalFace; src: url("https://unreachable.invalid/font.woff2"); }
+      body { font-family: OptionalFace, sans-serif; }
+    </style>
+  </head>
+  <body><main><h1>Fallback typography stays readable</h1><button id="control" type="button">Continue</button></main></body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-optimistic-malformed-svg.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-optimistic-malformed-svg.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>Malformed optional SVG path</title></head>
+  <body>
+    <main>
+      <h1>Summary beside an unusual chart</h1>
+      <svg width="320" height="120" aria-label="Optional chart"><path d="M nope" /></svg>
+      <button id="control" type="button">Continue</button>
+    </main>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-optimistic-module.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-optimistic-module.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>Missing optional module</title></head>
+  <body>
+    <main data-derive-ready>
+      <h1>Base document survives an enhancement module failure</h1>
+      <button id="control" type="button">Continue</button>
+      <script type="module" src="https://unreachable.invalid/enhancement.js"></script>
+    </main>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-optimistic-partial-script-error.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-optimistic-partial-script-error.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Partial document before script error</title>
+  </head>
+  <body>
+    <main data-derive-ready>
+      <h1>Content painted before one script failed</h1>
+      <button id="control" type="button" onclick="this.dataset.clicked='true'">Still usable</button>
+      <script>throw new Error("optional enhancement failed")</script>
+    </main>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-optimistic-picture.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-optimistic-picture.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>Broken responsive picture</title></head>
+  <body>
+    <main>
+      <h1>Responsive image failure keeps its siblings</h1>
+      <picture>
+        <source media="(min-width: 1px)" srcset="https://unreachable.invalid/chart.webp" />
+        <img src="https://unreachable.invalid/chart.png" alt="Optional chart unavailable" />
+      </picture>
+      <button id="control" type="button">Continue</button>
+    </main>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-optimistic-stylesheet.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-optimistic-stylesheet.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Missing optional stylesheet</title>
+    <link rel="stylesheet" href="https://unreachable.invalid/theme.css" />
+  </head>
+  <body><main><h1>Unstyled content is still content</h1><button id="control" type="button">Continue</button></main></body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-optimistic-video.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-optimistic-video.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>Missing optional video</title></head>
+  <body>
+    <main>
+      <h1>Transcript remains available</h1>
+      <p>The media clip is optional. This transcript is the durable content.</p>
+      <video controls poster="https://unreachable.invalid/poster.png">
+        <source src="https://unreachable.invalid/clip.mp4" type="video/mp4" />
+        <track kind="captions" src="data:text/vtt,WEBVTT" srclang="en" label="English" default />
+      </video>
+      <button id="control" type="button">Continue</button>
+    </main>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-optimistic-zero-svg.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-optimistic-zero-svg.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Partial document with unusual SVG geometry</title>
+  </head>
+  <body>
+    <main>
+      <h1>Text survives unusual SVG geometry</h1>
+      <svg width="0" height="0" aria-label="Optional zero-area chart"></svg>
+      <button id="control" type="button" onclick="this.dataset.clicked='true'">Keep working</button>
+    </main>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-painted-canvas-srcdoc.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-painted-canvas-srcdoc.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>Painted canvas srcdoc</title></head>
+  <body>
+    <iframe
+      title="Canvas visualization"
+      srcdoc="<!doctype html><canvas id='chart' width='320' height='180'></canvas><script>const c=document.getElementById('chart').getContext('2d');c.fillStyle='%231d4ed8';c.fillRect(0,0,320,180)<\/script>"
+      style="width: 320px; height: 180px"
+    ></iframe>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-platform-script-path-spoof.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-platform-script-path-spoof.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Platform script path spoof</title>
+    <script src="https://attacker.invalid/raw/derive-client.js"></script>
+  </head>
+  <body></body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-semantic-srcdoc.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-semantic-srcdoc.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>Semantic srcdoc</title></head>
+  <body>
+    <iframe title="Semantic report" srcdoc="<!doctype html><main><p>Report ready.</p></main>"></iframe>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-shadow-srcdoc.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-shadow-srcdoc.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>Shadow srcdoc</title></head>
+  <body>
+    <div id="host"></div>
+    <script>
+      const root = document.getElementById("host").attachShadow({ mode: "open" })
+      const frame = document.createElement("iframe")
+      frame.title = "Shadow generated visualization"
+      frame.style.cssText = "width: 640px; height: 360px; border: 0"
+      frame.srcdoc = "<!doctype html><h1>Shadow visualization is ready</h1>"
+      root.append(frame)
+    </script>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-svg-srcdoc-iframe.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-svg-srcdoc-iframe.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>SVG srcdoc</title></head>
+  <body>
+    <iframe
+      title="SVG generated visualization"
+      srcdoc="<!doctype html><svg xmlns='http://www.w3.org/2000/svg' width='640' height='360'><rect width='640' height='360' fill='#172554'/><text x='32' y='64' fill='white'>Quarterly visualization</text></svg>"
+      style="width: 640px; height: 360px; border: 0"
+    ></iframe>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-tiny-text-srcdoc-iframe.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-tiny-text-srcdoc-iframe.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>Tiny text srcdoc</title></head>
+  <body>
+    <iframe title="Tiny text frame" srcdoc="x" style="width: 800px; height: 600px"></iframe>
+    <script>throw new Error("bootstrap failed beside tiny placeholder")</script>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-trusted-platform-query-script.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-trusted-platform-query-script.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>Trusted platform script query</title></head>
+  <body>
+    <script src="/raw/derive-client.js?cache=bust#startup-control"></script>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-unreachable-cross-origin-iframe.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-unreachable-cross-origin-iframe.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>Unreachable cross-origin iframe</title></head>
+  <body>
+    <iframe
+      title="Unreachable generated visualization"
+      src="https://unreachable.invalid/generated-visualization.html"
+      style="width: 800px; height: 600px; border: 0"
+    ></iframe>
+    <script>throw new Error("bootstrap failed beside unreachable iframe")</script>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/fixtures/startup-zero-svg-srcdoc.html
+++ b/apps/web/e2e/render-fidelity/fixtures/startup-zero-svg-srcdoc.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="utf-8" /><title>Zero SVG srcdoc</title></head>
+  <body>
+    <iframe
+      title="Zero SVG placeholder"
+      srcdoc="<!doctype html><svg xmlns='http://www.w3.org/2000/svg' width='0' height='0'></svg>"
+      style="width: 800px; height: 600px"
+    ></iframe>
+    <script>throw new Error("bootstrap failed beside zero SVG")</script>
+  </body>
+</html>

--- a/apps/web/e2e/render-fidelity/render-fidelity.spec.ts
+++ b/apps/web/e2e/render-fidelity/render-fidelity.spec.ts
@@ -52,6 +52,324 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
     ).toBeVisible()
   })
 
+  test("a dynamically assigned srcdoc frame self-recovers after the generic timeout", async ({
+    owner: page,
+  }) => {
+    const html = readFileSync(join(FIXTURES, "startup-delayed-srcdoc-frame.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+
+    await page.goto(`/artifacts/${shortId}`)
+    const artifact = page.frameLocator('iframe[title="index"]')
+    const generated = artifact.frameLocator('iframe[title="Delayed generated visualization"]')
+    await expect(
+      generated.getByRole("heading", { name: "Delayed visualization is ready" }),
+    ).toBeVisible({ timeout: 25_000 })
+    await expect(page.getByText("Preview didn’t load")).toHaveCount(0)
+  })
+
+  for (const [fixture, title] of [
+    ["startup-broken-iframe.html", "a broken iframe with layout dimensions"],
+    ["startup-blank-iframe.html", "an about:blank iframe"],
+    ["startup-empty-srcdoc-iframe.html", "an empty srcdoc iframe"],
+  ] as const) {
+    test(`${title} cannot turn a bootstrap failure into Ready`, async ({ owner: page }) => {
+      const html = readFileSync(join(FIXTURES, fixture), "utf8")
+      const shortId = await publishArtifact(page, "index.html", html, "text/html")
+
+      await page.goto(`/artifacts/${shortId}`)
+      await expect(page.getByText("Artifact script stopped")).toBeVisible()
+      await expect(page.getByTestId("render-degraded")).toHaveCount(0)
+      await expect(page.getByTestId("render-retry")).toHaveCount(1)
+    })
+  }
+
+  test("a foreign script path cannot spoof Derive platform ownership", async ({ owner: page }) => {
+    const html = readFileSync(join(FIXTURES, "startup-platform-script-path-spoof.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+    await page.route("https://attacker.invalid/raw/derive-client.js", (route) => route.abort())
+
+    await page.goto(`/artifacts/${shortId}`)
+    await expect(page.getByText("Artifact script stopped")).toBeVisible()
+    await expect(page.getByText("Preview didn’t load")).toHaveCount(0)
+    await expect(page.getByTestId("render-retry")).toHaveCount(1)
+  })
+
+  test("an unreachable cross-origin iframe cannot turn a bootstrap failure into Ready", async ({
+    owner: page,
+  }) => {
+    const html = readFileSync(
+      join(FIXTURES, "startup-unreachable-cross-origin-iframe.html"),
+      "utf8",
+    )
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+    await page.route("https://unreachable.invalid/**", (route) => route.abort())
+
+    await page.goto(`/artifacts/${shortId}`)
+    await expect(page.getByText("Artifact script stopped")).toBeVisible()
+    await expect(page.getByTestId("render-degraded")).toHaveCount(0)
+  })
+
+  for (const [fixture, title] of [
+    ["startup-code-only-srcdoc-iframe.html", "code-only srcdoc"],
+    ["startup-empty-structure-srcdoc-iframe.html", "empty structural srcdoc"],
+  ] as const) {
+    test(`${title} cannot turn a bootstrap failure into Ready`, async ({ owner: page }) => {
+      const html = readFileSync(join(FIXTURES, fixture), "utf8")
+      const shortId = await publishArtifact(page, "index.html", html, "text/html")
+
+      await page.goto(`/artifacts/${shortId}`)
+      await expect(page.getByText("Artifact script stopped")).toBeVisible()
+      await expect(page.getByTestId("render-degraded")).toHaveCount(0)
+    })
+  }
+
+  test("platform script ownership accepts exact controls and rejects hostname lookalikes", async ({
+    owner: page,
+  }) => {
+    const trustedHtml = readFileSync(
+      join(FIXTURES, "startup-trusted-platform-query-script.html"),
+      "utf8",
+    )
+    const trustedId = await publishArtifact(page, "trusted.html", trustedHtml, "text/html")
+    await page.route("**/raw/derive-client.js?*", (route) => route.abort())
+    await page.goto(`/artifacts/${trustedId}`)
+    await expect(page.getByText("Preview didn’t load")).toBeVisible({ timeout: 20_000 })
+    await expect(page.getByText("Artifact script stopped")).toHaveCount(0)
+
+    const spoofHtml = readFileSync(join(FIXTURES, "startup-cloudflare-host-spoof.html"), "utf8")
+    const spoofId = await publishArtifact(page, "spoof.html", spoofHtml, "text/html")
+    await page.route("https://static.cloudflareinsights.com.attacker.invalid/**", (route) =>
+      route.abort(),
+    )
+    await page.goto(`/artifacts/${spoofId}`)
+    await expect(page.getByText("Artifact script stopped")).toBeVisible()
+    await expect(page.getByText("Preview didn’t load")).toHaveCount(0)
+  })
+
+  test("a late successful src assignment self-recovers after the generic timeout", async ({
+    owner: page,
+  }) => {
+    const html = readFileSync(join(FIXTURES, "startup-delayed-src-frame.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+
+    await page.goto(`/artifacts/${shortId}`)
+    const artifact = page.frameLocator('iframe[title="index"]')
+    const generated = artifact.frameLocator('iframe[title="Delayed URL visualization"]')
+    await expect(
+      generated.getByRole("heading", { name: "Delayed URL visualization is ready" }),
+    ).toBeVisible({ timeout: 25_000 })
+    await expect(page.getByText("Preview didn’t load")).toHaveCount(0)
+  })
+
+  test("tiny srcdoc placeholder text cannot turn a bootstrap failure into Ready", async ({
+    owner: page,
+  }) => {
+    const html = readFileSync(join(FIXTURES, "startup-tiny-text-srcdoc-iframe.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+    await page.goto(`/artifacts/${shortId}`)
+    await expect(page.getByText("Artifact script stopped")).toBeVisible()
+    await expect(page.getByTestId("render-degraded")).toHaveCount(0)
+  })
+
+  test("a visible SVG srcdoc frame reaches Ready", async ({ owner: page }) => {
+    const html = readFileSync(join(FIXTURES, "startup-svg-srcdoc-iframe.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+    await page.goto(`/artifacts/${shortId}`)
+    const generated = page
+      .frameLocator('iframe[title="index"]')
+      .frameLocator('iframe[title="SVG generated visualization"]')
+    await expect(generated.locator("svg")).toBeVisible()
+    await expect(page.getByText("Preview didn’t load")).toHaveCount(0)
+  })
+
+  test("a dynamically inserted srcdoc frame self-recovers after the generic timeout", async ({
+    owner: page,
+  }) => {
+    const html = readFileSync(join(FIXTURES, "startup-delayed-inserted-srcdoc-frame.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+    await page.goto(`/artifacts/${shortId}`)
+    const generated = page
+      .frameLocator('iframe[title="index"]')
+      .frameLocator('iframe[title="Late inserted visualization"]')
+    await expect(
+      generated.getByRole("heading", { name: "Late inserted visualization is ready" }),
+    ).toBeVisible({ timeout: 25_000 })
+    await expect(page.getByText("Preview didn’t load")).toHaveCount(0)
+  })
+
+  test("clearing a previously loaded iframe preserves the monotonic Ready boundary", async ({
+    owner: page,
+  }) => {
+    const html = readFileSync(join(FIXTURES, "startup-cleared-loaded-iframe.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+    await page.goto(`/artifacts/${shortId}`)
+    await expect(page.getByTestId("render-degraded")).toBeVisible()
+    await expect(page.getByText("Artifact script stopped")).toHaveCount(0)
+  })
+
+  test("direct about:blank DOM mutation fails closed under the opaque sandbox", async ({
+    owner: page,
+  }) => {
+    const html = readFileSync(join(FIXTURES, "startup-authored-aboutblank-iframe.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+    await page.goto(`/artifacts/${shortId}`)
+    await expect(page.getByText("Artifact script stopped")).toBeVisible()
+    await expect(page.getByTestId("render-degraded")).toHaveCount(0)
+  })
+
+  for (const [fixture, title, route] of [
+    ["startup-entity-space-srcdoc.html", "whitespace entities", null],
+    [
+      "startup-broken-image-srcdoc.html",
+      "a broken image-only srcdoc",
+      "https://unreachable.invalid/**",
+    ],
+    ["startup-zero-svg-srcdoc.html", "a zero-area SVG srcdoc", null],
+  ] as const) {
+    test(`${title} cannot turn a bootstrap failure into Ready`, async ({ owner: page }) => {
+      const html = readFileSync(join(FIXTURES, fixture), "utf8")
+      const shortId = await publishArtifact(page, "index.html", html, "text/html")
+      if (route) await page.route(route, (request) => request.abort())
+      await page.goto(`/artifacts/${shortId}`)
+      await expect(page.getByText("Artifact script stopped")).toBeVisible()
+      await expect(page.getByTestId("render-degraded")).toHaveCount(0)
+    })
+  }
+
+  test("short semantic text inside srcdoc reaches Ready", async ({ owner: page }) => {
+    const html = readFileSync(join(FIXTURES, "startup-semantic-srcdoc.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+    await page.goto(`/artifacts/${shortId}`)
+    const generated = page
+      .frameLocator('iframe[title="index"]')
+      .frameLocator('iframe[title="Semantic report"]')
+    await expect(generated.getByText("Report ready.")).toBeVisible()
+    await expect(page.getByText("Preview didn’t load")).toHaveCount(0)
+  })
+
+  test("a meaningful srcdoc frame inside a shadow root reaches Ready", async ({ owner: page }) => {
+    const html = readFileSync(join(FIXTURES, "startup-shadow-srcdoc.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+    await page.goto(`/artifacts/${shortId}`)
+    const generated = page
+      .frameLocator('iframe[title="index"]')
+      .frameLocator('iframe[title="Shadow generated visualization"]')
+    await expect(
+      generated.getByRole("heading", { name: "Shadow visualization is ready" }),
+    ).toBeVisible()
+    await expect(page.getByText("Preview didn’t load")).toHaveCount(0)
+  })
+
+  test("a successfully loaded image-only srcdoc reaches Ready", async ({ owner: page }) => {
+    const html = readFileSync(join(FIXTURES, "startup-loaded-image-srcdoc.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+    await page.goto(`/artifacts/${shortId}`)
+    const generated = page
+      .frameLocator('iframe[title="index"]')
+      .frameLocator('iframe[title="Loaded image visualization"]')
+    await expect(generated.getByRole("img", { name: "Blue visualization" })).toBeVisible()
+    await expect(page.getByText("Preview didn’t load")).toHaveCount(0)
+  })
+
+  test("a painted canvas inside srcdoc reaches Ready", async ({ owner: page }) => {
+    const html = readFileSync(join(FIXTURES, "startup-painted-canvas-srcdoc.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+    await page.goto(`/artifacts/${shortId}`)
+    const generated = page
+      .frameLocator('iframe[title="index"]')
+      .frameLocator('iframe[title="Canvas visualization"]')
+    await expect(generated.locator("canvas")).toBeVisible()
+    await expect(page.getByText("Preview didn’t load")).toHaveCount(0)
+  })
+
+  for (const [fixture, title] of [
+    ["startup-hidden-srcdoc-frame.html", "a hidden meaningful srcdoc frame"],
+    ["startup-aria-hidden-srcdoc-frame.html", "an aria-hidden meaningful srcdoc frame"],
+  ] as const) {
+    test(`${title} cannot turn a bootstrap failure into Ready`, async ({ owner: page }) => {
+      const html = readFileSync(join(FIXTURES, fixture), "utf8")
+      const shortId = await publishArtifact(page, "index.html", html, "text/html")
+      await page.goto(`/artifacts/${shortId}`)
+      await expect(page.getByText("Artifact script stopped")).toBeVisible()
+      await expect(page.getByTestId("render-degraded")).toHaveCount(0)
+    })
+  }
+
+  test("replacing a broken srcdoc after timeout self-recovers", async ({ owner: page }) => {
+    const html = readFileSync(join(FIXTURES, "startup-delayed-srcdoc-replacement.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+    await page.route("https://unreachable.invalid/**", (route) => route.abort())
+    await page.goto(`/artifacts/${shortId}`)
+    const generated = page
+      .frameLocator('iframe[title="index"]')
+      .frameLocator('iframe[title="Replaced visualization"]')
+    await expect(
+      generated.getByRole("heading", { name: "Replacement visualization is ready" }),
+    ).toBeVisible({ timeout: 25_000 })
+    await expect(page.getByText("Preview didn’t load")).toHaveCount(0)
+  })
+
+  for (const [fixture, frameTitle, heading] of [
+    [
+      "startup-delayed-hidden-reveal.html",
+      "Hidden then revealed visualization",
+      "Revealed visualization is ready",
+    ],
+    [
+      "startup-delayed-opacity-reveal.html",
+      "Transparent then revealed visualization",
+      "Opaque visualization is ready",
+    ],
+  ] as const) {
+    test(`${frameTitle} self-recovers after timeout`, async ({ owner: page }) => {
+      const html = readFileSync(join(FIXTURES, fixture), "utf8")
+      const shortId = await publishArtifact(page, "index.html", html, "text/html")
+      await page.goto(`/artifacts/${shortId}`)
+      const generated = page
+        .frameLocator('iframe[title="index"]')
+        .frameLocator(`iframe[title="${frameTitle}"]`)
+      await expect(generated.getByRole("heading", { name: heading })).toBeVisible({
+        timeout: 25_000,
+      })
+      await expect(page.getByText("Preview didn’t load")).toHaveCount(0)
+    })
+  }
+
+  for (const [fixture, title] of [
+    ["startup-closed-details-iframe.html", "an iframe inside closed details"],
+    ["startup-clipped-parent-iframe.html", "an iframe clipped by a zero-area parent"],
+  ] as const) {
+    test(`${title} cannot turn a bootstrap failure into Ready`, async ({ owner: page }) => {
+      const html = readFileSync(join(FIXTURES, fixture), "utf8")
+      const shortId = await publishArtifact(page, "index.html", html, "text/html")
+      await page.goto(`/artifacts/${shortId}`)
+      await expect(page.getByText("Artifact script stopped")).toBeVisible()
+      await expect(page.getByTestId("render-degraded")).toHaveCount(0)
+    })
+  }
+
+  test("Cloudflare beacon scheme and path lookalikes remain authored failures", async ({
+    owner: page,
+  }) => {
+    for (const [fixture, route] of [
+      [
+        "startup-cloudflare-scheme-spoof.html",
+        "http://static.cloudflareinsights.com/beacon.min.js",
+      ],
+      [
+        "startup-cloudflare-path-spoof.html",
+        "https://static.cloudflareinsights.com/beacon.min.js.evil",
+      ],
+    ] as const) {
+      const html = readFileSync(join(FIXTURES, fixture), "utf8")
+      const shortId = await publishArtifact(page, fixture, html, "text/html")
+      await page.route(route, (request) => request.abort())
+      await page.goto(`/artifacts/${shortId}`)
+      await expect(page.getByText("Artifact script stopped")).toBeVisible()
+      await expect(page.getByText("Preview didn’t load")).toHaveCount(0)
+    }
+  })
+
   test("viewer fails closed when a script throws before meaningful content", async ({
     browser,
     owner: page,

--- a/apps/web/e2e/render-fidelity/render-fidelity.spec.ts
+++ b/apps/web/e2e/render-fidelity/render-fidelity.spec.ts
@@ -68,7 +68,6 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
   })
 
   for (const [fixture, title] of [
-    ["startup-broken-iframe.html", "a broken iframe with layout dimensions"],
     ["startup-blank-iframe.html", "an about:blank iframe"],
     ["startup-empty-srcdoc-iframe.html", "an empty srcdoc iframe"],
   ] as const) {
@@ -83,6 +82,17 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
     })
   }
 
+  test("a broken nested iframe cannot suppress its loaded outer document", async ({
+    owner: page,
+  }) => {
+    const html = readFileSync(join(FIXTURES, "startup-broken-iframe.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+    await page.goto(`/artifacts/${shortId}`)
+    await expect(page.locator('iframe[title="index"]')).toBeVisible()
+    await expect(page.getByText("Loading preview…")).toHaveCount(0)
+    await expect(page.getByText("Artifact script stopped")).toHaveCount(0)
+  })
+
   test("a foreign script path cannot spoof Derive platform ownership", async ({ owner: page }) => {
     const html = readFileSync(join(FIXTURES, "startup-platform-script-path-spoof.html"), "utf8")
     const shortId = await publishArtifact(page, "index.html", html, "text/html")
@@ -94,7 +104,7 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
     await expect(page.getByTestId("render-retry")).toHaveCount(1)
   })
 
-  test("an unreachable cross-origin iframe cannot turn a bootstrap failure into Ready", async ({
+  test("an unreachable cross-origin iframe cannot suppress its loaded outer document", async ({
     owner: page,
   }) => {
     const html = readFileSync(
@@ -105,8 +115,9 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
     await page.route("https://unreachable.invalid/**", (route) => route.abort())
 
     await page.goto(`/artifacts/${shortId}`)
-    await expect(page.getByText("Artifact script stopped")).toBeVisible()
-    await expect(page.getByTestId("render-degraded")).toHaveCount(0)
+    await expect(page.locator('iframe[title="index"]')).toBeVisible()
+    await expect(page.getByText("Loading preview…")).toHaveCount(0)
+    await expect(page.getByText("Artifact script stopped")).toHaveCount(0)
   })
 
   for (const [fixture, title] of [
@@ -133,7 +144,9 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
     const trustedId = await publishArtifact(page, "trusted.html", trustedHtml, "text/html")
     await page.route("**/raw/derive-client.js?*", (route) => route.abort())
     await page.goto(`/artifacts/${trustedId}`)
-    await expect(page.getByText("Preview didn’t load")).toBeVisible({ timeout: 20_000 })
+    await expect(page.locator('iframe[title="trusted"]')).toBeVisible()
+    await expect(page.getByText("Loading preview…")).toHaveCount(0)
+    await expect(page.getByText("Preview didn’t load")).toHaveCount(0)
     await expect(page.getByText("Artifact script stopped")).toHaveCount(0)
 
     const spoofHtml = readFileSync(join(FIXTURES, "startup-cloudflare-host-spoof.html"), "utf8")
@@ -219,12 +232,6 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
 
   for (const [fixture, title, route] of [
     ["startup-entity-space-srcdoc.html", "whitespace entities", null],
-    [
-      "startup-broken-image-srcdoc.html",
-      "a broken image-only srcdoc",
-      "https://unreachable.invalid/**",
-    ],
-    ["startup-zero-svg-srcdoc.html", "a zero-area SVG srcdoc", null],
   ] as const) {
     test(`${title} cannot turn a bootstrap failure into Ready`, async ({ owner: page }) => {
       const html = readFileSync(join(FIXTURES, fixture), "utf8")
@@ -233,6 +240,24 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
       await page.goto(`/artifacts/${shortId}`)
       await expect(page.getByText("Artifact script stopped")).toBeVisible()
       await expect(page.getByTestId("render-degraded")).toHaveCount(0)
+    })
+  }
+
+  for (const [fixture, title, route] of [
+    [
+      "startup-broken-image-srcdoc.html",
+      "a broken image-only srcdoc",
+      "https://unreachable.invalid/**",
+    ],
+    ["startup-zero-svg-srcdoc.html", "a zero-area SVG srcdoc", null],
+  ] as const) {
+    test(`${title} remains visible instead of blocking the document`, async ({ owner: page }) => {
+      const html = readFileSync(join(FIXTURES, fixture), "utf8")
+      const shortId = await publishArtifact(page, "index.html", html, "text/html")
+      if (route) await page.route(route, (request) => request.abort())
+      await page.goto(`/artifacts/${shortId}`)
+      await expect(page.getByText("Artifact script stopped")).toHaveCount(0)
+      await expect(page.locator('iframe[title="index"]')).toBeVisible()
     })
   }
 
@@ -453,7 +478,7 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
     await expect(artifact.locator("#count")).toHaveText("1")
   })
 
-  test("viewer waits through iframe load, then degrades after delayed meaningful paint", async ({
+  test("viewer shows the loaded iframe while delayed meaningful paint catches up", async ({
     browser,
     owner: page,
   }) => {
@@ -461,8 +486,7 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
     const shortId = await publishArtifact(page, "index.html", html, "text/html")
 
     await page.goto(`/artifacts/${shortId}`)
-    await expect(page.getByText("Loading preview…")).toBeVisible()
-    await expect(page.getByTestId("render-degraded")).toHaveCount(0)
+    await expect(page.getByText("Loading preview…")).toHaveCount(0)
     await expect(page.getByTestId("render-degraded")).toBeVisible()
     const artifact = page.frameLocator('iframe[title="index"]')
     await expect(artifact.locator("#rows tr")).toHaveCount(30)
@@ -473,7 +497,7 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
     const publicPage = await publicContext.newPage()
     try {
       await publicPage.goto(`/artifacts/${shortId}`)
-      await expect(publicPage.getByText("Loading preview…")).toBeVisible()
+      await expect(publicPage.getByText("Loading preview…")).toHaveCount(0)
       await expect(publicPage.getByTestId("render-degraded")).toBeVisible()
       const publicArtifact = publicPage.frameLocator('iframe[title="index"]')
       await expect(publicArtifact.locator("#rows tr")).toHaveCount(30)
@@ -627,14 +651,13 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
     await expect(artifact.locator("#count")).toHaveText("1")
   })
 
-  test("zero-area SVG cannot turn a bootstrap failure into Ready", async ({ owner: page }) => {
+  test("zero-area SVG cannot suppress the rest of a loaded document", async ({ owner: page }) => {
     const html = readFileSync(join(FIXTURES, "startup-zero-area-svg.html"), "utf8")
     const shortId = await publishArtifact(page, "index.html", html, "text/html")
 
     await page.goto(`/artifacts/${shortId}`)
-    await expect(page.getByText("Artifact script stopped")).toBeVisible()
-    await expect(page.getByTestId("render-degraded")).toHaveCount(0)
-    await expect(page.getByTestId("render-retry")).toHaveCount(1)
+    await expect(page.getByText("Artifact script stopped")).toHaveCount(0)
+    await expect(page.locator('iframe[title="index"]')).toBeVisible()
   })
 
   test("meaningful paint after the generic timeout self-recovers to Ready", async ({
@@ -644,11 +667,12 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
     const shortId = await publishArtifact(page, "index.html", html, "text/html")
 
     await page.goto(`/artifacts/${shortId}`)
-    await expect(page.getByText("Preview didn’t load")).toBeVisible({ timeout: 16_000 })
+    await expect(page.getByText("Loading preview…")).toHaveCount(0)
+    await expect(page.getByText("Preview didn’t load")).toHaveCount(0)
     const artifact = page.frameLocator('iframe[title="index"]')
     await expect(
       artifact.getByRole("heading", { name: "Late content recovered automatically" }),
-    ).toBeVisible({ timeout: 5_000 })
+    ).toBeVisible({ timeout: 20_000 })
     await expect(page.getByText("Preview didn’t load")).toHaveCount(0)
     await artifact.locator("#control").click()
     await expect(artifact.locator("#count")).toHaveText("1")
@@ -724,7 +748,6 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
   for (const scenario of [
     { fixture: "startup-hidden-shadow-host.html", label: "an opacity-zero shadow host" },
     { fixture: "startup-hidden-loaded-image.html", label: "a hidden loaded image" },
-    { fixture: "startup-broken-sized-image.html", label: "a broken image with layout dimensions" },
   ]) {
     test(`${scenario.label} cannot satisfy readiness`, async ({ owner: page }) => {
       const html = readFileSync(join(FIXTURES, scenario.fixture), "utf8")
@@ -737,6 +760,17 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
     })
   }
 
+  test("a broken image with authored dimensions cannot block its document", async ({
+    owner: page,
+  }) => {
+    const html = readFileSync(join(FIXTURES, "startup-broken-sized-image.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+    await page.goto(`/artifacts/${shortId}`)
+    await expect(page.getByText("Artifact script stopped")).toHaveCount(0)
+    await expect(page.getByTestId("render-degraded")).toBeVisible()
+    await expect(page.locator('iframe[title="index"]')).toBeVisible()
+  })
+
   test("attribute-only visibility after timeout self-recovers to Ready", async ({
     owner: page,
   }) => {
@@ -747,7 +781,8 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
     const shortId = await publishArtifact(page, "index.html", html, "text/html")
 
     await page.goto(`/artifacts/${shortId}`)
-    await expect(page.getByText("Preview didn’t load")).toBeVisible({ timeout: 16_000 })
+    await expect(page.getByText("Loading preview…")).toHaveCount(0)
+    await expect(page.getByText("Preview didn’t load")).toHaveCount(0)
     const artifact = page.frameLocator('iframe[title="index"]')
     await expect(
       artifact.getByRole("heading", { name: "Attribute-only recovery reached Ready" }),
@@ -881,6 +916,190 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
     const artifact = page.frameLocator('iframe[title="index"]')
     await artifact.locator("#control").click({ timeout: 5_000 })
     await expect(artifact.locator("#count")).toHaveText("1")
+  })
+
+  // Self-learning loop iteration 21: the host optimistically reveals every
+  // successfully loaded document. Descendant/media diagnostics may warn, but they
+  // must not replace partial authored content or leave the wrapper in boot chrome.
+  test("case 80: a loaded empty document exits host loading", async ({ owner: page }) => {
+    const html = readFileSync(join(FIXTURES, "startup-optimistic-empty.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+    await page.goto(`/artifacts/${shortId}`)
+    await expect(page.locator('iframe[title="index"]')).toBeVisible()
+    await expect(page.getByText("Loading preview…")).toHaveCount(0)
+    await expect(page.getByText("Preview didn’t load")).toHaveCount(0)
+  })
+
+  test("case 81: a broken optional image preserves useful text and controls", async ({
+    owner: page,
+  }) => {
+    const html = readFileSync(join(FIXTURES, "startup-optimistic-broken-image.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+    await page.route("https://unreachable.invalid/**", (route) => route.abort())
+    await page.goto(`/artifacts/${shortId}`)
+    const artifact = page.frameLocator('iframe[title="index"]')
+    await expect(artifact.getByRole("heading", { name: "Available report content" })).toBeVisible()
+    await artifact.locator("#control").click()
+    await expect(artifact.locator("#control")).toHaveAttribute("data-clicked", "true")
+    await expect(page.getByText("Artifact script stopped")).toHaveCount(0)
+  })
+
+  test("case 82: zero-area SVG geometry cannot suppress useful siblings", async ({
+    owner: page,
+  }) => {
+    const html = readFileSync(join(FIXTURES, "startup-optimistic-zero-svg.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+    await page.goto(`/artifacts/${shortId}`)
+    const artifact = page.frameLocator('iframe[title="index"]')
+    await expect(
+      artifact.getByRole("heading", { name: "Text survives unusual SVG geometry" }),
+    ).toBeVisible()
+    await artifact.locator("#control").click()
+    await expect(artifact.locator("#control")).toHaveAttribute("data-clicked", "true")
+    await expect(page.getByText("Loading preview…")).toHaveCount(0)
+  })
+
+  test("case 83: a partial document survives a later script failure", async ({ owner: page }) => {
+    const html = readFileSync(
+      join(FIXTURES, "startup-optimistic-partial-script-error.html"),
+      "utf8",
+    )
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+    await page.goto(`/artifacts/${shortId}`)
+    const artifact = page.frameLocator('iframe[title="index"]')
+    await expect(
+      artifact.getByRole("heading", { name: "Content painted before one script failed" }),
+    ).toBeVisible()
+    await artifact.locator("#control").click()
+    await expect(artifact.locator("#control")).toHaveAttribute("data-clicked", "true")
+    await expect(page.getByTestId("render-degraded")).toBeVisible()
+    await expect(page.getByText("Artifact script stopped")).toHaveCount(0)
+  })
+
+  test("case 84: repeated wrapper reloads never strand a loaded document", async ({
+    owner: page,
+  }) => {
+    const html = readFileSync(join(FIXTURES, "startup-threshold-80.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+    await page.goto(`/artifacts/${shortId}`)
+    for (let reload = 0; reload < 5; reload += 1) {
+      await page.reload()
+      await expect(page.locator('iframe[title="index"]')).toBeVisible()
+      await expect(page.getByText("Loading preview…")).toHaveCount(0)
+      const artifact = page.frameLocator('iframe[title="index"]')
+      await artifact.locator("#control").click()
+      await expect(artifact.locator("#control")).toHaveAttribute("data-clicked", "true")
+    }
+  })
+
+  // Iteration 22 — five more optional/odd visual descendants.
+  for (const scenario of [
+    {
+      case: 85,
+      fixture: "startup-optimistic-css-background.html",
+      heading: "Report without its background",
+    },
+    {
+      case: 86,
+      fixture: "startup-optimistic-video.html",
+      heading: "Transcript remains available",
+    },
+    {
+      case: 87,
+      fixture: "startup-optimistic-malformed-svg.html",
+      heading: "Summary beside an unusual chart",
+    },
+    {
+      case: 88,
+      fixture: "startup-optimistic-broken-nested-frame.html",
+      heading: "Primary analysis remains usable",
+    },
+    {
+      case: 89,
+      fixture: "startup-optimistic-canvas.html",
+      heading: "Controls survive an empty canvas",
+    },
+  ]) {
+    test(`case ${scenario.case}: optional visual failure preserves useful siblings`, async ({
+      owner: page,
+    }) => {
+      const html = readFileSync(join(FIXTURES, scenario.fixture), "utf8")
+      const shortId = await publishArtifact(page, "index.html", html, "text/html")
+      await page.route("https://unreachable.invalid/**", (route) => route.abort())
+      await page.goto(`/artifacts/${shortId}`)
+      const artifact = page.frameLocator('iframe[title="index"]')
+      await expect(artifact.getByRole("heading", { name: scenario.heading })).toBeVisible()
+      const control = artifact.locator("#control")
+      await control.click()
+      await expect(control).toBeFocused()
+      await expect(page.getByText("Loading preview…")).toHaveCount(0)
+      await expect(page.getByText("Artifact script stopped")).toHaveCount(0)
+    })
+  }
+
+  // Iteration 23 — missing presentation dependencies plus public/mobile churn.
+  for (const scenario of [
+    {
+      case: 90,
+      fixture: "startup-optimistic-stylesheet.html",
+      heading: "Unstyled content is still content",
+    },
+    {
+      case: 91,
+      fixture: "startup-optimistic-font.html",
+      heading: "Fallback typography stays readable",
+    },
+    {
+      case: 92,
+      fixture: "startup-optimistic-picture.html",
+      heading: "Responsive image failure keeps its siblings",
+    },
+    {
+      case: 93,
+      fixture: "startup-optimistic-module.html",
+      heading: "Base document survives an enhancement module failure",
+    },
+  ]) {
+    test(`case ${scenario.case}: missing presentation dependency keeps the document`, async ({
+      owner: page,
+    }) => {
+      const html = readFileSync(join(FIXTURES, scenario.fixture), "utf8")
+      const shortId = await publishArtifact(page, "index.html", html, "text/html")
+      await page.route("https://unreachable.invalid/**", (route) => route.abort())
+      await page.goto(`/artifacts/${shortId}`)
+      const artifact = page.frameLocator('iframe[title="index"]')
+      await expect(artifact.getByRole("heading", { name: scenario.heading })).toBeVisible()
+      const control = artifact.locator("#control")
+      await control.click()
+      await expect(control).toBeFocused()
+      await expect(page.getByText("Loading preview…")).toHaveCount(0)
+      await expect(page.getByText("Artifact script stopped")).toHaveCount(0)
+    })
+  }
+
+  test("case 94: public mobile reload churn preserves partial content", async ({
+    browser,
+    owner: page,
+  }) => {
+    const html = readFileSync(join(FIXTURES, "startup-optimistic-broken-image.html"), "utf8")
+    const shortId = await publishArtifact(page, "index.html", html, "text/html")
+    const mobileContext = await browser.newContext({ viewport: { width: 390, height: 844 } })
+    const mobile = await mobileContext.newPage()
+    try {
+      await mobile.route("https://unreachable.invalid/**", (route) => route.abort())
+      await mobile.goto(`/artifacts/${shortId}`)
+      for (let reload = 0; reload < 3; reload += 1) {
+        await mobile.reload()
+        const artifact = mobile.frameLocator('iframe[title="index"]')
+        await expect(
+          artifact.getByRole("heading", { name: "Available report content" }),
+        ).toBeVisible()
+        await expect(mobile.getByText("Loading preview…")).toHaveCount(0)
+        await expect(mobile.getByText("Artifact script stopped")).toHaveCount(0)
+      }
+    } finally {
+      await mobileContext.close()
+    }
   })
 
   test("tier 1: a fully self-contained artifact renders with zero console errors, inline script executes", async ({

--- a/apps/web/src/pages/artifact/render-stage.tsx
+++ b/apps/web/src/pages/artifact/render-stage.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, type RefObject, useEffect, useRef, useState } from "react"
+import { type ReactNode, type RefObject, useEffect, useLayoutEffect, useRef, useState } from "react"
 import { Icon } from "@/components/icons"
 import { Spinner } from "@/components/shared/spinner"
 import { StatusPanel } from "@/components/shared/status-panel"
@@ -141,9 +141,9 @@ export function RenderStage({
   wrapRef: RefObject<HTMLDivElement | null>
   /** Called on the iframe's own `load` (the page's bridge handshakes off it). */
   onFrameLoad?: () => void
-  /** A source-free boot failure relayed by the first-injected sandbox runtime. */
+  /** A source-free runtime failure relayed by the first-injected sandbox runtime. */
   runtimeError?: ArtifactRuntimeError | null
-  /** The injected runtime found meaningful content, not merely an iframe load. */
+  /** The injected runtime found meaningful content after the iframe loaded. */
   runtimeReady?: boolean
   /** Editors get repair guidance; readers see a neutral failure. */
   canFixRuntimeError?: boolean
@@ -161,7 +161,7 @@ export function RenderStage({
   const [phase, setPhase] = useState<"booting" | "ready" | "failed">("booting")
   const [attempt, setAttempt] = useState(0)
   // biome-ignore lint/correctness/useExhaustiveDependencies: rawSrc identifies a new iframe document and intentionally resets its startup state.
-  useEffect(() => {
+  useLayoutEffect(() => {
     setPhase("booting")
   }, [rawSrc])
 
@@ -185,6 +185,11 @@ export function RenderStage({
   }, [phase, rawSrc, runtimeError])
 
   const handleLoad = () => {
+    // A successfully loaded document is the optimistic display boundary. The
+    // injected runtime can still classify authored failures after this point, but
+    // it must not keep otherwise usable markup behind host chrome just because a
+    // descendant image/SVG is broken, zero-area, slow, or otherwise unusual.
+    setPhase("ready")
     onFrameLoad?.()
   }
   const retry = () => {
@@ -314,8 +319,8 @@ export function RenderStage({
             // trapping the gesture on a phone (research's scroll-trap fix); the frame
             // opts into its own pan only inside an explicit zoom mode. The iframe keeps
             // its own bg-white (the right default for a transparent HTML doc) but starts
-            // hidden and cross-fades in on load, so the white→content swap resolves
-            // gently over the neutral canvas instead of hard-flashing.
+            // hidden and cross-fades in once the document load completes. Runtime
+            // diagnostics may add a warning without revoking this visible boundary.
             sandbox="allow-scripts allow-forms allow-popups allow-modals allow-downloads"
             className={cn(
               "min-h-0 flex-1 touch-pan-y border-0 bg-white opacity-0 transition-opacity duration-state",
@@ -324,9 +329,9 @@ export function RenderStage({
           />
         )}
 
-        {/* Boot — a calm centered spinner over the white canvas until the render's
-            own `load` fires. Announced politely; not a full skeleton because the
-            artifact's shape is unknowable. */}
+        {/* Boot — a calm centered spinner only until the iframe document's own
+            `load` fires. Descendant readiness is deliberately not a host-level gate:
+            partial authored content is more useful than a perfect loading verdict. */}
         {phase === "booting" && (
           <div
             role="status"

--- a/apps/web/src/pages/artifact/use-artifact-frame.ts
+++ b/apps/web/src/pages/artifact/use-artifact-frame.ts
@@ -220,6 +220,13 @@ export function useArtifactFrame(p: {
       if (d.type === "runtime-ready") {
         runtimeReadyRef.current = true
         setRuntimeReady(true)
+        // A loading-phase error can arrive while HTML is still parsing, before
+        // useful siblings have geometry. If the same document later proves it has
+        // meaningful content, preserve that content and downgrade the incident to
+        // a warning instead of leaving the earlier recovery overlay in its way.
+        setRuntimeError((current) =>
+          current?.phase === "loading" ? { ...current, phase: "ready" } : current,
+        )
         return
       }
       if (

--- a/packages/core/src/shared-state-client.ts
+++ b/packages/core/src/shared-state-client.ts
@@ -47,7 +47,7 @@ export const SHARED_STATE_CLIENT_JS = `(function () {
   // or a non-trivial visible body as meaningful so an optional failure cannot hide a
   // usable artifact behind the host's startup card. Hidden nodes and source text never
   // count: they give the viewer nothing usable to preserve.
-  function isVisiblyRendered(element) {
+  function isVisiblyRendered(element, allowUnpaintedMedia) {
     if (!element || element.hidden) return false;
     try {
       var elementRect = typeof element.getBoundingClientRect === "function"
@@ -88,9 +88,11 @@ export const SHARED_STATE_CLIENT_JS = `(function () {
           ? current.getRootNode() : null;
         current = current.parentElement || (rootNode && rootNode.host) || null;
       }
+      var mediaTag = String(element.tagName || "").toLowerCase();
+      var optimisticMedia = !!allowUnpaintedMedia && (mediaTag === "img" || mediaTag === "svg");
       if (typeof element.getClientRects === "function") {
         var rects = element.getClientRects();
-        if (!rects.length) return false;
+        if (!rects.length && !optimisticMedia) return false;
         var hasArea = false;
         for (var r = 0; r < rects.length; r += 1) {
           if (Number(rects[r].width || 0) > 0 && Number(rects[r].height || 0) > 0) {
@@ -98,9 +100,9 @@ export const SHARED_STATE_CLIENT_JS = `(function () {
             break;
           }
         }
-        if (!hasArea) return false;
+        if (!hasArea && !optimisticMedia) return false;
       }
-      if (String(element.tagName || "").toLowerCase() === "img" &&
+      if (mediaTag === "img" && !optimisticMedia &&
           (!element.complete || Number(element.naturalWidth || 0) <= 0 ||
            Number(element.naturalHeight || 0) <= 0)) return false;
     } catch (_) { /* structural checks and visible text remain as fallbacks */ }
@@ -155,7 +157,11 @@ export const SHARED_STATE_CLIENT_JS = `(function () {
       var rich = body.querySelectorAll
         ? body.querySelectorAll("table,canvas,svg,video,img,iframe") : [];
       for (var i = 0; i < Number(rich.length || 0); i += 1) {
-        if (isVisiblyRendered(rich[i])) return true;
+        // Authored image/SVG markup is optimistic content even when one media
+        // payload fails or reports unusual geometry. CSS-hidden descendants still
+        // fail the ancestor checks above; this only prevents a media oddity from
+        // suppressing the rest of an otherwise loadable document.
+        if (isVisiblyRendered(rich[i], true)) return true;
       }
       var visibleText = typeof body.innerText === "string" ? body.innerText : "";
       var text = String(visibleText).replace(/\\s+/g, "");
@@ -222,7 +228,7 @@ export const SHARED_STATE_CLIENT_JS = `(function () {
         for (var i = 0; i < Number(rich.length || 0); i += 1) {
           var tag = String(rich[i] && rich[i].tagName || "").toLowerCase();
           if (tag === "iframe" && !meaningfulIframe(rich[i])) continue;
-          if (isVisiblyRendered(rich[i])) { richContent = true; break; }
+          if (isVisiblyRendered(rich[i], true)) { richContent = true; break; }
         }
       }
       // innerText is layout-aware and omits script/style/hidden descendants. Falling

--- a/packages/core/src/shared-state-client.ts
+++ b/packages/core/src/shared-state-client.ts
@@ -15,6 +15,31 @@ export const SHARED_STATE_CLIENT_JS = `(function () {
   var ready = false;
   var contentReady = false;
   var reported = Object.create(null);
+  var iframeStates = typeof WeakMap === "function" ? new WeakMap() : null;
+  var watchedIframes = typeof WeakSet === "function" ? new WeakSet() : null;
+
+  function setIframeState(element, state) {
+    if (!element) return;
+    if (iframeStates) iframeStates.set(element, state);
+    else element.__deriveIframeState = state;
+  }
+  function iframeState(element) {
+    return iframeStates ? iframeStates.get(element) : element.__deriveIframeState;
+  }
+  function watchIframe(element) {
+    if (!element) return;
+    var watched = watchedIframes ? watchedIframes.has(element) : element.__deriveIframeWatched;
+    if (watched) return;
+    if (watchedIframes) watchedIframes.add(element);
+    else element.__deriveIframeWatched = true;
+    element.addEventListener("load", function () {
+      setIframeState(element, "loaded");
+      announceReady();
+    });
+    element.addEventListener("error", function () {
+      setIframeState(element, "failed");
+    });
+  }
 
   // The load event is too late to be the only readiness signal. Image error handlers run
   // while the document is still loading, after an app may already have painted a
@@ -93,6 +118,93 @@ export const SHARED_STATE_CLIENT_JS = `(function () {
     }
     return roots;
   }
+  function watchRuntimeIframes() {
+    var doc = window.document, body = doc && doc.body;
+    if (!body) return;
+    var roots = runtimeRoots(body);
+    for (var r = 0; r < roots.length; r += 1) {
+      var frames = roots[r].querySelectorAll ? roots[r].querySelectorAll("iframe") : [];
+      for (var i = 0; i < Number(frames.length || 0); i += 1) watchIframe(frames[i]);
+    }
+  }
+  function meaningfulSrcdoc(source) {
+    var html = String(source || "");
+    if (!html.trim()) return false;
+    var withoutCode = html
+      .replace(/<!--[\\s\\S]*?-->/g, "")
+      .replace(/<(script|style)\\b[^>]*>[\\s\\S]*?<\\/\\1\\s*>/gi, "");
+    var text = withoutCode
+      .replace(/<!doctype[^>]*>/gi, "")
+      .replace(/<[^>]+>/g, "")
+      .replace(/&(?:nbsp|#160|#xa0);/gi, "")
+      .replace(/\\s+/g, "");
+    if (/<(table|canvas|svg|video|img|iframe)\\b/i.test(withoutCode)) return true;
+    if (/<(h[1-6]|p|article|main|section|pre|ul|ol|dl|form|button)\\b/i.test(withoutCode))
+      return text.length > 0;
+    return text.length >= 80;
+  }
+  function meaningfulEmbeddedDocument(element) {
+    try {
+      var embedded = element.contentDocument;
+      if (!embedded || !embedded.body) return null;
+      var body = embedded.body;
+      var markers = body.querySelectorAll ? body.querySelectorAll("[data-derive-ready]") : [];
+      for (var m = 0; m < Number(markers.length || 0); m += 1) {
+        if (isVisiblyRendered(markers[m])) return true;
+      }
+      var rich = body.querySelectorAll
+        ? body.querySelectorAll("table,canvas,svg,video,img,iframe") : [];
+      for (var i = 0; i < Number(rich.length || 0); i += 1) {
+        if (isVisiblyRendered(rich[i])) return true;
+      }
+      var visibleText = typeof body.innerText === "string" ? body.innerText : "";
+      var text = String(visibleText).replace(/\\s+/g, "");
+      var semantic = body.querySelectorAll
+        ? body.querySelectorAll("h1,h2,h3,h4,h5,h6,p,article,main,section,pre,ul,ol,dl,form,button") : [];
+      for (var s = 0; s < Number(semantic.length || 0); s += 1) {
+        if (text.length && isVisiblyRendered(semantic[s])) return true;
+      }
+      return text.length >= 80;
+    } catch (_) {
+      return null;
+    }
+  }
+  function meaningfulIframe(element) {
+    try {
+      var srcdoc = element.getAttribute("srcdoc");
+      if (srcdoc !== null) {
+        var srcdocContent = meaningfulEmbeddedDocument(element);
+        if (srcdocContent !== null) return srcdocContent;
+        return iframeState(element) === "loaded" && meaningfulSrcdoc(srcdoc);
+      }
+      var rawSrc = element.getAttribute("src");
+      var src = rawSrc === null ? "" : String(rawSrc).trim();
+      if (!src || /^about:blank(?:[?#]|$)/i.test(src))
+        return meaningfulEmbeddedDocument(element) === true;
+      if (/^javascript:/i.test(src)) return false;
+      if (iframeState(element) !== "loaded") return false;
+
+      // Resource Timing Level 3 exposes same-origin iframe response status in
+      // modern browsers. A completed error document has geometry and a load event,
+      // but it is not authored content and must not unlock Ready.
+      try {
+        var entries = window.performance && typeof window.performance.getEntriesByName === "function"
+          ? window.performance.getEntriesByName(element.src) : [];
+        var entry = entries && entries.length ? entries[entries.length - 1] : null;
+        var status = entry && Number(entry.responseStatus || 0);
+        if (status && (status < 200 || status >= 400)) return false;
+      } catch (_) { /* opaque successful frames are still eligible after load */ }
+
+      // Same-origin frames are inspectable. Apply the normal meaningful-content
+      // threshold so a short browser/server error page cannot masquerade as the
+      // authored visualization. Cross-origin frames remain opaque and are judged
+      // by their non-blank source plus painted geometry.
+      var embeddedMeaningful = meaningfulEmbeddedDocument(element);
+      return embeddedMeaningful === null ? true : embeddedMeaningful;
+    } catch (_) {
+      return iframeState(element) === "loaded";
+    }
+  }
   function hasMeaningfulContent() {
     try {
       var doc = window.document, body = doc && doc.body;
@@ -106,8 +218,10 @@ export const SHARED_STATE_CLIENT_JS = `(function () {
           if (isVisiblyRendered(markers[m])) return true;
         }
         var rich = roots[r].querySelectorAll
-          ? roots[r].querySelectorAll("table,canvas,svg,video,img,iframe[src],iframe[srcdoc]") : [];
+          ? roots[r].querySelectorAll("table,canvas,svg,video,img,iframe") : [];
         for (var i = 0; i < Number(rich.length || 0); i += 1) {
+          var tag = String(rich[i] && rich[i].tagName || "").toLowerCase();
+          if (tag === "iframe" && !meaningfulIframe(rich[i])) continue;
           if (isVisiblyRendered(rich[i])) { richContent = true; break; }
         }
       }
@@ -129,13 +243,21 @@ export const SHARED_STATE_CLIENT_JS = `(function () {
   }
   function isPlatformScript(source) {
     var value = String(source || "");
-    var suffixAt = value.search(/[?#]/);
-    var bare = suffixAt < 0 ? value : value.slice(0, suffixAt);
-    var shared = "/raw/derive-shared.js";
-    var client = "/raw/derive-client.js";
-    var beacon = "https://static.cloudflareinsights.com/beacon.min.js";
-    return bare.slice(-shared.length) === shared || bare.slice(-client.length) === client ||
-      bare === beacon || bare.indexOf(beacon + "/") === 0;
+    try {
+      var fallback = "https://raw.derive.page/";
+      var base = window.location && window.location.href ? window.location.href : fallback;
+      var currentOrigin = window.location && window.location.origin
+        ? window.location.origin : new URL(base).origin;
+      var parsed = new URL(value, base);
+      var platformPath = parsed.pathname === "/raw/derive-shared.js" ||
+        parsed.pathname === "/raw/derive-client.js";
+      var cloudflare = parsed.protocol === "https:" &&
+        parsed.hostname === "static.cloudflareinsights.com" &&
+        (parsed.pathname === "/beacon.min.js" || parsed.pathname.indexOf("/beacon.min.js/") === 0);
+      return (parsed.origin === currentOrigin && platformPath) || cloudflare;
+    } catch (_) {
+      return false;
+    }
   }
   function announceReady() {
     if (contentReady || !hasMeaningfulContent()) return;
@@ -164,6 +286,9 @@ export const SHARED_STATE_CLIENT_JS = `(function () {
     send({ type: "runtime-error", code: code, phase: phase });
   }
   window.addEventListener("error", function (event) {
+    var target = event && event.target;
+    if (target && String(target.tagName || "").toLowerCase() === "iframe")
+      setIframeState(target, "failed");
     reportRuntimeError(event.error, event.message, event.target, event.filename);
   }, true);
   window.addEventListener("unhandledrejection", function (event) {
@@ -173,7 +298,14 @@ export const SHARED_STATE_CLIENT_JS = `(function () {
   window.addEventListener("load", announceReady);
   try {
     if (typeof MutationObserver === "function") {
-      var observer = new MutationObserver(function () {
+      var observer = new MutationObserver(function (records) {
+        for (var r = 0; r < Number(records && records.length || 0); r += 1) {
+          var record = records[r];
+          if (record && record.type === "attributes" && record.attributeName === "src" &&
+              String(record.target && record.target.tagName || "").toLowerCase() === "iframe")
+            setIframeState(record.target, "loading");
+        }
+        watchRuntimeIframes();
         announceReady();
         if (contentReady) observer.disconnect();
       });
@@ -181,8 +313,9 @@ export const SHARED_STATE_CLIENT_JS = `(function () {
         childList: true,
         subtree: true,
         attributes: true,
-        attributeFilter: ["style", "class", "hidden", "aria-hidden", "open"]
+        attributeFilter: ["style", "class", "hidden", "aria-hidden", "open", "src", "srcdoc"]
       });
+      watchRuntimeIframes();
     }
   } catch (_) { /* the lifecycle events remain as the compatibility path */ }
 

--- a/packages/core/test/shared-state.test.ts
+++ b/packages/core/test/shared-state.test.ts
@@ -224,8 +224,27 @@ describe("shared-state contract", () => {
         height: 600,
       }),
       getClientRects: () => ({ 0: { width: 800, height: 600 }, length: 1 }),
-      getAttribute: () => null,
+      getAttribute: (name: string) =>
+        name === "srcdoc" ? "<h1>Generated report is ready</h1>" : null,
       getRootNode: () => null,
+      contentDocument: {
+        body: {
+          innerText: "Generated report is ready",
+          querySelectorAll: (selector: string) =>
+            selector.startsWith("h1")
+              ? {
+                  0: {
+                    hidden: false,
+                    tagName: "H1",
+                    parentElement: null,
+                    getClientRects: () => ({ 0: { width: 300, height: 40 }, length: 1 }),
+                    getRootNode: () => null,
+                  },
+                  length: 1,
+                }
+              : { length: 0 },
+        },
+      },
     }
     const frame = {
       derive: undefined as DeriveRuntime | undefined,


### PR DESCRIPTION
## Summary
- reveal a successfully loaded outer artifact immediately, so descendant readiness heuristics cannot strand usable content behind `Loading preview…`
- preserve partial documents when images, SVG, canvas, video, CSS, fonts, optional modules, or nested frames are broken, slow, empty, or unusually sized
- downgrade an early loading-phase incident when the same document later proves meaningful, preserving controls under a non-blocking warning
- retain exact platform-script ownership, iframe lifecycle tracking, late mutation recovery, and security/integrity fail-closed behavior
- add 45 deterministic startup-resilience cases across iterations 15–23; the render-fidelity suite now has 86 tests

## Self-learning loop
- iterations 15–18 found and repaired iframe readiness and ownership defects
- iterations 19–20 were clean, but Luna preview dogfood then found an intermittent reload stranded on host loading chrome
- iteration 21 repaired that escape and reset the streak
- Luna independently passed all five new cases in iteration 22 and all five in iteration 23
- stop condition reached again: 2 consecutive clean five-case iterations, 94 accumulated mandatory cases

## Verification
- `pnpm verify`
- `pnpm --filter @derive/web test:e2e:fidelity` — 86/86 passed
- GitHub required checks green, including render-fidelity, accessibility, CodeQL, tests, DB, images, and preview
- rebased onto current `origin/main` before publication

## Luna dogfood
- iteration 22: cases 85–89 passed (missing background/video, malformed SVG, failed nested frame, zero-area canvas)
- iteration 23: cases 90–94 passed (missing CSS/font/picture/module, public mobile reload churn)
- PR preview replay: desktop baseline + 5 reloads passed; 390×844 mobile baseline + 3 reloads passed; no loading, blocked, degraded, recovery, console, overflow, or page-error escape
