### PR TITLE
One byline rule for a person, everywhere: display name first

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -2203,7 +2203,7 @@
           },
           "actor": {
             "type": "string",
-            "description": "Who triggered it; for follow/publish this is the person's @handle"
+            "description": "Who triggered it — a person's display name (their handle when they have none)"
           },
           "kind": {
             "type": "string",

--- a/apps/api/src/lib/access-request.ts
+++ b/apps/api/src/lib/access-request.ts
@@ -152,7 +152,7 @@ export const askerName = (asker: Asker): string =>
   // By code point, not code unit: a plain slice can cut an emoji in half and leave a
   // lone surrogate, and this string reaches an email subject line and a stored
   // notification row.
-  [...(asker.name ?? asker.email)].slice(0, ACCESS_REQUEST_NAME_MAX).join("")
+  [...(asker.name ?? asker.username ?? asker.email)].slice(0, ACCESS_REQUEST_NAME_MAX).join("")
 
 /** The bell line: who to grant to, whether to believe the address, then why. */
 export const accessRequestPreview = (asker: Asker, note: string | null): string => {

--- a/apps/api/src/lib/boot-shapes.ts
+++ b/apps/api/src/lib/boot-shapes.ts
@@ -67,7 +67,9 @@ export const Notification = z
   .object({
     id: z.string(),
     user_id: z.string().describe("The recipient this notification belongs to"),
-    actor: z.string().describe("Who triggered it; for follow/publish this is the person's @handle"),
+    actor: z
+      .string()
+      .describe("Who triggered it — a person's display name (their handle when they have none)"),
     kind: z
       .enum(["mention", "comment", "share", "follow", "publish", "review", "access_request"])
       .describe(

--- a/apps/api/src/lib/comments.ts
+++ b/apps/api/src/lib/comments.ts
@@ -1,4 +1,5 @@
 import type { ArtifactRecord, CommentRecord, MetaStore } from "@derive/core"
+import type { UserByline } from "./author"
 import { DERIVE_AUTHOR_ID, type PrincipalKind, principalKind } from "./principal-kind"
 
 /** A deep link to a comment thread on an artifact — channel-neutral and shared by the email
@@ -112,10 +113,22 @@ export function parseMentions(input: unknown): Mention[] {
 }
 
 /** Wire shape for a comment: meta unpacked into clean fields; deleted bodies blanked. */
-export function commentJson(cm: CommentRecord, anchored?: boolean) {
+/**
+ * The wire shape of a comment. `bylines` (lib/author.ts resolveUserBylines) heals a PERSON's
+ * byline — the author's, and a resolution's "by" — to their live display name, the same rule
+ * a version's byline follows: the stored string is a denormalized cache written from the
+ * principal (which prefers the public handle), so without this one person read as "Mert" on
+ * their versions and "mert-testing" on their comments. Agents keep their recorded names.
+ */
+export function commentJson(
+  cm: CommentRecord,
+  anchored?: boolean,
+  bylines: Record<string, UserByline> = {},
+) {
   const { meta, ...rest } = cm
   const md = parseMeta(meta)
   const deleted = !!md.deleted
+  const live = (id: string | null | undefined) => (id ? bylines[id]?.name : undefined) || null
   // The author's kind, from the recorded id — a reader never has to guess it from the name.
   // Rows before `author_id` existed are people (agents came later).
   const author_kind: PrincipalKind | "anonymous" = cm.author_id
@@ -125,8 +138,11 @@ export function commentJson(cm: CommentRecord, anchored?: boolean) {
       : "user"
   return {
     ...rest,
+    author: live(cm.author_id) ?? cm.author,
     author_kind,
-    resolution: md.resolved ?? null,
+    resolution: md.resolved
+      ? { ...md.resolved, by: live(md.resolved.by_id) ?? md.resolved.by }
+      : null,
     body_md: deleted ? "" : cm.body_md,
     reactions: md.reactions ?? {},
     edited: !!md.edited_at,

--- a/apps/api/src/routes/comments.ts
+++ b/apps/api/src/routes/comments.ts
@@ -10,9 +10,11 @@ import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import type { Context } from "hono"
 import type { BlankEnv } from "hono/types"
 import type { AppContext } from "../context"
+import { resolveUserBylines } from "../lib/author"
 import { commentCreatedAction } from "../lib/comment-actions"
 import { commentJson, parseMentions, parseMeta, REACTIONS } from "../lib/comments"
 import { bail, fail, readJson } from "../lib/http"
+import { principalKind } from "../lib/principal-kind"
 import { resolveThreadAction } from "../lib/thread-actions"
 import { Mention as MentionSchema } from "../schemas"
 
@@ -133,8 +135,29 @@ export const commentRoutes = (ctx: AppContext) => {
   // renaming your profile to a victim's name must not grant edit/delete rights.
   // Legacy rows (author_id null, written before this column) fall back to the
   // name match so their authors don't lose access.
-  const ownsComment = (cm: CommentRecord, acting: { id: string; name: string }): boolean =>
-    cm.author_id ? cm.author_id === acting.id : cm.author === acting.name
+  // The live display names behind these rows' people — authors, and whoever settled a
+  // thread — so a byline reads the same here as on a version (see commentJson).
+  const bylinesFor = async (rows: CommentRecord[]) =>
+    resolveUserBylines(
+      meta,
+      rows.flatMap((cm) => {
+        const md = parseMeta(cm.meta)
+        return [cm.author_id, md.resolved?.by_id].filter(
+          (id): id is string => !!id && principalKind(id) === "user",
+        )
+      }),
+    )
+  const commentOut = async (cm: CommentRecord) => commentJson(cm, undefined, await bylinesFor([cm]))
+
+  // By id. A legacy row (no author_id) matches by the byline it was written with — the
+  // display name now, the handle before principalActor changed rule — so both are tried.
+  const ownsComment = (
+    cm: CommentRecord,
+    acting: { id: string; name: string; handle?: string | null },
+  ): boolean =>
+    cm.author_id
+      ? cm.author_id === acting.id
+      : cm.author === acting.name || (!!acting.handle && cm.author === acting.handle)
 
   // Create a comment (new thread) or a reply (pass thread_id).
   app.openapi(
@@ -257,7 +280,7 @@ export const commentRoutes = (ctx: AppContext) => {
           { mentions, actorId: acting?.id ?? null, onBehalfOf: await privateOwnerId(c) },
         ),
       )
-      return c.json(commentJson(created), 201)
+      return c.json(await commentOut(created), 201)
     },
   )
 
@@ -303,9 +326,10 @@ export const commentRoutes = (ctx: AppContext) => {
       // anchor content once (tag-stripping HTML for text-quote matching) and reuse it.
       const raw = cur ? await sourceText(cur) : null
       const content = raw === null ? null : anchorContentFor(raw, cur?.content_type ?? "")
+      const bylines = await bylinesFor(comments)
       return c.json({
         comments: comments.map((cm) =>
-          commentJson(cm, content === null ? true : isAnchored(cm.anchor, content)),
+          commentJson(cm, content === null ? true : isAnchored(cm.anchor, content), bylines),
         ),
       })
     },
@@ -397,7 +421,7 @@ export const commentRoutes = (ctx: AppContext) => {
       md.reactions = reactions
       const updated = await meta.updateComment(cm.id, { meta: JSON.stringify(md) })
       bus.publish(artifact.id, { type: "comment.reacted", thread_id: cm.thread_id })
-      return c.json(commentJson(updated ?? cm))
+      return c.json(await commentOut(updated ?? cm))
     },
   )
 
@@ -439,7 +463,7 @@ export const commentRoutes = (ctx: AppContext) => {
         meta: JSON.stringify(md),
       })
       bus.publish(artifact.id, { type: "comment.updated", thread_id: cm.thread_id })
-      return c.json(commentJson(updated ?? cm))
+      return c.json(await commentOut(updated ?? cm))
     },
   )
 
@@ -490,7 +514,7 @@ export const commentRoutes = (ctx: AppContext) => {
       // two deletes race here, both may run this; deleteThread is idempotent.
       if (live.length === 0) await meta.deleteThread(artifact.id, cm.thread_id)
       bus.publish(artifact.id, { type: "comment.updated", thread_id: cm.thread_id })
-      return c.json(commentJson({ ...cm, meta: JSON.stringify(md) }))
+      return c.json(await commentOut({ ...cm, meta: JSON.stringify(md) }))
     },
   )
 

--- a/apps/api/src/routes/follows.ts
+++ b/apps/api/src/routes/follows.ts
@@ -146,14 +146,16 @@ export const followRoutes = (ctx: AppContext) => {
         await meta.createNotification({
           id: newId("ntf"),
           user_id: r.followedUserId,
-          actor: me.username ?? me.name ?? "Someone",
+          actor: me.name ?? me.username ?? "Someone",
           kind: "follow",
           artifact_id: "",
           artifact_short_id: "",
           artifact_title: null,
           thread_id: "",
           comment_id: "",
-          preview: "started following you",
+          // The follower's handle, for the bell's profile link (the row's text is the bell's
+          // own). `actor` is the display name, like every other notification's.
+          preview: me.username ?? "",
         })
       }
       return c.json({ follow }, 201)

--- a/apps/api/src/routes/realtime.ts
+++ b/apps/api/src/routes/realtime.ts
@@ -182,7 +182,9 @@ export const realtimeRoutes = (ctx: AppContext) => {
       const me = await currentUser(c)
       const gid = guestViewerId(c)
       const id = me?.id ?? gid
-      const name = me ? (me.username ?? "someone") : anonName(gid)
+      // A person's display name, the byline every other surface uses — the facepile and
+      // cursor flags sit beside the activity rail, and must not call the same person "@ada".
+      const name = me ? (me.name ?? me.username ?? "someone") : anonName(gid)
       bus.publish(artifact.id, {
         type: "cursor",
         id,

--- a/apps/api/test/agents.test.ts
+++ b/apps/api/test/agents.test.ts
@@ -88,7 +88,14 @@ describe("agents: @mention → pull inbox → ack", () => {
 })
 
 describe("agents: the record says who did the work", () => {
-  const owner: TestUser = { id: "u_ag_rec", email: "agrec@derive.test", name: "Owner" }
+  // A handle AND a display name: the comment is written from the handle (principalActor),
+  // and must still read by the display name, like the person's versions do.
+  const owner: TestUser = {
+    id: "u_ag_rec",
+    email: "agrec@derive.test",
+    name: "Owner",
+    username: "owner-handle",
+  }
   const { app } = makeAuthedApp("agents-record", [owner], "owner")
 
   it("an agent's publish, ask, comment and resolve are recorded as the agent's, on the person's behalf", async () => {
@@ -139,7 +146,7 @@ describe("agents: the record says who did the work", () => {
         jsonAs(as(owner.email), { body_md: "Is §3 right?" }),
       )
     ).json()
-    expect(theirs.author_kind).toBe("user")
+    expect(theirs).toMatchObject({ author: "Owner", author_kind: "user" })
     const agents = await (
       await app.request(
         `/v1/artifacts/${shortId}/comments`,
@@ -170,5 +177,20 @@ describe("agents: the record says who did the work", () => {
       by_kind: "agent",
       version: 3,
     })
+
+    // A person's own resolve reads by their display name too — healed from the live record.
+    const byHand = await app.request(
+      `/v1/artifacts/${shortId}/comments/${agents.id}/resolve`,
+      jsonAs(as(owner.email), { state: "resolved" }),
+    )
+    expect(byHand.status).toBe(200)
+    const mine = (
+      await (
+        await app.request(`/v1/artifacts/${shortId}/comments?state=resolved`, {
+          headers: as(owner.email),
+        })
+      ).json()
+    ).comments.find((c: { id: string }) => c.id === agents.id)
+    expect(mine.resolution).toMatchObject({ by: "Owner", by_id: owner.id, by_kind: "user" })
   })
 })

--- a/apps/api/test/comment-access.test.ts
+++ b/apps/api/test/comment-access.test.ts
@@ -100,7 +100,7 @@ describe("comment access via the general-access link", () => {
     expect((await comment(shortId, as(bob.email))).status).toBe(403)
   })
 
-  it("lets commenters interact with shared state and stamps their identity server-side", async () => {
+  it("lets commenters interact with shared state and stamps their identity server-side (by display name — the one byline rule)", async () => {
     await app.request("/v1/me", { headers: as(alice.email) })
     const shortId = (await (await publishAs(app, "<h1>bugs</h1>", {}, as(alice.email))).json())
       .short_id
@@ -137,7 +137,7 @@ describe("comment access via the general-access link", () => {
         op: "add",
         initial: [],
         value: { title: "Voting is stale", votes: 0 },
-        actor: { id: alice.id, name: "alice-handle" },
+        actor: { id: alice.id, name: "Alice" },
       },
       as(bob.email),
     )
@@ -196,8 +196,8 @@ describe("comment access via the general-access link", () => {
     expect((await activity.json()).activity).toMatchObject([
       { action: "update", item_id: itemId },
       { action: "update", item_id: itemId },
-      { action: "update", item_id: itemId, actor: { id: bob.id, name: "bob-handle" } },
-      { action: "add", item_id: itemId, actor: { id: bob.id, name: "bob-handle" } },
+      { action: "update", item_id: itemId, actor: { id: bob.id, name: "Bob" } },
+      { action: "add", item_id: itemId, actor: { id: bob.id, name: "Bob" } },
     ])
 
     // Comment rights enable the intended public interaction vocabulary, not an
@@ -325,11 +325,11 @@ describe("comment access via the general-access link", () => {
       expect.arrayContaining([
         expect.objectContaining({
           action: "set_mine",
-          actor: { id: bob.id, name: "bob-handle" },
+          actor: { id: bob.id, name: "Bob" },
         }),
         expect.objectContaining({
           action: "set_mine",
-          actor: { id: alice.id, name: "alice-handle" },
+          actor: { id: alice.id, name: "Alice" },
         }),
       ]),
     )

--- a/apps/api/test/follows.test.ts
+++ b/apps/api/test/follows.test.ts
@@ -87,9 +87,10 @@ describe("people follow", () => {
     const amyProfile = await (await app.request("/v1/users/amy", { headers: as(bob.email) })).json()
     expect(amyProfile.user.followed_by_me).toBe(true)
 
-    // amy sees a "follow" notification from bob (by his handle).
+    // amy sees a "follow" notification from bob — by his display name, like every other
+    // byline; his handle rides in `preview` for the bell's profile link.
     const notifs = await (await app.request("/v1/notifications", { headers: as(amy.email) })).json()
-    expect(notifs.notifications[0]).toMatchObject({ kind: "follow", actor: "bob" })
+    expect(notifs.notifications[0]).toMatchObject({ kind: "follow", actor: "Bob", preview: "bob" })
 
     // Unfollow removes it (and the follower count drops back).
     const del = await app.request("/v1/follows", {

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -7316,7 +7316,7 @@ export interface components {
             id: string;
             /** @description The recipient this notification belongs to */
             user_id: string;
-            /** @description Who triggered it; for follow/publish this is the person's @handle */
+            /** @description Who triggered it — a person's display name (their handle when they have none) */
             actor: string;
             /**
              * @description What happened: mention, comment, share, follow, publish, review, or access_request (someone who cannot open the artifact is asking you to grant it)

--- a/apps/web/src/components/billing/upgrade-dialog.tsx
+++ b/apps/web/src/components/billing/upgrade-dialog.tsx
@@ -40,7 +40,7 @@ function UpgradeDialogBody({ reason }: { reason: PaywallReason }) {
   const isAdmin = ws?.role === "owner"
   const admins = (ws?.members ?? [])
     .filter((m) => m.role === "owner")
-    .map((m) => m.name ?? m.handle ?? "a workspace admin")
+    .map((m) => m.name ?? (m.handle ? `@${m.handle}` : "a workspace admin"))
 
   const checkout = useCheckout()
 

--- a/apps/web/src/components/chrome/notification-bell.tsx
+++ b/apps/web/src/components/chrome/notification-bell.tsx
@@ -93,7 +93,10 @@ export function NotificationBell() {
     }
     // A follow notification has no artifact — open the follower's profile instead.
     if (n.kind === "follow") {
-      nav({ to: "/users/$handle", params: { handle: n.actor } })
+      // The handle rides in `preview` (older rows carried the row's text there, and their
+      // `actor` was the handle itself).
+      const handle = n.preview && !/\s/.test(n.preview) ? n.preview : n.actor
+      nav({ to: "/users/$handle", params: { handle } })
       return
     }
     nav({

--- a/apps/web/src/pages/artifact/artifact-actions.ts
+++ b/apps/web/src/pages/artifact/artifact-actions.ts
@@ -10,7 +10,12 @@ import type { CommentActions } from "./comment-actions"
 import { toggleReaction } from "./lib/reactions"
 import type { ComposerState, Sel, Selection } from "./types"
 
-type Me = { id?: string; name?: string | null; email?: string | null } | null
+type Me = {
+  id?: string
+  name?: string | null
+  username?: string | null
+  email?: string | null
+} | null
 
 /**
  * Every mutating action the artifact page drives: editing (publish a version / submit a
@@ -141,7 +146,9 @@ export function useArtifactActions(p: {
       path: null,
       anchor: opts?.anchor ? JSON.stringify(opts.anchor) : null,
       body_md: text,
-      author: me?.name ?? me?.email ?? "You",
+      // The server's byline rule (name, else handle, else email), so the optimistic row
+      // reads exactly as the saved one will.
+      author: me?.name ?? me?.username ?? me?.email ?? "You",
       author_kind: "user",
       state: "open",
       created_at: new Date().toISOString(),
@@ -201,7 +208,9 @@ export function useArtifactActions(p: {
       const rollback = snapshot(client, commentsKey)
       client.setQueryData<Comment[]>(commentsKey, (cs) =>
         (cs ?? []).map((c) =>
-          c.id === commentId ? toggleReaction(c, emoji, me?.name ?? me?.email ?? "anonymous") : c,
+          c.id === commentId
+            ? toggleReaction(c, emoji, me?.name ?? me?.username ?? me?.email ?? "anonymous")
+            : c,
         ),
       )
       return rollback
@@ -229,7 +238,7 @@ export function useArtifactActions(p: {
   })
   const actions: CommentActions = {
     meId: me?.id ?? "",
-    meName: me?.name ?? me?.email ?? "",
+    meName: me?.name ?? me?.username ?? me?.email ?? "",
     react: (commentId, emoji) => react.mutate({ commentId, emoji }),
     edit: (commentId, body) => editComment.mutate({ commentId, body }),
     remove: (commentId) => removeComment.mutate(commentId),

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -1639,7 +1639,7 @@ export function Artifact({ template = false }: { template?: boolean }) {
               rounds={review?.rounds ?? []}
               pendingRound={review?.pending ?? null}
               meId={me?.id ?? ""}
-              meName={me?.name ?? me?.email ?? ""}
+              meName={me?.name ?? me?.username ?? me?.email ?? ""}
               lastSeen={seen.lastSeen}
               onGoToVersion={goToVersion}
               onSendBack={(note) => sendBack.mutate(note)}

--- a/apps/web/src/pages/artifact/lib/activity.test.ts
+++ b/apps/web/src/pages/artifact/lib/activity.test.ts
@@ -333,6 +333,22 @@ describe("buildStream", () => {
     expect(countUnread(items)).toBe(1)
   })
 
+  it("folds by identity: one person renamed stays one turn, two people sharing a name stay apart", () => {
+    const versions = [
+      { ...version(1, "Mert", at(0, 9), "One"), handle: "mert" },
+      // The same person, renamed between publishes.
+      { ...version(2, "Mert O.", at(0, 10), "Two"), handle: "mert" },
+      // Someone else who happens to share the first name.
+      { ...version(3, "Mert", at(0, 11), "Three"), handle: "other-mert" },
+    ]
+    const turns = buildStream({ ...base, versions, comments: [] }).filter(
+      (it) => it.type === "turn",
+    )
+    expect(
+      turns.map((t) => t.rows.map((r) => (r.kind === "version" ? `v${r.from}-${r.to}` : r.kind))),
+    ).toEqual([["v1-2"], ["v3-3"]])
+  })
+
   it("knows the viewer by id, so their own reply under a different byline is not news", () => {
     const seen = new Date(at(0, 12)).getTime()
     const comments = [
@@ -422,6 +438,7 @@ describe("leadRow / phrase / hasDetail", () => {
         id: "",
         at: "",
         by: "",
+        byId: null,
         agent: false,
         from: 9,
         to: 11,
@@ -436,6 +453,7 @@ describe("leadRow / phrase / hasDetail", () => {
         id: "",
         at: "",
         by: "",
+        byId: null,
         agent: false,
         from: 4,
         to: 4,
@@ -450,6 +468,7 @@ describe("leadRow / phrase / hasDetail", () => {
         id: "",
         at: "",
         by: null,
+        byId: null,
         agent: false,
         version: 3,
         note: null,
@@ -461,6 +480,7 @@ describe("leadRow / phrase / hasDetail", () => {
         id: "",
         at: "",
         by: "Noor",
+        byId: null,
         agent: false,
         threadId: "t",
         threadAuthor: "Ada",
@@ -473,6 +493,7 @@ describe("leadRow / phrase / hasDetail", () => {
         id: "",
         at: "",
         by: "Claude Code",
+        byId: CLAUDE.id,
         agent: true,
         threadId: "t",
         threadAuthor: "Ada",

--- a/apps/web/src/pages/artifact/lib/activity.ts
+++ b/apps/web/src/pages/artifact/lib/activity.ts
@@ -33,6 +33,9 @@ export type VersionRow = {
   at: string
   /** The actor — the agent's name when one produced the versions on the author's behalf. */
   by: string
+  /** The actor's stable identity when the record has one (an agent id, a person's handle):
+   *  turns fold by it, so a rename never splits one person and a shared name never joins two. */
+  byId: string | null
   agent: boolean
   /** The version range this row covers (a session folds several). */
   from: number
@@ -50,6 +53,7 @@ export type ReviewRequestRow = {
   at: string
   /** The requester's recorded name; null on a row the server could not name. */
   by: string | null
+  byId: string | null
   agent: boolean
   version: number
   note: string | null
@@ -60,6 +64,7 @@ export type ReviewSentBackRow = {
   id: string
   at: string
   by: string | null
+  byId: string | null
   agent: boolean
   version: number
   note: string | null
@@ -69,6 +74,7 @@ export type ReplyRow = {
   id: string
   at: string
   by: string
+  byId: string | null
   agent: boolean
   threadId: string
   threadAuthor: string
@@ -80,6 +86,7 @@ export type ResolvedRow = {
   at: string
   /** The resolver's recorded name; null when the record has none (a Slack click). */
   by: string | null
+  byId: string | null
   agent: boolean
   threadId: string
   threadAuthor: string
@@ -96,6 +103,7 @@ export type TurnItem = {
   /** The newest row's time — the stamp the line carries. */
   until: string
   by: string | null
+  byId: string | null
   /** The actor is an agent (acting on someone's behalf). */
   agent: boolean
   /** Never empty — a turn is made from its first row. */
@@ -161,6 +169,7 @@ function versionRows(versions: Version[]): VersionRow[] {
     id: `v-${v.n}`,
     at: v.created_at,
     by: v.agent?.name ?? v.author,
+    byId: v.agent?.id ?? (v.handle ? `@${v.handle}` : null),
     agent: !!v.agent,
     from: v.n,
     to: v.n,
@@ -182,6 +191,7 @@ function reviewRows(rounds: ReviewRound[]) {
       id: `rr-${r.id}`,
       at: r.created_at,
       by: r.requested_by_name,
+      byId: r.requested_by,
       agent: r.requested_by_kind === "agent",
       version: r.version,
       note: pending ? r.note : null,
@@ -193,6 +203,8 @@ function reviewRows(rounds: ReviewRound[]) {
         id: `rs-${r.id}`,
         at: r.resolved_at,
         by: r.resolved_by_name,
+        // The round keeps the answerer's name, not their id.
+        byId: null,
         // Only a person answers a round (the route insists on one).
         agent: false,
         version: r.version,
@@ -225,6 +237,7 @@ function threadRows(
         id: `r-${c.id}`,
         at: c.created_at,
         by: c.author,
+        byId: c.author_id ?? null,
         agent: c.author_kind === "agent",
         threadId: root.thread_id,
         threadAuthor: root.author,
@@ -238,6 +251,7 @@ function threadRows(
         id: `x-${root.thread_id}`,
         at: res.at,
         by: res.by,
+        byId: res.by_id,
         agent: res.by_kind === "agent",
         threadId: root.thread_id,
         threadAuthor: root.author,
@@ -260,18 +274,21 @@ function mergeVersions(into: VersionRow, row: VersionRow): void {
 }
 
 /** Fold consecutive rows by one actor on one day into a turn. A row with no actor (a
- *  round or a resolve the record could not name) rides with the turn before it. An actor
- *  is a name AND a kind: a person who shares an agent's name is not that agent. The
- *  viewer's last visit is a boundary too: what happened since must start its own turn,
- *  or it folds into one that sits before the "New" marker and is never new. */
+ *  round or a resolve the record could not name) rides with the turn before it. Actors
+ *  match by identity when both rows carry one, else by name AND kind (a person who shares
+ *  an agent's name is not that agent). The viewer's last visit is a boundary too: what
+ *  happened since must start its own turn, or it folds into one that sits before the
+ *  "New" marker and is never new. */
 function foldTurns(rows: ActivityRow[], lastSeen: number | null): TurnItem[] {
   const turns: TurnItem[] = []
   let cur: TurnItem | null = null
   const seen = (iso: string) => lastSeen != null && ms(iso) <= lastSeen
   for (const row of rows) {
+    const sameActor = (a: TurnItem, b: ActivityRow) =>
+      a.byId && b.byId ? a.byId === b.byId : a.by === b.by && a.agent === b.agent
     const joins =
       cur !== null &&
-      (row.by === null || (cur.by === row.by && cur.agent === row.agent)) &&
+      (row.by === null || sameActor(cur, row)) &&
       dayKey(cur.at) === dayKey(row.at) &&
       seen(cur.at) === seen(row.at)
     if (joins && cur) {
@@ -286,6 +303,7 @@ function foldTurns(rows: ActivityRow[], lastSeen: number | null): TurnItem[] {
         at: row.at,
         until: row.at,
         by: row.by,
+        byId: row.byId,
         agent: row.agent,
         rows: [row],
       }

--- a/packages/core/src/principal.ts
+++ b/packages/core/src/principal.ts
@@ -42,14 +42,27 @@ export const principalOwnerId = (p: Principal): string | null =>
 
 /**
  * The ACTING identity for authorship bylines: an agent authors as ITSELF (never spoofing a
- * person), a human as themselves (public handle preferred over profile name/email). Null for anonymous
- * or the static token (no authored byline).
+ * person), a human as themselves. Null for anonymous or the static token (no authored byline).
+ *
+ * A person's byline is their DISPLAY NAME — `name`, else the handle, else the email — the one
+ * rule every surface follows (a version's healed byline, `actingHuman`, `requireDirectHuman`,
+ * lib/author.ts bylinesFrom). This used to prefer the handle, which is why one person read as
+ * "Mert" on their versions and "mert-testing" on their comments, reactions, resolves, share
+ * and follow notifications, Slack footers and the audit log. The handle rides along as
+ * `handle` for the one legacy check that still matches by name (routes/comments.ts
+ * ownsComment, for rows written before comments kept an author id).
  */
-export const principalActor = (p: Principal): { id: string; name: string } | null =>
+export const principalActor = (
+  p: Principal,
+): { id: string; name: string; handle: string | null } | null =>
   p.kind === "agent"
-    ? { id: p.agent.id, name: p.agent.name }
+    ? { id: p.agent.id, name: p.agent.name, handle: null }
     : p.kind === "human"
-      ? { id: p.user.id, name: p.user.username ?? p.user.name ?? p.user.email }
+      ? {
+          id: p.user.id,
+          name: p.user.name ?? p.user.username ?? p.user.email,
+          handle: p.user.username ?? null,
+        }
       : null
 
 /** Is this an authenticated principal (token, agent, or human) rather than an anonymous

--- a/packages/core/test/principal.test.ts
+++ b/packages/core/test/principal.test.ts
@@ -43,23 +43,27 @@ describe("principalActor — the authorship byline identity", () => {
     expect(principalActor({ kind: "agent", agent: agent(), onBehalfOf: "u9" })).toEqual({
       id: "ag_1",
       name: "Claude",
+      handle: null,
     })
   })
-  it("a human authors as themselves, preferring handle over email", () => {
-    expect(principalActor(human)).toEqual({ id: "u1", name: "ada" })
+  it("a human authors by display name — the one byline rule — with the handle riding along", () => {
+    // Name first: the same rule as a version's healed byline, actingHuman and
+    // requireDirectHuman, so one person never reads as "Ada" here and "ada" there.
+    expect(principalActor(human)).toEqual({ id: "u1", name: "Ada", handle: "ada" })
+    // No display name: the handle is the name.
     expect(
       principalActor({
         kind: "human",
         user: { id: "u2", email: "b@x.com", name: null, username: "bo" },
       }),
-    ).toEqual({ id: "u2", name: "bo" })
+    ).toEqual({ id: "u2", name: "bo", handle: "bo" })
     // Email is only the last-ditch fallback when name + handle are both unset.
     expect(
       principalActor({
         kind: "human",
         user: { id: "u3", email: "c@x.com", name: null, username: null },
       }),
-    ).toEqual({ id: "u3", name: "c@x.com" })
+    ).toEqual({ id: "u3", name: "c@x.com", handle: null })
   })
   it("is null for anonymous and the static token (no authored byline)", () => {
     expect(principalActor({ kind: "anonymous" })).toBeNull()


### PR DESCRIPTION
## Summary

A person read as "Mert" on their versions and "mert-testing" on their comments. The record was consistent (one author id); the names were not, because two rules were in play: version bylines are healed on read from the live user record, **display name first** (`lib/author.ts`), while comments — and everything else written through `principalActor` — took the **handle first**.

**The rule is now one, at the source.** `principalActor` names a person by display name, then handle, then email — the chain `actingHuman`, `requireDirectHuman` and the healed readers already used. Everything it feeds follows: comments, reactions, thread resolves, review requesters over HTTP, share and follow notifications and their emails, Slack footers and DMs, shared-state actors, the moderation audit log. It still carries the handle for the one legacy check that matches by byline (`ownsComment`, on rows written before comments kept an author id — it tries name *or* handle, so those rows keep Edit/Delete).

**Aligned to the same rule:** presence + cursor names (were handle-only: "@ada is viewing" beside "Ada published v9"); the access-request asker; the follow notification (the handle rides in `preview` for the bell's profile link; older rows still work); the web's own-name chain (an optimistic comment reads exactly as the saved one will); a bare handle in the upgrade dialog.

**Healed on read, as versions are:** comment responses resolve a person's byline — the author's, and a resolution's "by" — from the live record, so handle-era rows and renames read right without a migration.

**Stream folds by identity:** rows carry `byId` (agent id / person's handle / author id), so a rename never splits one person into two turns and a shared name never merges two people.

Left as-is, deliberately: `@handle` inside comment bodies (the mention token); a Slack-button resolve records the Slack username; avatar tint keyed on label; old notification rows have no actor id to heal from; MCP `catch_up` returns stored authors raw (display-first going forward).

## Test plan
- [x] core `principal.test.ts` updated to the rule; api `agents.test.ts` (handle + display name → comment and hand-resolve read by display name), `comment-access`, `follows` updated; OpenAPI snapshot + web types regenerated
- [x] API 1596/1596, core 490, web 147, `pnpm run ci` 34/34, typecheck, pre-push `verify` on the rebased tree
- [x] Screens harnesses (activity, comments) + smoke 24/24 — the rail reads one name per person
- [ ] CI on this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790448063&installation_model_id=428097&pr_number=839&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F839&signature=f01fc64b5f9ef7136ca44365addff9c49706548821fc3cba303f9b1a17f02372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->