### PR TITLE
Activity rail: a shape-matched loading frame while the stream's sources settle

### DIFF
--- a/apps/web/src/pages/artifact/activity-panel.tsx
+++ b/apps/web/src/pages/artifact/activity-panel.tsx
@@ -16,7 +16,7 @@ import {
 import { Kbd } from "@/components/ui/kbd"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { DockedComposer } from "./activity-composer"
-import { ActivityStream } from "./activity-stream"
+import { ActivityStream, StreamSkeleton } from "./activity-stream"
 import { FloatingControl } from "./floating-control"
 import type { Lens, StreamItem } from "./lib/activity"
 import { useCommentScope } from "./lib/comment-scope"
@@ -328,6 +328,7 @@ export function ActivityPanel(p: {
           className="flex h-full flex-col overflow-auto px-2.5 pb-3"
         >
           {p.hints}
+          {!p.ready && <StreamSkeleton />}
           {p.ready && (
             <ActivityStream
               items={p.items}

--- a/apps/web/src/pages/artifact/activity-stream.tsx
+++ b/apps/web/src/pages/artifact/activity-stream.tsx
@@ -4,12 +4,50 @@ import { EmptyState } from "@/components/shared/empty-state"
 import { Eyebrow } from "@/components/shared/section-eyebrow"
 import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
+import { Skeleton } from "@/components/ui/skeleton"
 import { cn } from "@/lib/utils"
 import { ResolvedRow, TurnRow } from "./activity-rows"
 import { CommentCard } from "./comment-thread"
 import type { StreamItem } from "./lib/activity"
 import { useCommentScope } from "./lib/comment-scope"
 import { useCommentTree } from "./lib/comment-tree"
+
+/**
+ * The stream's loading frame, in the stream's own grammar — a turn line (glyph, sentence,
+ * stamp), a card, two more lines — so the rail is visibly the rail while its sources
+ * settle (a reload with a cold cache waits on three requests). Shape doctrine: the boxes'
+ * dims and rhythm, never a border or fill (those arrive with the content). The region
+ * announces; the blocks are decoration.
+ */
+export function StreamSkeleton() {
+  const line = (w: string) => (
+    <div className="grid grid-cols-[1.25rem_minmax(0,1fr)_auto] items-center gap-x-2 py-1.5">
+      <Skeleton className="size-5 rounded-full" />
+      <Skeleton className={cn("h-3.5", w)} />
+      <Skeleton className="h-2.5 w-7" />
+    </div>
+  )
+  return (
+    <div role="status" data-testid="activity-stream-loading" className="flex flex-col pt-1">
+      <span className="sr-only">Loading activity…</span>
+      {line("w-2/3")}
+      <div className="my-1 flex flex-col gap-2 rounded-lg px-3 py-2.5">
+        <Skeleton className="h-3.5 w-3/5" />
+        <div className="flex items-center gap-2">
+          <Skeleton className="size-5 rounded-full" />
+          <Skeleton className="h-3.5 w-24" />
+          <Skeleton className="h-2.5 w-6" />
+        </div>
+        <div className="flex flex-col gap-2 pl-7">
+          <Skeleton className="h-3.5 w-full" />
+          <Skeleton className="h-3.5 w-3/4" />
+        </div>
+      </div>
+      {line("w-1/2")}
+      {line("w-3/5")}
+    </div>
+  )
+}
 
 /**
  * The stream itself — the items `buildStream` produced, rendered: day eyebrows, the one

--- a/apps/web/src/pages/artifact/comment-panels.tsx
+++ b/apps/web/src/pages/artifact/comment-panels.tsx
@@ -5,7 +5,7 @@ import { Count } from "@/components/shared/section-eyebrow"
 import { Button } from "@/components/ui/button"
 import { useKeyboardInset } from "@/lib/use-keyboard-inset"
 import { cn } from "@/lib/utils"
-import { ActivityStream } from "./activity-stream"
+import { ActivityStream, StreamSkeleton } from "./activity-stream"
 import { type RailTab, RailTabs } from "./artifact-chat"
 import { Composer } from "./comment-composer"
 import type { StreamItem } from "./lib/activity"
@@ -385,6 +385,7 @@ export function MobileComments({
             data-testid="activity-stream"
             className="flex min-h-0 flex-1 flex-col overflow-auto px-3 pb-[max(14px,env(safe-area-inset-bottom))]"
           >
+            {!ready && <StreamSkeleton />}
             {ready && (
               <ActivityStream
                 items={items}


### PR DESCRIPTION
## Summary

#849 made the rail paint its stream once, when every source has settled — which left the list **empty** until then: on a cold reload, a few hundred milliseconds of a rail that reads as "nothing here".

It now shows a loading frame in the stream's own grammar — a turn line (glyph · sentence · stamp), a card (header line, two body lines), two more lines — so the swap is a fill-in, not a layout change. Per the design system's skeleton doctrine and the `WorkbenchSkeleton` precedent: the region announces (`role="status"`, sr-only "Loading activity…"), the blocks are decoration (`aria-hidden` via the primitive), the house breath motion is off under reduced-motion, and no border or fill — those arrive with the content. Both the desktop rail and the phone sheet use it.

## Test plan
- [x] Captured in dark and light under a cold cache with injected latency (frame visible, then replaced by the complete stream)
- [x] `pnpm run ci` 34/34, typecheck, 101 artifact unit tests; smoke 20/20 incl. the load-order regression (which samples only real stream rows, so the frame never counts as a paint); activity harness passes
- [ ] CI on this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790493066&installation_model_id=428097&pr_number=850&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F850&signature=2958aef9c4ff97864f234d4e5fe850f35a05e492a8accf7328289a53ba2033cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->