### PR TITLE
fix(exports): preserve deck email snapshots

### DIFF
--- a/apps/api/src/exports.ts
+++ b/apps/api/src/exports.ts
@@ -82,7 +82,15 @@ const chartPng = async (
   deps: RenderTickDeps,
   url: string,
   options: ExportOptions,
+  deckSnapshot = false,
 ): Promise<Uint8Array> => {
+  if (deckSnapshot) {
+    if (!deps.renderer.deckImages)
+      throw new Error("deck rendering is not supported by this renderer")
+    const first = (await deps.renderer.deckImages(url, RENDER_TIMEOUT_MS))[0]
+    if (!first) throw new Error("deck renderer returned no slides")
+    return first
+  }
   const selector = options.region ?? "[data-derive-export-region]"
   try {
     return await deps.renderer.screenshot(url, {
@@ -240,7 +248,15 @@ const processJob = async (deps: RenderTickDeps, job: ExportJobRecord): Promise<v
     }
   }
 
-  const png = await chartPng(deps, url, options)
+  // A deck's first slide is its email snapshot. The native deck renderer preserves the slide's
+  // aspect ratio; the generic chart viewport would crop it to 1200×630. Rich email-layout jobs
+  // return above, so this only affects the snapshot fallback.
+  const png = await chartPng(
+    deps,
+    url,
+    options,
+    job.kind === "email" && version.content_type === "text/x-derive-deck",
+  )
   if (job.kind === "chart_png") {
     await output(deps, job, png, "image/png", !!options.publicImage)
     return

--- a/apps/api/src/routes/exports.ts
+++ b/apps/api/src/routes/exports.ts
@@ -52,7 +52,7 @@ const jobJson = (baseUrl: string, job: Awaited<ReturnType<AppContext["meta"]["ge
 }
 
 export const exportRoutes = (ctx: AppContext) => {
-  const { meta, blobs, requireArtifact, requireUser, overStorage, blockCopy, deps } = ctx
+  const { meta, blobs, requireArtifact, actingHuman, overStorage, blockCopy, deps } = ctx
   const app = new OpenAPIHono<BlankEnv>()
   const ExportRequest = z.object({
     kind: z.enum(EXPORT_KINDS),
@@ -79,8 +79,8 @@ export const exportRoutes = (ctx: AppContext) => {
       responses: { 202: { description: "Export accepted." } },
     }),
     async (c) => {
-      const user = await requireUser(c)
-      if (user instanceof Response) return bail(user)
+      const user = await actingHuman(c)
+      if (!user) return bail(fail(c, 401, "unauthenticated"))
       const artifact = await requireArtifact(c, "read", { split: true })
       if (artifact instanceof Response) return bail(artifact)
       const body = c.req.valid("json")
@@ -138,17 +138,17 @@ export const exportRoutes = (ctx: AppContext) => {
   )
 
   app.get("/v1/artifacts/:shortId/exports", async (c) => {
-    const user = await requireUser(c)
-    if (user instanceof Response) return user
+    const user = await actingHuman(c)
+    if (!user) return fail(c, 401, "unauthenticated")
     const artifact = await requireArtifact(c, "read", { split: true })
     if (artifact instanceof Response) return artifact
     const jobs = await meta.listExportJobs(artifact.id, user.id, 20)
     return c.json({ jobs: jobs.map((job) => jobJson(deps.baseUrl.replace(/\/$/, ""), job)) })
   })
 
-  const ownJob = async (c: Parameters<typeof requireUser>[0]) => {
-    const user = await requireUser(c)
-    if (user instanceof Response) return user
+  const ownJob = async (c: Parameters<typeof actingHuman>[0]) => {
+    const user = await actingHuman(c)
+    if (!user) return fail(c, 401, "unauthenticated")
     const job = await meta.getExportJob(c.req.param("id") ?? "")
     if (!job || job.requested_by !== user.id) return fail(c, 404, "not found")
     const artifact = await meta.getArtifactById(job.artifact_id)

--- a/apps/api/test/api-token.test.ts
+++ b/apps/api/test/api-token.test.ts
@@ -127,6 +127,43 @@ describe.skipIf(process.env.DERIVE_TEST_DB === "pg")("api token on the wire", ()
     expect(res.status).toBe(200)
   })
 
+  it("creates and retrieves a version-pinned export on behalf of its human", async () => {
+    const { app: a } = app("api-tok-export")
+    const tok = await signApiToken(SECRET, "u_api", "ws_api", "editor", "cli", Date.now() + 60_000)
+    const form = new FormData()
+    form.set(
+      "file",
+      new Blob(
+        [
+          '<script type="application/derive+json" data-name="series">[{"label":"A","value":1}]</script>',
+        ],
+        { type: "text/html" },
+      ),
+      "export.html",
+    )
+    form.set("title", "API token export")
+    const published = await a.request("/v1/artifacts", {
+      method: "POST",
+      headers: authed(tok),
+      body: form,
+    })
+    expect(published.status).toBe(201)
+    const artifact = (await published.json()) as { short_id: string }
+
+    const accepted = await a.request(`/v1/artifacts/${artifact.short_id}/exports`, {
+      method: "POST",
+      headers: { ...authed(tok), "content-type": "application/json" },
+      body: JSON.stringify({ kind: "chart_json", dataSlot: "series" }),
+    })
+    expect(accepted.status).toBe(202)
+    const job = (await accepted.json()) as { id: string; version: number }
+    expect(job.version).toBe(1)
+
+    const own = await a.request(`/v1/exports/${job.id}`, { headers: authed(tok) })
+    expect(own.status).toBe(200)
+    expect(((await own.json()) as { id: string }).id).toBe(job.id)
+  })
+
   it("a token minted BELOW the human's role can't reach past it (least privilege holds)", async () => {
     const { app: a } = app("api-tok-narrow")
     // The human is an owner; this token was minted `viewer`. Minting an agent is a

--- a/apps/api/test/artifacts.test.ts
+++ b/apps/api/test/artifacts.test.ts
@@ -121,6 +121,7 @@ describe("version-pinned export requests", () => {
         blobs: captureCtx.blobs,
         renderer: {
           screenshot: async () => new Uint8Array([1, 2, 3]),
+          deckImages: async () => [new Uint8Array([1, 2, 3])],
           pdf: async (_url, options) => {
             deckPdf = options.deck === true
             return new TextEncoder().encode("%PDF-1.7 deck fixture")

--- a/apps/api/test/export-expanded.test.ts
+++ b/apps/api/test/export-expanded.test.ts
@@ -1,3 +1,4 @@
+import { INTERNAL_DELIVERY } from "@derive/core"
 import { unzipSync } from "fflate"
 import { describe, expect, it } from "vitest"
 import { runExportTick } from "../src/exports"
@@ -286,6 +287,73 @@ describe("expanded export and email dogfood contracts", () => {
     expect(html).toContain("Enterprise")
     expect(html).not.toContain("data:image/png")
     expect(html).toContain("<li>None</li>")
+  })
+
+  it("renders a deck email snapshot from the first native deck image and sends PNG bytes", async () => {
+    const { app, meta, ctx } = makeAuthedApp("expanded-deck-email-snapshot", [owner], undefined, {
+      deps: { renderExports: true },
+    })
+    const deck =
+      '<!doctype html><html><head><meta name="viewport" content="width=device-width"></head><body>' +
+      '<section class="slide" data-derive-slide="0"><h1>First slide</h1></section>' +
+      '<section class="slide" data-derive-slide="1"><h1>Second slide</h1></section>' +
+      '<script>parent.postMessage({source:"derive-deck",type:"state",i:0,total:2},"*")</script>' +
+      "</body></html>"
+    const artifact = await (
+      await publishAs(
+        app,
+        deck,
+        { title: "Deck snapshot", workspace_access: "none" },
+        as(owner.email),
+      )
+    ).json()
+    const accepted = await postExport(app, artifact.short_id, {
+      kind: "email",
+      recipient: "qa@example.test",
+      emailMode: "auto",
+    })
+    expect(accepted.status).toBe(202)
+    const job = await accepted.json()
+    let screenshots = 0
+    let deckCalls = 0
+    const deckPng = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x01])
+    expect(
+      await runExportTick({
+        meta,
+        blobs: ctx.blobs,
+        renderer: {
+          screenshot: async () => {
+            screenshots += 1
+            throw new Error("generic screenshot must not render a deck email snapshot")
+          },
+          deckImages: async (url, timeoutMs) => {
+            deckCalls += 1
+            expect(url).toContain("/raw/")
+            expect(timeoutMs).toBe(20_000)
+            return [deckPng, new Uint8Array([2])]
+          },
+        },
+        baseUrl: "http://derive.test",
+        secret: "expanded-deck-email-secret",
+      }),
+    ).toBe(1)
+    expect(deckCalls).toBe(1)
+    expect(screenshots).toBe(0)
+
+    const finished = await meta.getExportJob(job.id)
+    expect(finished?.status).toBe("ready")
+    expect(finished?.output_type).toBe("image/png")
+    expect(finished?.output_key).toBeTruthy()
+    expect(await ctx.blobs.get(finished?.output_key as string)).toEqual(deckPng)
+
+    const [delivery] = await meta.recentDeliveries(INTERNAL_DELIVERY, 10)
+    expect(delivery?.id).toBe(`wd_export_${job.id}`)
+    expect(JSON.parse(delivery?.payload ?? "{}")).toMatchObject({
+      to: "qa@example.test",
+      attachments: [
+        { filename: "derive-export.png", contentType: "image/png", contentId: "derive-export" },
+      ],
+    })
   })
 
   it("C18 replays CID and hosted delivery independently without duplicate jobs", async () => {


### PR DESCRIPTION
## What changed

- render deck email snapshot fallbacks from the first native deck slide
- preserve 16:9 fidelity instead of using the generic 1200×630 chart viewport
- add a wire-level regression that proves the automatic fallback uses deck rendering, stores PNG output, and enqueues the CID image

## Why

Production dogfooding of the eight-case HTML email loop exposed a clipped first-slide image for a deck with no `derive.email/v1` layout. PDF and PPTX exports were correct; only the email snapshot fallback used the wrong capture path.

## Verification

- `pnpm --filter @derive/api test -- export-expanded.test.ts`
- 150 test files passed, 2 skipped; 1,627 tests passed, 3 skipped

## Dogfood evidence

- [Live Derive learning loop](https://derive.to/artifacts/derive-html-email-self-learning-loop-lqrd9zy7)
- [Deck fixture](https://derive.to/artifacts/email-lab-08-deck-delivery-du3v8abd)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790475856&installation_model_id=428097&pr_number=844&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F844&signature=f3d20d3a4622ed0318dd7e1d0bfe1583dd9f4a5f19d1c25cab92a31dc2d64813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->