### PR TITLE
Rich HTML email layouts and preview-gated export loop

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -5625,6 +5625,13 @@
                   },
                   "attachPdf": {
                     "type": "boolean"
+                  },
+                  "emailMode": {
+                    "type": "string",
+                    "enum": [
+                      "auto",
+                      "snapshot"
+                    ]
                   }
                 },
                 "required": [

--- a/apps/api/src/exports.ts
+++ b/apps/api/src/exports.ts
@@ -1,4 +1,5 @@
 import { artifactUrl, type ExportJobRecord } from "@derive/core"
+import { buildRichExportEmail, parseEmailLayout } from "./lib/email-layout"
 import {
   buildExportEmail,
   buildQaEmailCapture,
@@ -168,6 +169,75 @@ const processJob = async (deps: RenderTickDeps, job: ExportJobRecord): Promise<v
       "application/vnd.openxmlformats-officedocument.presentationml.presentation",
     )
     return
+  }
+
+  if (job.kind === "email" && options.emailMode !== "snapshot") {
+    const row = (await deps.meta.getVersionData(artifact.id, job.version_n, "email-layout"))[0]
+    if (row) {
+      let declared: unknown
+      try {
+        declared = JSON.parse(row.json) as unknown
+      } catch {
+        throw new Error("declared email-layout fact is not valid JSON")
+      }
+      const layout = parseEmailLayout(declared)
+      if (!layout) throw new Error("declared email-layout fact must use derive.email/v1")
+      if (!options.recipient) throw new Error("email recipient is required")
+      const attachments: Array<{
+        filename: string
+        contentType: string
+        blobKey: string
+      }> = []
+      let pdfLinked = false
+      if (options.attachPdf) {
+        if (!deps.renderer.pdf) throw new Error("PDF rendering is not supported by this renderer")
+        const pdf = await deps.renderer.pdf(url, {
+          timeoutMs: RENDER_TIMEOUT_MS,
+          deck: version.content_type === "text/x-derive-deck",
+        })
+        const pdfKey = await deps.blobs.put(pdf)
+        if (pdf.byteLength <= EXPORT_LIMITS.maxEmailPdfAttachmentBytes)
+          attachments.push({
+            filename: "derive-export.pdf",
+            contentType: "application/pdf",
+            blobKey: pdfKey,
+          })
+        else pdfLinked = true
+      }
+      const msg = buildRichExportEmail({
+        to: options.recipient,
+        subjectTitle: options.title ?? artifact.title ?? artifact.short_id,
+        note: [
+          options.note,
+          pdfLinked
+            ? "The PDF exceeded the safe email attachment limit; open the pinned artifact in Derive."
+            : undefined,
+        ]
+          .filter((value): value is string => !!value)
+          .join("\n\n"),
+        openUrl: `${artifactUrl(deps.baseUrl, artifact)}/v/${job.version_n}`,
+        version: job.version_n,
+        layout,
+      })
+      if ((await deps.meta.getExportJob(job.id))?.status === "cancelled") return
+      if (options.qaCapture) {
+        const capture = buildQaEmailCapture({
+          message: msg,
+          attachments: attachments.map(({ filename, contentType }) => ({ filename, contentType })),
+        })
+        await output(deps, job, capture, "text/html")
+        return
+      }
+      await enqueueCoalescedChannelDelivery(
+        deps.meta,
+        `wd_export_${job.id}`,
+        "email",
+        "artifact.export",
+        { ...msg, attachments },
+      )
+      await output(deps, job, new TextEncoder().encode(msg.html), "text/html")
+      return
+    }
   }
 
   const png = await chartPng(deps, url, options)

--- a/apps/api/src/lib/email-layout.ts
+++ b/apps/api/src/lib/email-layout.ts
@@ -1,0 +1,355 @@
+import { escapeHtml } from "@derive/core"
+import type { ExportEmailMessage } from "./export-system"
+
+const MAX_BLOCKS = 16
+const MAX_ITEMS = 12
+
+type EmailTone = "neutral" | "positive" | "warning" | "critical"
+
+type EmailBlock =
+  | { type: "paragraph"; body: string }
+  | { type: "kpis"; items: Array<{ label: string; value: string; delta?: string }> }
+  | {
+      type: "bars"
+      title?: string
+      max?: number
+      items: Array<{ label: string; value: number; display?: string; color?: string }>
+    }
+  | {
+      type: "segments"
+      title?: string
+      items: Array<{ label: string; value: number; display?: string; color?: string }>
+    }
+  | {
+      type: "funnel"
+      title?: string
+      items: Array<{ label: string; value: number; display?: string; color?: string }>
+    }
+  | { type: "table"; title?: string; columns: string[]; rows: string[][] }
+  | { type: "callout"; tone: EmailTone; title?: string; body: string }
+  | { type: "button"; label: string; url: string }
+  | { type: "divider" }
+
+export interface EmailLayout {
+  schema: "derive.email/v1"
+  preheader?: string
+  title: string
+  subtitle?: string
+  blocks: EmailBlock[]
+}
+
+const record = (value: unknown): Record<string, unknown> | null =>
+  value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+
+const string = (
+  value: unknown,
+  label: string,
+  max = 2_000,
+  required = false,
+): string | undefined => {
+  if (value === undefined || value === null) {
+    if (required) throw new Error(`${label} is required`)
+    return undefined
+  }
+  if (typeof value !== "string") throw new Error(`${label} must be a string`)
+  const trimmed = value.trim()
+  if (required && !trimmed) throw new Error(`${label} is required`)
+  if (trimmed.length > max) throw new Error(`${label} exceeds ${max} characters`)
+  return trimmed || undefined
+}
+
+const number = (value: unknown, label: string): number => {
+  if (typeof value !== "number" || !Number.isFinite(value))
+    throw new Error(`${label} must be a finite number`)
+  return value
+}
+
+const color = (value: unknown, label: string): string | undefined => {
+  const parsed = string(value, label, 7)
+  if (parsed && !/^#[0-9a-f]{6}$/i.test(parsed)) throw new Error(`${label} must be a hex color`)
+  return parsed
+}
+
+const tone = (value: unknown): EmailTone => {
+  if (value === undefined) return "neutral"
+  if (["neutral", "positive", "warning", "critical"].includes(String(value)))
+    return value as EmailTone
+  throw new Error("callout tone is invalid")
+}
+
+const array = (value: unknown, label: string, max = MAX_ITEMS): unknown[] => {
+  if (!Array.isArray(value) || !value.length) throw new Error(`${label} must be a non-empty array`)
+  if (value.length > max) throw new Error(`${label} exceeds ${max} items`)
+  return value
+}
+
+const chartItems = (
+  value: unknown,
+  label: string,
+): Array<{ label: string; value: number; display?: string; color?: string }> =>
+  array(value, label).map((raw, index) => {
+    const item = record(raw)
+    if (!item) throw new Error(`${label}[${index}] must be an object`)
+    return {
+      label: string(item.label, `${label}[${index}].label`, 120, true) as string,
+      value: number(item.value, `${label}[${index}].value`),
+      ...(string(item.display, `${label}[${index}].display`, 80)
+        ? { display: string(item.display, `${label}[${index}].display`, 80) }
+        : {}),
+      ...(color(item.color, `${label}[${index}].color`)
+        ? { color: color(item.color, `${label}[${index}].color`) }
+        : {}),
+    }
+  })
+
+const parseBlock = (raw: unknown, index: number): EmailBlock => {
+  const block = record(raw)
+  if (!block || typeof block.type !== "string") throw new Error(`blocks[${index}] is invalid`)
+  const label = `blocks[${index}]`
+  if (block.type === "paragraph")
+    return { type: "paragraph", body: string(block.body, `${label}.body`, 4_000, true) as string }
+  if (block.type === "kpis") {
+    const items = array(block.items, `${label}.items`, 9).map((rawItem, itemIndex) => {
+      const item = record(rawItem)
+      if (!item) throw new Error(`${label}.items[${itemIndex}] must be an object`)
+      return {
+        label: string(item.label, `${label}.items[${itemIndex}].label`, 80, true) as string,
+        value: string(item.value, `${label}.items[${itemIndex}].value`, 80, true) as string,
+        ...(string(item.delta, `${label}.items[${itemIndex}].delta`, 80)
+          ? { delta: string(item.delta, `${label}.items[${itemIndex}].delta`, 80) }
+          : {}),
+      }
+    })
+    return { type: "kpis", items }
+  }
+  if (block.type === "bars" || block.type === "segments" || block.type === "funnel") {
+    const common = {
+      title: string(block.title, `${label}.title`, 160),
+      items: chartItems(block.items, `${label}.items`),
+    }
+    if (block.type === "bars")
+      return {
+        type: "bars",
+        ...(common.title ? { title: common.title } : {}),
+        items: common.items,
+        ...(block.max === undefined ? {} : { max: number(block.max, `${label}.max`) }),
+      }
+    return {
+      type: block.type,
+      ...(common.title ? { title: common.title } : {}),
+      items: common.items,
+    }
+  }
+  if (block.type === "table") {
+    const columns = array(block.columns, `${label}.columns`, 6).map(
+      (value, column) => string(value, `${label}.columns[${column}]`, 120, true) as string,
+    )
+    const rows = array(block.rows, `${label}.rows`, 20).map((rawRow, rowIndex) => {
+      if (!Array.isArray(rawRow) || rawRow.length !== columns.length)
+        throw new Error(`${label}.rows[${rowIndex}] must match the column count`)
+      return rawRow.map(
+        (value, column) =>
+          string(String(value ?? ""), `${label}.rows[${rowIndex}][${column}]`, 500) ?? "",
+      )
+    })
+    const title = string(block.title, `${label}.title`, 160)
+    return { type: "table", ...(title ? { title } : {}), columns, rows }
+  }
+  if (block.type === "callout") {
+    const title = string(block.title, `${label}.title`, 160)
+    return {
+      type: "callout",
+      tone: tone(block.tone),
+      ...(title ? { title } : {}),
+      body: string(block.body, `${label}.body`, 2_000, true) as string,
+    }
+  }
+  if (block.type === "button") {
+    const url = string(block.url, `${label}.url`, 2_000, true) as string
+    if (!/^https:\/\//i.test(url)) throw new Error(`${label}.url must use https`)
+    return {
+      type: "button",
+      label: string(block.label, `${label}.label`, 80, true) as string,
+      url,
+    }
+  }
+  if (block.type === "divider") return { type: "divider" }
+  throw new Error(`${label}.type is unsupported`)
+}
+
+/** Missing or unrelated facts return null. A declared v1 layout is validated strictly so
+ * preview catches authoring mistakes instead of silently switching representation. */
+export const parseEmailLayout = (value: unknown): EmailLayout | null => {
+  const layout = record(value)
+  if (layout?.schema !== "derive.email/v1") return null
+  return {
+    schema: "derive.email/v1",
+    preheader: string(layout.preheader, "preheader", 200),
+    title: string(layout.title, "title", 240, true) as string,
+    subtitle: string(layout.subtitle, "subtitle", 500),
+    blocks: array(layout.blocks, "blocks", MAX_BLOCKS).map(parseBlock),
+  }
+}
+
+const esc = (value: string): string => escapeHtml(value)
+const richText = (value: string): string => esc(value).replaceAll("\n", "<br>")
+const sectionTitle = (value?: string): string =>
+  value
+    ? `<h2 style="margin:0 0 14px;font-size:18px;line-height:1.3;color:#17201d">${esc(value)}</h2>`
+    : ""
+const palette = ["#155f52", "#4f46e5", "#c77700", "#b42318", "#6d28d9", "#087f8c"]
+
+const renderKpis = (block: Extract<EmailBlock, { type: "kpis" }>): string => {
+  const rows = Array.from({ length: Math.ceil(block.items.length / 3) }, (_, row) =>
+    block.items.slice(row * 3, row * 3 + 3),
+  )
+  return rows
+    .map(
+      (items) =>
+        `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin:0 0 10px"><tr>${items
+          .map(
+            (item) =>
+              `<td width="33.33%" valign="top" style="padding:0 5px"><div style="border:1px solid #d9ddd7;border-radius:12px;padding:15px;background:#f8faf7"><div style="font-size:11px;line-height:1.3;text-transform:uppercase;letter-spacing:.08em;color:#66706b">${esc(item.label)}</div><div style="margin-top:7px;font-size:24px;line-height:1.1;font-weight:750;color:#17201d">${esc(item.value)}</div>${item.delta ? `<div style="margin-top:6px;font-size:12px;color:#155f52">${esc(item.delta)}</div>` : ""}</div></td>`,
+          )
+          .join("")}</tr></table>`,
+    )
+    .join("")
+}
+
+const renderBars = (block: Extract<EmailBlock, { type: "bars" }>): string => {
+  const max = Math.max(
+    Math.abs(block.max ?? 0),
+    ...block.items.map((item) => Math.abs(item.value)),
+    1,
+  )
+  const rows = block.items
+    .map((item, index) => {
+      const width = Math.max(2, Math.min(100, (Math.abs(item.value) / max) * 100))
+      const fill = item.color ?? (item.value < 0 ? "#b42318" : palette[index % palette.length])
+      return `<tr><td width="30%" valign="middle" style="padding:7px 10px 7px 0;font-size:12px;color:#35403c">${esc(item.label)}</td><td width="52%" valign="middle" style="padding:7px 8px 7px 0"><table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#e9ece8;border-radius:999px"><tr><td width="${width}%" height="12" style="width:${width}%;height:12px;background:${fill};border-radius:999px;font-size:0">&nbsp;</td><td></td></tr></table></td><td width="18%" align="right" style="padding:7px 0;font-size:12px;font-weight:700;color:#17201d">${esc(item.display ?? String(item.value))}</td></tr>`
+    })
+    .join("")
+  return `${sectionTitle(block.title)}<table role="presentation" width="100%" cellpadding="0" cellspacing="0">${rows}</table>`
+}
+
+const renderSegments = (block: Extract<EmailBlock, { type: "segments" }>): string => {
+  const total = block.items.reduce((sum, item) => sum + Math.max(0, item.value), 0) || 1
+  const cells = block.items
+    .map((item, index) => {
+      const width = Math.max(3, (Math.max(0, item.value) / total) * 100)
+      return `<td width="${width}%" height="24" style="width:${width}%;height:24px;background:${item.color ?? palette[index % palette.length]};font-size:0">&nbsp;</td>`
+    })
+    .join("")
+  const legend = block.items
+    .map(
+      (item, index) =>
+        `<tr><td width="18" style="padding:5px 0"><span style="display:block;width:10px;height:10px;border-radius:3px;background:${item.color ?? palette[index % palette.length]}">&nbsp;</span></td><td style="padding:5px 4px;font-size:12px;color:#35403c">${esc(item.label)}</td><td align="right" style="padding:5px 0;font-size:12px;font-weight:700;color:#17201d">${esc(item.display ?? String(item.value))}</td></tr>`,
+    )
+    .join("")
+  return `${sectionTitle(block.title)}<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border-radius:8px;overflow:hidden"><tr>${cells}</tr></table><table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-top:10px">${legend}</table>`
+}
+
+const renderFunnel = (block: Extract<EmailBlock, { type: "funnel" }>): string => {
+  const max = Math.max(...block.items.map((item) => Math.abs(item.value)), 1)
+  const rows = block.items
+    .map((item, index) => {
+      const width = Math.max(26, Math.min(100, (Math.abs(item.value) / max) * 100))
+      return `<tr><td align="center" style="padding:4px 0"><table role="presentation" width="${width}%" cellpadding="0" cellspacing="0" style="width:${width}%;background:${item.color ?? palette[index % palette.length]};border-radius:8px"><tr><td align="center" style="padding:10px 8px;color:#fff;font-size:12px"><strong>${esc(item.label)}</strong>&nbsp;&nbsp;${esc(item.display ?? String(item.value))}</td></tr></table></td></tr>`
+    })
+    .join("")
+  return `${sectionTitle(block.title)}<table role="presentation" width="100%" cellpadding="0" cellspacing="0">${rows}</table>`
+}
+
+const renderTable = (block: Extract<EmailBlock, { type: "table" }>): string => {
+  const head = block.columns
+    .map(
+      (column) =>
+        `<th align="left" style="padding:9px 8px;border-bottom:1px solid #cfd5d1;font-size:10px;text-transform:uppercase;letter-spacing:.06em;color:#66706b">${esc(column)}</th>`,
+    )
+    .join("")
+  const rows = block.rows
+    .map(
+      (row) =>
+        `<tr>${row.map((cell) => `<td valign="top" style="padding:10px 8px;border-bottom:1px solid #e6e9e6;font-size:12px;line-height:1.4;color:#26302c">${richText(cell)}</td>`).join("")}</tr>`,
+    )
+    .join("")
+  return `${sectionTitle(block.title)}<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="table-layout:fixed;border:1px solid #d9ddd7;border-radius:10px"> <tr>${head}</tr>${rows}</table>`
+}
+
+const renderCallout = (block: Extract<EmailBlock, { type: "callout" }>): string => {
+  const colors: Record<EmailTone, [string, string]> = {
+    neutral: ["#edf2ef", "#35403c"],
+    positive: ["#e8f8ee", "#126c3d"],
+    warning: ["#fff4d6", "#7a5300"],
+    critical: ["#fdecea", "#9d2018"],
+  }
+  const [background, foreground] = colors[block.tone]
+  return `<div style="padding:16px 18px;border-radius:12px;background:${background};color:${foreground}">${block.title ? `<div style="font-weight:750;margin-bottom:5px">${esc(block.title)}</div>` : ""}<div style="font-size:13px;line-height:1.55">${richText(block.body)}</div></div>`
+}
+
+const renderBlock = (block: EmailBlock): string => {
+  let body = ""
+  if (block.type === "paragraph")
+    body = `<p style="margin:0;font-size:14px;line-height:1.65;color:#35403c">${richText(block.body)}</p>`
+  else if (block.type === "kpis") body = renderKpis(block)
+  else if (block.type === "bars") body = renderBars(block)
+  else if (block.type === "segments") body = renderSegments(block)
+  else if (block.type === "funnel") body = renderFunnel(block)
+  else if (block.type === "table") body = renderTable(block)
+  else if (block.type === "callout") body = renderCallout(block)
+  else if (block.type === "button")
+    body = `<a href="${esc(block.url)}" style="display:inline-block;padding:11px 16px;border-radius:9px;background:#155f52;color:#fff;text-decoration:none;font-weight:700;font-size:13px">${esc(block.label)}</a>`
+  else body = '<div style="height:1px;background:#e2e6e3;font-size:0">&nbsp;</div>'
+  return `<tr><td style="padding:0 28px 22px">${body}</td></tr>`
+}
+
+const blockText = (block: EmailBlock): string => {
+  if (block.type === "paragraph") return block.body
+  if (block.type === "kpis")
+    return block.items
+      .map((item) => `${item.label}: ${item.value}${item.delta ? ` (${item.delta})` : ""}`)
+      .join("\n")
+  if (block.type === "bars" || block.type === "segments" || block.type === "funnel")
+    return [
+      block.title,
+      ...block.items.map((item) => `${item.label}: ${item.display ?? item.value}`),
+    ]
+      .filter(Boolean)
+      .join("\n")
+  if (block.type === "table")
+    return [block.title, block.columns.join(" | "), ...block.rows.map((row) => row.join(" | "))]
+      .filter(Boolean)
+      .join("\n")
+  if (block.type === "callout") return [block.title, block.body].filter(Boolean).join(": ")
+  if (block.type === "button") return `${block.label}: ${block.url}`
+  return ""
+}
+
+export const buildRichExportEmail = (input: {
+  to: string
+  subjectTitle: string
+  note?: string
+  openUrl: string
+  version: number
+  layout: EmailLayout
+}): ExportEmailMessage => {
+  const subject = input.subjectTitle.replace(/[\r\n]+/g, " ").trim()
+  const preheader = input.layout.preheader ?? input.layout.subtitle ?? input.layout.title
+  const note = input.note
+    ? `<tr><td style="padding:0 28px 22px"><div style="padding:13px 15px;border-left:3px solid #c9f77b;background:#f5f8f3;color:#35403c;font-size:13px;line-height:1.5">${richText(input.note)}</div></td></tr>`
+    : ""
+  const html = `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><style>@media(max-width:620px){.derive-shell{border-radius:0!important}.derive-pad{padding-left:18px!important;padding-right:18px!important}}</style></head><body style="margin:0;background:#eef1ee;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Arial,sans-serif;color:#17201d"><div style="display:none;max-height:0;overflow:hidden;opacity:0;color:transparent">${esc(preheader)}&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;</div><table role="presentation" width="100%" cellpadding="0" cellspacing="0"><tr><td align="center" style="padding:24px 10px"><table role="presentation" width="620" cellpadding="0" cellspacing="0" class="derive-shell" style="width:100%;max-width:620px;background:#fff;border:1px solid #d9ddd7;border-radius:16px;overflow:hidden"><tr><td class="derive-pad" style="padding:26px 28px 9px"><div style="font-size:10px;text-transform:uppercase;letter-spacing:.12em;font-weight:800;color:#155f52">Derive · version ${input.version}</div><h1 style="margin:10px 0 0;font-size:28px;line-height:1.1;letter-spacing:-.03em;color:#17201d">${esc(input.layout.title)}</h1>${input.layout.subtitle ? `<p style="margin:9px 0 0;font-size:14px;line-height:1.55;color:#66706b">${richText(input.layout.subtitle)}</p>` : ""}</td></tr><tr><td style="padding:0 28px 20px"><div style="height:1px;background:#e2e6e3;font-size:0">&nbsp;</div></td></tr>${note}${input.layout.blocks.map(renderBlock).join("")}<tr><td class="derive-pad" style="padding:4px 28px 28px"><a href="${esc(input.openUrl)}" style="display:inline-block;padding:11px 16px;border-radius:9px;background:#17201d;color:#fff;text-decoration:none;font-weight:700;font-size:13px">Open in Derive</a><p style="margin:16px 0 0;color:#7b847f;font-size:11px;line-height:1.5">This email-safe rendering is pinned to version ${input.version}. It does not change access to the original.</p></td></tr></table></td></tr></table></body></html>`
+  const text = [
+    input.layout.title,
+    input.layout.subtitle,
+    `Derive version ${input.version}`,
+    input.note,
+    ...input.layout.blocks.map(blockText),
+    `Open: ${input.openUrl}`,
+  ]
+    .filter(Boolean)
+    .join("\n\n")
+  return { to: input.to, subject: `${subject} · Derive`, html, text }
+}

--- a/apps/api/src/lib/export-system.ts
+++ b/apps/api/src/lib/export-system.ts
@@ -54,6 +54,7 @@ export interface ExportOptions {
   recipient?: string
   note?: string
   attachPdf?: boolean
+  emailMode?: "auto" | "snapshot"
   title?: string
   /** Internal-only PR-preview guard. Never accepted from the public request schema. */
   qaCapture?: boolean
@@ -70,6 +71,9 @@ export const normalizeExportOptions = (input: ExportOptions): ExportOptions => (
     : {}),
   ...(input.note?.trim() ? { note: input.note.trim().slice(0, 2_000) } : {}),
   ...(input.attachPdf !== undefined ? { attachPdf: input.attachPdf } : {}),
+  ...(input.emailMode === "auto" || input.emailMode === "snapshot"
+    ? { emailMode: input.emailMode }
+    : {}),
   ...(input.title?.trim() ? { title: input.title.trim().slice(0, 240) } : {}),
   ...(input.qaCapture === true ? { qaCapture: true } : {}),
 })
@@ -123,6 +127,13 @@ export const csvFromJson = (value: unknown): string => {
   ].join("\r\n")
 }
 
+export interface ExportEmailMessage {
+  to: string
+  subject: string
+  html: string
+  text: string
+}
+
 export const buildExportEmail = (input: {
   to: string
   title: string
@@ -131,7 +142,7 @@ export const buildExportEmail = (input: {
   imageUrl: string
   alt: string
   version: number
-}) => {
+}): ExportEmailMessage => {
   // Keep untrusted artifact titles from becoming transport-level header input.
   // Cloudflare already flattens the subject at its adapter boundary, but the
   // self-hosted Resend adapter consumes this shared message directly.
@@ -164,7 +175,7 @@ const base64 = (bytes: Uint8Array): string => {
  * artifact capture, not an email transport: CID content is embedded as a data URL,
  * attachments are inventoried, and no row ever enters the notification outbox. */
 export const buildQaEmailCapture = (input: {
-  message: ReturnType<typeof buildExportEmail>
+  message: ExportEmailMessage
   cidImage?: Uint8Array
   attachments: Array<{ filename: string; contentType: string }>
 }): Uint8Array => {
@@ -181,7 +192,7 @@ export const buildQaEmailCapture = (input: {
             `<li><strong>${escapeHtml(item.filename)}</strong> · ${escapeHtml(item.contentType)}</li>`,
         )
         .join("")
-    : "<li>None (hosted image mode)</li>"
+    : "<li>None</li>"
   const capture = `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><title>Derive QA email capture</title></head><body style="margin:0;background:#e9e9e9;font-family:-apple-system,Segoe UI,Roboto,sans-serif;color:#181818"><section style="padding:16px 20px;background:#fff4cc;border-bottom:1px solid #e2cf7a"><strong>QA capture · no email was sent</strong><div style="margin-top:6px;font-size:13px">To: ${escapeHtml(input.message.to)} · Subject: ${escapeHtml(input.message.subject)}</div><details style="margin-top:8px"><summary>Plain-text alternative</summary><pre style="white-space:pre-wrap">${escapeHtml(input.message.text)}</pre></details><details><summary>Attachment manifest</summary><ul>${attachmentRows}</ul></details></section>${html}</body></html>`
   return new TextEncoder().encode(capture)
 }

--- a/apps/api/src/routes/exports.ts
+++ b/apps/api/src/routes/exports.ts
@@ -63,6 +63,7 @@ export const exportRoutes = (ctx: AppContext) => {
     recipient: z.email().max(320).optional(),
     note: z.string().max(2_000).optional(),
     attachPdf: z.boolean().optional(),
+    emailMode: z.enum(["auto", "snapshot"]).optional(),
   })
 
   app.openapi(

--- a/apps/api/test/export-expanded.test.ts
+++ b/apps/api/test/export-expanded.test.ts
@@ -220,6 +220,74 @@ describe("expanded export and email dogfood contracts", () => {
     expect(html).not.toContain("derive-export.pdf")
   })
 
+  it("renders a declared email-layout as native HTML without taking a screenshot", async () => {
+    const { app, meta, ctx } = makeFixture("expanded-rich-html-email")
+    const layout = {
+      schema: "derive.email/v1",
+      preheader: "Pipeline pulse",
+      title: "Pipeline pulse — native HTML",
+      subtitle: "Charts remain readable when images are blocked.",
+      blocks: [
+        {
+          type: "kpis",
+          items: [
+            { label: "Qualified pipeline", value: "$8.4M", delta: "+14%" },
+            { label: "Coverage", value: "3.1×" },
+          ],
+        },
+        {
+          type: "bars",
+          title: "Pipeline by segment",
+          items: [
+            { label: "Enterprise", value: 84, display: "$4.2M" },
+            { label: "Mid-market", value: 56, display: "$2.8M" },
+          ],
+        },
+      ],
+    }
+    const artifact = await (
+      await publishAs(
+        app,
+        `<h1>Pipeline pulse</h1><script type="application/derive-facts" data-fact="email-layout">${JSON.stringify(layout)}</script>`,
+        { title: "Pipeline pulse", workspace_access: "none" },
+        as(owner.email),
+      )
+    ).json()
+    const accepted = await postExport(app, artifact.short_id, {
+      kind: "email",
+      recipient: "qa@example.test",
+      emailMode: "auto",
+    })
+    expect(accepted.status).toBe(202)
+    const job = await accepted.json()
+    let screenshots = 0
+    expect(
+      await runExportTick({
+        meta,
+        blobs: ctx.blobs,
+        renderer: {
+          screenshot: async () => {
+            screenshots += 1
+            return new Uint8Array([1, 2, 3])
+          },
+        },
+        baseUrl: "http://derive.test",
+        secret: "expanded-rich-html-secret",
+      }),
+    ).toBe(1)
+    expect(screenshots).toBe(0)
+    const capture = await app.request(`/v1/exports/${job.id}/preview`, {
+      headers: as(owner.email),
+    })
+    expect(capture.status).toBe(200)
+    const html = await capture.text()
+    expect(html).toContain("Pipeline pulse — native HTML")
+    expect(html).toContain("$8.4M")
+    expect(html).toContain("Enterprise")
+    expect(html).not.toContain("data:image/png")
+    expect(html).toContain("<li>None</li>")
+  })
+
   it("C18 replays CID and hosted delivery independently without duplicate jobs", async () => {
     const { app } = makeFixture("expanded-email-replay")
     const artifact = await (

--- a/apps/api/test/previews.test.ts
+++ b/apps/api/test/previews.test.ts
@@ -18,6 +18,7 @@ import {
   markFinalDeckSlideForPrint,
   prepareDeckPrint,
 } from "../src/lib/deck-print"
+import { buildRichExportEmail, parseEmailLayout } from "../src/lib/email-layout"
 import {
   buildExportEmail,
   buildQaEmailCapture,
@@ -171,6 +172,60 @@ describe("export contracts", () => {
       ]),
     )
     expect(new TextDecoder().decode(pptx["docProps/core.xml"])).toContain("artifact v3")
+  })
+
+  it("renders declared KPIs and charts as escaped, image-independent email HTML", () => {
+    const layout = parseEmailLayout({
+      schema: "derive.email/v1",
+      preheader: "Executive pulse",
+      title: "Revenue & pipeline",
+      subtitle: "Actual email HTML — no canvas or JavaScript",
+      blocks: [
+        {
+          type: "kpis",
+          items: [
+            { label: "ARR", value: "$12.4M", delta: "+18% YoY" },
+            { label: "Coverage", value: "3.2×" },
+          ],
+        },
+        {
+          type: "bars",
+          title: "Pipeline by segment",
+          items: [
+            { label: "Enterprise <script>", value: 72, display: "$7.2M" },
+            { label: "Mid-market", value: -14, display: "−$1.4M" },
+          ],
+        },
+      ],
+    })
+    expect(layout).not.toBeNull()
+    if (!layout) throw new Error("expected a parsed email layout")
+    const email = buildRichExportEmail({
+      to: "qa@example.test",
+      subjectTitle: "Quarterly pulse",
+      openUrl: "https://derive.test/artifacts/pulse/v/4",
+      version: 4,
+      layout,
+    })
+    expect(email.html).toContain("$12.4M")
+    expect(email.html).toContain("width:100%")
+    expect(email.html).toContain("−$1.4M")
+    expect(email.html).toContain("Enterprise &lt;script&gt;")
+    expect(email.html).not.toContain("<script>")
+    expect(email.html).not.toContain("<canvas")
+    expect(email.html).not.toContain("<img")
+    expect(email.text).toContain("Pipeline by segment")
+  })
+
+  it("rejects malformed declared layouts instead of silently changing representation", () => {
+    expect(() =>
+      parseEmailLayout({
+        schema: "derive.email/v1",
+        title: "Bad layout",
+        blocks: [{ type: "button", label: "Unsafe", url: "javascript:alert(1)" }],
+      }),
+    ).toThrow(/must use https/)
+    expect(parseEmailLayout({ schema: "some-other-contract" })).toBeNull()
   })
 })
 

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -2024,6 +2024,8 @@ export interface paths {
                         recipient?: string;
                         note?: string;
                         attachPdf?: boolean;
+                        /** @enum {string} */
+                        emailMode?: "auto" | "snapshot";
                     };
                 };
             };

--- a/apps/web/src/pages/artifact/export-dialog.tsx
+++ b/apps/web/src/pages/artifact/export-dialog.tsx
@@ -45,6 +45,7 @@ export function ExportButton({
   const [slot, setSlot] = useState("")
   const [publicImage, setPublicImage] = useState(false)
   const [attachPdf, setAttachPdf] = useState(false)
+  const [emailMode, setEmailMode] = useState<"auto" | "snapshot">("auto")
   const recipientInvalid = !!recipient.trim() && !isValidExportRecipient(recipient)
   const option = EXPORT_OPTIONS[kind]
   const choices = exportChoices(isDeck)
@@ -63,7 +64,7 @@ export function ExportButton({
       ...(recipient.trim() ? { recipient: recipient.trim() } : {}),
       ...(note.trim() ? { note: note.trim() } : {}),
       ...(option.supportsPublicImage ? { publicImage } : {}),
-      ...(option.email ? { attachPdf } : {}),
+      ...(option.email ? { attachPdf, emailMode } : {}),
     })
 
   return (
@@ -139,6 +140,31 @@ export function ExportButton({
                     Enter a valid email address.
                   </p>
                 )}
+              </div>
+              <div>
+                <label className="mb-1.5 block text-sm font-medium" htmlFor="export-email-mode">
+                  Email body
+                </label>
+                <Select
+                  value={emailMode}
+                  onValueChange={(value) => setEmailMode(value as "auto" | "snapshot")}
+                >
+                  <SelectTrigger
+                    id="export-email-mode"
+                    className="w-full"
+                    data-testid="export-email-mode"
+                  >
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="auto">Rich HTML when declared (recommended)</SelectItem>
+                    <SelectItem value="snapshot">Artifact snapshot</SelectItem>
+                  </SelectContent>
+                </Select>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Uses the version&apos;s email-layout fact for email-safe text and charts, with a
+                  snapshot fallback.
+                </p>
               </div>
               <div>
                 <label className="mb-1.5 block text-sm font-medium" htmlFor="export-note">


### PR DESCRIPTION
## What

- add a strict `derive.email/v1` fact contract for responsive email-safe HTML
- render KPI cards, tables, bars, segments, funnels, callouts, narrative, and buttons without screenshots
- preserve snapshot fallback and optional pinned PDF attachments
- expose Auto vs Snapshot in Export & email
- keep production HTML as a previewable export result

## Safety

- artifact DOM/JS is never reused as email HTML
- all strings are escaped; links require HTTPS; blocks and rows are bounded
- preview captures still require reserved `.test` recipients

## Verification

- focused backend: 34/34
- focused web: 3/3
- repository guardrails: 34/34
- full typecheck: pass
- affected suite: 1803/1803 pass
- full suite: 1 unrelated timeout; isolated rerun passed

## Derive workflow

https://derive.to/artifacts/derive-html-email-self-learning-loop-lqrd9zy7
