### PR TITLE
Activity page: what needs you across the workspace, and what happened

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -2455,11 +2455,130 @@
           "resolved_at"
         ]
       },
+      "WorkspaceActivity": {
+        "type": "object",
+        "properties": {
+          "since": {
+            "type": "string",
+            "description": "The window's start (ISO)."
+          },
+          "artifacts": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "short_id": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "short_id",
+                "title"
+              ]
+            },
+            "description": "The artifacts the rows below belong to — only those the viewer can read."
+          },
+          "versions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ActivityVersion"
+            }
+          },
+          "comments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Comment"
+            }
+          },
+          "rounds": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReviewRound"
+            },
+            "description": "Pending rounds (any age) and rounds opened or settled in the window."
+          }
+        },
+        "required": [
+          "since",
+          "artifacts",
+          "versions",
+          "comments",
+          "rounds"
+        ]
+      },
+      "ActivityVersion": {
+        "type": "object",
+        "properties": {
+          "artifact_id": {
+            "type": "string"
+          },
+          "n": {
+            "type": "number"
+          },
+          "author": {
+            "type": "string",
+            "description": "The person's byline, healed to their live name."
+          },
+          "handle": {
+            "type": "string",
+            "nullable": true
+          },
+          "agent": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "name"
+            ],
+            "description": "The agent that produced this version on the author's behalf; null for the person's own."
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "artifact_id",
+          "n",
+          "author",
+          "handle",
+          "agent",
+          "message",
+          "name",
+          "created_at"
+        ]
+      },
       "Comment": {
         "type": "object",
         "properties": {
           "id": {
             "type": "string"
+          },
+          "artifact_id": {
+            "type": "string",
+            "description": "The artifact the comment is on."
           },
           "thread_id": {
             "type": "string",
@@ -2590,6 +2709,7 @@
         },
         "required": [
           "id",
+          "artifact_id",
           "thread_id",
           "base_version",
           "path",
@@ -7833,6 +7953,40 @@
                     "rounds",
                     "pending"
                   ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/workspace/activity": {
+      "get": {
+        "tags": [
+          "Workspace"
+        ],
+        "summary": "Recent activity across the workspace, for the home.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 30,
+              "description": "The window in days (default 7, max 30)."
+            },
+            "required": false,
+            "description": "The window in days (default 7, max 30).",
+            "name": "days",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The window's versions, comments and review rounds, over visible artifacts.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceActivity"
                 }
               }
             }

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -15,6 +15,7 @@ import { serveContent } from "./lib/serve-content"
 import { isTemplateLibrarySchemaUnavailable } from "./lib/template-library-schema"
 import { log } from "./log"
 import { mountMcp } from "./mcp"
+import { activityRoutes } from "./routes/activity"
 import { agentDiscoveryRoutes } from "./routes/agent-discovery"
 import { agentRoutes } from "./routes/agents"
 import { analyticsRoutes } from "./routes/analytics"
@@ -447,6 +448,7 @@ export function createApp(deps: AppDeps): Hono {
     bootstrapRoutes,
     moderationRoutes,
     reviewRoutes,
+    activityRoutes,
     automationRoutes,
     planRoutes,
     connectionRoutes,

--- a/apps/api/src/lib/review-json.ts
+++ b/apps/api/src/lib/review-json.ts
@@ -1,0 +1,14 @@
+import type { MetaStore, ReviewRoundRecord } from "@derive/core"
+import { agentName, principalKind } from "./principal-kind"
+
+/** A review round's wire shape: the record, plus the requester's kind read off its id, and —
+ *  for a round from before the name was recorded — the directory's name while it still has
+ *  one. Shared by the review routes and the workspace activity feed. */
+export const roundJson = async (
+  meta: Pick<MetaStore, "getAgent" | "getOAuthClientName">,
+  r: ReviewRoundRecord,
+) => ({
+  ...r,
+  requested_by_name: r.requested_by_name ?? (await agentName(meta, r.requested_by)),
+  requested_by_kind: principalKind(r.requested_by) ?? "user",
+})

--- a/apps/api/src/lib/spa-paths.ts
+++ b/apps/api/src/lib/spa-paths.ts
@@ -10,6 +10,7 @@
 const SPA_EXACT = new Set([
   "/",
   "/archived",
+  "/activity",
   "/agents",
   "/brandprint",
   "/chat",

--- a/apps/api/src/routes/activity.ts
+++ b/apps/api/src/routes/activity.ts
@@ -1,0 +1,126 @@
+import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
+import type { BlankEnv } from "hono/types"
+import type { AppContext } from "../context"
+import { resolveUserBylines } from "../lib/author"
+import { commentJson, parseMeta } from "../lib/comments"
+import { bail } from "../lib/http"
+import { principalKind } from "../lib/principal-kind"
+import { roundJson } from "../lib/review-json"
+import { WorkspaceActivity } from "../schemas"
+
+/** How far back the home looks by default, and at most. */
+const DAYS_DEFAULT = 7
+const DAYS_MAX = 30
+/** Rows per kind — well past a week of a busy workspace; the client folds them to lines. */
+const LIMIT = 400
+
+/**
+ * The workspace's recent activity — the records the home's "Needs you" and "Recent
+ * activity" are built from: versions, comments and review rounds across the workspace,
+ * over a window, plus every open comment on the artifacts that need this person's
+ * feedback (a thread waiting on someone is current however old it is) and every pending
+ * round (likewise). The client folds them with the same grouping the artifact rail uses.
+ *
+ * VISIBILITY: the cross-artifact reads are org-wide and decide nothing; the artifacts are
+ * then listed for THIS viewer through the one viewer-aware listing, and only rows on the
+ * artifacts it returns are served — a listing must never leak an artifact the viewer
+ * cannot open.
+ */
+export const activityRoutes = (ctx: AppContext) => {
+  const { meta, requireUser, requireWorkspace } = ctx
+  const app = new OpenAPIHono<BlankEnv>()
+
+  app.openapi(
+    createRoute({
+      method: "get",
+      path: "/v1/workspace/activity",
+      tags: ["Workspace"],
+      summary: "Recent activity across the workspace, for the home.",
+      request: {
+        query: z.object({
+          days: z.coerce
+            .number()
+            .int()
+            .min(1)
+            .max(DAYS_MAX)
+            .optional()
+            .describe(`The window in days (default ${DAYS_DEFAULT}, max ${DAYS_MAX}).`),
+        }),
+      },
+      responses: {
+        200: {
+          description: "The window's versions, comments and review rounds, over visible artifacts.",
+          content: { "application/json": { schema: WorkspaceActivity } },
+        },
+      },
+    }),
+    async (c) => {
+      const me = await requireUser(c)
+      if (me instanceof Response) return bail(me)
+      const org = await requireWorkspace(c, "read")
+      if (org instanceof Response) return bail(org)
+      const days = c.req.valid("query").days ?? DAYS_DEFAULT
+      const since = new Date(Date.now() - days * 86_400_000).toISOString()
+
+      const needing = await meta.artifactIdsNeedingFeedback(me.id, org)
+      const [versions, comments, rounds] = await Promise.all([
+        meta.listVersionsInOrg(org, { since, limit: LIMIT }),
+        meta.listCommentsInOrg(org, { since, limit: LIMIT, openOn: needing }),
+        meta.listReviewRoundsInOrg(org, { since, limit: LIMIT }),
+      ])
+
+      // The gate: list the candidate artifacts FOR THIS VIEWER, keep only rows on those.
+      const candidates = [
+        ...new Set([...versions, ...comments, ...rounds].map((r) => r.artifact_id)),
+      ]
+      const visible = candidates.length
+        ? await meta.listArtifacts({
+            ids: candidates,
+            orgId: org,
+            viewerId: me.id,
+            limit: candidates.length,
+            archived: "exclude",
+          })
+        : []
+      const byId = new Map(visible.map((a) => [a.id, a]))
+      const onVisible = <T extends { artifact_id: string }>(rows: T[]) =>
+        rows.filter((r) => byId.has(r.artifact_id))
+      const vs = onVisible(versions)
+      const cs = onVisible(comments)
+      const rs = onVisible(rounds)
+
+      // People read by their live display name, as everywhere (lib/author.ts).
+      const bylines = await resolveUserBylines(
+        meta,
+        [
+          ...vs.map((v) => v.author_id),
+          ...cs.map((cm) => cm.author_id),
+          ...cs.map((cm) => parseMeta(cm.meta).resolved?.by_id),
+        ].filter((id): id is string => !!id && principalKind(id) === "user"),
+      )
+      const live = (id: string | null) => (id ? bylines[id] : undefined)
+
+      return c.json({
+        since,
+        artifacts: visible.map((a) => ({
+          id: a.id,
+          short_id: a.short_id,
+          title: a.title ?? a.short_id,
+        })),
+        versions: vs.map((v) => ({
+          artifact_id: v.artifact_id,
+          n: v.n,
+          author: live(v.author_id)?.name || v.author,
+          handle: live(v.author_id)?.handle ?? null,
+          agent: v.agent_id ? { id: v.agent_id, name: v.agent_name ?? "Agent" } : null,
+          message: v.message,
+          name: v.name,
+          created_at: v.created_at,
+        })),
+        comments: cs.map((cm) => commentJson(cm, undefined, bylines)),
+        rounds: await Promise.all(rs.map((r) => roundJson(meta, r))),
+      })
+    },
+  )
+  return app
+}

--- a/apps/api/src/routes/comments.ts
+++ b/apps/api/src/routes/comments.ts
@@ -16,7 +16,7 @@ import { commentJson, parseMentions, parseMeta, REACTIONS } from "../lib/comment
 import { bail, fail, readJson } from "../lib/http"
 import { principalKind } from "../lib/principal-kind"
 import { resolveThreadAction } from "../lib/thread-actions"
-import { Mention as MentionSchema } from "../schemas"
+import { Comment as CommentSchema } from "../schemas"
 
 /** Comments: threaded, anchored to text quotes, with reactions, edits, and soft
  *  deletes. @mentions notify people (bell) or land in an agent's pull inbox. The
@@ -38,79 +38,7 @@ export const commentRoutes = (ctx: AppContext) => {
   } = ctx
   const app = new OpenAPIHono<BlankEnv>()
 
-  const Comment = z
-    .object({
-      id: z.string(),
-      thread_id: z
-        .string()
-        .describe("The thread this comment belongs to; equals id for the thread's root comment."),
-      base_version: z.number().describe("Artifact version this comment was anchored against."),
-      path: z
-        .string()
-        .nullable()
-        .describe("File within a bundle the comment targets; null if not file-scoped."),
-      anchor: z
-        .string()
-        .nullable()
-        .describe(
-          "Serialized text-quote or element anchor locating the comment; null if unanchored.",
-        ),
-      body_md: z
-        .string()
-        .describe("Comment body in Markdown; blanked when the comment is deleted."),
-      author: z.string().describe('Author\'s display name; "anonymous" for an anonymous poster.'),
-      author_id: z
-        .string()
-        .nullable()
-        .optional()
-        .describe(
-          'Stable id of the author — a user id, an agent id, or "derive" for the built-in chat agent; null for anonymous or legacy rows.',
-        ),
-      author_kind: z
-        .enum(["user", "agent", "anonymous"])
-        .describe("What kind of principal wrote it, from the recorded id."),
-      resolution: z
-        .object({
-          at: z.string(),
-          by: z.string().nullable().describe("The resolver's display name at the time."),
-          by_id: z.string().nullable(),
-          by_kind: z.enum(["user", "agent"]).nullable(),
-          version: z
-            .number()
-            .nullable()
-            .describe("The version whose publish resolved the thread; null for a hand resolve."),
-        })
-        .nullable()
-        .optional()
-        .describe("On a resolved thread's root: who settled it, when, and by which version."),
-      state: z
-        .enum(["open", "resolved", "outdated"])
-        .describe("Thread state: open, resolved, or outdated (the quoted text changed)."),
-      created_at: z.string(),
-      anchored: z
-        .boolean()
-        .optional()
-        .describe("Whether the anchor still resolves against the current version (list only)."),
-      reactions: z
-        .record(z.string(), z.array(z.string()))
-        .optional()
-        .describe("Emoji → list of reactor display names."),
-      edited: z.boolean().optional().describe("True if the body was edited after posting."),
-      edited_at: z
-        .string()
-        .nullable()
-        .optional()
-        .describe("When the comment was last edited; null if never."),
-      deleted: z
-        .boolean()
-        .optional()
-        .describe("True if soft-deleted; the row stays but the body is blanked."),
-      mentions: z
-        .array(MentionSchema)
-        .optional()
-        .describe("Users or agents @mentioned in the comment body."),
-    })
-    .openapi("Comment")
+  const Comment = CommentSchema
 
   // Loads (artifact, comment) for a mutation, 404ing on mismatch. Tagged union so
   // the @hono/zod-openapi handler return type narrows cleanly on `!r.ok`.

--- a/apps/api/src/routes/review.ts
+++ b/apps/api/src/routes/review.ts
@@ -3,7 +3,8 @@ import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import type { BlankEnv } from "hono/types"
 import type { AppContext } from "../context"
 import { bail, fail, readJson, str } from "../lib/http"
-import { agentName, principalKind } from "../lib/principal-kind"
+import { roundJson as roundJsonFor } from "../lib/review-json"
+import { ReviewRound as ReviewRoundSchema } from "../schemas"
 
 /** Review rounds: the human side of the /derive loop. An agent requests a review
  *  (on publish); the person answers in the doc and hits **Send back** — their note
@@ -14,48 +15,9 @@ export const reviewRoutes = (ctx: AppContext) => {
   const { meta, bus, notify, currentUser, requireArtifact, requireDirectHuman } = ctx
   const app = new OpenAPIHono<BlankEnv>()
 
-  const ReviewRound = z
-    .object({
-      id: z.string(),
-      artifact_id: z.string(),
-      version: z.number().describe("The artifact version this round is reviewing."),
-      requested_by: z
-        .string()
-        .describe("Who asked for the review (usually the agent that published)."),
-      requested_by_name: z
-        .string()
-        .nullable()
-        .describe(
-          "The requester's name when the round opened (a row from before the name was kept is named from the directory, while the agent exists).",
-        ),
-      requested_by_kind: z
-        .enum(["user", "agent"])
-        .describe("What kind of principal asked, from the recorded id."),
-      requested_for: z.string().describe("The person asked to answer this round."),
-      state: z
-        .enum(["pending", "sent_back"])
-        .describe(
-          "Round state: pending, or sent_back (the answers came back — a note saying go IS the go-signal).",
-        ),
-      note: z.string().nullable().describe("Free-text note attached to the round; null if none."),
-      resolved_by_name: z
-        .string()
-        .nullable()
-        .describe(
-          "The human who settled the round; null while pending, or when the store has no name for the resolver.",
-        ),
-      created_at: z.string(),
-      resolved_at: z.string().nullable().describe("When it was sent back; null while pending."),
-    })
-    .openapi("ReviewRound")
+  const ReviewRound = ReviewRoundSchema
 
-  // The wire shape: the record, plus the requester's kind read off its id, and — for a
-  // round from before the name was recorded — the directory's name while it still has one.
-  const roundJson = async (r: ReviewRoundRecord) => ({
-    ...r,
-    requested_by_name: r.requested_by_name ?? (await agentName(meta, r.requested_by)),
-    requested_by_kind: principalKind(r.requested_by) ?? "user",
-  })
+  const roundJson = (r: ReviewRoundRecord) => roundJsonFor(meta, r)
 
   // The round this caller should settle: their own pending round if they were the
   // one asked, else any pending round on the artifact (single-player: the one asker

--- a/apps/api/src/schemas.ts
+++ b/apps/api/src/schemas.ts
@@ -143,6 +143,153 @@ export const CollectionGrant = z
  *  by the artifacts router AND session's /users/:handle/artifacts, so it's shared here.
  *  Fields match the web Artifact interface exactly; the handler may return extra fields
  *  (org_id, raw bytes) that are omitted here — extras are tolerated. */
+/** A comment, as every comment route serves it (lib/comments.ts commentJson). */
+export const Comment = z
+  .object({
+    id: z.string(),
+    artifact_id: z.string().describe("The artifact the comment is on."),
+    thread_id: z
+      .string()
+      .describe("The thread this comment belongs to; equals id for the thread's root comment."),
+    base_version: z.number().describe("Artifact version this comment was anchored against."),
+    path: z
+      .string()
+      .nullable()
+      .describe("File within a bundle the comment targets; null if not file-scoped."),
+    anchor: z
+      .string()
+      .nullable()
+      .describe(
+        "Serialized text-quote or element anchor locating the comment; null if unanchored.",
+      ),
+    body_md: z.string().describe("Comment body in Markdown; blanked when the comment is deleted."),
+    author: z.string().describe('Author\'s display name; "anonymous" for an anonymous poster.'),
+    author_id: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        'Stable id of the author — a user id, an agent id, or "derive" for the built-in chat agent; null for anonymous or legacy rows.',
+      ),
+    author_kind: z
+      .enum(["user", "agent", "anonymous"])
+      .describe("What kind of principal wrote it, from the recorded id."),
+    resolution: z
+      .object({
+        at: z.string(),
+        by: z.string().nullable().describe("The resolver's display name at the time."),
+        by_id: z.string().nullable(),
+        by_kind: z.enum(["user", "agent"]).nullable(),
+        version: z
+          .number()
+          .nullable()
+          .describe("The version whose publish resolved the thread; null for a hand resolve."),
+      })
+      .nullable()
+      .optional()
+      .describe("On a resolved thread's root: who settled it, when, and by which version."),
+    state: z
+      .enum(["open", "resolved", "outdated"])
+      .describe("Thread state: open, resolved, or outdated (the quoted text changed)."),
+    created_at: z.string(),
+    anchored: z
+      .boolean()
+      .optional()
+      .describe("Whether the anchor still resolves against the current version (list only)."),
+    reactions: z
+      .record(z.string(), z.array(z.string()))
+      .optional()
+      .describe("Emoji → list of reactor display names."),
+    edited: z.boolean().optional().describe("True if the body was edited after posting."),
+    edited_at: z
+      .string()
+      .nullable()
+      .optional()
+      .describe("When the comment was last edited; null if never."),
+    deleted: z
+      .boolean()
+      .optional()
+      .describe("True if soft-deleted; the row stays but the body is blanked."),
+    mentions: z
+      .array(Mention)
+      .optional()
+      .describe("Users or agents @mentioned in the comment body."),
+  })
+  .openapi("Comment")
+
+/** A review round, as the review routes and the workspace activity serve it
+ *  (lib/review-json.ts roundJson). */
+export const ReviewRound = z
+  .object({
+    id: z.string(),
+    artifact_id: z.string(),
+    version: z.number().describe("The artifact version this round is reviewing."),
+    requested_by: z
+      .string()
+      .describe("Who asked for the review (usually the agent that published)."),
+    requested_by_name: z
+      .string()
+      .nullable()
+      .describe(
+        "The requester's name when the round opened (a row from before the name was kept is named from the directory, while the agent exists).",
+      ),
+    requested_by_kind: z
+      .enum(["user", "agent"])
+      .describe("What kind of principal asked, from the recorded id."),
+    requested_for: z.string().describe("The person asked to answer this round."),
+    state: z
+      .enum(["pending", "sent_back"])
+      .describe(
+        "Round state: pending, or sent_back (the answers came back — a note saying go IS the go-signal).",
+      ),
+    note: z.string().nullable().describe("Free-text note attached to the round; null if none."),
+    resolved_by_name: z
+      .string()
+      .nullable()
+      .describe(
+        "The human who settled the round; null while pending, or when the store has no name for the resolver.",
+      ),
+    created_at: z.string(),
+    resolved_at: z.string().nullable().describe("When it was sent back; null while pending."),
+  })
+  .openapi("ReviewRound")
+
+/** One version in the workspace activity feed: the artifact rail's version shape, cut to
+ *  what a line needs, plus the artifact it belongs to. */
+export const ActivityVersion = z
+  .object({
+    artifact_id: z.string(),
+    n: z.number(),
+    author: z.string().describe("The person's byline, healed to their live name."),
+    handle: z.string().nullable(),
+    agent: z
+      .object({ id: z.string(), name: z.string() })
+      .nullable()
+      .describe(
+        "The agent that produced this version on the author's behalf; null for the person's own.",
+      ),
+    message: z.string().nullable(),
+    name: z.string().nullable(),
+    created_at: z.string(),
+  })
+  .openapi("ActivityVersion")
+
+/** The workspace's recent activity, for the home: everything the stream is built from,
+ *  over the artifacts the viewer can see. The client folds it (pages/artifact/lib/activity.ts). */
+export const WorkspaceActivity = z
+  .object({
+    since: z.string().describe("The window's start (ISO)."),
+    artifacts: z
+      .array(z.object({ id: z.string(), short_id: z.string(), title: z.string() }))
+      .describe("The artifacts the rows below belong to — only those the viewer can read."),
+    versions: z.array(ActivityVersion),
+    comments: z.array(Comment),
+    rounds: z
+      .array(ReviewRound)
+      .describe("Pending rounds (any age) and rounds opened or settled in the window."),
+  })
+  .openapi("WorkspaceActivity")
+
 export const Artifact = z
   .object({
     short_id: z.string().describe("Stable public id — the /a/<short_id> URL slug."),

--- a/apps/api/test/workspace-activity.test.ts
+++ b/apps/api/test/workspace-activity.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest"
+import { as, bearer, jsonAs, makeAuthedApp, publishAs, type TestUser } from "./helpers"
+
+describe("GET /v1/workspace/activity — the home's needs-you + recent activity", () => {
+  const owner: TestUser = { id: "u_wa_own", email: "waown@derive.test", name: "Owner" }
+  const mate: TestUser = { id: "u_wa_mate", email: "wamate@derive.test", name: "Mate" }
+  const { app } = makeAuthedApp("workspace-activity", [owner, mate], "editor")
+
+  it("serves versions, comments and rounds over the artifacts the viewer can see, healed and typed", async () => {
+    await app.request("/v1/me", { headers: as(owner.email) })
+    await app.request("/v1/me", { headers: as(mate.email) })
+    // A team document listed to the workspace (an UNlisted draft never appears in a feed by
+    // access alone — the library's rule, which the home's activity follows), and one the
+    // owner keeps to themself.
+    const shared = (
+      await (
+        await publishAs(
+          app,
+          "<h1>team</h1>",
+          { workspace_access: "member", listed: "workspace" },
+          as(owner.email),
+        )
+      ).json()
+    ).short_id
+    const secret = (
+      await (
+        await publishAs(app, "<h1>mine</h1>", { workspace_access: "none" }, as(owner.email))
+      ).json()
+    ).short_id
+    // An agent publishes a version of the team doc and asks the owner to review it.
+    const reg = await (
+      await app.request(
+        "/v1/agents",
+        jsonAs(as(owner.email), { name: "Claude Code", role: "editor" }),
+      )
+    ).json()
+    const pub = await publishAs(
+      app,
+      "<h1>team v2</h1>",
+      { request_review: "true", review_note: "Please check." },
+      bearer(reg.token),
+      shared,
+    )
+    expect(pub.status).toBe(201)
+    // The owner comments on both documents.
+    const onShared = await (
+      await app.request(
+        `/v1/artifacts/${shared}/comments`,
+        jsonAs(as(owner.email), { body_md: "Team note" }),
+      )
+    ).json()
+    await app.request(
+      `/v1/artifacts/${secret}/comments`,
+      jsonAs(as(owner.email), { body_md: "Private note" }),
+    )
+
+    // The owner sees everything, credited: the agent's version, the round for them, both comments.
+    const mine = await (
+      await app.request("/v1/workspace/activity", { headers: as(owner.email) })
+    ).json()
+    expect(mine.artifacts.map((a: { short_id: string }) => a.short_id).sort()).toEqual(
+      [shared, secret].sort(),
+    )
+    const v2 = mine.versions.find((v: { n: number; artifact_id: string }) => v.n === 2)
+    expect(v2).toMatchObject({ author: "Owner", agent: { id: reg.id, name: "Claude Code" } })
+    expect(mine.rounds).toHaveLength(1)
+    expect(mine.rounds[0]).toMatchObject({
+      state: "pending",
+      requested_for: owner.id,
+      requested_by_kind: "agent",
+      requested_by_name: "Claude Code",
+    })
+    expect(mine.comments.map((c: { body_md: string }) => c.body_md).sort()).toEqual([
+      "Private note",
+      "Team note",
+    ])
+    expect(mine.comments.find((c: { id: string }) => c.id === onShared.id)).toMatchObject({
+      author: "Owner",
+      author_kind: "user",
+    })
+
+    // A workmate sees the team document's rows only — never the private one's.
+    const theirs = await (
+      await app.request("/v1/workspace/activity", { headers: as(mate.email) })
+    ).json()
+    expect(theirs.artifacts.map((a: { short_id: string }) => a.short_id)).toEqual([shared])
+    expect(theirs.comments.map((c: { body_md: string }) => c.body_md)).toEqual(["Team note"])
+    expect(
+      theirs.versions.every(
+        (v: { artifact_id: string }) => v.artifact_id === theirs.artifacts[0].id,
+      ),
+    ).toBe(true)
+    // The round is on the team doc, so it is visible; it is pending FOR the owner, which the
+    // client reads off requested_for.
+    expect(theirs.rounds).toHaveLength(1)
+  })
+
+  it("rejects the signed-out and clamps the window", async () => {
+    expect((await app.request("/v1/workspace/activity")).status).toBe(401)
+    expect(
+      (await app.request("/v1/workspace/activity?days=90", { headers: as(owner.email) })).status,
+    ).toBe(400)
+  })
+})

--- a/apps/web/e2e/screens/activity.screens.ts
+++ b/apps/web/e2e/screens/activity.screens.ts
@@ -146,6 +146,16 @@ test("capture activity rail states", async ({ owner: page }) => {
   await page.waitForTimeout(1200)
   await shoot("activity-dark")
 
+  // The Activity page: the same records as the workspace's "Needs you" (the agent's ask,
+  // the open thread) and "Recent activity" (the folded turns), newest first.
+  await page.goto("/activity")
+  await expect(page.getByTestId("wa-needs-you")).toBeVisible()
+  await expect(page.getByTestId("wa-recent")).toBeVisible()
+  await page.waitForTimeout(600)
+  await shoot("activity-page")
+  await page.goto(`/artifacts/${shortId}`)
+  await expect(page.getByTestId("activity-stream")).toBeVisible()
+
   // A phone: the same stream in the docked sheet, and a round answered from its bar.
   await page.evaluate(() => localStorage.setItem("derive_theme", "light"))
   await page.setViewportSize({ width: 390, height: 844 })

--- a/apps/web/e2e/screens/workspace-activity.screens.ts
+++ b/apps/web/e2e/screens/workspace-activity.screens.ts
@@ -1,0 +1,245 @@
+import { Buffer } from "node:buffer"
+import { mkdirSync } from "node:fs"
+import { join } from "node:path"
+import type { Route } from "@playwright/test"
+import { expect, test } from "../fixtures"
+
+// Visual-QA capture for the ACTIVITY page ("Needs you" + "Recent activity"):
+// seeds a workspace with a person's documents, a registered agent that publishes, asks
+// for review, replies and resolves, then captures the page resting, a turn opened, the
+// folded Needs-you groups, dark mode, the loading frame, and where Answer lands. Not a
+// test gate: self-skips unless SHOTS=1.
+//   SHOTS=1 SHOT_DIR=/tmp/shots npx playwright test --project=screens e2e/screens/workspace-activity.screens.ts
+test.skip(() => process.env.SHOTS !== "1", "visual capture harness — set SHOTS=1 to run")
+
+const OUT = process.env.SHOT_DIR ?? join(process.cwd(), "test-results", "screens")
+mkdirSync(OUT, { recursive: true })
+
+const doc = (title: string, body: string) =>
+  `<!doctype html><html><head><meta charset="utf-8"><title>${title}</title></head>
+<body style="font:17px/1.6 system-ui;padding:40px;max-width:640px"><h1>${title}</h1>${body}</body></html>`
+
+test("capture workspace activity states", async ({ owner: page }) => {
+  // A publish by the signed-in person, or — with `as` — by a registered agent's bearer.
+  const publish = async (
+    shortId: string | null,
+    body: string,
+    fields: Record<string, string> = {},
+    as?: Record<string, string>,
+  ) => {
+    const res = await page.request.post(
+      shortId ? `/v1/artifacts/${shortId}/versions` : "/v1/artifacts",
+      {
+        headers: as,
+        multipart: {
+          file: { name: "doc.html", mimeType: "text/html", buffer: Buffer.from(body) },
+          listed: "workspace",
+          ...(shortId ? {} : { title: /<title>(.*?)<\/title>/.exec(body)?.[1] ?? "Untitled" }),
+          ...fields,
+        },
+      },
+    )
+    expect(res.ok(), await res.text()).toBeTruthy()
+    return ((await res.json()) as { short_id: string }).short_id
+  }
+  const comment = async (
+    shortId: string,
+    body_md: string,
+    extra: Record<string, unknown> = {},
+    as?: Record<string, string>,
+  ) => {
+    const res = await page.request.post(`/v1/artifacts/${shortId}/comments`, {
+      headers: as,
+      data: { body_md, ...extra },
+    })
+    expect(res.ok(), await res.text()).toBeTruthy()
+    return (await res.json()) as { id: string; thread_id: string }
+  }
+
+  // The person's documents.
+  let narrative = ""
+  await expect(async () => {
+    narrative = await publish(
+      null,
+      doc("Q3 Growth Narrative", "<p id=p1>Q2 closed with activation at 41%.</p>"),
+      { message: "Create" },
+    )
+  }).toPass({ timeout: 10_000 })
+  await publish(
+    narrative,
+    doc(
+      "Q3 Growth Narrative",
+      "<p id=p1>Q2 closed with activation at 41%, three points above plan.</p>",
+    ),
+    { message: "Add the plan delta" },
+  )
+  await publish(
+    narrative,
+    doc(
+      "Q3 Growth Narrative",
+      "<p id=p1>Q2 closed with activation at 41%, three points above plan. Retention did not follow.</p>",
+    ),
+    { message: "Add retention" },
+  )
+  const pricing = await publish(null, doc("Pricing page test", "<p>Two variants, one week.</p>"), {
+    message: "Create",
+  })
+  const onboarding = await publish(
+    null,
+    doc("Onboarding metrics", "<p>Time to first artifact.</p>"),
+    { message: "Create" },
+  )
+
+  // The person's threads: one the agent will answer and resolve, one settled by hand.
+  const capacity = await comment(
+    narrative,
+    "Do we have the sales capacity for this in Q3? Feels like a Q4 bet.",
+    {
+      anchor: { type: "TextQuoteSelector", exact: "three points above plan" },
+    },
+  )
+  const typo = await comment(narrative, "Typo in the second paragraph.")
+  await page.request.post(`/v1/artifacts/${narrative}/comments/${typo.id}/resolve`, {
+    data: { state: "resolved" },
+  })
+
+  // A REAL agent, registered here and acting through its own bearer.
+  const reg = await page.request.post("/v1/agents", {
+    data: { name: "Claude Code", role: "editor" },
+  })
+  expect(reg.ok(), await reg.text()).toBeTruthy()
+  const agent = (await reg.json()) as { id: string; token: string }
+  const asAgent = { authorization: `Bearer ${agent.token}` }
+
+  // It replies in the person's thread, publishes a version that resolves it and asks for
+  // review, then works two more documents and asks on each.
+  await comment(
+    narrative,
+    "Checked the pipeline: two named accounts are already in late stage, so Q3 holds.",
+    { thread_id: capacity.thread_id },
+    asAgent,
+  )
+  await publish(
+    narrative,
+    doc(
+      "Q3 Growth Narrative",
+      "<p id=p1>Q2 closed with activation at 41%, three points above plan. Retention did not follow.</p><p>Two named accounts are in late stage; Q3 holds.</p>",
+    ),
+    {
+      message: "Answer the capacity question in the narrative",
+      resolves: capacity.id,
+      request_review: "true",
+      review_note:
+        "Folded the capacity answer into the narrative and closed the thread. Does the framing read right?",
+    },
+    asAgent,
+  )
+  await publish(
+    pricing,
+    doc("Pricing page test", "<p>Two variants, one week. Variant B leads by 4 points.</p>"),
+    {
+      message: "Add the interim result",
+      request_review: "true",
+      review_note: "Interim result added — call it early, or wait the week?",
+    },
+    asAgent,
+  )
+  await publish(
+    onboarding,
+    doc("Onboarding metrics", "<p>Time to first artifact: 6 minutes.</p>"),
+    { message: "Fill in the number" },
+    asAgent,
+  )
+  // More asks, so the group folds.
+  for (const n of [1, 2, 3, 4]) {
+    const id = await publish(null, doc(`Weekly digest #${n}`, "<p>Draft.</p>"), {
+      message: "Create",
+    })
+    await publish(
+      id,
+      doc(`Weekly digest #${n}`, "<p>Draft, with this week's numbers.</p>"),
+      { message: "Fill in the week", request_review: "true" },
+      asAgent,
+    )
+  }
+  // Someone tags the person in a thread on the pricing test.
+  const meRes = (await (await page.request.get("/v1/me")).json()) as {
+    id?: string
+    name?: string
+    user?: { id: string; name: string }
+  }
+  const me = meRes.user ?? { id: meRes.id ?? "", name: meRes.name ?? "" }
+  await comment(
+    pricing,
+    "@you should this wait for the full week?",
+    { mentions: [{ id: me.id, name: me.name }] },
+    asAgent,
+  )
+
+  const shoot = (name: string) => page.screenshot({ path: `${OUT}/${name}.png` })
+  await page.evaluate(() => localStorage.setItem("derive_theme", "light"))
+  // The sign-in painted the rail's Activity count from an empty workspace and persisted
+  // that answer; drop it so this visit reads the seeded workspace (a person's own reload
+  // refreshes within 30s anyway).
+  await page.goto("/")
+  await page.evaluate(async () => {
+    for (const db of await indexedDB.databases())
+      if (db.name)
+        await new Promise((r) => {
+          const q = indexedDB.deleteDatabase(db.name as string)
+          q.onsuccess = q.onerror = q.onblocked = () => r(null)
+        })
+  })
+  await page.goto("/activity")
+  await expect(page.getByTestId("wa-needs-you")).toBeVisible()
+  await expect(page.getByTestId("wa-recent")).toBeVisible()
+  await page.waitForTimeout(800)
+  await shoot("activity-page-light")
+  // A turn opened: the versions and the ask behind one line.
+  await page.getByTestId("activity-turn-toggle").first().click()
+  await page.waitForTimeout(300)
+  await shoot("activity-page-turn-open")
+  await page.getByTestId("activity-turn-toggle").first().click()
+  // The folded group, unfolded.
+  await page.getByTestId("wa-needs-more-asks").click()
+  await page.waitForTimeout(300)
+  await shoot("activity-page-needs-more")
+  // Dark.
+  await page.evaluate(() => localStorage.setItem("derive_theme", "dark"))
+  await page.reload()
+  await expect(page.getByTestId("wa-recent")).toBeVisible()
+  await page.waitForTimeout(800)
+  await shoot("activity-page-dark")
+  // The loading frame: a cold cache and a slow request.
+  await page.evaluate(() => localStorage.setItem("derive_theme", "light"))
+  const delay = (ms: number) => async (route: Route) => {
+    await new Promise((r) => setTimeout(r, ms))
+    await route.continue().catch(() => {})
+  }
+  await page.route("**/v1/workspace/activity*", delay(2500))
+  await page.evaluate(async () => {
+    for (const db of await indexedDB.databases())
+      if (db.name)
+        await new Promise((r) => {
+          const q = indexedDB.deleteDatabase(db.name as string)
+          q.onsuccess = q.onerror = q.onblocked = () => r(null)
+        })
+  })
+  await page.reload()
+  await expect(page.getByTestId("activity-stream-loading")).toBeVisible({ timeout: 5000 })
+  await page.waitForTimeout(200)
+  await shoot("activity-page-loading")
+  await expect(page.getByTestId("wa-recent")).toBeVisible({ timeout: 10_000 })
+  await page.unroute("**/v1/workspace/activity*")
+  // Answer lands on the document with the composer armed.
+  await page.getByTestId("wa-ask-answer").first().click()
+  await expect(page.getByTestId("review-send-back")).toBeVisible({ timeout: 10_000 })
+  await page.waitForTimeout(800)
+  await shoot("activity-page-answer-lands")
+  // A phone: the same page in one column; rows truncate, the action stays on the line.
+  await page.setViewportSize({ width: 390, height: 844 })
+  await page.goto("/activity")
+  await expect(page.getByTestId("wa-needs-you")).toBeVisible()
+  await page.waitForTimeout(600)
+  await shoot("activity-page-mobile")
+})

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -4174,6 +4174,45 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/workspace/activity": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Recent activity across the workspace, for the home. */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description The window in days (default 7, max 30). */
+                    days?: number;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description The window's versions, comments and review rounds, over visible artifacts. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["WorkspaceActivity"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/workflows": {
         parameters: {
             query?: never;
@@ -7508,8 +7547,39 @@ export interface components {
             /** @description When it was sent back; null while pending. */
             resolved_at: string | null;
         };
+        WorkspaceActivity: {
+            /** @description The window's start (ISO). */
+            since: string;
+            /** @description The artifacts the rows below belong to — only those the viewer can read. */
+            artifacts: {
+                id: string;
+                short_id: string;
+                title: string;
+            }[];
+            versions: components["schemas"]["ActivityVersion"][];
+            comments: components["schemas"]["Comment"][];
+            /** @description Pending rounds (any age) and rounds opened or settled in the window. */
+            rounds: components["schemas"]["ReviewRound"][];
+        };
+        ActivityVersion: {
+            artifact_id: string;
+            n: number;
+            /** @description The person's byline, healed to their live name. */
+            author: string;
+            handle: string | null;
+            /** @description The agent that produced this version on the author's behalf; null for the person's own. */
+            agent: {
+                id: string;
+                name: string;
+            } | null;
+            message: string | null;
+            name: string | null;
+            created_at: string;
+        };
         Comment: {
             id: string;
+            /** @description The artifact the comment is on. */
+            artifact_id: string;
             /** @description The thread this comment belongs to; equals id for the thread's root comment. */
             thread_id: string;
             /** @description Artifact version this comment was anchored against. */

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -328,6 +328,7 @@ export type Mention = components["schemas"]["Mention"]
  *  the answer. `pending` = waiting; `sent_back` = they returned answers (a note that
  *  reads "good to go" is the go-signal). Generated from the OpenAPI spec. */
 export type ReviewRound = components["schemas"]["ReviewRound"]
+export type WorkspaceActivity = components["schemas"]["WorkspaceActivity"]
 
 /** A comment: threaded, anchored to a text quote, with reactions/edits/soft-delete.
  *  Generated from the OpenAPI spec. */
@@ -1096,6 +1097,9 @@ export const api = {
   runAutomation: (id: string): Promise<{ id: string; status: string }> =>
     f(`/v1/automations/${id}/run`, opts({})).then(j),
   listRuns: (): Promise<{ runs: Run[] }> => f("/v1/workspace/runs", opts()).then(j),
+  // The home's activity: versions, comments and review rounds across the workspace over a
+  // window, on the artifacts the caller can see (routes/activity.ts).
+  workspaceActivity: (): Promise<WorkspaceActivity> => f("/v1/workspace/activity", opts()).then(j),
 
   // Per-user model-plan credentials (the caller's own; see routes/model-credentials.ts).
   listModelCredentials: (): Promise<{ credentials: ModelCredentialHint[] }> =>

--- a/apps/web/src/components/chrome/nav-rail.tsx
+++ b/apps/web/src/components/chrome/nav-rail.tsx
@@ -28,6 +28,7 @@ import { getMonogram } from "@/lib/initials"
 import {
   collectionsQuery,
   summaryQuery,
+  workspaceActivityQuery,
   workspaceSettingsQuery,
   workspacesQuery,
 } from "@/lib/queries"
@@ -53,6 +54,34 @@ const COUNT_BADGE = "top-1.5 text-muted-foreground"
 // The row's inner glyph — icon, label, and the ink-earning count badge — shared by
 // FilterItem and NavItem below (a zero count is noise, so the badge only renders
 // once it's nonzero).
+/** The Activity page's row, beside Notifications: the count is the reviews waiting on
+ *  this person across the workspace — the one number that is an ask, not news. */
+function ActivityRow() {
+  const loc = useLocation()
+  const { me } = useAuth()
+  const { setOpenMobile } = useSidebar()
+  const { data } = useQuery({ ...workspaceActivityQuery(), enabled: !!me })
+  const waiting = me
+    ? (data?.rounds.filter((r) => r.state === "pending" && r.requested_for === me.id).length ?? 0)
+    : 0
+  const active = loc.pathname === "/activity"
+  return (
+    <SidebarMenuItem>
+      <SidebarMenuButton asChild isActive={active} tooltip="Activity">
+        <Link
+          to="/activity"
+          data-testid="menu-activity"
+          aria-current={active ? "page" : undefined}
+          onClick={() => setOpenMobile(false)}
+          className={ROW_ICON}
+        >
+          <RowGlyph icon="history" label="Activity" count={waiting || undefined} />
+        </Link>
+      </SidebarMenuButton>
+    </SidebarMenuItem>
+  )
+}
+
 function RowGlyph({ icon, label, count }: { icon: IconName; label: string; count?: number }) {
   return (
     <>
@@ -463,6 +492,7 @@ export function NavRail() {
           <SidebarGroupContent>
             <SidebarMenu>
               <NotificationBell />
+              <ActivityRow />
               <SidebarMenuItem>
                 <SidebarMenuButton asChild isActive={onSettings} tooltip="Settings">
                   <Link

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -568,6 +568,16 @@ export const poolCredentialsQuery = () =>
     queryFn: () => api.listPoolCredentials().then((r) => r.credentials),
   })
 
+/** The home's "Needs you" + "Recent activity", in one request so the sections paint
+ *  once (the rail's lesson). Fresh on every visit — asks settle and work lands
+ *  constantly — but the persisted copy paints a reload like a nav. */
+export const workspaceActivityQuery = () =>
+  queryOptions({
+    queryKey: ["workspace-activity"] as const,
+    queryFn: () => api.workspaceActivity(),
+    staleTime: 30_000,
+  })
+
 export const runsQuery = () =>
   queryOptions({
     queryKey: ["runs"] as const,

--- a/apps/web/src/pages/activity.tsx
+++ b/apps/web/src/pages/activity.tsx
@@ -1,0 +1,344 @@
+import { useQuery } from "@tanstack/react-query"
+import { useNavigate } from "@tanstack/react-router"
+import { useState } from "react"
+import type { Comment, ReviewRound } from "@/api"
+import { Icon } from "@/components/icons"
+import { EmptyState } from "@/components/shared/empty-state"
+import { Eyebrow, SectionEyebrow } from "@/components/shared/section-eyebrow"
+import { StatusPanel } from "@/components/shared/status-panel"
+import { Button } from "@/components/ui/button"
+import { Separator } from "@/components/ui/separator"
+import { useAuth } from "@/ctx"
+import { workspaceActivityQuery, workspaceQuery } from "@/lib/queries"
+import { cn } from "@/lib/utils"
+import { ActorGlyph, LINE, TurnRow } from "./artifact/activity-rows"
+import { StreamSkeleton } from "./artifact/activity-stream"
+import { type ActivityArtifact, buildStream, stamp } from "./artifact/lib/activity"
+import { groupThreads } from "./artifact/lib/layout"
+import { refFor } from "./artifact/parse-ref"
+import { useActivitySeen } from "./artifact/use-activity-seen"
+
+/** An ask is "waiting" once it has sat this long. */
+const STALE_MS = 3 * 86_400_000
+/** Rows shown per Needs-you group before "Show more". */
+const NEEDS_CAP = 5
+
+/**
+ * The Activity page's two sections — the workspace's "Needs you" and its "Recent
+ * activity" — from one request (lib/queries.ts workspaceActivityQuery). Its own place,
+ * beside Notifications: the Library stays the library (the grid is what that page is),
+ * the bell stays what was addressed to you, and this is what is happening.
+ *
+ * Needs you: the review rounds pending FOR this person across the workspace, and the open
+ * threads they are tagged in or have commented on — one line each, the action at the
+ * line's end. A round can only be settled from its document, so Answer opens it (the rail
+ * arms itself to answer).
+ *
+ * Recent activity: the artifact rail's stream over the whole workspace — actor × document
+ * × day folded to one line ("Codex published v5–v6 of Luna dogfood"), newest first, the
+ * "New" marker from this person's last visit to the home (per browser), every line
+ * opening to its versions or its thread on the document.
+ */
+export function WorkspaceActivity() {
+  const { me } = useAuth()
+  const nav = useNavigate()
+  const { data: workspace } = useQuery(workspaceQuery())
+  const activity = useQuery({ ...workspaceActivityQuery(), enabled: !!me })
+  // The last visit is per workspace, keyed like the rail's per artifact; being on the page
+  // is "open", so leaving it (or hiding the tab) advances the marker.
+  const { lastSeen } = useActivitySeen(`ws.${workspace?.id ?? ""}`, true)
+  const [expanded, setExpanded] = useState<ReadonlySet<string>>(() => new Set())
+  const [showAll, setShowAll] = useState<ReadonlySet<string>>(() => new Set())
+
+  const open = (a: ActivityArtifact, search?: { comment?: string }) =>
+    nav({ to: "/artifacts/$ref", params: { ref: refFor(a) }, search: search ?? {} })
+
+  if (!me) return null
+  if (activity.isPending)
+    return (
+      <section>
+        <SectionEyebrow>Recent activity</SectionEyebrow>
+        <StreamSkeleton />
+      </section>
+    )
+  if (activity.isError)
+    return (
+      <StatusPanel
+        tone="danger"
+        layout="inline"
+        title="Couldn’t load activity."
+        action={
+          <Button
+            variant="outline"
+            size="sm"
+            data-testid="wa-retry"
+            onClick={() => activity.refetch()}
+          >
+            Try again
+          </Button>
+        }
+      />
+    )
+
+  const data = activity.data
+  const now = Date.now()
+  const artifacts: Record<string, ActivityArtifact> = Object.fromEntries(
+    data.artifacts.map((a) => [a.id, { short_id: a.short_id, title: a.title }]),
+  )
+  const docOf = (id: string) => artifacts[id]
+
+  // ---- Needs you
+  const asks = data.rounds
+    .flatMap((r) => {
+      const artifact = docOf(r.artifact_id)
+      return r.state === "pending" && r.requested_for === me.id && artifact
+        ? [{ round: r, artifact }]
+        : []
+    })
+    .sort((a, b) => b.round.created_at.localeCompare(a.round.created_at))
+  const threads = groupThreads(data.comments).flatMap((t) => {
+    const root = t[0]
+    const artifact = root && docOf(root.artifact_id)
+    if (!root || !artifact || root.state !== "open" || root.deleted) return []
+    const tagged = t.some((c) => c.mentions?.some((m) => m.id === me.id))
+    const mine = t.some((c) => c.author_id === me.id)
+    return tagged || mine ? [{ root, artifact, replies: t.length - 1 }] : []
+  })
+  threads.sort((a, b) => b.root.created_at.localeCompare(a.root.created_at))
+  const needsCount = asks.length + threads.length
+
+  // ---- Recent activity
+  const items = buildStream({
+    versions: data.versions,
+    comments: data.comments,
+    rounds: data.rounds,
+    workspace: { artifacts, since: data.since },
+    order: "desc",
+    lastSeen,
+    meId: me.id,
+    me: me.name ?? undefined,
+    lens: "all",
+    now,
+  })
+  const turnCount = items.filter((it) => it.type === "turn").length
+  if (!needsCount && !turnCount)
+    return (
+      <EmptyState
+        className="py-16"
+        icon={<Icon name="history" strokeWidth={1.75} />}
+        title="Quiet so far."
+        description="When people and agents publish, comment, or ask for a review, it shows up here."
+      />
+    )
+
+  const toggle = (set: ReadonlySet<string>, id: string) => {
+    const next = new Set(set)
+    if (next.has(id)) next.delete(id)
+    else next.add(id)
+    return next
+  }
+  const capped = <T,>(key: string, all: T[]) => (showAll.has(key) ? all : all.slice(0, NEEDS_CAP))
+  const more = (key: string, all: unknown[]) =>
+    all.length > NEEDS_CAP &&
+    !showAll.has(key) && (
+      <Button
+        variant="ghost"
+        size="sm"
+        className="ml-5 self-start text-muted-foreground"
+        data-testid={`wa-needs-more-${key}`}
+        onClick={() => setShowAll((s) => toggle(s, key))}
+      >
+        Show {all.length - NEEDS_CAP} more
+      </Button>
+    )
+
+  return (
+    <div className="flex flex-col gap-7" data-testid="wa-root">
+      {needsCount > 0 && (
+        <section data-testid="wa-needs-you">
+          <SectionEyebrow count={needsCount}>Needs you</SectionEyebrow>
+          {asks.length > 0 && (
+            <div className="mt-1 flex flex-col">
+              <Eyebrow className="px-1.5 pt-2 pb-1">Reviews waiting on you</Eyebrow>
+              {capped("asks", asks).map(({ round, artifact }) => (
+                <AskLine key={round.id} round={round} artifact={artifact} now={now} onOpen={open} />
+              ))}
+              {more("asks", asks)}
+            </div>
+          )}
+          {threads.length > 0 && (
+            <div className="mt-1 flex flex-col">
+              <Eyebrow className="px-1.5 pt-2 pb-1">Open threads with you</Eyebrow>
+              {capped("threads", threads).map(({ root, artifact, replies }) => (
+                <ThreadLine
+                  key={root.thread_id}
+                  root={root}
+                  replies={replies}
+                  artifact={artifact}
+                  now={now}
+                  onOpen={open}
+                />
+              ))}
+              {more("threads", threads)}
+            </div>
+          )}
+        </section>
+      )}
+      {turnCount > 0 && (
+        <section data-testid="wa-recent">
+          <SectionEyebrow count={turnCount}>Recent activity</SectionEyebrow>
+          <div className="mt-1 flex flex-col">
+            {items.map((it) => {
+              switch (it.type) {
+                case "section":
+                  return (
+                    <div key={it.id} className="flex items-center gap-2 pt-3 pb-1">
+                      <Eyebrow>{it.label}</Eyebrow>
+                      <Separator className="flex-1" />
+                    </div>
+                  )
+                case "unread":
+                  return (
+                    <div
+                      key={it.id}
+                      data-testid="wa-unread-marker"
+                      className="flex items-center gap-2 py-2"
+                    >
+                      <Eyebrow className="text-primary">New above</Eyebrow>
+                      <Separator className="flex-1 bg-primary" />
+                    </div>
+                  )
+                case "turn": {
+                  const doc = it.artifact
+                  const go = (search?: { comment?: string }) => doc && open(doc, search)
+                  return (
+                    <TurnRow
+                      key={it.id}
+                      turn={it}
+                      now={now}
+                      expanded={expanded.has(it.id)}
+                      onToggle={() => setExpanded((s) => toggle(s, it.id))}
+                      currentVersion={0}
+                      answering={false}
+                      onGoToVersion={() => go()}
+                      onJump={(threadId) => go({ comment: threadId })}
+                      onAnswer={() => go()}
+                    />
+                  )
+                }
+                default:
+                  return null
+              }
+            })}
+          </div>
+        </section>
+      )}
+    </div>
+  )
+}
+
+function AskLine({
+  round,
+  artifact,
+  now,
+  onOpen,
+}: {
+  round: ReviewRound
+  artifact: ActivityArtifact
+  now: number
+  onOpen: (a: ActivityArtifact) => void
+}) {
+  const stale = now - new Date(round.created_at).getTime() > STALE_MS
+  return (
+    <div
+      className={cn(LINE, "rounded-md px-1.5 py-1 max-sm:items-start sm:items-center")}
+      data-testid={`wa-ask-${round.id}`}
+    >
+      <ActorGlyph
+        by={round.requested_by_name ?? "Review"}
+        agent={round.requested_by_kind === "agent"}
+      />
+      <div className="flex min-w-0 items-center gap-2">
+        <span className="min-w-0 text-sm text-muted-foreground max-sm:line-clamp-2 sm:truncate">
+          <span className="font-medium text-foreground">
+            {round.requested_by_name ?? "An agent"}
+          </span>{" "}
+          asked for review of <span className="font-mono text-xs">v{round.version}</span> ·{" "}
+          <span className="text-foreground">{artifact.title}</span>
+          {round.note && <span className="italic"> — {round.note}</span>}
+        </span>
+      </div>
+      <span className="flex shrink-0 items-center gap-2 max-sm:pt-0.5">
+        <span
+          className={cn(
+            "font-mono text-2xs tabular-nums",
+            stale ? "text-warning" : "text-muted-foreground/80",
+          )}
+          title={new Date(round.created_at).toLocaleString()}
+        >
+          {stale ? "waiting " : ""}
+          {stamp(round.created_at, now)}
+        </span>
+        <Button
+          variant="outline"
+          size="xs"
+          data-testid="wa-ask-answer"
+          onClick={() => onOpen(artifact)}
+        >
+          Answer
+        </Button>
+      </span>
+    </div>
+  )
+}
+
+function ThreadLine({
+  root,
+  replies,
+  artifact,
+  now,
+  onOpen,
+}: {
+  root: Comment
+  replies: number
+  artifact: ActivityArtifact
+  now: number
+  onOpen: (a: ActivityArtifact, search: { comment: string }) => void
+}) {
+  return (
+    <div
+      className={cn(LINE, "rounded-md px-1.5 py-1 max-sm:items-start sm:items-center")}
+      data-testid={`wa-thread-${root.thread_id}`}
+    >
+      <ActorGlyph by={root.author} agent={root.author_kind === "agent"} />
+      <div className="flex min-w-0 items-center gap-2">
+        <span className="min-w-0 text-sm text-muted-foreground max-sm:line-clamp-2 sm:truncate">
+          <span className="font-medium text-foreground">{root.author}</span> on{" "}
+          <span className="text-foreground">{artifact.title}</span>
+          <span className="italic"> — {root.body_md}</span>
+        </span>
+        {replies > 0 && (
+          <span className="shrink-0 font-mono text-2xs tabular-nums text-muted-foreground">
+            {replies} {replies === 1 ? "reply" : "replies"}
+          </span>
+        )}
+      </div>
+      <span className="flex shrink-0 items-center gap-2 max-sm:pt-0.5">
+        <span
+          className="font-mono text-2xs tabular-nums text-muted-foreground/80"
+          title={new Date(root.created_at).toLocaleString()}
+        >
+          {stamp(root.created_at, now)}
+        </span>
+        <Button
+          variant="outline"
+          size="xs"
+          data-testid="wa-thread-reply"
+          onClick={() => onOpen(artifact, { comment: root.thread_id })}
+        >
+          Reply
+        </Button>
+      </span>
+    </div>
+  )
+}

--- a/apps/web/src/pages/artifact/activity-rows.tsx
+++ b/apps/web/src/pages/artifact/activity-rows.tsx
@@ -23,7 +23,7 @@ import { quoteChipClass } from "./quote-chip"
 // The stream's line grammar: a 20px glyph column (who, or what), the sentence, and a
 // mono stamp pinned right so it can never orphan onto its own line when the sentence
 // wraps or truncates.
-const LINE = "grid grid-cols-[1.25rem_minmax(0,1fr)_auto] items-start gap-x-2"
+export const LINE = "grid grid-cols-[1.25rem_minmax(0,1fr)_auto] items-start gap-x-2"
 
 const FOCUS =
   "outline-none focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-ring"
@@ -42,7 +42,7 @@ function Stamp({ iso, now }: { iso: string; now: number }) {
 // Who did it: a 20px initials avatar (the comment-row register), the soft ink tint
 // with a sparkles glyph for an agent, and the review glyph when a round's requester
 // resolves to nobody we can name.
-function ActorGlyph({ by, agent }: { by: string | null; agent: boolean }) {
+export function ActorGlyph({ by, agent }: { by: string | null; agent: boolean }) {
   if (!by)
     return (
       <span className="grid size-5 place-items-center text-muted-foreground">
@@ -178,6 +178,23 @@ function DetailRow({
               <span className="truncate">Replied in {row.threadAuthor}'s thread</span>
             </span>
           )}
+          <span className="line-clamp-2 text-sm text-foreground [word-break:break-word]">
+            {row.body}
+          </span>
+        </button>
+      )
+    case "commented":
+      return (
+        <button
+          type="button"
+          data-testid={`activity-commented-${row.threadId}`}
+          onClick={() => onJump(row.threadId)}
+          title="Open the thread"
+          className={cn(
+            "flex w-full flex-col gap-0.5 rounded-md text-left hover:bg-secondary",
+            FOCUS,
+          )}
+        >
           <span className="line-clamp-2 text-sm text-foreground [word-break:break-word]">
             {row.body}
           </span>

--- a/apps/web/src/pages/artifact/artifact-actions.ts
+++ b/apps/web/src/pages/artifact/artifact-actions.ts
@@ -141,6 +141,8 @@ export function useArtifactActions(p: {
     const tempId = `temp-${crypto.randomUUID()}`
     const optimistic: Comment = {
       id: tempId,
+      // The web knows the artifact by short_id only; the saved row carries the real id.
+      artifact_id: "",
       thread_id: opts?.threadId ?? tempId,
       base_version: p.art.current_version,
       path: null,

--- a/apps/web/src/pages/artifact/lib/activity.test.ts
+++ b/apps/web/src/pages/artifact/lib/activity.test.ts
@@ -40,6 +40,7 @@ const version = (
 const comment = (
   p: Partial<Comment> & { id: string; author: string; created_at: string },
 ): Comment => ({
+  artifact_id: "a",
   thread_id: p.id,
   base_version: 1,
   path: null,
@@ -392,6 +393,56 @@ describe("buildStream", () => {
     const only = buildStream({ ...base, versions, comments, lens: "comments" })
     expect(all.map((it) => it.type)).toEqual(["turn", "thread"])
     expect(only.map((it) => it.type)).toEqual(["thread"])
+  })
+})
+
+describe("buildStream — workspace mode", () => {
+  const DOCS = {
+    a: { short_id: "aaaaaaaa", title: "Q3 Narrative" },
+    b: { short_id: "bbbbbbbb", title: "Roadmap" },
+  }
+  const ws = { artifacts: DOCS, since: at(7, 0) }
+
+  it("names the document, makes threads lines, keeps pending asks out, folds per document", () => {
+    const versions = [
+      { ...version(1, "Mert", at(0, 9), "One", CLAUDE), artifact_id: "a" },
+      { ...version(2, "Mert", at(0, 9, 30), "Two", CLAUDE), artifact_id: "a" },
+      { ...version(4, "Mert", at(0, 10), "Four", CLAUDE), artifact_id: "b" },
+    ]
+    const comments = [
+      { ...comment({ id: "t1", author: "Ada", created_at: at(0, 11) }), artifact_id: "a" },
+      // A thread from before the window: served for Needs you, never a line here.
+      { ...comment({ id: "t0", author: "Ada", created_at: at(9, 11) }), artifact_id: "a" },
+    ]
+    const rounds = [round({ id: "rr", version: 2, created_at: at(0, 9, 40), note: "Look?" })]
+    const items = buildStream({ ...base, versions, comments, rounds, workspace: ws })
+    const turns = items.filter((it) => it.type === "turn")
+    // Same actor, same day, two documents → two turns; the thread is a line, not a card.
+    expect(items.some((it) => it.type === "thread")).toBe(false)
+    expect(turns.map((t) => phrase(leadRow(t)))).toEqual([
+      "published v1–v2 of Q3 Narrative",
+      "published v4 of Roadmap",
+      "commented on Q3 Narrative",
+    ])
+    expect(turns.flatMap((t) => t.rows.map((r) => r.kind))).not.toContain("review_request")
+  })
+
+  it("reads newest first, with the marker after the last new item", () => {
+    const versions = [
+      { ...version(1, "Mert", at(2, 9), "Old"), artifact_id: "a" },
+      { ...version(2, "Mert", at(0, 9), "New"), artifact_id: "a" },
+    ]
+    const items = buildStream({
+      ...base,
+      versions,
+      comments: [],
+      workspace: ws,
+      order: "desc",
+      lastSeen: new Date(at(1, 12)).getTime(),
+    })
+    const kinds = items.map((it) => (it.type === "section" ? `section:${it.label}` : it.type))
+    expect(kinds).toEqual(["section:Today", "turn", "unread", "section:Earlier", "turn"])
+    expect(countUnread(items)).toBe(1)
   })
 })
 

--- a/apps/web/src/pages/artifact/lib/activity.ts
+++ b/apps/web/src/pages/artifact/lib/activity.ts
@@ -24,6 +24,15 @@ export type Lens = "all" | "comments"
 export type SectionLabel = "Today" | "Yesterday" | "Earlier"
 
 type Version = Artifact["versions"][number]
+/** What a version row needs of a version — the artifact's own, or the workspace feed's
+ *  (`ActivityVersion`, which adds `artifact_id`). */
+export type VersionLike = Pick<Version, "n" | "author" | "created_at" | "message" | "name"> & {
+  agent?: Version["agent"]
+  handle?: string | null
+  artifact_id?: string
+}
+/** The document a row belongs to — set in workspace mode, where the stream spans many. */
+export type ActivityArtifact = { short_id: string; title: string }
 
 export type VersionRow = {
   kind: "version"
@@ -45,7 +54,8 @@ export type VersionRow = {
   message: string | null
   /** The versions in the range, oldest first — the expanded list reads down the way the
    *  stream does, so the current version is its last line. */
-  versions: Version[]
+  versions: VersionLike[]
+  artifact?: ActivityArtifact
 }
 export type ReviewRequestRow = {
   kind: "review_request"
@@ -58,6 +68,7 @@ export type ReviewRequestRow = {
   version: number
   note: string | null
   pending: boolean
+  artifact?: ActivityArtifact
 }
 export type ReviewSentBackRow = {
   kind: "review_sent_back"
@@ -68,6 +79,7 @@ export type ReviewSentBackRow = {
   agent: boolean
   version: number
   note: string | null
+  artifact?: ActivityArtifact
 }
 export type ReplyRow = {
   kind: "reply"
@@ -79,6 +91,20 @@ export type ReplyRow = {
   threadId: string
   threadAuthor: string
   body: string
+  artifact?: ActivityArtifact
+}
+/** A new thread, as a LINE — the workspace feed's shape for it (the artifact rail shows
+ *  threads as cards, where they are answered in place). */
+export type CommentedRow = {
+  kind: "commented"
+  id: string
+  at: string
+  by: string
+  byId: string | null
+  agent: boolean
+  threadId: string
+  body: string
+  artifact?: ActivityArtifact
 }
 export type ResolvedRow = {
   kind: "resolved"
@@ -92,8 +118,15 @@ export type ResolvedRow = {
   threadAuthor: string
   /** The version whose publish settled the thread; null for a hand resolve. */
   version: number | null
+  artifact?: ActivityArtifact
 }
-export type ActivityRow = VersionRow | ReviewRequestRow | ReviewSentBackRow | ReplyRow | ResolvedRow
+export type ActivityRow =
+  | VersionRow
+  | ReviewRequestRow
+  | ReviewSentBackRow
+  | ReplyRow
+  | CommentedRow
+  | ResolvedRow
 
 export type ThreadItem = { type: "thread"; id: string; at: string; thread: Comment[] }
 export type TurnItem = {
@@ -108,6 +141,7 @@ export type TurnItem = {
   agent: boolean
   /** Never empty — a turn is made from its first row. */
   rows: [ActivityRow, ...ActivityRow[]]
+  artifact?: ActivityArtifact
 }
 export type StreamItem =
   | { type: "section"; id: string; label: SectionLabel }
@@ -116,9 +150,16 @@ export type StreamItem =
   | TurnItem
 
 export interface StreamInput {
-  versions: Version[]
+  versions: VersionLike[]
   comments: Comment[]
   rounds: ReviewRound[]
+  /** WORKSPACE mode (the home): rows span many documents and carry theirs (looked up by
+   *  `artifact_id` here); a new thread is a line, not a card; a pending ask is not a row
+   *  (it is the home's "Needs you"); rows before `since` are left out. */
+  workspace?: { artifacts: Record<string, ActivityArtifact>; since: string }
+  /** Newest first (a page reads down from now) or oldest first (the rail reads up to its
+   *  composer). Default oldest first. */
+  order?: "asc" | "desc"
   /** The viewer — their own replies and resolves are not news to them. Matched by id when
    *  the record has one, by name for rows written before ids were kept. */
   meId?: string
@@ -163,10 +204,10 @@ export function stamp(iso: string, now: number): string {
  *  answer, a card — keeps them apart. The server's time-clustered `sessions` are not
  *  used here on purpose: a session is blind to what happened between its versions, so
  *  "asked for review of v6" would sit before a v6–v7 row that includes v6. */
-function versionRows(versions: Version[]): VersionRow[] {
+function versionRows(versions: VersionLike[], docOf: DocOf): VersionRow[] {
   return versions.map((v) => ({
     kind: "version",
-    id: `v-${v.n}`,
+    id: `v-${v.artifact_id ?? ""}-${v.n}`,
     at: v.created_at,
     by: v.agent?.name ?? v.author,
     byId: v.agent?.id ?? (v.handle ? `@${v.handle}` : null),
@@ -176,16 +217,21 @@ function versionRows(versions: Version[]): VersionRow[] {
     count: 1,
     message: v.message ?? v.name ?? null,
     versions: [v],
+    artifact: docOf(v.artifact_id),
   }))
 }
+
+/** The document a record belongs to, in workspace mode; nothing in the rail. */
+type DocOf = (artifactId: string | undefined) => ActivityArtifact | undefined
 
 // A round carries ONE note: the requester's while pending, then the answer once sent
 // back (send-back overwrites it). So a settled round's request row has no note to show —
 // the answer belongs to the sent-back row alone.
-function reviewRows(rounds: ReviewRound[]) {
+function reviewRows(rounds: ReviewRound[], docOf: DocOf) {
   const rows: ActivityRow[] = []
   for (const r of rounds) {
     const pending = r.state === "pending"
+    const artifact = docOf(r.artifact_id)
     rows.push({
       kind: "review_request",
       id: `rr-${r.id}`,
@@ -196,6 +242,7 @@ function reviewRows(rounds: ReviewRound[]) {
       version: r.version,
       note: pending ? r.note : null,
       pending,
+      artifact,
     })
     if (r.state === "sent_back" && r.resolved_at)
       rows.push({
@@ -209,6 +256,7 @@ function reviewRows(rounds: ReviewRound[]) {
         agent: false,
         version: r.version,
         note: r.note,
+        artifact,
       })
   }
   return rows
@@ -220,18 +268,37 @@ function reviewRows(rounds: ReviewRound[]) {
 function threadRows(
   threads: Comment[][],
   lastSeen: number | null,
+  docOf: DocOf,
+  workspace: boolean,
   meId?: string,
   me?: string,
-): (ReplyRow | ResolvedRow)[] {
-  if (lastSeen == null) return []
+): (ReplyRow | ResolvedRow | CommentedRow)[] {
   const isMe = (id: string | null | undefined, name: string | null) =>
     id ? id === meId : !!name && name === me
-  const rows: (ReplyRow | ResolvedRow)[] = []
+  const rows: (ReplyRow | ResolvedRow | CommentedRow)[] = []
   for (const t of threads) {
     const root = t[0]
     if (!root) continue
+    const artifact = docOf(root.artifact_id)
+    // In the workspace feed a thread is a line like any other action; in the rail it is a
+    // card, and only what happened INSIDE it since the last visit gets a row.
+    if (workspace && !root.deleted)
+      rows.push({
+        kind: "commented",
+        id: `t-${root.id}`,
+        at: root.created_at,
+        by: root.author,
+        byId: root.author_id ?? null,
+        agent: root.author_kind === "agent",
+        threadId: root.thread_id,
+        body: root.body_md,
+        artifact,
+      })
+    // Replies and resolves are news only after a visit; in the workspace feed, always.
+    const floor = workspace ? Number.NEGATIVE_INFINITY : lastSeen
+    if (floor == null) continue
     for (const c of t.slice(1)) {
-      if (c.deleted || ms(c.created_at) <= lastSeen || isMe(c.author_id, c.author)) continue
+      if (c.deleted || ms(c.created_at) <= floor || isMe(c.author_id, c.author)) continue
       rows.push({
         kind: "reply",
         id: `r-${c.id}`,
@@ -242,10 +309,11 @@ function threadRows(
         threadId: root.thread_id,
         threadAuthor: root.author,
         body: c.body_md,
+        artifact,
       })
     }
     const res = root.state === "resolved" ? root.resolution : null
-    if (res && ms(res.at) > lastSeen && !isMe(res.by_id, res.by))
+    if (res && ms(res.at) > floor && !isMe(res.by_id, res.by))
       rows.push({
         kind: "resolved",
         id: `x-${root.thread_id}`,
@@ -256,6 +324,7 @@ function threadRows(
         threadId: root.thread_id,
         threadAuthor: root.author,
         version: res.version,
+        artifact,
       })
   }
   return rows
@@ -286,9 +355,12 @@ function foldTurns(rows: ActivityRow[], lastSeen: number | null): TurnItem[] {
   for (const row of rows) {
     const sameActor = (a: TurnItem, b: ActivityRow) =>
       a.byId && b.byId ? a.byId === b.byId : a.by === b.by && a.agent === b.agent
+    // Across documents (the workspace feed) a turn is one actor on ONE document.
+    const sameDoc = (a: TurnItem, b: ActivityRow) => a.artifact?.short_id === b.artifact?.short_id
     const joins =
       cur !== null &&
       (row.by === null || sameActor(cur, row)) &&
+      sameDoc(cur, row) &&
       dayKey(cur.at) === dayKey(row.at) &&
       seen(cur.at) === seen(row.at)
     if (joins && cur) {
@@ -306,6 +378,7 @@ function foldTurns(rows: ActivityRow[], lastSeen: number | null): TurnItem[] {
         byId: row.byId,
         agent: row.agent,
         rows: [row],
+        artifact: row.artifact,
       }
       turns.push(cur)
     }
@@ -313,22 +386,33 @@ function foldTurns(rows: ActivityRow[], lastSeen: number | null): TurnItem[] {
   return turns
 }
 
-const THREAD_KINDS = new Set<ActivityRow["kind"]>(["reply", "resolved"])
+const THREAD_KINDS = new Set<ActivityRow["kind"]>(["reply", "resolved", "commented"])
 
 export function buildStream(input: StreamInput): StreamItem[] {
   const threads = groupThreads(input.comments)
+  const ws = input.workspace
+  const docOf: DocOf = (id) => (ws && id ? ws.artifacts[id] : undefined)
+  const since = ws ? ms(ws.since) : Number.NEGATIVE_INFINITY
   const rows: ActivityRow[] = [
-    ...versionRows(input.versions),
-    ...reviewRows(input.rounds),
-    ...threadRows(threads, input.lastSeen, input.meId, input.me),
-  ]
+    ...versionRows(input.versions, docOf),
+    ...reviewRows(input.rounds, docOf),
+    ...threadRows(threads, input.lastSeen, docOf, !!ws, input.meId, input.me),
+  ].filter(
+    (r) =>
+      // Workspace mode: a pending ask is the home's "Needs you", not a line; rows before the
+      // window (open threads served for Needs you) stay out of the stream.
+      !ws || (!(r.kind === "review_request" && r.pending) && ms(r.at) >= since),
+  )
   const lensRows = input.lens === "comments" ? rows.filter((r) => THREAD_KINDS.has(r.kind)) : rows
-  const threadItems: ThreadItem[] = threads.flatMap((t) => {
-    const root = t[0]
-    return root
-      ? [{ type: "thread" as const, id: root.thread_id, at: root.created_at, thread: t }]
-      : []
-  })
+  // Cards only in the rail: the workspace feed made its threads lines above.
+  const threadItems: ThreadItem[] = ws
+    ? []
+    : threads.flatMap((t) => {
+        const root = t[0]
+        return root
+          ? [{ type: "thread" as const, id: root.thread_id, at: root.created_at, thread: t }]
+          : []
+      })
 
   // Merge in time, then fold the runs of rows between cards into turns. Cards break a
   // turn: what happened after a comment is a different story from what happened before.
@@ -348,16 +432,23 @@ export function buildStream(input: StreamInput): StreamItem[] {
     } else run.push(m)
   }
   flush()
+  // Newest first reads down from now: the same items, reversed, and the marker sits
+  // after the last new item instead of before the first.
+  if (input.order === "desc") items.reverse()
+  const isNew = (it: { at: string }) => ms(it.at) > (input.lastSeen ?? 0)
 
-  // Sections + the unread marker (before the first item newer than the last visit).
-  // A stream that all happened today needs no eyebrow — labels earn their place only
-  // when there are two days to tell apart.
+  // Sections + the unread marker (before the first item newer than the last visit —
+  // or, newest first, before the first item that is not). A stream that all happened
+  // today needs no eyebrow — labels earn their place only when there are two days to
+  // tell apart.
   const labelled = new Set(items.map((it) => sectionOf(it.at, input.now))).size > 1
   const out: StreamItem[] = []
   let section: SectionLabel | null = null
   let marked = input.lastSeen == null
   for (const it of items) {
-    if (!marked && ms(it.at) > (input.lastSeen ?? 0)) {
+    const boundary =
+      input.order === "desc" ? !isNew(it) && out.some((o) => o.type !== "section") : isNew(it)
+    if (!marked && boundary) {
       out.push({ type: "unread", id: "unread" })
       marked = true
     }
@@ -385,6 +476,7 @@ const PRIORITY: ActivityRow["kind"][] = [
   "version",
   "review_sent_back",
   "review_request",
+  "commented",
   "reply",
   "resolved",
 ]
@@ -397,17 +489,30 @@ export function leadRow(turn: TurnItem): ActivityRow {
 /** A row's plain-text phrase, actor excluded ("published v9–v11"). Shared by the turn
  *  line and its opened detail rows so the two can never disagree. */
 export function phrase(row: ActivityRow): string {
+  // In the workspace feed the sentence names the document; in the rail the document is
+  // the page.
+  const doc = row.artifact?.title
   switch (row.kind) {
-    case "version":
-      return row.count > 1 ? `published v${row.from}–v${row.to}` : `published v${row.to}`
+    case "version": {
+      const span = row.count > 1 ? `v${row.from}–v${row.to}` : `v${row.to}`
+      return doc ? `published ${span} of ${doc}` : `published ${span}`
+    }
     case "review_request":
-      return `asked for review of v${row.version}`
+      return doc
+        ? `asked for review of v${row.version} · ${doc}`
+        : `asked for review of v${row.version}`
     case "review_sent_back":
-      return `sent v${row.version} back`
+      return doc ? `sent v${row.version} of ${doc} back` : `sent v${row.version} back`
+    case "commented":
+      return doc ? `commented on ${doc}` : "commented"
     case "reply":
-      return `replied in ${row.threadAuthor}'s thread`
+      return doc
+        ? `replied in ${row.threadAuthor}'s thread on ${doc}`
+        : `replied in ${row.threadAuthor}'s thread`
     case "resolved":
-      return `resolved ${row.threadAuthor}'s thread`
+      return doc
+        ? `resolved ${row.threadAuthor}'s thread on ${doc}`
+        : `resolved ${row.threadAuthor}'s thread`
   }
 }
 

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -27,6 +27,7 @@ import { Route as FavoritesRouteImport } from './routes/favorites'
 import { Route as ChatRouteImport } from './routes/chat'
 import { Route as BrandprintRouteImport } from './routes/brandprint'
 import { Route as ArchivedRouteImport } from './routes/archived'
+import { Route as ActivityRouteImport } from './routes/activity'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as TemplatesIndexRouteImport } from './routes/templates.index'
 import { Route as TemplateLibrariesIndexRouteImport } from './routes/template-libraries.index'
@@ -138,6 +139,11 @@ const ArchivedRoute = ArchivedRouteImport.update({
   path: '/archived',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ActivityRoute = ActivityRouteImport.update({
+  id: '/activity',
+  path: '/activity',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -241,6 +247,7 @@ const InviteATokenRoute = InviteATokenRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/activity': typeof ActivityRoute
   '/archived': typeof ArchivedRoute
   '/brandprint': typeof BrandprintRoute
   '/chat': typeof ChatRoute
@@ -281,6 +288,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/activity': typeof ActivityRoute
   '/archived': typeof ArchivedRoute
   '/brandprint': typeof BrandprintRoute
   '/chat': typeof ChatRoute
@@ -321,6 +329,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/activity': typeof ActivityRoute
   '/archived': typeof ArchivedRoute
   '/brandprint': typeof BrandprintRoute
   '/chat': typeof ChatRoute
@@ -363,6 +372,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/activity'
     | '/archived'
     | '/brandprint'
     | '/chat'
@@ -403,6 +413,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/activity'
     | '/archived'
     | '/brandprint'
     | '/chat'
@@ -442,6 +453,7 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/activity'
     | '/archived'
     | '/brandprint'
     | '/chat'
@@ -483,6 +495,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  ActivityRoute: typeof ActivityRoute
   ArchivedRoute: typeof ArchivedRoute
   BrandprintRoute: typeof BrandprintRoute
   ChatRoute: typeof ChatRoute
@@ -648,6 +661,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ArchivedRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/activity': {
+      id: '/activity'
+      path: '/activity'
+      fullPath: '/activity'
+      preLoaderRoute: typeof ActivityRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -807,6 +827,7 @@ const SettingsRouteWithChildren = SettingsRoute._addFileChildren(
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  ActivityRoute: ActivityRoute,
   ArchivedRoute: ArchivedRoute,
   BrandprintRoute: BrandprintRoute,
   ChatRoute: ChatRoute,

--- a/apps/web/src/routes/activity.tsx
+++ b/apps/web/src/routes/activity.tsx
@@ -1,0 +1,25 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { PageHeader } from "@/components/shared/page-header"
+import { PageShell } from "@/components/shared/page-shell"
+import { useDocumentTitle } from "@/lib/use-document-title"
+import { WorkspaceActivity } from "@/pages/activity"
+
+// What is happening in the workspace, and what needs you — its own page beside
+// Notifications. Not the Library (the grid is what that page is) and not the bell (what
+// was addressed to you); the third question, answered in one place.
+function ActivityPage() {
+  useDocumentTitle("Activity")
+  return (
+    <PageShell width="wide" className="flex flex-col gap-5">
+      <PageHeader
+        title="Activity"
+        subtitle="What needs you across the workspace, and what people and agents have done."
+      />
+      <WorkspaceActivity />
+    </PageShell>
+  )
+}
+
+export const Route = createFileRoute("/activity")({
+  component: ActivityPage,
+})

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -1539,6 +1539,26 @@ export interface ReviewStore {
   getPendingRound(artifactId: string, requestedFor?: string): Promise<ReviewRoundRecord | null>
   /** All rounds on an artifact, newest first (the audit trail). */
   listReviewRounds(artifactId: string): Promise<ReviewRoundRecord[]>
+
+  // ---- Workspace activity (the home's "Needs you" + "Recent activity") ------------
+  // Cross-artifact reads over one workspace, joined through the artifact (versions and
+  // comments carry no org). Each is bounded by `since` and `limit`; the route gates the
+  // artifacts for the viewer afterwards, so these never decide visibility.
+  /** Versions in the workspace created at or after `since`, newest first. */
+  listVersionsInOrg(orgId: string, opts: { since: string; limit: number }): Promise<VersionRecord[]>
+  /** Comments in the workspace created at or after `since`, newest first — plus, when
+   *  `openOn` names artifacts, EVERY open comment on those artifacts regardless of age (a
+   *  thread waiting on someone is current however old it is). */
+  listCommentsInOrg(
+    orgId: string,
+    opts: { since: string; limit: number; openOn?: string[] },
+  ): Promise<CommentRecord[]>
+  /** Review rounds in the workspace that are pending (any age), or were opened or settled
+   *  at or after `since`; newest first. */
+  listReviewRoundsInOrg(
+    orgId: string,
+    opts: { since: string; limit: number },
+  ): Promise<ReviewRoundRecord[]>
   /** Settle a round (`sent_back`), stamping resolved_at + note. */
   /** Settle the pending round as sent back — the loop's one settling gesture.
    *  Returns null when the round is not pending (someone else settled it first). */

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -4191,6 +4191,60 @@ export class PgMetaStore implements MetaStore {
       .limit(1)
     return rows[0] ?? null
   }
+  // ---- Workspace activity -----------------------------------------------------------
+  async listVersionsInOrg(
+    orgId: string,
+    opts: { since: string; limit: number },
+  ): Promise<VersionRecord[]> {
+    const rows = await this.db
+      .select({ v: version })
+      .from(version)
+      .innerJoin(artifact, eq(artifact.id, version.artifact_id))
+      .where(and(eq(artifact.org_id, orgId), gte(version.created_at, opts.since)))
+      .orderBy(desc(version.created_at))
+      .limit(opts.limit)
+    return rows.map((r) => r.v)
+  }
+  async listCommentsInOrg(
+    orgId: string,
+    opts: { since: string; limit: number; openOn?: string[] },
+  ): Promise<CommentRecord[]> {
+    const recent = gte(comment.created_at, opts.since)
+    const open =
+      opts.openOn && opts.openOn.length
+        ? and(eq(comment.state, "open"), inArray(comment.artifact_id, opts.openOn))
+        : null
+    const rows = await this.db
+      .select({ c: comment })
+      .from(comment)
+      .innerJoin(artifact, eq(artifact.id, comment.artifact_id))
+      .where(and(eq(artifact.org_id, orgId), open ? or(recent, open) : recent))
+      .orderBy(desc(comment.created_at))
+      .limit(opts.limit)
+    return rows.map((r) => r.c)
+  }
+  async listReviewRoundsInOrg(
+    orgId: string,
+    opts: { since: string; limit: number },
+  ): Promise<ReviewRoundRecord[]> {
+    const rows = await this.db
+      .select({ r: reviewRound })
+      .from(reviewRound)
+      .innerJoin(artifact, eq(artifact.id, reviewRound.artifact_id))
+      .where(
+        and(
+          eq(artifact.org_id, orgId),
+          or(
+            eq(reviewRound.state, "pending"),
+            gte(reviewRound.created_at, opts.since),
+            gte(reviewRound.resolved_at, opts.since),
+          ),
+        ),
+      )
+      .orderBy(desc(reviewRound.created_at))
+      .limit(opts.limit)
+    return rows.map((r) => r.r)
+  }
   listReviewRounds(artifactId: string): Promise<ReviewRoundRecord[]> {
     return this.db
       .select()

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -3452,6 +3452,62 @@ export function makeRepos(db: SqliteDb) {
         .get()) ?? null
     )
   }
+  // ---- Workspace activity -----------------------------------------------------------
+  const listVersionsInOrg = async (
+    orgId: string,
+    opts: { since: string; limit: number },
+  ): Promise<VersionRecord[]> =>
+    (
+      await db
+        .select({ v: version })
+        .from(version)
+        .innerJoin(artifact, eq(artifact.id, version.artifact_id))
+        .where(and(eq(artifact.org_id, orgId), gte(version.created_at, opts.since)))
+        .orderBy(desc(version.created_at))
+        .limit(opts.limit)
+    ).map((r) => r.v)
+  const listCommentsInOrg = async (
+    orgId: string,
+    opts: { since: string; limit: number; openOn?: string[] },
+  ): Promise<CommentRecord[]> => {
+    const recent = gte(comment.created_at, opts.since)
+    const open =
+      opts.openOn && opts.openOn.length
+        ? and(eq(comment.state, "open"), inArray(comment.artifact_id, opts.openOn))
+        : null
+    return (
+      await db
+        .select({ c: comment })
+        .from(comment)
+        .innerJoin(artifact, eq(artifact.id, comment.artifact_id))
+        .where(and(eq(artifact.org_id, orgId), open ? or(recent, open) : recent))
+        .orderBy(desc(comment.created_at))
+        .limit(opts.limit)
+    ).map((r) => r.c)
+  }
+  const listReviewRoundsInOrg = async (
+    orgId: string,
+    opts: { since: string; limit: number },
+  ): Promise<ReviewRoundRecord[]> =>
+    (
+      await db
+        .select({ r: reviewRound })
+        .from(reviewRound)
+        .innerJoin(artifact, eq(artifact.id, reviewRound.artifact_id))
+        .where(
+          and(
+            eq(artifact.org_id, orgId),
+            or(
+              eq(reviewRound.state, "pending"),
+              gte(reviewRound.created_at, opts.since),
+              gte(reviewRound.resolved_at, opts.since),
+            ),
+          ),
+        )
+        .orderBy(desc(reviewRound.created_at))
+        .limit(opts.limit)
+    ).map((r) => r.r)
+
   const listReviewRounds = async (artifactId: string): Promise<ReviewRoundRecord[]> =>
     db
       .select()
@@ -5589,6 +5645,9 @@ export function makeRepos(db: SqliteDb) {
     createReviewRound,
     getPendingRound,
     listReviewRounds,
+    listVersionsInOrg,
+    listCommentsInOrg,
+    listReviewRoundsInOrg,
     resolveReviewRound,
     createContext,
     getContext,


### PR DESCRIPTION
## Summary

A workspace-level activity page at `/activity`, reached from a sidebar row right after Notifications. It answers two questions and nothing more:

- **Needs you** — reviews waiting on you, and open threads you were tagged in or took part in. Each line names the document, shows how long it has waited (amber past three days), and has one verb: Answer / Reply.
- **Recent activity** — what people and agents published, commented, and asked for across the workspace in the last seven days, newest first, folded per document with the same `buildStream` grammar as the artifact activity rail. A "New above" marker sits at your last visit.

Deliberately not built: lenses, runs, stuck detection, dismiss, bell changes, digests. One endpoint, three store reads.

### Server
- `GET /v1/workspace/activity?days` (default 7, max 30): three org-scoped reads (`listVersionsInOrg`, `listCommentsInOrg`, `listReviewRoundsInOrg`, on both the drizzle and Postgres stores) → candidates are gated through the viewer-aware `listArtifacts` before any row is served, so unlisted drafts never appear in a feed by access alone. Bylines healed to live display names; agent credit and principal kind on versions and rounds.
- `Comment` and `ReviewRound` schemas move to `schemas.ts` (comments now carry `artifact_id`); `roundJson` extracted to `lib/review-json.ts` and shared with the review routes.
- `/activity` added to the SPA path allowlist so a direct load serves the shell.

### Web
- `pages/activity.tsx` + `routes/activity.tsx` (`PageShell wide` + `PageHeader`), sidebar `ActivityRow` with a count of reviews waiting on you.
- `buildStream` gains a workspace mode (document names, `commented` rows, pending asks excluded, per-document fold, `order: "desc"` with the marker after the last new item); `ActorGlyph`/`LINE` exported from the rail.
- Loading = `StreamSkeleton` under the section eyebrow; error = inline danger `StatusPanel` with Try again; empty = `EmptyState`. Phone: lines wrap to two lines instead of truncating.

## Test plan
- [x] `apps/api/test/workspace-activity.test.ts`: owner sees team + private docs, agent credit, pending round with kind/name, comment author kinds; an editor sees only the listed team doc; 401 signed out; 400 for `days=90`.
- [x] `buildStream` unit tests for workspace mode and newest-first ordering (web 152 passing).
- [x] `pnpm verify` (ci 34/34, typecheck, all suites incl. the serve-web route contract).
- [x] Screens harness `workspace-activity.screens.ts`: page, open turn, show-more, dark, loading, Answer → send-back, 390×844 phone. Smoke 20/20.
- [x] Demo document with real captures: https://derive.to/artifacts/workspace-activity-demo-tmscywe6

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790503446&installation_model_id=428097&pr_number=852&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F852&signature=befa356828234bc1515301b2889425fba9a915c959b1d48be6fcb3f9472b6167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->