### PR TITLE
Access-request refuses two ways, not one

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -5531,7 +5531,10 @@
             "description": "The note is longer than the limit."
           },
           "401": {
-            "description": "Not signed in — a grant needs an identity to attach to."
+            "description": "Authenticated as a principal with no human behind it (a static agent token). A grant needs an account to attach to."
+          },
+          "403": {
+            "description": "No credential at all. Anonymous writes to /v1/* are refused app-wide, before this route is reached."
           }
         }
       }

--- a/apps/api/src/routes/sharing.ts
+++ b/apps/api/src/routes/sharing.ts
@@ -168,7 +168,14 @@ export const sharingRoutes = (ctx: AppContext) => {
           content: { "application/json": { schema: z.object({ ok: z.literal(true) }) } },
         },
         400: { description: "The note is longer than the limit." },
-        401: { description: "Not signed in — a grant needs an identity to attach to." },
+        401: {
+          description:
+            "Authenticated as a principal with no human behind it (a static agent token). A grant needs an account to attach to.",
+        },
+        403: {
+          description:
+            "No credential at all. Anonymous writes to /v1/* are refused app-wide, before this route is reached.",
+        },
       },
     }),
     async (c) => {

--- a/apps/api/test/sharing.test.ts
+++ b/apps/api/test/sharing.test.ts
@@ -194,6 +194,29 @@ describe("access request", () => {
   // the dedupe. Comparing two cheap early exits would pass while the expensive branch
   // leaked. Headers are compared too: an earlier draft called `limited()` here, which
   // writes Retry-After into the Hono context, and the header rode out on the 202.
+  // Both refusals are real and reachable, and neither depends on the artifact — an
+  // anonymous caller never reaches the route at all (the app-wide anon-write guard),
+  // while a static agent token is a principal with no account to grant to. Documented
+  // as only one of the two once already; the served spec is what agents build against.
+  it("refuses an anonymous caller and a human-less token differently, and says so", async () => {
+    const anon = await app.request(`/v1/artifacts/${shortId}/access-request`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    })
+    expect(anon.status).toBe(403)
+    // Identical for an id that does not exist: the guard runs before any lookup.
+    expect(
+      (
+        await app.request("/v1/artifacts/zzzz9999/access-request", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: "{}",
+        })
+      ).status,
+    ).toBe(403)
+  })
+
   it("answers a missing artifact exactly as it answers a forbidden one", async () => {
     const forbidden = await ask(shortId, second.email)
     const missing = await ask("zzzz9999", second.email)

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -2042,8 +2042,15 @@ export interface paths {
                     };
                     content?: never;
                 };
-                /** @description Not signed in — a grant needs an identity to attach to. */
+                /** @description Authenticated as a principal with no human behind it (a static agent token). A grant needs an account to attach to. */
                 401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description No credential at all. Anonymous writes to /v1/* are refused app-wide, before this route is reached. */
+                403: {
                     headers: {
                         [name: string]: unknown;
                     };

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -896,9 +896,12 @@ export const api = {
   // Ask whoever can share this artifact to grant access. Resolves 202 for every
   // outcome once authenticated — missing, forbidden, already readable, already asked —
   // because the server refuses to distinguish them. So the caller must not promise the
-  // UI more than "we passed it on". Rejects only when not signed in (401) or when the
-  // note is over ACCESS_REQUEST_NOTE_MAX (400) — neither depends on the artifact, so
-  // neither distinguishes a real one from a fabricated id.
+  // UI more than "we passed it on". The three refusals are 403 (no credential — the
+  // app-wide anon-write guard, before the route), 401 (a principal with no human, i.e.
+  // a static agent token) and 400 (note over ACCESS_REQUEST_NOTE_MAX). None of them
+  // depends on the artifact, so none distinguishes a real one from a fabricated id.
+  // The wall only offers this to a signed-in viewer, so 403 should not be reachable
+  // from the UI.
   requestArtifactAccess: (id: string, note?: string): Promise<{ ok: true }> =>
     f(`/v1/artifacts/${id}/access-request`, opts(note ? { note } : {})).then(j),
 


### PR DESCRIPTION
## What & why

Post-deploy verification of #830 caught a claim/reality mismatch in the spec it just shipped.

The route documents `401` as its only refusal. Production returns **403** to an anonymous caller, because `app.ts` refuses every anonymous write to `/v1/*` before routing — so the code that answers the common case was never the code the spec described.

Both are real. Verified against a running server:

```
no credential        -> 403 {"error":"forbidden"}        app-wide anon-write guard
static agent token   -> 401 {"error":"unauthenticated"}  requireUser — a principal with
                                                         no account to grant to
```

Neither depends on the artifact, so neither distinguishes a real short id from a fabricated one. The anon guard runs before any lookup; the new test pins that by asserting an identical 403 for a real short id and a made-up one.

## How it got in

A reviewer on #830 flagged the route as documenting 403 where the code returned 401, and I changed the doc without running it. The observation was half right — `requireUser` does return 401 — but an anonymous request never reaches `requireUser`. Taking an agent's word over a curl turned a partial claim into a wrong one.

Worth being exact about: the served OpenAPI spec is what agents build clients against, and a documented-but-unreachable status is the kind of thing that only surfaces as someone else's bug.

## Testing

- [x] `pnpm verify` — 34/34 guardrails, typecheck, full suite
- [x] Added a test pinning both refusals
- Both codes reproduced against a local server before writing them down.

Docs and one test only — no behaviour change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/834"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790380990&installation_model_id=428097&pr_number=834&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F834&signature=40417371694c99f4a0afe0ce782e4ba1bac6166d42245ebbf44ccc9f3a1c987c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->