### PR TITLE
fix(exports): honor deck email layouts

### DIFF
--- a/apps/api/src/exports.ts
+++ b/apps/api/src/exports.ts
@@ -1,5 +1,5 @@
 import { artifactUrl, type ExportJobRecord } from "@derive/core"
-import { buildRichExportEmail, parseEmailLayout } from "./lib/email-layout"
+import { buildRichExportEmail, EMAIL_LAYOUT_FACT, parseEmailLayout } from "./lib/email-layout"
 import {
   buildExportEmail,
   buildQaEmailCapture,
@@ -180,7 +180,7 @@ const processJob = async (deps: RenderTickDeps, job: ExportJobRecord): Promise<v
   }
 
   if (job.kind === "email" && options.emailMode !== "snapshot") {
-    const row = (await deps.meta.getVersionData(artifact.id, job.version_n, "email-layout"))[0]
+    const row = (await deps.meta.getVersionData(artifact.id, job.version_n, EMAIL_LAYOUT_FACT))[0]
     if (row) {
       let declared: unknown
       try {

--- a/apps/api/src/lib/after-publish.ts
+++ b/apps/api/src/lib/after-publish.ts
@@ -10,6 +10,7 @@
 import {
   type ArtifactRecord,
   type BlobStore,
+  DECK_CONTENT_TYPE,
   deriveFacts,
   FACT_GEN,
   isAuthoredFactType,
@@ -26,6 +27,7 @@ import { log } from "../log"
 import { type Summarizer, sanitizeSummary, summaryInput } from "../summarizer"
 import { publishSweepEvents } from "./anchor-sweep"
 import { fanOutNewContentMentions } from "./content-mentions"
+import { EMAIL_LAYOUT_FACT } from "./email-layout"
 import { indexArtifactVersion, isTextType } from "./search"
 import { recordThreadResolution } from "./thread-actions"
 
@@ -169,9 +171,10 @@ const summarizeVersion = async (
 }
 
 /** Extract a single-file HTML/markdown version's facts and persist them (see
- *  @derive/core data-facts). Zip bundles, decks and non-text versions carry no authored facts and are
- *  skipped. Writes only when at least one slot parsed — a fresh version has no prior rows,
- *  so there is nothing to clear when it has none. */
+ *  @derive/core data-facts). Decks may carry the one operational fact their export path
+ *  consumes (`email-layout`); arbitrary authored deck facts stay excluded. Writes only when at
+ *  least one slot parsed — a fresh version has no prior rows, so there is nothing to clear when
+ *  it has none. */
 const extractVersionData = async (
   meta: Pick<MetaStore, "setVersionData" | "getVersionData" | "getVersion">,
   blobs: BlobStore,
@@ -192,7 +195,12 @@ const extractVersionData = async (
   const bytes = await blobs.get(version.blob_key)
   if (!bytes) return
   const source = new TextDecoder().decode(bytes)
-  const { facts } = authored ? parseFacts(source, ct) : { facts: [] }
+  const baseType = ct.split(";")[0]?.trim()
+  const facts = authored
+    ? parseFacts(source, ct).facts
+    : baseType === DECK_CONTENT_TYPE
+      ? parseFacts(source, "text/html").facts.filter((fact) => fact.slot === EMAIL_LAYOUT_FACT)
+      : []
   // Derived facts ($outline/$links/$stats) ride the same pass over bytes already decoded:
   // the host's mechanical reading, in the namespace the author grammar can't reach. They
   // are cache entries with names — recomputable, never counted, never rewarded — so each

--- a/apps/api/src/lib/email-layout.ts
+++ b/apps/api/src/lib/email-layout.ts
@@ -1,6 +1,8 @@
 import { escapeHtml } from "@derive/core"
 import type { ExportEmailMessage } from "./export-system"
 
+export const EMAIL_LAYOUT_FACT = "email-layout"
+
 const MAX_BLOCKS = 16
 const MAX_ITEMS = 12
 

--- a/apps/api/test/doc-map-read.test.ts
+++ b/apps/api/test/doc-map-read.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { deriveFacts } from "@derive/core"
+import { DECK_CONTENT_TYPE, deriveFacts } from "@derive/core"
 import { afterAll, describe, expect, it } from "vitest"
 import { appWithGrant } from "./mcp-helpers"
 
@@ -75,6 +75,8 @@ const DECK = `<!doctype html><html><head><title>d</title><style>.slide{opacity:0
   <section class="slide" data-derive-slide="0"><h2>The problem</h2><p>one</p></section>
   <section class="slide" data-derive-slide="1"><h2>The ask</h2><p>two</p></section>
 <script>parent.postMessage({source:"derive-deck",type:"state",i:0,total:2},"*")</script>
+<script type="application/derive-facts" data-fact="email-layout">{"schema":"derive.email/v1","title":"Deck summary","blocks":[{"type":"paragraph","body":"A rich deck email."}]}</script>
+<script type="application/derive-facts" data-fact="ignored-deck-fact">{"secret":"not an operational contract"}</script>
 </body></html>`
 
 /** A published deck plus a ready MCP session. */
@@ -190,5 +192,21 @@ describe("a deck carries its derived facts", () => {
     expect(one.fact).toBe("$map")
     expect(one.data.kind).toBe("deck")
     expect((one.data.nodes as { ref: string }[]).map((n) => n.ref)).toContain("slide:1")
+  })
+
+  it("persists only the email-layout operational fact from authored deck facts", async () => {
+    const { app, token, short_id, meta } = await setup("deck-email-layout-fact")
+    const artifact = await meta.getByShortId(short_id)
+    const version = await meta.getVersion((artifact as { id: string }).id, 1)
+    expect(version?.content_type).toBe(DECK_CONTENT_TYPE)
+    expect(
+      await meta.getVersionData((artifact as { id: string }).id, 1, "email-layout"),
+    ).toHaveLength(1)
+    const layout = await readJson(app, token, { short_id, data: "email-layout" })
+    expect(layout.fact).toBe("email-layout")
+    expect(layout.data).toMatchObject({ schema: "derive.email/v1", title: "Deck summary" })
+
+    const ignored = await readTool(app, token, { short_id, data: "ignored-deck-fact" })
+    expect(ignored.text).toContain('No facts "ignored-deck-fact"')
   })
 })

--- a/apps/api/test/export-expanded.test.ts
+++ b/apps/api/test/export-expanded.test.ts
@@ -1,4 +1,4 @@
-import { INTERNAL_DELIVERY } from "@derive/core"
+import { DECK_CONTENT_TYPE, INTERNAL_DELIVERY } from "@derive/core"
 import { unzipSync } from "fflate"
 import { describe, expect, it } from "vitest"
 import { runExportTick } from "../src/exports"
@@ -221,7 +221,7 @@ describe("expanded export and email dogfood contracts", () => {
     expect(html).not.toContain("derive-export.pdf")
   })
 
-  it("renders a declared email-layout as native HTML without taking a screenshot", async () => {
+  it("renders a deck's declared email-layout as native HTML without taking a screenshot", async () => {
     const { app, meta, ctx } = makeFixture("expanded-rich-html-email")
     const layout = {
       schema: "derive.email/v1",
@@ -249,11 +249,12 @@ describe("expanded export and email dogfood contracts", () => {
     const artifact = await (
       await publishAs(
         app,
-        `<h1>Pipeline pulse</h1><script type="application/derive-facts" data-fact="email-layout">${JSON.stringify(layout)}</script>`,
+        `<section class="slide" data-derive-slide="0"><h1>Pipeline pulse</h1></section><section class="slide" data-derive-slide="1"><h1>Next step</h1></section><script>parent.postMessage({source:"derive-deck",type:"state",i:0,total:2},"*")</script><script type="application/derive-facts" data-fact="email-layout">${JSON.stringify(layout)}</script>`,
         { title: "Pipeline pulse", workspace_access: "none" },
         as(owner.email),
       )
     ).json()
+    expect(artifact.current_content_type).toBe(DECK_CONTENT_TYPE)
     const accepted = await postExport(app, artifact.short_id, {
       kind: "email",
       recipient: "qa@example.test",

--- a/packages/core/src/content-types.ts
+++ b/packages/core/src/content-types.ts
@@ -20,7 +20,8 @@ export const isHtmlLike = (contentType: string): boolean =>
 export const isMarkdownLike = (contentType: string): boolean =>
   baseType(contentType) === MARKDOWN_CONTENT_TYPE
 
-/** Types that may carry author-declared facts. Decks receive derived structure only. */
+/** Types that may carry the full author-declared fact grammar. Decks receive derived structure
+ * plus narrowly allowlisted operational contracts at the API boundary. */
 export const isAuthoredFactType = (contentType: string): boolean =>
   [HTML_CONTENT_TYPE, MARKDOWN_CONTENT_TYPE, LINKED_BUNDLE_HTML_CONTENT_TYPE].includes(
     baseType(contentType),

--- a/packages/core/src/doc-text.ts
+++ b/packages/core/src/doc-text.ts
@@ -12,7 +12,7 @@
 import { decodeEntities, pageText } from "./anchor"
 import { isHtmlLike } from "./content-types"
 
-export { isAuthoredFactType, isHtmlLike } from "./content-types"
+export { DECK_CONTENT_TYPE, isAuthoredFactType, isHtmlLike } from "./content-types"
 
 const safeLinkHref = (raw: string | null): string | null => {
   if (!raw) return null


### PR DESCRIPTION
## What changed

- allow Derive decks to persist the narrowly scoped `email-layout` operational fact
- keep arbitrary authored deck facts excluded
- share one `EMAIL_LAYOUT_FACT` constant between extraction and export
- prove the full deck → fact → rich HTML email path without screenshot rendering

## Why

Inbox dogfooding showed that the deck already declared a valid `derive.email/v1` layout, but deck fact extraction discarded it. Export therefore fell back to a slide image instead of the intended native HTML summary.

## Verification

- focused deck fact and export tests: 19 passed
- API typecheck passed
- pre-commit guardrails: 34/34 passed

## Dogfood evidence

- [Live Derive learning loop](https://derive.to/artifacts/derive-html-email-self-learning-loop-lqrd9zy7)
- [Deck fixture](https://derive.to/artifacts/email-lab-08-deck-delivery-du3v8abd)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/845"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790477548&installation_model_id=428097&pr_number=845&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F845&signature=91f41bddd7f3363eebcf9e32b17e66e8acba7b0094a57dac604d18475b3498ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->