### PR TITLE
Fix export email attachments and deck PDFs

### DIFF
--- a/apps/api/src/email-cf.ts
+++ b/apps/api/src/email-cf.ts
@@ -28,10 +28,10 @@ export interface SendEmailBinding {
     headers?: Record<string, string>
     attachments?: Array<{
       filename: string
-      contentType: string
+      type: string
       content: Uint8Array
       contentId?: string
-      disposition?: "inline" | "attachment"
+      disposition: "inline" | "attachment"
     }>
   }): Promise<{ messageId: string }>
 }
@@ -62,9 +62,11 @@ export const cloudflareEmailSender = (binding: SendEmailBinding, from: string): 
       text: msg.text,
       attachments: msg.resolvedAttachments?.map((a) => ({
         filename: a.filename,
-        contentType: a.contentType,
+        type: a.contentType,
         content: a.content,
-        ...(a.contentId ? { contentId: a.contentId, disposition: "inline" as const } : {}),
+        ...(a.contentId
+          ? { contentId: a.contentId, disposition: "inline" as const }
+          : { disposition: "attachment" as const }),
       })),
     })
   },

--- a/apps/api/src/exports.ts
+++ b/apps/api/src/exports.ts
@@ -210,7 +210,10 @@ const processJob = async (deps: RenderTickDeps, job: ExportJobRecord): Promise<v
   let pdfLinked = false
   if (options.attachPdf) {
     if (!deps.renderer.pdf) throw new Error("PDF rendering is not supported by this renderer")
-    const pdf = await deps.renderer.pdf(url, { timeoutMs: RENDER_TIMEOUT_MS })
+    const pdf = await deps.renderer.pdf(url, {
+      timeoutMs: RENDER_TIMEOUT_MS,
+      deck: version.content_type === "text/x-derive-deck",
+    })
     const pdfKey = await deps.blobs.put(pdf)
     if (pdf.byteLength <= EXPORT_LIMITS.maxEmailPdfAttachmentBytes)
       attachments.push({

--- a/apps/api/test/artifacts.test.ts
+++ b/apps/api/test/artifacts.test.ts
@@ -93,6 +93,46 @@ describe("version-pinned export requests", () => {
     expect(html).toContain("derive-export.pdf")
   })
 
+  it("renders an attached deck PDF with the complete deck profile", async () => {
+    const created = await (
+      await publishAs(
+        captureApp,
+        '<section class="slide" data-derive-slide="0"><h1>One</h1></section>' +
+          '<section class="slide" data-derive-slide="1"><h2>Two</h2></section>' +
+          '<script>parent.postMessage({source:"derive-deck",type:"state",i:0,total:2},"*")</script>',
+        { title: "Email deck", workspace_access: "none" },
+        as(captureOwner.email),
+      )
+    ).json()
+    const accepted = await captureApp.request(`/v1/artifacts/${created.short_id}/exports`, {
+      method: "POST",
+      headers: { ...as(captureOwner.email), "content-type": "application/json" },
+      body: JSON.stringify({
+        kind: "email",
+        recipient: "qa@example.test",
+        attachPdf: true,
+      }),
+    })
+    expect(accepted.status).toBe(202)
+    let deckPdf = false
+    expect(
+      await runExportTick({
+        meta: captureMeta,
+        blobs: captureCtx.blobs,
+        renderer: {
+          screenshot: async () => new Uint8Array([1, 2, 3]),
+          pdf: async (_url, options) => {
+            deckPdf = options.deck === true
+            return new TextEncoder().encode("%PDF-1.7 deck fixture")
+          },
+        },
+        baseUrl: "http://derive.test",
+        secret: "capture-deck-secret",
+      }),
+    ).toBe(1)
+    expect(deckPdf).toBe(true)
+  })
+
   it("bounds concurrent export work and rejects an estimated over-quota render", async () => {
     const created = await (
       await publishAs(

--- a/apps/api/test/integration-hardening.test.ts
+++ b/apps/api/test/integration-hardening.test.ts
@@ -79,6 +79,7 @@ type SentMsg = {
   from: string | { name: string; email: string }
   to: string | { name: string; email: string }
   subject: string
+  attachments?: Array<Record<string, unknown>>
 }
 
 describe("email header-injection defense", () => {
@@ -107,5 +108,56 @@ describe("email header-injection defense", () => {
     // The "Name <addr>" form is split into the structured { name, email } the builder wants,
     // so the sender keeps its display name instead of showing a bare address.
     expect(sent[0]?.from).toEqual({ name: "Derive", email: "notifications@derive.to" })
+  })
+
+  it("maps attachment MIME type and disposition to the Email Service builder contract", async () => {
+    const sent: SentMsg[] = []
+    const sender = cloudflareEmailSender(
+      {
+        send: async (m) => {
+          sent.push(m)
+          return { messageId: "attachment-test" }
+        },
+      },
+      "Derive <notifications@derive.to>",
+    )
+    const inline = new Uint8Array([1, 2, 3])
+    const pdf = new Uint8Array([4, 5, 6])
+    await sender.send({
+      to: "recipient@example.com",
+      subject: "Export",
+      html: '<img src="cid:derive-export">',
+      text: "Export",
+      resolvedAttachments: [
+        {
+          filename: "derive-export.png",
+          contentType: "image/png",
+          content: inline,
+          contentId: "derive-export",
+        },
+        {
+          filename: "derive-export.pdf",
+          contentType: "application/pdf",
+          content: pdf,
+        },
+      ],
+    })
+
+    expect(sent[0]?.attachments).toEqual([
+      {
+        filename: "derive-export.png",
+        type: "image/png",
+        content: inline,
+        contentId: "derive-export",
+        disposition: "inline",
+      },
+      {
+        filename: "derive-export.pdf",
+        type: "application/pdf",
+        content: pdf,
+        disposition: "attachment",
+      },
+    ])
+    expect(sent[0]?.attachments?.[0]).not.toHaveProperty("contentType")
   })
 })


### PR DESCRIPTION
## What changed
- map export attachments to Cloudflare Email Service’s required `type` and explicit `disposition` fields
- preserve `contentId` for inline CID images
- render email PDF attachments with the full deck profile for Derive decks
- add regressions for the exact transport payload and deck renderer selection

## Why
Production dogfood delivered a message whose HTML referenced `cid:derive-export`, but the MIME message contained no attachment parts. The adapter sent `contentType`, while Cloudflare requires `type`; it also omitted the required disposition for ordinary attachments.

## Verification
- `pnpm verify`
- focused API tests: 54 passed
- full API suite: 1,622 passed / 3 skipped

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/841"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790468737&installation_model_id=428097&pr_number=841&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F841&signature=6fc332b39de0cfa3481623e4a0db7c4284242f7c7ca31bbdc117342c7bf278a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->