### PR TITLE
Activity rail: fold publishes per event, one record line for a settled thread

### DIFF
--- a/apps/web/src/pages/artifact/activity-rows.tsx
+++ b/apps/web/src/pages/artifact/activity-rows.tsx
@@ -1,3 +1,4 @@
+import { RotateCcw } from "lucide-react"
 import type { Comment } from "@/api"
 import { Icon } from "@/components/icons"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
@@ -15,6 +16,8 @@ import {
   stamp,
   type TurnItem,
 } from "./lib/activity"
+import { useCommentScope } from "./lib/comment-scope"
+import { useCommentTree } from "./lib/comment-tree"
 import { quoteChipClass } from "./quote-chip"
 
 // The stream's line grammar: a 20px glyph column (who, or what), the sentence, and a
@@ -62,11 +65,15 @@ const clock = (iso: string) =>
 // (each a jump to that version), the review note and its Answer, the reply body.
 function DetailRow({
   row,
+  solo,
   currentVersion,
   onGoToVersion,
   onJump,
 }: {
   row: ActivityRow
+  /** The turn's only row: its line already says what this is, so only the payload
+   *  (the note, the reply) shows — never the same phrase twice. */
+  solo: boolean
   currentVersion: number
   onGoToVersion: (n: number) => void
   onJump: (threadId: string) => void
@@ -112,12 +119,14 @@ function DetailRow({
       if (row.pending) return null
       return (
         <div className="flex flex-col gap-1.5">
-          <div className={head}>
-            <Icon name="review" className="shrink-0" />
-            <span className="min-w-0 truncate">
-              Asked for your review of <span className="font-mono text-xs">v{row.version}</span>
-            </span>
-          </div>
+          {!solo && (
+            <div className={head}>
+              <Icon name="review" className="shrink-0" />
+              <span className="min-w-0 truncate">
+                Asked for your review of <span className="font-mono text-xs">v{row.version}</span>
+              </span>
+            </div>
+          )}
           {row.note && (
             <p
               className={quoteChipClass({
@@ -132,12 +141,14 @@ function DetailRow({
     case "review_sent_back":
       return (
         <div className="flex flex-col gap-1.5">
-          <div className={head}>
-            <Icon name="check" className="shrink-0 text-success" />
-            <span className="min-w-0 truncate">
-              Sent <span className="font-mono text-xs">v{row.version}</span> back
-            </span>
-          </div>
+          {!solo && (
+            <div className={head}>
+              <Icon name="check" className="shrink-0 text-success" />
+              <span className="min-w-0 truncate">
+                Sent <span className="font-mono text-xs">v{row.version}</span> back
+              </span>
+            </div>
+          )}
           {row.note && (
             <p
               className={quoteChipClass({
@@ -161,10 +172,12 @@ function DetailRow({
             FOCUS,
           )}
         >
-          <span className={head}>
-            <Icon name="comments" className="shrink-0" />
-            <span className="truncate">Replied in {row.threadAuthor}'s thread</span>
-          </span>
+          {!solo && (
+            <span className={head}>
+              <Icon name="comments" className="shrink-0" />
+              <span className="truncate">Replied in {row.threadAuthor}'s thread</span>
+            </span>
+          )}
           <span className="line-clamp-2 text-sm text-foreground [word-break:break-word]">
             {row.body}
           </span>
@@ -303,6 +316,7 @@ export function TurnRow({
               <DetailRow
                 key={r.id}
                 row={r}
+                solo={turn.rows.length === 1}
                 currentVersion={currentVersion}
                 onGoToVersion={onGoToVersion}
                 onJump={onJump}
@@ -332,8 +346,11 @@ export function ResolvedRow({
   open: boolean
   onToggle: () => void
 }) {
+  const { canComment } = useCommentScope()
+  const { onResolve } = useCommentTree()
   const root = thread[0]
   if (!root) return null
+  const res = root.resolution
   return (
     <div className="flex flex-col gap-1 py-0.5">
       <button
@@ -360,24 +377,36 @@ export function ResolvedRow({
       </button>
       {open && (
         <>
-          {/* Its settling, from the root's record — who, by which version, when. A thread
-              settled before the record was kept shows only the card. */}
-          {root.resolution && (
-            <div
-              data-testid="thread-resolution"
-              className="flex items-center gap-1.5 pl-7 text-xs text-muted-foreground"
-            >
-              <Icon name="check" size={12} className="text-success" />
-              <span className="min-w-0 truncate">
-                Resolved{root.resolution.by ? ` by ${root.resolution.by}` : ""}
-                {root.resolution.version != null ? ` in v${root.resolution.version}` : ""}
-              </span>
-              <span className="font-mono text-2xs tabular-nums">
-                {stamp(root.resolution.at, now)}
-              </span>
-            </div>
-          )}
-          <CommentCard thread={thread} />
+          {/* The record line: its settling — who, by which version, when — and the one
+              action a settled thread has. State is said here and nowhere in the card
+              below (`settled`): the card is just the conversation. */}
+          <div
+            data-testid="thread-resolution"
+            className="flex items-center gap-1.5 pl-7 text-xs text-muted-foreground"
+          >
+            <Icon name="check" size={12} className="shrink-0 text-success" />
+            <span className="min-w-0 truncate">
+              Resolved{res?.by ? ` by ${res.by}` : ""}
+              {res?.version != null ? ` in v${res.version}` : ""}
+            </span>
+            {res && (
+              <span className="shrink-0 font-mono text-2xs tabular-nums">{stamp(res.at, now)}</span>
+            )}
+            <span className="flex-1" />
+            {canComment && (
+              <Button
+                variant="ghost"
+                size="xs"
+                data-testid="comment-reopen"
+                className="-my-1 -mr-1 text-muted-foreground hover:text-foreground"
+                onClick={() => onResolve(root)}
+              >
+                <RotateCcw aria-hidden className="size-3.5" />
+                Reopen
+              </Button>
+            )}
+          </div>
+          <CommentCard thread={thread} settled />
         </>
       )}
     </div>

--- a/apps/web/src/pages/artifact/artifact-comments.tsx
+++ b/apps/web/src/pages/artifact/artifact-comments.tsx
@@ -59,11 +59,10 @@ export function ArtifactComments(p: {
   canComment: boolean
   /** The suggestion / locked one-liners shown above the stream. */
   hints?: ReactNode
-  /** What the activity stream is built from besides the comments: the versions (and
-   *  the server's time-clustered sessions), the review rounds, and the reader's last
-   *  visit. The page owns the version jump and the send-back write. */
+  /** What the activity stream is built from besides the comments: the versions, the
+   *  review rounds, and the reader's last visit. The page owns the version jump and the
+   *  send-back write. */
   versions: Artifact["versions"]
-  sessions?: Artifact["sessions"]
   currentVersion: number
   rounds: ReviewRound[]
   pendingRound: ReviewRound | null
@@ -132,7 +131,6 @@ export function ArtifactComments(p: {
   // kind, a round's requester) — nothing here is looked up by name.
   const items = buildStream({
     versions: p.versions,
-    sessions: p.sessions,
     comments: p.comments,
     rounds: p.rounds,
     meId: p.meId,

--- a/apps/web/src/pages/artifact/comment-thread.tsx
+++ b/apps/web/src/pages/artifact/comment-thread.tsx
@@ -152,7 +152,18 @@ function roleGuess(snapshot: ElementSnapshotLite | undefined, label: string): st
 // thread, a reply box, and resolve controls. Its interaction state (active/hovered/
 // present) and handlers come from the CommentTree context — the card is the leaf, so a
 // render site is just `<CommentCard thread={t} />` with no drilled props.
-export function CommentCard({ thread, inLayer }: { thread: Comment[]; inLayer?: boolean }) {
+export function CommentCard({
+  thread,
+  inLayer,
+  settled,
+}: {
+  thread: Comment[]
+  inLayer?: boolean
+  /** Rendered under the stream's record line ("Resolved by X in vN · Reopen"), which
+   *  already states the thread's state and carries its one action — so the card shows
+   *  neither: no title-bar Reopen, no status pill, just the conversation. */
+  settled?: boolean
+}) {
   const { canComment, currentSlide, landedSlides, anchorConf, agentIds } = useCommentScope()
   const { activeThread, hoverThread, inDoc, onActivate, onHover, onResolve, onReply, onJump } =
     useCommentTree()
@@ -286,7 +297,7 @@ export function CommentCard({ thread, inLayer }: { thread: Comment[]; inLayer?: 
           here made every card lead with a gray slab) and, when the thread is
           open, its ONE state action: the resolve check, quiet at rest, success
           on hover. The footer below stays purely about replying. */}
-      {(refLabel || active) && (
+      {(refLabel || (active && !settled)) && (
         <div className="flex items-center gap-1.5 px-3 pt-2.5">
           <div className="min-w-0 flex-1">
             {refLabel &&
@@ -331,7 +342,7 @@ export function CommentCard({ thread, inLayer }: { thread: Comment[]; inLayer?: 
                 </div>
               ))}
           </div>
-          {active && (
+          {active && !settled && (
             // Labeled, not icon-only: at launch, "Resolve" has to teach itself.
             // Still quiet in the title bar (ghost, muted → success on hover) —
             // the verb carries the meaning, no tooltip needed.
@@ -363,6 +374,7 @@ export function CommentCard({ thread, inLayer }: { thread: Comment[]; inLayer?: 
           active card, labeling the ordinary state. An agent request shows its
           state in the ribbon above, so the plain badge is suppressed there too. */}
       {active &&
+        !settled &&
         (() => {
           const changed = refLabel && !textPresent && !resolved && !outdated
           const statused = !requestStage && (resolved || outdated)

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -998,7 +998,6 @@ export function Artifact({ template = false }: { template?: boolean }) {
   const unread = countUnread(
     buildStream({
       versions: art.versions,
-      sessions: art.sessions,
       comments,
       rounds: review?.rounds ?? [],
       me: me?.name ?? undefined,
@@ -1636,7 +1635,6 @@ export function Artifact({ template = false }: { template?: boolean }) {
               }
               onSheetHeight={setSheetInset}
               versions={art.versions}
-              sessions={art.sessions}
               currentVersion={art.current_version}
               rounds={review?.rounds ?? []}
               pendingRound={review?.pending ?? null}

--- a/apps/web/src/pages/artifact/lib/activity.test.ts
+++ b/apps/web/src/pages/artifact/lib/activity.test.ts
@@ -1,18 +1,26 @@
 import { describe, expect, it } from "vitest"
 import type { Artifact, Comment, ReviewRound } from "@/api"
-import { buildStream, countUnread, hasDetail, leadRow, phrase, sectionOf, stamp } from "./activity"
+import {
+  buildStream,
+  countUnread,
+  hasDetail,
+  leadRow,
+  phrase,
+  sectionOf,
+  stamp,
+  type TurnItem,
+} from "./activity"
 
 // A fixed clock: Aug 27, 2026, 15:00 local.
 const NOW = new Date(2026, 7, 27, 15, 0).getTime()
-const at = (daysAgo: number, hour = 12, minute = 0) => {
+const at = (daysAgo: number, hour = 12, minute = 0, second = 0) => {
   const d = new Date(NOW)
   d.setDate(d.getDate() - daysAgo)
-  d.setHours(hour, minute, 0, 0)
+  d.setHours(hour, minute, second, 0)
   return d.toISOString()
 }
 
 type Version = Artifact["versions"][number]
-type Session = NonNullable<Artifact["sessions"]>[number]
 // The byline is always the person; an agent that did the work is recorded beside it.
 const CLAUDE = { id: "agent-1", name: "Claude Code" }
 const version = (
@@ -28,15 +36,6 @@ const version = (
   name: null,
   created_at,
   agent,
-})
-const session = (
-  p: Partial<Session> & { n: number; from_n: number; created_at: string },
-): Session => ({
-  count: p.n - p.from_n + 1,
-  author: "Mert",
-  agent_name: null,
-  name: null,
-  ...p,
 })
 const comment = (
   p: Partial<Comment> & { id: string; author: string; created_at: string },
@@ -67,18 +66,14 @@ const round = (p: Partial<ReviewRound> & { id: string; created_at: string }): Re
 const base = { rounds: [], lastSeen: null, lens: "all" as const, now: NOW }
 
 describe("buildStream", () => {
-  it("makes one version row per server session, credited to the agent that did the work", () => {
+  it("folds a run of one actor's versions into one row, credited to the agent that did the work", () => {
     const versions = [
       version(1, "Mert", at(3, 10), "Create"),
       version(2, "Mert", at(3, 10, 15), "Draft", CLAUDE),
       version(3, "Mert", at(3, 10, 18), "Chart", CLAUDE),
       version(4, "Mert", at(3, 10, 24), "Tighten", CLAUDE),
     ]
-    const sessions = [
-      session({ n: 4, from_n: 2, agent_name: "Claude Code", created_at: at(3, 10, 24) }),
-      session({ n: 1, from_n: 1, created_at: at(3, 10) }),
-    ]
-    const items = buildStream({ ...base, versions, sessions, comments: [] })
+    const items = buildStream({ ...base, versions, comments: [] })
     const turns = items.filter((it) => it.type === "turn")
     expect(turns).toHaveLength(2)
     expect(turns[0]).toMatchObject({
@@ -97,7 +92,7 @@ describe("buildStream", () => {
     expect(row?.versions.map((v) => v.n)).toEqual([2, 3, 4])
   })
 
-  it("folds an actor's several sessions in one day into one publish row spanning them", () => {
+  it("folds an actor's whole day of publishes into one row spanning them", () => {
     const versions = [
       version(1, "Mert", at(0, 9), "Walkthrough"),
       version(2, "Mert", at(0, 10), "v2"),
@@ -105,12 +100,7 @@ describe("buildStream", () => {
       version(4, "Mert", at(0, 10, 30), null),
       version(5, "Mert", at(0, 11, 30), null),
     ]
-    const sessions = [
-      session({ n: 5, from_n: 5, created_at: at(0, 11, 30) }),
-      session({ n: 4, from_n: 2, created_at: at(0, 10, 30) }),
-      session({ n: 1, from_n: 1, created_at: at(0, 9) }),
-    ]
-    const [turn] = buildStream({ ...base, versions, sessions, comments: [] })
+    const [turn] = buildStream({ ...base, versions, comments: [] })
     if (turn?.type !== "turn") throw new Error("no turn")
     expect(turn.rows).toHaveLength(1)
     const row = turn.rows[0]
@@ -288,6 +278,40 @@ describe("buildStream", () => {
     expect(only.filter((it) => it.type === "turn")).toHaveLength(1)
   })
 
+  it("keeps a publish before the ask about it, whatever happened between two publishes", () => {
+    // v6 published and asked about; the person answers; v7 published and asked about.
+    // (The server's 30-minute session would cluster v6 and v7 into one — blind to the
+    // ask and the answer between them, and the ask for v6 would precede "v6".)
+    const versions = [
+      version(6, "Mert", at(0, 18, 50), "Merged and deployed", CLAUDE),
+      version(7, "Mert", at(0, 18, 53), "Lead with the live rail", CLAUDE),
+    ]
+    const rounds = [
+      round({
+        id: "rr6",
+        version: 6,
+        created_at: at(0, 18, 50, 30),
+        state: "sent_back",
+        note: "Hmm can we make this better?",
+        resolved_by_name: "Mert",
+        resolved_at: at(0, 18, 51),
+      }),
+      round({ id: "rr7", version: 7, created_at: at(0, 18, 53, 30), note: "Read your note…" }),
+    ]
+    const turns = buildStream({ ...base, versions, comments: [], rounds }).filter(
+      (it) => it.type === "turn",
+    )
+    expect(turns.map((t) => [t.by, t.rows.map((r) => r.kind)])).toEqual([
+      ["Claude Code", ["version", "review_request"]],
+      ["Mert", ["review_sent_back"]],
+      ["Claude Code", ["version", "review_request"]],
+    ])
+    const last = turns[2]?.rows[0]
+    if (last?.kind !== "version") throw new Error("not a version row")
+    expect(last.versions.map((v) => v.n)).toEqual([7])
+    expect(phrase(leadRow(turns[2] as TurnItem))).toBe("asked for review of v7")
+  })
+
   it("never folds what happened since the last visit into a turn from before it", () => {
     // A day's work: v1 at 3:40, v2–v4 by 4:47, v5 at 5:29. The viewer last looked at 5:00.
     const versions = [
@@ -297,15 +321,9 @@ describe("buildStream", () => {
       version(4, "Mert", at(0, 16, 47), null),
       version(5, "Mert", at(0, 17, 29), null),
     ]
-    const sessions = [
-      session({ n: 5, from_n: 5, created_at: at(0, 17, 29) }),
-      session({ n: 4, from_n: 2, created_at: at(0, 16, 47) }),
-      session({ n: 1, from_n: 1, created_at: at(0, 15, 40) }),
-    ]
     const items = buildStream({
       ...base,
       versions,
-      sessions,
       comments: [],
       lastSeen: new Date(at(0, 17)).getTime(),
     })

--- a/apps/web/src/pages/artifact/lib/activity.ts
+++ b/apps/web/src/pages/artifact/lib/activity.ts
@@ -3,9 +3,8 @@ import { groupThreads } from "./layout"
 
 /**
  * The activity stream — the artifact rail's one chronological feed, built from the
- * records the page already holds: versions (grouped into the server's time-clustered
- * `sessions`), comment threads, and review rounds. Pure, so the grouping is unit-tested
- * like `bucketThreads` and the component only renders.
+ * records the page already holds: versions, comment threads, and review rounds. Pure, so
+ * the grouping is unit-tested like `bucketThreads` and the component only renders.
  *
  * Who did what comes from the records, never from a name: a version carries its `agent`,
  * a round its requester's name and kind, a comment its author's kind, a resolved thread
@@ -25,16 +24,12 @@ export type Lens = "all" | "comments"
 export type SectionLabel = "Today" | "Yesterday" | "Earlier"
 
 type Version = Artifact["versions"][number]
-type Session = NonNullable<Artifact["sessions"]>[number]
 
 export type VersionRow = {
   kind: "version"
   id: string
-  /** The session's END — its newest version's time. A publish row sits in the stream
-   *  where it was last touched, carries that as its stamp, and counts as new when it
-   *  was touched since the last visit. (Sessions are disjoint version ranges, so end
-   *  order is version order: two of one actor's sessions can only merge when nothing
-   *  else was published between them.) */
+  /** The first version's time — where the run of publishes began, which is where it
+   *  sits in the stream; the turn's `until` carries the last one, for its stamp. */
   at: string
   /** The actor — the agent's name when one produced the versions on the author's behalf. */
   by: string
@@ -114,8 +109,6 @@ export type StreamItem =
 
 export interface StreamInput {
   versions: Version[]
-  /** The server's time-clustered view of `versions`; absent on a list-row seed. */
-  sessions?: Session[] | null
   comments: Comment[]
   rounds: ReviewRound[]
   /** The viewer — their own replies and resolves are not news to them. Matched by id when
@@ -157,30 +150,12 @@ export function stamp(iso: string, now: number): string {
   return new Date(iso).toLocaleDateString([], { month: "short", day: "numeric" })
 }
 
-/** Version rows: one per server session (several versions by one author within the
- *  clustering window), else one per version when the record carries no sessions. */
-function versionRows(versions: Version[], sessions: Session[] | null | undefined): VersionRow[] {
-  const byN = new Map(versions.map((v) => [v.n, v]))
-  if (sessions?.length) {
-    return sessions.map((s) => {
-      const members = versions
-        .filter((v) => v.n >= s.from_n && v.n <= s.n)
-        .sort((a, b) => a.n - b.n)
-      const newest = byN.get(s.n)
-      return {
-        kind: "version",
-        id: `v-${s.n}`,
-        at: s.created_at,
-        by: s.agent_name ?? (s.author || newest?.author || ""),
-        agent: !!s.agent_name,
-        from: s.from_n,
-        to: s.n,
-        count: s.count,
-        message: newest?.message ?? s.name ?? null,
-        versions: members,
-      }
-    })
-  }
+/** One row per version. The stream does its own folding (`foldTurns`): a run of one
+ *  actor's publishes becomes one row, and ANY event between two of them — an ask, an
+ *  answer, a card — keeps them apart. The server's time-clustered `sessions` are not
+ *  used here on purpose: a session is blind to what happened between its versions, so
+ *  "asked for review of v6" would sit before a v6–v7 row that includes v6. */
+function versionRows(versions: Version[]): VersionRow[] {
   return versions.map((v) => ({
     kind: "version",
     id: `v-${v.n}`,
@@ -273,8 +248,8 @@ function threadRows(
 }
 
 /** Two publish rows by the turn's actor become one: the span widens, the versions run
- *  on in order, the newest message speaks for the range. So a day's sessions read as
- *  "published v1–v5", never "published v1 · +2" with the rest hidden in the count. */
+ *  on in order, the newest message speaks for the range. So a run of publishes reads as
+ *  "published v1–v5", never "published v1 · +4" with the rest hidden in the count. */
 function mergeVersions(into: VersionRow, row: VersionRow): void {
   into.from = Math.min(into.from, row.from)
   into.to = Math.max(into.to, row.to)
@@ -325,7 +300,7 @@ const THREAD_KINDS = new Set<ActivityRow["kind"]>(["reply", "resolved"])
 export function buildStream(input: StreamInput): StreamItem[] {
   const threads = groupThreads(input.comments)
   const rows: ActivityRow[] = [
-    ...versionRows(input.versions, input.sessions),
+    ...versionRows(input.versions),
     ...reviewRows(input.rounds),
     ...threadRows(threads, input.lastSeen, input.meId, input.me),
   ]


### PR DESCRIPTION
## Summary

Three fixes from reading the live rail after #837 shipped.

**A publish sat after the ask about it.** The stream grouped versions by the server's time-clustered `sessions`, which are blind to what happens between two versions: v6 and v7 published three minutes apart became one session, placed at its end — so "asked for review of v6" and the person's answer came *before* any "published v6", and v6 appeared inside v7's list. The stream now builds one row per version and folds them itself: a run of one actor's publishes still reads as one line ("published v1–v5"), but anything between two publishes — an ask, an answer, a card, another actor — keeps them apart. Sessions stay what they were built for: the Version history drawer.

**A one-row turn repeated its own phrase** when opened ("Mert sent v6 back" → "Sent v6 back"); the detail now shows only the payload.

**An opened resolved thread said "resolved" three times** (folded line, record line, status pill) and floated Reopen in a title bar that, for a general comment, had nothing on its left. State is said once and the action lives with the record: the stream's record line reads *Resolved by X in vN · stamp … Reopen*, and the card beneath it (`settled`) is just the conversation — no title-bar action, no pill, a quote chip only if anchored.

## Test plan
- [x] Unit: the real v6/v7 timeline ("keeps a publish before the ask about it, whatever happened between two publishes"), last-visit boundary, merged spans — 97 artifact tests
- [x] `pnpm run ci` 34/34, typecheck, pre-push `verify`
- [x] Screens harnesses (activity, comments) + a resolved *general* comment opened and reopened from the record line, dark mode; smoke 19/19
- [ ] CI on this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790445925&installation_model_id=428097&pr_number=838&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F838&signature=4b38132dfaa8ca377dbfc089793add0c6068395641d8aec2ea860d321c65f597"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->