### PR TITLE
Harden email exports and add no-send preview

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -5636,6 +5636,9 @@
                       "auto",
                       "snapshot"
                     ]
+                  },
+                  "preview": {
+                    "type": "boolean"
                   }
                 },
                 "required": [

--- a/apps/api/src/lib/email-layout.ts
+++ b/apps/api/src/lib/email-layout.ts
@@ -197,9 +197,10 @@ export const parseEmailLayout = (value: unknown): EmailLayout | null => {
 
 const esc = (value: string): string => escapeHtml(value)
 const richText = (value: string): string => esc(value).replaceAll("\n", "<br>")
+const WRAP = "overflow-wrap:anywhere;word-break:break-word"
 const sectionTitle = (value?: string): string =>
   value
-    ? `<h2 style="margin:0 0 14px;font-size:18px;line-height:1.3;color:#17201d">${esc(value)}</h2>`
+    ? `<h2 style="margin:0 0 14px;font-size:18px;line-height:1.3;color:#17201d;${WRAP}">${esc(value)}</h2>`
     : ""
 const palette = ["#155f52", "#4f46e5", "#c77700", "#b42318", "#6d28d9", "#087f8c"]
 
@@ -213,7 +214,7 @@ const renderKpis = (block: Extract<EmailBlock, { type: "kpis" }>): string => {
         `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin:0 0 10px;table-layout:fixed"><tr>${items
           .map(
             (item) =>
-              `<td width="33.33%" valign="top" class="derive-kpi-cell" style="padding:0 5px"><div style="border:1px solid #d9ddd7;border-radius:12px;padding:15px;background:#f8faf7"><div style="font-size:11px;line-height:1.3;text-transform:uppercase;letter-spacing:.08em;color:#66706b">${esc(item.label)}</div><div style="margin-top:7px;font-size:24px;line-height:1.1;font-weight:750;color:#17201d">${esc(item.value)}</div>${item.delta ? `<div style="margin-top:6px;font-size:12px;color:#155f52">${esc(item.delta)}</div>` : ""}</div></td>`,
+              `<td width="33.33%" valign="top" class="derive-kpi-cell" style="padding:0 5px"><div style="box-sizing:border-box;border:1px solid #d9ddd7;border-radius:12px;padding:15px;background:#f8faf7;${WRAP}"><div style="font-size:11px;line-height:1.3;text-transform:uppercase;letter-spacing:.08em;color:#66706b;${WRAP}">${esc(item.label)}</div><div style="margin-top:7px;font-size:24px;line-height:1.1;font-weight:750;color:#17201d;${WRAP}">${esc(item.value)}</div>${item.delta ? `<div style="margin-top:6px;font-size:12px;color:#155f52;${WRAP}">${esc(item.delta)}</div>` : ""}</div></td>`,
           )
           .join("")}</tr></table>`,
     )
@@ -230,24 +231,27 @@ const renderBars = (block: Extract<EmailBlock, { type: "bars" }>): string => {
     .map((item, index) => {
       const width = Math.max(2, Math.min(100, (Math.abs(item.value) / max) * 100))
       const fill = item.color ?? (item.value < 0 ? "#b42318" : palette[index % palette.length])
-      return `<tr><td width="30%" valign="middle" style="padding:7px 10px 7px 0;font-size:12px;color:#35403c">${esc(item.label)}</td><td width="52%" valign="middle" style="padding:7px 8px 7px 0"><table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#e9ece8;border-radius:999px"><tr><td width="${width}%" height="12" style="width:${width}%;height:12px;background:${fill};border-radius:999px;font-size:0">&nbsp;</td><td></td></tr></table></td><td width="18%" align="right" style="padding:7px 0;font-size:12px;font-weight:700;color:#17201d">${esc(item.display ?? String(item.value))}</td></tr>`
+      return `<tr><td width="30%" valign="middle" style="padding:7px 10px 7px 0;font-size:12px;color:#35403c;${WRAP}">${esc(item.label)}</td><td width="52%" valign="middle" style="padding:7px 8px 7px 0"><table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#e9ece8;border-radius:999px"><tr><td width="${width}%" height="12" style="width:${width}%;height:12px;background:${fill};border-radius:999px;font-size:0">&nbsp;</td><td></td></tr></table></td><td width="18%" align="right" style="padding:7px 0;font-size:12px;font-weight:700;color:#17201d;${WRAP}">${esc(item.display ?? String(item.value))}</td></tr>`
     })
     .join("")
   return `${sectionTitle(block.title)}<table role="presentation" width="100%" cellpadding="0" cellspacing="0">${rows}</table>`
 }
 
 const renderSegments = (block: Extract<EmailBlock, { type: "segments" }>): string => {
-  const total = block.items.reduce((sum, item) => sum + Math.max(0, item.value), 0) || 1
-  const cells = block.items
-    .map((item, index) => {
-      const width = Math.max(3, (Math.max(0, item.value) / total) * 100)
-      return `<td width="${width}%" height="24" style="width:${width}%;height:24px;background:${item.color ?? palette[index % palette.length]};font-size:0">&nbsp;</td>`
-    })
-    .join("")
+  const total = block.items.reduce((sum, item) => sum + Math.max(0, item.value), 0)
+  const positiveItems = block.items.filter((item) => item.value > 0)
+  const cells = positiveItems.length
+    ? positiveItems
+        .map((item, index) => {
+          const width = (item.value / total) * 100
+          return `<td width="${width}%" height="24" style="width:${width}%;height:24px;background:${item.color ?? palette[index % palette.length]};font-size:0">&nbsp;</td>`
+        })
+        .join("")
+    : '<td width="100%" height="24" style="width:100%;height:24px;background:#e9ece8;font-size:0">&nbsp;</td>'
   const legend = block.items
     .map(
       (item, index) =>
-        `<tr><td width="18" style="padding:5px 0"><span style="display:block;width:10px;height:10px;border-radius:3px;background:${item.color ?? palette[index % palette.length]}">&nbsp;</span></td><td style="padding:5px 4px;font-size:12px;color:#35403c">${esc(item.label)}</td><td align="right" style="padding:5px 0;font-size:12px;font-weight:700;color:#17201d">${esc(item.display ?? String(item.value))}</td></tr>`,
+        `<tr><td width="18" style="padding:5px 0"><span style="display:block;width:10px;height:10px;border-radius:3px;background:${item.color ?? palette[index % palette.length]}">&nbsp;</span></td><td style="padding:5px 4px;font-size:12px;color:#35403c;${WRAP}">${esc(item.label)}</td><td align="right" style="padding:5px 0;font-size:12px;font-weight:700;color:#17201d;${WRAP}">${esc(item.display ?? String(item.value))}</td></tr>`,
     )
     .join("")
   return `${sectionTitle(block.title)}<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border-radius:8px;overflow:hidden"><tr>${cells}</tr></table><table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-top:10px">${legend}</table>`
@@ -258,23 +262,37 @@ const renderFunnel = (block: Extract<EmailBlock, { type: "funnel" }>): string =>
   const rows = block.items
     .map((item, index) => {
       const width = Math.max(26, Math.min(100, (Math.abs(item.value) / max) * 100))
-      return `<tr><td align="center" style="padding:4px 0"><table role="presentation" width="${width}%" cellpadding="0" cellspacing="0" style="width:${width}%;background:${item.color ?? palette[index % palette.length]};border-radius:8px"><tr><td align="center" style="padding:10px 8px;color:#fff;font-size:12px"><strong>${esc(item.label)}</strong>&nbsp;&nbsp;${esc(item.display ?? String(item.value))}</td></tr></table></td></tr>`
+      return `<tr><td align="center" style="padding:4px 0"><table role="presentation" width="${width}%" cellpadding="0" cellspacing="0" style="width:${width}%;background:${item.color ?? palette[index % palette.length]};border-radius:8px"><tr><td align="center" style="padding:10px 8px;color:#fff;font-size:12px;${WRAP}"><strong>${esc(item.label)}</strong>&nbsp;&nbsp;${esc(item.display ?? String(item.value))}</td></tr></table></td></tr>`
     })
     .join("")
   return `${sectionTitle(block.title)}<table role="presentation" width="100%" cellpadding="0" cellspacing="0">${rows}</table>`
 }
 
 const renderTable = (block: Extract<EmailBlock, { type: "table" }>): string => {
+  if (block.columns.length > 3) {
+    const cards = block.rows
+      .map(
+        (row) =>
+          `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin:0 0 10px;table-layout:fixed;border:1px solid #d9ddd7;border-radius:10px">${row
+            .map(
+              (cell, index) =>
+                `<tr><td width="34%" valign="top" style="padding:9px 10px;border-bottom:1px solid #e6e9e6;font-size:10px;line-height:1.4;text-transform:uppercase;letter-spacing:.04em;color:#66706b;${WRAP}">${esc(block.columns[index] ?? "")}</td><td width="66%" valign="top" style="padding:9px 10px;border-bottom:1px solid #e6e9e6;font-size:12px;line-height:1.4;color:#26302c;${WRAP}">${richText(cell)}</td></tr>`,
+            )
+            .join("")}</table>`,
+      )
+      .join("")
+    return `${sectionTitle(block.title)}${cards}`
+  }
   const head = block.columns
     .map(
       (column) =>
-        `<th align="left" style="padding:9px 8px;border-bottom:1px solid #cfd5d1;font-size:10px;text-transform:uppercase;letter-spacing:.06em;color:#66706b">${esc(column)}</th>`,
+        `<th align="left" style="padding:9px 8px;border-bottom:1px solid #cfd5d1;font-size:10px;text-transform:uppercase;letter-spacing:.06em;color:#66706b;${WRAP}">${esc(column)}</th>`,
     )
     .join("")
   const rows = block.rows
     .map(
       (row) =>
-        `<tr>${row.map((cell) => `<td valign="top" style="padding:10px 8px;border-bottom:1px solid #e6e9e6;font-size:12px;line-height:1.4;color:#26302c">${richText(cell)}</td>`).join("")}</tr>`,
+        `<tr>${row.map((cell) => `<td valign="top" style="padding:10px 8px;border-bottom:1px solid #e6e9e6;font-size:12px;line-height:1.4;color:#26302c;${WRAP}">${richText(cell)}</td>`).join("")}</tr>`,
     )
     .join("")
   return `${sectionTitle(block.title)}<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="table-layout:fixed;border:1px solid #d9ddd7;border-radius:10px"> <tr>${head}</tr>${rows}</table>`
@@ -288,13 +306,13 @@ const renderCallout = (block: Extract<EmailBlock, { type: "callout" }>): string 
     critical: ["#fdecea", "#9d2018"],
   }
   const [background, foreground] = colors[block.tone]
-  return `<div style="padding:16px 18px;border-radius:12px;background:${background};color:${foreground}">${block.title ? `<div style="font-weight:750;margin-bottom:5px">${esc(block.title)}</div>` : ""}<div style="font-size:13px;line-height:1.55">${richText(block.body)}</div></div>`
+  return `<div style="padding:16px 18px;border-radius:12px;background:${background};color:${foreground};${WRAP}">${block.title ? `<div style="font-weight:750;margin-bottom:5px;${WRAP}">${esc(block.title)}</div>` : ""}<div style="font-size:13px;line-height:1.55;${WRAP}">${richText(block.body)}</div></div>`
 }
 
 const renderBlock = (block: EmailBlock): string => {
   let body = ""
   if (block.type === "paragraph")
-    body = `<p style="margin:0;font-size:14px;line-height:1.65;color:#35403c">${richText(block.body)}</p>`
+    body = `<p style="margin:0;font-size:14px;line-height:1.65;color:#35403c;${WRAP}">${richText(block.body)}</p>`
   else if (block.type === "kpis") body = renderKpis(block)
   else if (block.type === "bars") body = renderBars(block)
   else if (block.type === "segments") body = renderSegments(block)
@@ -302,7 +320,7 @@ const renderBlock = (block: EmailBlock): string => {
   else if (block.type === "table") body = renderTable(block)
   else if (block.type === "callout") body = renderCallout(block)
   else if (block.type === "button")
-    body = `<a href="${esc(block.url)}" style="display:inline-block;padding:11px 16px;border-radius:9px;background:#155f52;color:#fff;text-decoration:none;font-weight:700;font-size:13px">${esc(block.label)}</a>`
+    body = `<a href="${esc(block.url)}" style="display:inline-block;max-width:100%;box-sizing:border-box;padding:11px 16px;border-radius:9px;background:#155f52;color:#fff;text-decoration:none;font-weight:700;font-size:13px;${WRAP}">${esc(block.label)}</a>`
   else body = '<div style="height:1px;background:#e2e6e3;font-size:0">&nbsp;</div>'
   return `<tr><td style="padding:0 28px 22px">${body}</td></tr>`
 }
@@ -340,9 +358,9 @@ export const buildRichExportEmail = (input: {
   const subject = input.subjectTitle.replace(/[\r\n]+/g, " ").trim()
   const preheader = input.layout.preheader ?? input.layout.subtitle ?? input.layout.title
   const note = input.note
-    ? `<tr><td style="padding:0 28px 22px"><div style="padding:13px 15px;border-left:3px solid #c9f77b;background:#f5f8f3;color:#35403c;font-size:13px;line-height:1.5">${richText(input.note)}</div></td></tr>`
+    ? `<tr><td style="padding:0 28px 22px"><div style="padding:13px 15px;border-left:3px solid #c9f77b;background:#f5f8f3;color:#35403c;font-size:13px;line-height:1.5;${WRAP}">${richText(input.note)}</div></td></tr>`
     : ""
-  const html = `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><style>@media(max-width:620px){.derive-shell{border-radius:0!important}.derive-pad{padding-left:18px!important;padding-right:18px!important}}@media(max-width:360px){.derive-kpi-cell{display:block!important;width:100%!important;padding:0 0 10px!important}}</style></head><body style="margin:0;background:#eef1ee;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Arial,sans-serif;color:#17201d"><div style="display:none;max-height:0;overflow:hidden;opacity:0;color:transparent">${esc(preheader)}&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;</div><table role="presentation" width="100%" cellpadding="0" cellspacing="0"><tr><td align="center" style="padding:24px 10px"><table role="presentation" width="620" cellpadding="0" cellspacing="0" class="derive-shell" style="width:100%;max-width:620px;background:#fff;border:1px solid #d9ddd7;border-radius:16px;overflow:hidden"><tr><td class="derive-pad" style="padding:26px 28px 9px"><div style="font-size:10px;text-transform:uppercase;letter-spacing:.12em;font-weight:800;color:#155f52">Derive · version ${input.version}</div><h1 style="margin:10px 0 0;font-size:28px;line-height:1.1;letter-spacing:-.03em;color:#17201d">${esc(input.layout.title)}</h1>${input.layout.subtitle ? `<p style="margin:9px 0 0;font-size:14px;line-height:1.55;color:#66706b">${richText(input.layout.subtitle)}</p>` : ""}</td></tr><tr><td style="padding:0 28px 20px"><div style="height:1px;background:#e2e6e3;font-size:0">&nbsp;</div></td></tr>${note}${input.layout.blocks.map(renderBlock).join("")}<tr><td class="derive-pad" style="padding:4px 28px 28px"><a href="${esc(input.openUrl)}" style="display:inline-block;padding:11px 16px;border-radius:9px;background:#17201d;color:#fff;text-decoration:none;font-weight:700;font-size:13px">Open in Derive</a><p style="margin:16px 0 0;color:#7b847f;font-size:11px;line-height:1.5">This email-safe rendering is pinned to version ${input.version}. It does not change access to the original.</p></td></tr></table></td></tr></table></body></html>`
+  const html = `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><style>@media(max-width:620px){.derive-shell{border-radius:0!important}.derive-pad{padding-left:18px!important;padding-right:18px!important}}@media(max-width:420px){.derive-kpi-cell{display:block!important;width:100%!important;padding:0 0 10px!important}}</style></head><body style="margin:0;background:#eef1ee;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Arial,sans-serif;color:#17201d"><div style="display:none;max-height:0;overflow:hidden;opacity:0;color:transparent">${esc(preheader)}&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;</div><table role="presentation" width="100%" cellpadding="0" cellspacing="0"><tr><td align="center" style="padding:24px 10px"><table role="presentation" width="620" cellpadding="0" cellspacing="0" class="derive-shell" style="width:100%;max-width:620px;background:#fff;border:1px solid #d9ddd7;border-radius:16px;overflow:hidden"><tr><td class="derive-pad" style="padding:26px 28px 9px"><div style="font-size:10px;text-transform:uppercase;letter-spacing:.12em;font-weight:800;color:#155f52">Derive · version ${input.version}</div><h1 style="margin:10px 0 0;font-size:28px;line-height:1.1;letter-spacing:-.03em;color:#17201d;${WRAP}">${esc(input.layout.title)}</h1>${input.layout.subtitle ? `<p style="margin:9px 0 0;font-size:14px;line-height:1.55;color:#66706b;${WRAP}">${richText(input.layout.subtitle)}</p>` : ""}</td></tr><tr><td style="padding:0 28px 20px"><div style="height:1px;background:#e2e6e3;font-size:0">&nbsp;</div></td></tr>${note}${input.layout.blocks.map(renderBlock).join("")}<tr><td class="derive-pad" style="padding:4px 28px 28px"><a href="${esc(input.openUrl)}" style="display:inline-block;padding:11px 16px;border-radius:9px;background:#17201d;color:#fff;text-decoration:none;font-weight:700;font-size:13px">Open in Derive</a><p style="margin:16px 0 0;color:#7b847f;font-size:11px;line-height:1.5">This email-safe rendering is pinned to version ${input.version}. It does not change access to the original.</p></td></tr></table></td></tr></table></body></html>`
   const text = [
     input.layout.title,
     input.layout.subtitle,

--- a/apps/api/src/lib/export-system.ts
+++ b/apps/api/src/lib/export-system.ts
@@ -56,7 +56,7 @@ export interface ExportOptions {
   attachPdf?: boolean
   emailMode?: "auto" | "snapshot"
   title?: string
-  /** Internal-only PR-preview guard. Never accepted from the public request schema. */
+  /** Internal no-send capture guard. Public `preview` requests map to this server-side. */
   qaCapture?: boolean
 }
 

--- a/apps/api/src/routes/exports.ts
+++ b/apps/api/src/routes/exports.ts
@@ -64,6 +64,7 @@ export const exportRoutes = (ctx: AppContext) => {
     note: z.string().max(2_000).optional(),
     attachPdf: z.boolean().optional(),
     emailMode: z.enum(["auto", "snapshot"]).optional(),
+    preview: z.boolean().optional(),
   })
 
   app.openapi(
@@ -87,17 +88,21 @@ export const exportRoutes = (ctx: AppContext) => {
       const versionN = body.version ?? artifact.current_version
       const version = await meta.getVersion(artifact.id, versionN)
       if (!version) return bail(fail(c, 404, "version not found"))
+      if (body.preview === true && body.kind !== "email")
+        return bail(fail(c, 400, "preview is only supported for email exports"))
+      const previewOnly = body.kind === "email" && body.preview === true
       const qaCapture = body.kind === "email" && deps.qaEmailCapture === true
       const options = normalizeExportOptions({
         ...body,
         title: artifact.title ?? undefined,
-        ...(qaCapture ? { qaCapture: true } : {}),
+        ...(previewOnly ? { recipient: "preview@derive.test" } : {}),
+        ...(qaCapture || previewOnly ? { qaCapture: true } : {}),
       })
       if (isDataExport(body.kind) && !options.dataSlot)
         return bail(fail(c, 400, "dataSlot is required for declared data export"))
       if (body.kind === "email" && !options.recipient)
         return bail(fail(c, 400, "recipient is required for email export"))
-      if (qaCapture && options.recipient && !isQaEmailRecipient(options.recipient))
+      if ((qaCapture || previewOnly) && options.recipient && !isQaEmailRecipient(options.recipient))
         return bail(fail(c, 400, "preview email capture requires a recipient under .test"))
       if (isDeckExport(body.kind) && version.content_type !== "text/x-derive-deck")
         return bail(fail(c, 400, "deck export requires a Derive deck"))

--- a/apps/api/test/export-expanded.test.ts
+++ b/apps/api/test/export-expanded.test.ts
@@ -60,6 +60,12 @@ describe("expanded export and email dogfood contracts", () => {
     const missingRecipient = await postExport(app, artifact.short_id, { kind: "email" })
     expect(missingRecipient.status).toBe(400)
     expect(await missingRecipient.text()).toContain("recipient is required")
+    const invalidPreview = await postExport(app, artifact.short_id, {
+      kind: "page_pdf",
+      preview: true,
+    })
+    expect(invalidPreview.status).toBe(400)
+    expect(await invalidPreview.text()).toContain("preview is only supported for email")
     expect((await postExport(app, artifact.short_id, { kind: "not-a-format" })).status).toBe(400)
   })
 
@@ -288,6 +294,69 @@ describe("expanded export and email dogfood contracts", () => {
     expect(html).toContain("Enterprise")
     expect(html).not.toContain("data:image/png")
     expect(html).toContain("<li>None</li>")
+  })
+
+  it("previews a production email without a recipient or delivery side effect", async () => {
+    const { app, meta, ctx } = makeAuthedApp("expanded-public-email-preview", [owner], undefined, {
+      deps: { renderExports: true },
+    })
+    const layout = {
+      schema: "derive.email/v1",
+      title: "No-send preview",
+      blocks: [
+        { type: "kpis", items: [{ label: "ARR", value: "$12.4M" }] },
+        { type: "paragraph", body: "This exact HTML can be inspected before delivery." },
+      ],
+    }
+    const artifact = await (
+      await publishAs(
+        app,
+        `<h1>No-send preview</h1><script type="application/derive-facts" data-fact="email-layout">${JSON.stringify(layout)}</script>`,
+        { title: "No-send preview", workspace_access: "none" },
+        as(owner.email),
+      )
+    ).json()
+    const requests = await Promise.all([
+      postExport(app, artifact.short_id, { kind: "email", preview: true }),
+      postExport(app, artifact.short_id, {
+        kind: "email",
+        recipient: "real-address@example.com",
+        preview: true,
+      }),
+    ])
+    expect(requests.map((response) => response.status)).toEqual([202, 202])
+    const jobs = await Promise.all(requests.map((response) => response.json()))
+    expect(new Set(jobs.map((job) => job.id))).toHaveLength(1)
+    const [job] = jobs
+    const queued = await meta.getExportJob(job.id)
+    expect(JSON.parse(queued?.options_json ?? "{}")).toMatchObject({
+      recipient: "preview@derive.test",
+      qaCapture: true,
+    })
+    expect(
+      await runExportTick({
+        meta,
+        blobs: ctx.blobs,
+        renderer: {
+          screenshot: async () => {
+            throw new Error("native HTML preview must not take a screenshot")
+          },
+        },
+        baseUrl: "http://derive.test",
+        secret: "expanded-public-preview-secret",
+      }),
+    ).toBe(1)
+    expect(await meta.recentDeliveries(INTERNAL_DELIVERY, 10)).toEqual([])
+
+    const capture = await app.request(`/v1/exports/${job.id}/preview`, {
+      headers: as(owner.email),
+    })
+    expect(capture.status).toBe(200)
+    expect(capture.headers.get("content-security-policy")).toContain("sandbox")
+    const html = await capture.text()
+    expect(html).toContain("QA capture · no email was sent")
+    expect(html).toContain("preview@derive.test")
+    expect(html).toContain("$12.4M")
   })
 
   it("renders a deck email snapshot from the first native deck image and sends PNG bytes", async () => {

--- a/apps/api/test/previews.test.ts
+++ b/apps/api/test/previews.test.ts
@@ -212,7 +212,7 @@ describe("export contracts", () => {
     expect(email.html).toContain("margin:0 0 10px;table-layout:fixed")
     expect(email.html).toContain('class="derive-kpi-cell"')
     expect(email.html).toContain(
-      "@media(max-width:360px){.derive-kpi-cell{display:block!important;width:100%!important",
+      "@media(max-width:420px){.derive-kpi-cell{display:block!important;width:100%!important",
     )
     expect(email.html).toContain("−$1.4M")
     expect(email.html).toContain("Enterprise &lt;script&gt;")
@@ -231,6 +231,44 @@ describe("export contracts", () => {
       }),
     ).toThrow(/must use https/)
     expect(parseEmailLayout({ schema: "some-other-contract" })).toBeNull()
+  })
+
+  it("wraps hostile long content and turns wide tables into readable field cards", () => {
+    const token = "x".repeat(200)
+    const cellToken = "x".repeat(400)
+    const layout = parseEmailLayout({
+      schema: "derive.email/v1",
+      title: token,
+      blocks: [
+        { type: "paragraph", body: `https://derive.test/${token}` },
+        {
+          type: "segments",
+          items: [
+            { label: "Only positive", value: 1 },
+            { label: "Zero", value: 0 },
+            { label: "Negative", value: -3 },
+          ],
+        },
+        {
+          type: "table",
+          columns: ["Account", "Region", "Owner", "Evidence"],
+          rows: [[cellToken, "Worldwide", "Revenue", `https://derive.test/${cellToken}`]],
+        },
+      ],
+    })
+    expect(layout).not.toBeNull()
+    if (!layout) throw new Error("expected a parsed email layout")
+    const email = buildRichExportEmail({
+      to: "qa@example.test",
+      subjectTitle: "Adversarial email",
+      openUrl: "https://derive.test/artifacts/adversarial/v/1",
+      version: 1,
+      layout,
+    })
+    expect(email.html).toContain("overflow-wrap:anywhere;word-break:break-word")
+    expect(email.html).toContain('width="34%"')
+    expect(email.html).toContain('width="66%"')
+    expect(email.html).not.toContain('width="3%"')
   })
 })
 

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -2026,6 +2026,7 @@ export interface paths {
                         attachPdf?: boolean;
                         /** @enum {string} */
                         emailMode?: "auto" | "snapshot";
+                        preview?: boolean;
                     };
                 };
             };

--- a/apps/web/src/pages/artifact/export-dialog.tsx
+++ b/apps/web/src/pages/artifact/export-dialog.tsx
@@ -54,9 +54,14 @@ export function ExportButton({
   const create = useApiMutation<ExportJob, CreateInput>({
     mutationFn: (input) => api.createExport(shortId, input),
     invalidate: [["exports", shortId]],
-    success: (_, input) => (input.kind === "email" ? "Email is preparing" : "Export is preparing"),
+    success: (_, input) =>
+      input.kind === "email"
+        ? input.preview
+          ? "Email preview is preparing"
+          : "Email is preparing"
+        : "Export is preparing",
   })
-  const start = () =>
+  const start = (preview = false) =>
     create.mutate({
       kind,
       version,
@@ -65,6 +70,7 @@ export function ExportButton({
       ...(note.trim() ? { note: note.trim() } : {}),
       ...(option.supportsPublicImage ? { publicImage } : {}),
       ...(option.email ? { attachPdf, emailMode } : {}),
+      ...(option.email && preview ? { preview: true } : {}),
     })
 
   return (
@@ -216,17 +222,35 @@ export function ExportButton({
             </p>
           )}
 
-          <Button
-            data-testid="export-create"
-            onClick={start}
-            disabled={
-              create.isPending ||
-              (option.email && (!recipient.trim() || recipientInvalid)) ||
-              (option.requiresDataSlot && !slot.trim())
-            }
-          >
-            {create.isPending ? "Starting…" : option.email ? "Prepare & send" : "Create export"}
-          </Button>
+          {option.email ? (
+            <div className="grid grid-cols-2 gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                data-testid="export-preview-email"
+                onClick={() => start(true)}
+                disabled={create.isPending}
+              >
+                {create.isPending ? "Starting…" : "Preview email"}
+              </Button>
+              <Button
+                type="button"
+                data-testid="export-create"
+                onClick={() => start(false)}
+                disabled={create.isPending || !recipient.trim() || recipientInvalid}
+              >
+                {create.isPending ? "Starting…" : "Prepare & send"}
+              </Button>
+            </div>
+          ) : (
+            <Button
+              data-testid="export-create"
+              onClick={() => start(false)}
+              disabled={create.isPending || (option.requiresDataSlot && !slot.trim())}
+            >
+              {create.isPending ? "Starting…" : "Create export"}
+            </Button>
+          )}
           <ExportJobList shortId={shortId} open={open} />
         </div>
       </DialogContent>


### PR DESCRIPTION
## What changed
- adds a public no-send email preview using the production renderer and immutable export job path
- forces preview recipients to `preview@derive.test` and never creates delivery rows
- wraps hostile long content, stacks wide tables, fixes zero-value segments, and stacks KPIs below 420px
- adds regression coverage for preview safety and adversarial layouts

## Dogfood
- Luna rendered 16 fixtures at 6 widths: 96/96 with zero overflow, clipping, image dependency, or missing CTAs
- independent Luna review caught a metric-only KPI readability miss; the mobile threshold was raised and visually rechecked

## Verification
- 34/34 repository guardrails
- API: 1,631 passed, 3 skipped
- Web: 150 passed
- MCP: 28 passed
- production web build passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790491358&installation_model_id=428097&pr_number=848&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F848&signature=37f802d68b4774b46641fb25017b9c22ddc78fb8a272f57b65bfaf09f761cd47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->