### PR TITLE
fix(exports): honor delegated API tokens

### DIFF
--- a/apps/api/src/routes/exports.ts
+++ b/apps/api/src/routes/exports.ts
@@ -52,7 +52,7 @@ const jobJson = (baseUrl: string, job: Awaited<ReturnType<AppContext["meta"]["ge
 }
 
 export const exportRoutes = (ctx: AppContext) => {
-  const { meta, blobs, requireArtifact, requireUser, overStorage, blockCopy, deps } = ctx
+  const { meta, blobs, requireArtifact, actingHuman, overStorage, blockCopy, deps } = ctx
   const app = new OpenAPIHono<BlankEnv>()
   const ExportRequest = z.object({
     kind: z.enum(EXPORT_KINDS),
@@ -79,8 +79,8 @@ export const exportRoutes = (ctx: AppContext) => {
       responses: { 202: { description: "Export accepted." } },
     }),
     async (c) => {
-      const user = await requireUser(c)
-      if (user instanceof Response) return bail(user)
+      const user = await actingHuman(c)
+      if (!user) return bail(fail(c, 401, "unauthenticated"))
       const artifact = await requireArtifact(c, "read", { split: true })
       if (artifact instanceof Response) return bail(artifact)
       const body = c.req.valid("json")
@@ -138,17 +138,17 @@ export const exportRoutes = (ctx: AppContext) => {
   )
 
   app.get("/v1/artifacts/:shortId/exports", async (c) => {
-    const user = await requireUser(c)
-    if (user instanceof Response) return user
+    const user = await actingHuman(c)
+    if (!user) return fail(c, 401, "unauthenticated")
     const artifact = await requireArtifact(c, "read", { split: true })
     if (artifact instanceof Response) return artifact
     const jobs = await meta.listExportJobs(artifact.id, user.id, 20)
     return c.json({ jobs: jobs.map((job) => jobJson(deps.baseUrl.replace(/\/$/, ""), job)) })
   })
 
-  const ownJob = async (c: Parameters<typeof requireUser>[0]) => {
-    const user = await requireUser(c)
-    if (user instanceof Response) return user
+  const ownJob = async (c: Parameters<typeof actingHuman>[0]) => {
+    const user = await actingHuman(c)
+    if (!user) return fail(c, 401, "unauthenticated")
     const job = await meta.getExportJob(c.req.param("id") ?? "")
     if (!job || job.requested_by !== user.id) return fail(c, 404, "not found")
     const artifact = await meta.getArtifactById(job.artifact_id)

--- a/apps/api/test/api-token.test.ts
+++ b/apps/api/test/api-token.test.ts
@@ -127,6 +127,43 @@ describe.skipIf(process.env.DERIVE_TEST_DB === "pg")("api token on the wire", ()
     expect(res.status).toBe(200)
   })
 
+  it("creates and retrieves a version-pinned export on behalf of its human", async () => {
+    const { app: a } = app("api-tok-export")
+    const tok = await signApiToken(SECRET, "u_api", "ws_api", "editor", "cli", Date.now() + 60_000)
+    const form = new FormData()
+    form.set(
+      "file",
+      new Blob(
+        [
+          '<script type="application/derive+json" data-name="series">[{"label":"A","value":1}]</script>',
+        ],
+        { type: "text/html" },
+      ),
+      "export.html",
+    )
+    form.set("title", "API token export")
+    const published = await a.request("/v1/artifacts", {
+      method: "POST",
+      headers: authed(tok),
+      body: form,
+    })
+    expect(published.status).toBe(201)
+    const artifact = (await published.json()) as { short_id: string }
+
+    const accepted = await a.request(`/v1/artifacts/${artifact.short_id}/exports`, {
+      method: "POST",
+      headers: { ...authed(tok), "content-type": "application/json" },
+      body: JSON.stringify({ kind: "chart_json", dataSlot: "series" }),
+    })
+    expect(accepted.status).toBe(202)
+    const job = (await accepted.json()) as { id: string; version: number }
+    expect(job.version).toBe(1)
+
+    const own = await a.request(`/v1/exports/${job.id}`, { headers: authed(tok) })
+    expect(own.status).toBe(200)
+    expect(((await own.json()) as { id: string }).id).toBe(job.id)
+  })
+
   it("a token minted BELOW the human's role can't reach past it (least privilege holds)", async () => {
     const { app: a } = app("api-tok-narrow")
     // The human is an owner; this token was minted `viewer`. Minting an agent is a


### PR DESCRIPTION
## Why

Dogfooding the new HTML email loop exposed that short-lived `dkapi_` tokens could read and publish over REST, but every export endpoint still required a browser session. That contradicted the API-token contract and blocked agent-driven exports.

## What

- Attribute export creation, listing, preview, and download to the human behind a delegated principal.
- Preserve existing direct-session behavior.
- Add a wire-level regression test that publishes, creates, and retrieves a version-pinned export using only a minted API token.

## Verification

- 1,626 API tests passed.
- 28 MCP tests passed.
- API typecheck passed.
- 34/34 guardrails passed.
- Isolated substrate-loop rerun: 35/35. The first pre-push run hit its existing parallel timeout flake; the second full run passed.
