### PR TITLE
Activity rail: paint the stream once, when every source has settled

### DIFF
--- a/apps/web/e2e/activity-load.smoke.spec.ts
+++ b/apps/web/e2e/activity-load.smoke.spec.ts
@@ -1,0 +1,107 @@
+import { Buffer } from "node:buffer"
+import type { Route } from "@playwright/test"
+import { expect, openArtifact, test } from "./fixtures"
+
+// The activity stream is the union of sources that settle at different times (versions,
+// comments, review rounds — each gated on the session). It must paint ONCE, complete: a
+// partial stream is a different stream (a card splits a turn, an ask lands between two
+// publishes), and the open-scroll and "N new" logic would run against the wrong picture.
+// Reproduced by a cold cache plus production-like latency, then sampled across the reload.
+test("a cold reload paints the activity stream once, complete and in order", async ({
+  owner: page,
+}) => {
+  let shortId = ""
+  const html = (v: number) => `<h1>Doc v${v}</h1><p id="p1">Paragraph one.</p><p id="p2">Two.</p>`
+  await expect(async () => {
+    const res = await page.request.post("/v1/artifacts", {
+      multipart: {
+        file: { name: "doc.html", mimeType: "text/html", buffer: Buffer.from(html(1)) },
+      },
+    })
+    expect(res.ok()).toBeTruthy()
+    shortId = ((await res.json()) as { short_id: string }).short_id
+  }).toPass({ timeout: 10_000 })
+  const post = async (data: Record<string, unknown>) =>
+    (await (await page.request.post(`/v1/artifacts/${shortId}/comments`, { data })).json()) as {
+      id: string
+      thread_id: string
+    }
+  const t1 = await post({
+    body_md: "First thread",
+    anchor: { type: "TextQuoteSelector", exact: "Paragraph one." },
+  })
+  await post({ thread_id: t1.thread_id, body_md: "A reply" })
+  const t2 = await post({ body_md: "Second thread" })
+  await page.request.post(`/v1/artifacts/${shortId}/comments/${t2.id}/resolve`, {
+    data: { state: "resolved" },
+  })
+  for (const v of [2, 3]) {
+    const r = await page.request.post(`/v1/artifacts/${shortId}/versions`, {
+      multipart: {
+        file: { name: "doc.html", mimeType: "text/html", buffer: Buffer.from(html(v)) },
+        message: `v${v}`,
+      },
+    })
+    expect(r.ok()).toBeTruthy()
+  }
+  await openArtifact(page, shortId)
+  await page.waitForTimeout(800)
+
+  // A last visit a minute ago arms the marker and the arrivals logic (set at document
+  // start, so the reload's own pagehide stamp can't overwrite it).
+  await page.addInitScript(
+    (id) => localStorage.setItem(`derive.activity.seen.${id}`, String(Date.now() - 60_000)),
+    shortId,
+  )
+  // Production latency, staggered the way the gates stagger it.
+  const delay = (ms: number) => async (route: Route) => {
+    await new Promise((r) => setTimeout(r, ms))
+    await route.continue()
+  }
+  await page.route("**/v1/me", delay(150))
+  await page.route("**/v1/artifacts/*/comments*", delay(300))
+  await page.route("**/v1/artifacts/*/review", delay(500))
+  // Cold: no persisted cache to paint from.
+  await page.evaluate(async () => {
+    for (const db of await indexedDB.databases())
+      if (db.name)
+        await new Promise((r) => {
+          const q = indexedDB.deleteDatabase(db.name as string)
+          q.onsuccess = q.onerror = q.onblocked = () => r(null)
+        })
+  })
+  await page.reload()
+
+  const orders: string[] = []
+  let pill = false
+  const t0 = Date.now()
+  while (Date.now() - t0 < 2500) {
+    const ids = await page
+      .evaluate(() =>
+        Array.from(
+          document.querySelectorAll(
+            '[data-testid="activity-stream"] [data-thread-id], [data-testid="activity-stream"] [data-testid^="resolved-thread-"], [data-testid="activity-stream"] [data-testid="activity-turn-toggle"], [data-testid="activity-stream"] [data-testid="activity-unread-marker"]',
+          ),
+        )
+          .map((el) => el.getAttribute("data-thread-id") ?? el.getAttribute("data-testid") ?? "?")
+          .join(" | "),
+      )
+      .catch(() => "")
+    if (ids && orders[orders.length - 1] !== ids) orders.push(ids)
+    if (
+      await page
+        .getByTestId("activity-jump-latest")
+        .isVisible()
+        .catch(() => false)
+    )
+      pill = true
+    await page.waitForTimeout(50)
+  }
+  // One paint, already complete: marker, v1 turn, the anchored card, the folded resolved
+  // thread, the v2–v3 turn. Never a versions-only first frame that reflows.
+  expect(orders, orders.join("\n")).toHaveLength(1)
+  expect(orders[0]).toMatch(
+    /^activity-unread-marker \| activity-turn-toggle \| c_\w+ \| resolved-thread-c_\w+ \| activity-turn-toggle$/,
+  )
+  expect(pill).toBe(false)
+})

--- a/apps/web/src/pages/artifact/activity-panel.tsx
+++ b/apps/web/src/pages/artifact/activity-panel.tsx
@@ -52,6 +52,8 @@ export function ActivityPanel(p: {
   onToggleVisualPin?: () => void
   /** The suggestion / locked one-liners, above the stream. */
   hints?: ReactNode
+  /** All sources settled — the list paints only then (index.tsx `streamReady`). */
+  ready: boolean
   editing?: boolean
   onGoToVersion: (n: number) => void
   onSendBack: (note?: string) => void
@@ -103,7 +105,11 @@ export function ActivityPanel(p: {
   const atBottom = useRef(true)
   const opened = useRef(false)
   const [pendingNew, setPendingNew] = useState(0)
-  const count = p.items.filter((it) => it.type === "thread" || it.type === "turn").length
+  // Until ready there is no list: the open-scroll waits for the whole picture, and the
+  // first paint is never counted as arrivals.
+  const count = p.ready
+    ? p.items.filter((it) => it.type === "thread" || it.type === "turn").length
+    : 0
   const lastCount = useRef(count)
   const lastLens = useRef(p.lens)
   useLayoutEffect(() => {
@@ -322,20 +328,22 @@ export function ActivityPanel(p: {
           className="flex h-full flex-col overflow-auto px-2.5 pb-3"
         >
           {p.hints}
-          <ActivityStream
-            items={p.items}
-            currentVersion={p.currentVersion}
-            answeringRoundId={answering?.id ?? null}
-            inView={inView}
-            markerRef={(el) => {
-              marker.current = el
-            }}
-            editing={p.editing}
-            emptyTestId="comments-empty-new"
-            onNewComment={newComment}
-            onGoToVersion={p.onGoToVersion}
-            onAnswer={answer}
-          />
+          {p.ready && (
+            <ActivityStream
+              items={p.items}
+              currentVersion={p.currentVersion}
+              answeringRoundId={answering?.id ?? null}
+              inView={inView}
+              markerRef={(el) => {
+                marker.current = el
+              }}
+              editing={p.editing}
+              emptyTestId="comments-empty-new"
+              onNewComment={newComment}
+              onGoToVersion={p.onGoToVersion}
+              onAnswer={answer}
+            />
+          )}
         </div>
         {pendingNew > 0 && (
           <FloatingControl

--- a/apps/web/src/pages/artifact/artifact-comments.tsx
+++ b/apps/web/src/pages/artifact/artifact-comments.tsx
@@ -59,6 +59,9 @@ export function ArtifactComments(p: {
   canComment: boolean
   /** The suggestion / locked one-liners shown above the stream. */
   hints?: ReactNode
+  /** Every source the stream is built from has settled (index.tsx `streamReady`): the
+   *  surfaces paint the list only then, never a partial one that reflows. */
+  ready: boolean
   /** What the activity stream is built from besides the comments: the versions, the
    *  review rounds, and the reader's last visit. The page owns the version jump and the
    *  send-back write. */
@@ -252,6 +255,7 @@ export function ArtifactComments(p: {
                   ) : undefined
                 }
                 items={items}
+                ready={p.ready}
                 openCount={p.openCount}
                 currentVersion={p.currentVersion}
                 pendingRound={p.pendingRound}
@@ -285,6 +289,7 @@ export function ArtifactComments(p: {
             open={panel === "open"}
             openThreads={p.openThreads}
             items={items}
+            ready={p.ready}
             currentVersion={p.currentVersion}
             pendingRound={p.pendingRound}
             onGoToVersion={p.onGoToVersion}

--- a/apps/web/src/pages/artifact/comment-panels.tsx
+++ b/apps/web/src/pages/artifact/comment-panels.tsx
@@ -35,6 +35,7 @@ export function MobileComments({
   open,
   openThreads,
   items,
+  ready,
   currentVersion,
   pendingRound,
   onGoToVersion,
@@ -60,6 +61,7 @@ export function MobileComments({
   openThreads: Comment[][]
   /** The activity stream (see ArtifactComments); the sheet renders it in its full state. */
   items: StreamItem[]
+  ready: boolean
   currentVersion: number
   pendingRound: ReviewRound | null
   onGoToVersion: (n: number) => void
@@ -383,20 +385,22 @@ export function MobileComments({
             data-testid="activity-stream"
             className="flex min-h-0 flex-1 flex-col overflow-auto px-3 pb-[max(14px,env(safe-area-inset-bottom))]"
           >
-            <ActivityStream
-              items={items}
-              currentVersion={currentVersion}
-              // Answering shows the composer bar instead of the list, so nothing here is.
-              answeringRoundId={null}
-              editing={editing}
-              emptyTestId="comments-sheet-empty-new"
-              onNewComment={() => {
-                setSize("full")
-                onNewGeneral()
-              }}
-              onGoToVersion={onGoToVersion}
-              onAnswer={() => setAnswering(true)}
-            />
+            {ready && (
+              <ActivityStream
+                items={items}
+                currentVersion={currentVersion}
+                // Answering shows the composer bar instead of the list, so nothing here is.
+                answeringRoundId={null}
+                editing={editing}
+                emptyTestId="comments-sheet-empty-new"
+                onNewComment={() => {
+                  setSize("full")
+                  onNewGeneral()
+                }}
+                onGoToVersion={onGoToVersion}
+                onAnswer={() => setAnswering(true)}
+              />
+            )}
           </div>
         </CommentTreeProvider>
       ) : latest ? (

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -238,10 +238,11 @@ export function Artifact({ template = false }: { template?: boolean }) {
   useDocumentTitle(art ? (art.title ?? shortId) : null)
   const commentsAvailable =
     !!me && !seeded && !!art && (!isGuest || canCommentWithRole(art.my_role))
-  const { data: comments = [] } = useQuery({
+  const commentsQ = useQuery({
     ...commentsQuery(shortId),
     enabled: commentsAvailable,
   })
+  const comments = commentsQ.data ?? []
   // Workspace tools are loaded only when their workspace is active.
   const { data: agents = [] } = useQuery({
     ...artifactAgentsQuery(shortId),
@@ -249,10 +250,22 @@ export function Artifact({ template = false }: { template?: boolean }) {
   })
   // The review rounds the activity rail renders — and the pending one its composer
   // answers. Members who can act only, like the card this replaced.
-  const { data: review } = useQuery({
+  const reviewEnabled = commentsAvailable && !isGuest
+  const reviewQ = useQuery({
     ...reviewQuery(shortId),
-    enabled: commentsAvailable && !isGuest,
+    enabled: reviewEnabled,
   })
+  const review = reviewQ.data
+  // The activity stream is the union of three sources that settle at different times
+  // (the artifact's versions, the comments, the review rounds — each gated on the
+  // session). It paints ONCE, when every source it will use has its first result: a
+  // partial stream is not an early stream, it is a different one (a card splits a turn,
+  // an ask lands between two publishes), and its open-scroll and "N new" logic would
+  // run against the wrong picture. A disabled source counts as settled.
+  const streamReady =
+    !loading &&
+    (!commentsAvailable || !commentsQ.isPending) &&
+    (!reviewEnabled || !reviewQ.isPending)
   const { data: workspaces } = useQuery({ ...workspacesQuery(), enabled: isGuest })
   // A password artifact returns 401 until the visitor unlocks it — show the
   // password prompt rather than the not-found state or a bounce to login.
@@ -997,9 +1010,9 @@ export function Artifact({ template = false }: { template?: boolean }) {
   // rail is closed (open, the rail shows its own "New" marker).
   const unread = countUnread(
     buildStream({
-      versions: art.versions,
-      comments,
-      rounds: review?.rounds ?? [],
+      versions: streamReady ? art.versions : [],
+      comments: streamReady ? comments : [],
+      rounds: streamReady ? (review?.rounds ?? []) : [],
       me: me?.name ?? undefined,
       lastSeen: seen.lastSeen,
       lens: "all",
@@ -1639,6 +1652,7 @@ export function Artifact({ template = false }: { template?: boolean }) {
               currentVersion={art.current_version}
               rounds={review?.rounds ?? []}
               pendingRound={review?.pending ?? null}
+              ready={streamReady}
               meId={me?.id ?? ""}
               meName={me?.name ?? me?.username ?? me?.email ?? ""}
               lastSeen={seen.lastSeen}

--- a/apps/web/src/pages/artifact/route-config.ts
+++ b/apps/web/src/pages/artifact/route-config.ts
@@ -1,5 +1,5 @@
 import type { QueryClient } from "@tanstack/react-query"
-import { artifactQuery, commentsQuery, meQuery } from "@/lib/queries"
+import { artifactQuery, commentsQuery, meQuery, reviewQuery } from "@/lib/queries"
 import { canCommentWithRole } from "./lib/comment-access"
 import { candidateShortIds } from "./parse-ref"
 
@@ -57,13 +57,22 @@ export const artifactRouteLoader = ({
   params: { ref: string }
 }) => {
   void (async () => {
+    // The session resolves alongside the artifact (it is never persisted, so on a reload
+    // it is NOT already in the cache — reading it synchronously here left the comments
+    // unwarmed on every cold load, and the rail painted in waves as each source landed).
+    const mePromise = queryClient.ensureQueryData(meQuery()).catch(() => null)
     for (const id of candidateShortIds(params.ref)) {
       const art = await queryClient.ensureQueryData(artifactQuery(id)).catch(() => null)
       if (art) {
-        const signedIn = queryClient.getQueryData(meQuery().queryKey)
+        const signedIn = await mePromise
         const commentsAvailable =
           art.is_workspace_member === true || canCommentWithRole(art.my_role)
-        if (signedIn && commentsAvailable) queryClient.prefetchQuery(commentsQuery(id))
+        // Everything the activity stream is built from, in flight together: the page
+        // paints the stream once, when all of it has settled (see `streamReady`).
+        if (signedIn && commentsAvailable) {
+          void queryClient.prefetchQuery(commentsQuery(id))
+          if (art.is_workspace_member === true) void queryClient.prefetchQuery(reviewQuery(id))
+        }
         return
       }
     }


### PR DESCRIPTION
## Summary

On a reload the activity rail painted in waves. The stream is the union of three sources that settle at different times — the artifact's versions, the comments, the review rounds — each gated on the session, and nothing said when the union was complete. So: a versions-only frame, then the comments landing and **splitting a turn around a card** (`published v1–v3` → `v1 | card | v2–v3`), then the rounds interleaving. The rail treated the first frame as "opened" (its open-at-marker scroll ran against the partial list) and every later wave as *arrivals* — re-scrolling, or an "N new" pill for activity that wasn't new. The header's unread dot came from the same partial picture.

**Where the waterfall started:** the route loader prefetched comments only if the session was *already* cached — and the session is never persisted (auth re-resolves on every boot), so a cold reload never warmed them; the review query was never prefetched at all.

**The fix:**
- The loader resolves the session alongside the artifact and prefetches comments and review together.
- The page derives one `streamReady` — session settled, and each enabled source past its first result (a disabled source counts as settled). Both surfaces render the list only then: the first paint is the complete stream, the open-scroll waits for it, and it's never counted as arrivals. The unread dot is computed from the complete stream.

**Why it wasn't caught:** on localhost every source lands in one frame. The new smoke spec (`e2e/activity-load.smoke.spec.ts`) injects a cold persisted cache and production-like per-request latency, stamps a last visit, samples the DOM order across the reload, and asserts one complete paint and no pill. Before the fix it observed two orders (380 ms / 682 ms); after: one (cold 683 ms, warm 391 ms).

## Test plan
- [x] New smoke regression spec; smoke 20/20, screens harnesses (activity, comments) pass
- [x] `pnpm run ci` 34/34, typecheck, 101 artifact unit tests, pre-push `verify` on the rebased tree
- [ ] CI on this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790491924&installation_model_id=428097&pr_number=849&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F849&signature=8e652ac5dae67731dd286dc5bf42f6264dab6aecdd36ded95ebc479a09fbe132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->