### PR TITLE
One header grammar: lines mark structure and position, never groups

### DIFF
--- a/apps/web/src/components/chat/context-card.tsx
+++ b/apps/web/src/components/chat/context-card.tsx
@@ -81,7 +81,7 @@ export function ContextCard({ card }: { card: BuilderCard }) {
           to="/agents/$id"
           params={{ id: created.context_id }}
           data-testid="builder-context-card-open"
-          className="flex items-center gap-1 border-t border-border-soft pt-2.5 text-sm text-foreground hover:underline"
+          className="flex items-center gap-1 text-sm text-foreground hover:underline"
         >
           {BUILDER_COPY.createdPrefix} <span className="font-medium">{created.name}</span>
         </Link>

--- a/apps/web/src/components/chrome/palette-ask.tsx
+++ b/apps/web/src/components/chrome/palette-ask.tsx
@@ -6,6 +6,7 @@ import { ChatComposer } from "@/components/chat/chat-composer"
 import { ChatThread } from "@/components/chat/chat-thread"
 import { useChatSession } from "@/components/chat/use-chat-session"
 import { Icon } from "@/components/icons"
+import { Eyebrow } from "@/components/shared/section-eyebrow"
 import { Kbd } from "@/components/ui/kbd"
 import { isInAppPath } from "@/lib/in-app-path"
 import { workspaceQuery } from "@/lib/queries"
@@ -148,7 +149,10 @@ export function PaletteAsk(props: {
           commits: it never navigates on its own, because a model deciding to move you off the
           page you were on is delightful exactly once. */}
       {destinations.length > 0 && (
-        <div className="max-h-32 shrink-0 overflow-y-auto border-t px-2 py-1.5">
+        <div className="max-h-32 shrink-0 overflow-y-auto px-2 py-1.5">
+          <Eyebrow as="div" className="px-2 pb-1">
+            Go to
+          </Eyebrow>
           {destinations.map((d) => (
             <button
               key={d.path}

--- a/apps/web/src/components/shared/section-eyebrow.tsx
+++ b/apps/web/src/components/shared/section-eyebrow.tsx
@@ -5,15 +5,16 @@ import { cn } from "@/lib/utils"
 // The mono smallcaps micro-label register — the ONE compliant place uppercase is
 // used (always with tracking-wide). Medium weight so 10px caps stay legible while
 // muted keeps it quiet; this also matches the stock menu/select/command group
-// labels, so the register reads identically everywhere. SectionEyebrow re-inks it
-// for section-header presence; use Eyebrow directly where the rule doesn't fit
-// (card step labels, popover section headers, inline dividers).
+// labels, so the register reads identically everywhere. It is the lowest heading
+// level: sub-groups, day labels, column headers, card step labels, popover section
+// labels — always bare, never with a rule (headings are SectionHeading /
+// SectionTitle in section-title.tsx).
 export function Eyebrow({
   as: Tag = "span",
   className,
   children,
 }: {
-  as?: "span" | "div" | "h2" | "h3" | "h4" | "th" | "footer"
+  as?: "span" | "div" | "p" | "h2" | "h3" | "h4" | "th" | "dt" | "footer"
   className?: string
   children: ReactNode
 }) {
@@ -26,46 +27,6 @@ export function Eyebrow({
     >
       {children}
     </Tag>
-  )
-}
-
-// A list-section heading in the mono eyebrow register: smallcaps label, an optional
-// leading icon and tabular count, a hairline rule that runs to the edge, and an
-// optional right-aligned action. Re-inks the Eyebrow to `text-foreground` — a
-// section header should be seen — while the count stays muted (label ink, count
-// quiet). The one compliant place uppercase is used (mono + wide tracking).
-export function SectionEyebrow({
-  children,
-  count,
-  action,
-  icon,
-  as: Tag = "h2",
-  className,
-}: {
-  children: ReactNode
-  count?: number
-  action?: ReactNode
-  icon?: ReactNode
-  as?: "h2" | "h3"
-  className?: string
-}) {
-  return (
-    <div className={cn("flex items-center gap-3", className)}>
-      <Eyebrow as={Tag} className="flex shrink-0 items-center gap-1.5 text-foreground">
-        {icon}
-        <span>{children}</span>
-        {count !== undefined && (
-          <span className="tabular-nums normal-case tracking-normal text-muted-foreground/80">
-            {/* The dot is visual punctuation — don't let SRs announce "middle dot". */}
-            <span aria-hidden>· </span>
-            {count}
-            <span className="sr-only"> items</span>
-          </span>
-        )}
-      </Eyebrow>
-      <Separator className="flex-1" />
-      {action && <div className="shrink-0">{action}</div>}
-    </div>
   )
 }
 
@@ -91,8 +52,8 @@ export function LabeledDivider({
 
 // The machine-register count that rides beside a label ("Members · 12") — mono,
 // tabular, muted, led by an aria-hidden middle dot so screen readers read just the
-// number. SectionEyebrow bakes this same treatment into its own count; use Count
-// for standalone label + count rows that aren't a full SectionEyebrow.
+// number. SectionHeading and SectionTitle bake this same treatment into their
+// counts; use Count for standalone label + count rows.
 export function Count({ children, className }: { children: ReactNode; className?: string }) {
   return (
     <span className={cn("font-mono text-2xs tabular-nums text-muted-foreground", className)}>

--- a/apps/web/src/components/shared/section-title.tsx
+++ b/apps/web/src/components/shared/section-title.tsx
@@ -1,22 +1,73 @@
 import type { ReactNode } from "react"
+import { Count } from "@/components/shared/section-eyebrow"
 import { cn } from "@/lib/utils"
 
-// A section title in the chrome register (Geist, medium — never bold) — heads a
-// block of settings/controls with an optional trailing action. The louder
-// counterpart to SectionEyebrow's mono smallcaps.
-export function SectionTitle({
+// The page-level section heading in the chrome register (Geist, medium — never
+// bold): one step below PageHeader, one above SectionTitle. It carries the
+// machine-register count and an optional trailing action, and draws NO rule —
+// at page width a section separates from the next by whitespace and by being
+// the second-largest type on the page. Lines are for structure (a container's
+// edge, a table's column row) and for positions (the unread marker), never for
+// groups, and no label ever carries one.
+export function SectionHeading({
   children,
+  count,
   action,
+  as: Tag = "h2",
   className,
 }: {
   children: ReactNode
+  count?: number
   action?: ReactNode
+  as?: "h2" | "h3"
   className?: string
 }) {
   return (
     <div className={cn("flex items-center justify-between gap-3", className)}>
-      <h3 className="text-balance text-sm font-medium text-foreground">{children}</h3>
-      {action}
+      <Tag className="flex min-w-0 items-baseline gap-2 text-balance text-base font-medium text-foreground">
+        <span>{children}</span>
+        {count !== undefined && (
+          <Count className="shrink-0">
+            {count}
+            <span className="sr-only"> items</span>
+          </Count>
+        )}
+      </Tag>
+      {action && <div className="shrink-0">{action}</div>}
+    </div>
+  )
+}
+
+// A section title in the chrome register (Geist, medium — never bold) — heads a
+// block inside a bounded container: a settings group, a dialog section, a panel
+// or console column, a card. Same anatomy as SectionHeading one step down
+// (`text-sm`): the machine-register count, an optional trailing action, and no
+// rule — inside a panel the container's own edges are the only lines.
+export function SectionTitle({
+  children,
+  count,
+  action,
+  as: Tag = "h3",
+  className,
+}: {
+  children: ReactNode
+  count?: number
+  action?: ReactNode
+  as?: "h2" | "h3" | "h4"
+  className?: string
+}) {
+  return (
+    <div className={cn("flex items-center justify-between gap-3", className)}>
+      <Tag className="flex min-w-0 items-baseline gap-2 text-balance text-sm font-medium text-foreground">
+        <span>{children}</span>
+        {count !== undefined && (
+          <Count className="shrink-0">
+            {count}
+            <span className="sr-only"> items</span>
+          </Count>
+        )}
+      </Tag>
+      {action && <div className="shrink-0">{action}</div>}
     </div>
   )
 }

--- a/apps/web/src/components/shared/share-dialog-sections.tsx
+++ b/apps/web/src/components/shared/share-dialog-sections.tsx
@@ -4,7 +4,7 @@ import { Icon, type IconName } from "@/components/icons"
 import { AccessSegmentToggle } from "@/components/shared/access-segment-toggle"
 import { PersonSearchInput } from "@/components/shared/person-search-input"
 import { ROLE_LABELS, RoleSelect } from "@/components/shared/role-select"
-import { SectionEyebrow } from "@/components/shared/section-eyebrow"
+import { SectionTitle } from "@/components/shared/section-title"
 import { Spinner } from "@/components/shared/spinner"
 import { WorldLinkControls } from "@/components/shared/world-link-controls"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
@@ -113,9 +113,9 @@ export function ShareAccessSection({
 }) {
   return (
     <div>
-      <SectionEyebrow action={pending && <Spinner className="size-3" />}>
+      <SectionTitle action={pending && <Spinner className="size-3" />}>
         Who can open this
-      </SectionEyebrow>
+      </SectionTitle>
       {canManage ? (
         <div className="mt-2 flex flex-col">
           <AccessSegmentToggle
@@ -199,7 +199,7 @@ export function SharePeopleSection({
 }) {
   return (
     <div>
-      <SectionEyebrow count={members.length || undefined}>People with access</SectionEyebrow>
+      <SectionTitle count={members.length || undefined}>People with access</SectionTitle>
       {members.length === 0 ? (
         <p
           data-testid={`${testPrefix}-empty`}

--- a/apps/web/src/components/showcase/showcase.tsx
+++ b/apps/web/src/components/showcase/showcase.tsx
@@ -5,7 +5,8 @@ import { ConfirmDialog } from "@/components/shared/confirm-dialog"
 import { EmptyState } from "@/components/shared/empty-state"
 import { FormField } from "@/components/shared/form-field"
 import { SearchField } from "@/components/shared/search-field"
-import { Eyebrow, SectionEyebrow } from "@/components/shared/section-eyebrow"
+import { Eyebrow } from "@/components/shared/section-eyebrow"
+import { SectionHeading, SectionTitle } from "@/components/shared/section-title"
 import { Spinner } from "@/components/shared/spinner"
 import { StatusPanel } from "@/components/shared/status-panel"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
@@ -304,7 +305,7 @@ function IconGridDemo() {
   )
 }
 
-/** Separator — a hairline rule dividing a quiet action row. */
+/** Separator — the vertical rule between control groups inside a bar. */
 function SeparatorDemo() {
   return (
     <div className="flex h-5 items-center gap-3 text-sm text-muted-foreground">
@@ -752,19 +753,58 @@ function AvatarDemo() {
   )
 }
 
-/** Section label — the mono smallcaps + hairline rule + tabular count list head. */
+/** The header grammar, all levels on one canvas: a page section is a heading; a
+ *  sub-group or a day is a bare eyebrow; inside a panel the title is one step
+ *  down and the panel's edges are the only lines; a line on its own marks a
+ *  position. No label ever carries a rule. */
 function SectionLabelDemo() {
   return (
-    <div className="space-y-6">
-      <SectionEyebrow count={12} icon={<Icon name="comments" size={12} />}>
-        Needs your feedback
-      </SectionEyebrow>
-      <SectionEyebrow
-        count={128}
-        action={<span className="font-mono text-2xs text-muted-foreground">Browse all →</span>}
-      >
-        All artifacts
-      </SectionEyebrow>
+    <div className="flex flex-col gap-8">
+      <div className="flex flex-col gap-2">
+        <SectionHeading
+          count={12}
+          action={<span className="font-mono text-2xs text-muted-foreground">View all</span>}
+        >
+          Needs you
+        </SectionHeading>
+        <div className="flex flex-col">
+          <Eyebrow as="h3" className="pt-1 pb-1">
+            Reviews waiting on you
+          </Eyebrow>
+          <p className="py-1 text-sm text-muted-foreground">
+            <span className="font-medium text-foreground">Claude Code</span> asked for review of v4
+          </p>
+          <p className="py-1 text-sm text-muted-foreground">
+            <span className="font-medium text-foreground">Codex</span> asked for review of v2
+          </p>
+        </div>
+        <div className="flex flex-col">
+          <Eyebrow as="h3" className="pt-3 pb-1">
+            Yesterday
+          </Eyebrow>
+          <p className="py-1 text-sm text-muted-foreground">
+            <span className="font-medium text-foreground">Mert</span> published v3 of Q3 Growth
+            Narrative
+          </p>
+        </div>
+        <div className="flex items-center gap-2 py-2">
+          <Separator className="flex-1 bg-primary" />
+          <Eyebrow className="text-primary">New</Eyebrow>
+          <Separator className="flex-1 bg-primary" />
+        </div>
+      </div>
+      <div className="flex flex-col gap-2 rounded-xl border bg-card p-4">
+        <SectionTitle
+          count={3}
+          action={<span className="font-mono text-2xs text-muted-foreground">Manage</span>}
+        >
+          People with access
+        </SectionTitle>
+        <p className="text-sm text-muted-foreground">
+          Inside a dialog, a card or a rail the title steps down one size, and the container's edges
+          are the only lines.
+        </p>
+      </div>
     </div>
   )
 }
@@ -1253,7 +1293,10 @@ export function Showcase() {
           >
             <IconGridDemo />
           </Row>
-          <Row title="Separator" note="A hairline rule, horizontal or vertical, to divide groups.">
+          <Row
+            title="Separator"
+            note="A hairline for structure or position: a bar's edge, a table row, the unread marker, or a vertical rule between control groups inside a bar. Never between two sections, and never on a label."
+          >
             <SeparatorDemo />
           </Row>
         </Group>
@@ -1323,8 +1366,8 @@ export function Showcase() {
             <AvatarDemo />
           </Row>
           <Row
-            title="Section label"
-            note="Mono smallcaps, a hairline rule, and a tabular count head every list section."
+            title="Headings"
+            note="A page section is a heading, a sub-group or a day is a bare eyebrow, a panel's title steps down one size. No label carries a rule; a line on its own marks a position."
           >
             <SectionLabelDemo />
           </Row>

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -408,7 +408,7 @@ function SidebarGroupLabel({
       data-slot="sidebar-group-label"
       data-sidebar="group-label"
       className={cn(
-        // Group labels are the house mono eyebrow (SectionEyebrow register), not
+        // Group labels are the house mono eyebrow (Eyebrow register), not
         // shadcn's default sans text-xs — one machine register for micro-labels.
         "flex h-8 shrink-0 items-center rounded-lg px-2 font-mono text-2xs font-medium tracking-wide text-sidebar-foreground/70 uppercase outline-none transition-[margin,opacity] duration-move ease-linear group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-ring [&>svg]:size-4 [&>svg]:shrink-0",
         className,

--- a/apps/web/src/pages/activity.tsx
+++ b/apps/web/src/pages/activity.tsx
@@ -4,7 +4,8 @@ import { useState } from "react"
 import type { Comment, ReviewRound } from "@/api"
 import { Icon } from "@/components/icons"
 import { EmptyState } from "@/components/shared/empty-state"
-import { Eyebrow, SectionEyebrow } from "@/components/shared/section-eyebrow"
+import { Eyebrow } from "@/components/shared/section-eyebrow"
+import { SectionHeading } from "@/components/shared/section-title"
 import { StatusPanel } from "@/components/shared/status-panel"
 import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
@@ -57,7 +58,7 @@ export function WorkspaceActivity() {
   if (activity.isPending)
     return (
       <section>
-        <SectionEyebrow>Recent activity</SectionEyebrow>
+        <SectionHeading>Recent activity</SectionHeading>
         <StreamSkeleton />
       </section>
     )
@@ -153,13 +154,15 @@ export function WorkspaceActivity() {
     )
 
   return (
-    <div className="flex flex-col gap-7" data-testid="wa-root">
+    <div className="flex flex-col gap-10" data-testid="wa-root">
       {needsCount > 0 && (
-        <section data-testid="wa-needs-you">
-          <SectionEyebrow count={needsCount}>Needs you</SectionEyebrow>
+        <section className="flex flex-col gap-2" data-testid="wa-needs-you">
+          <SectionHeading count={needsCount}>Needs you</SectionHeading>
           {asks.length > 0 && (
-            <div className="mt-1 flex flex-col">
-              <Eyebrow className="px-1.5 pt-2 pb-1">Reviews waiting on you</Eyebrow>
+            <div className="flex flex-col">
+              <Eyebrow as="h3" className="px-1.5 pt-1 pb-1">
+                Reviews waiting on you
+              </Eyebrow>
               {capped("asks", asks).map(({ round, artifact }) => (
                 <AskLine key={round.id} round={round} artifact={artifact} now={now} onOpen={open} />
               ))}
@@ -167,8 +170,10 @@ export function WorkspaceActivity() {
             </div>
           )}
           {threads.length > 0 && (
-            <div className="mt-1 flex flex-col">
-              <Eyebrow className="px-1.5 pt-2 pb-1">Open threads with you</Eyebrow>
+            <div className="flex flex-col">
+              <Eyebrow as="h3" className="px-1.5 pt-1 pb-1">
+                Open threads with you
+              </Eyebrow>
               {capped("threads", threads).map(({ root, artifact, replies }) => (
                 <ThreadLine
                   key={root.thread_id}
@@ -185,17 +190,16 @@ export function WorkspaceActivity() {
         </section>
       )}
       {turnCount > 0 && (
-        <section data-testid="wa-recent">
-          <SectionEyebrow count={turnCount}>Recent activity</SectionEyebrow>
-          <div className="mt-1 flex flex-col">
+        <section className="flex flex-col gap-2" data-testid="wa-recent">
+          <SectionHeading count={turnCount}>Recent activity</SectionHeading>
+          <div className="flex flex-col">
             {items.map((it) => {
               switch (it.type) {
                 case "section":
                   return (
-                    <div key={it.id} className="flex items-center gap-2 pt-3 pb-1">
-                      <Eyebrow>{it.label}</Eyebrow>
-                      <Separator className="flex-1" />
-                    </div>
+                    <Eyebrow key={it.id} as="h3" className="pt-4 pb-1 first:pt-1">
+                      {it.label}
+                    </Eyebrow>
                   )
                 case "unread":
                   return (
@@ -204,6 +208,7 @@ export function WorkspaceActivity() {
                       data-testid="wa-unread-marker"
                       className="flex items-center gap-2 py-2"
                     >
+                      <Separator className="flex-1 bg-primary" />
                       <Eyebrow className="text-primary">New above</Eyebrow>
                       <Separator className="flex-1 bg-primary" />
                     </div>

--- a/apps/web/src/pages/artifact/activity-stream.tsx
+++ b/apps/web/src/pages/artifact/activity-stream.tsx
@@ -50,7 +50,8 @@ export function StreamSkeleton() {
 }
 
 /**
- * The stream itself — the items `buildStream` produced, rendered: day eyebrows, the one
+ * The stream itself — the items `buildStream` produced, rendered: day labels (no rule —
+ * lines mark positions, not groups), the one
  * ink "New" line, comment threads as cards (resolved ones folded to a line), every other
  * action as a one-line turn. Shared by the desktop rail and the phone sheet, so the two
  * can't drift; each surface brings its own header, composer and scroll behaviour.
@@ -118,10 +119,9 @@ export function ActivityStream({
     switch (it.type) {
       case "section":
         return (
-          <div key={it.id} className="flex items-center gap-2 pt-3 pb-1">
-            <Eyebrow>{it.label}</Eyebrow>
-            <Separator className="flex-1" />
-          </div>
+          <Eyebrow key={it.id} as="h3" className="pt-3 pb-1">
+            {it.label}
+          </Eyebrow>
         )
       case "unread":
         return (

--- a/apps/web/src/pages/artifact/artifact-inspect.tsx
+++ b/apps/web/src/pages/artifact/artifact-inspect.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react"
 import { Icon } from "@/components/icons"
+import { Eyebrow } from "@/components/shared/section-eyebrow"
+import { SectionTitle } from "@/components/shared/section-title"
 import { Button } from "@/components/ui/button"
 import { Kbd } from "@/components/ui/kbd"
 import { cn } from "@/lib/utils"
@@ -66,7 +68,7 @@ export function ArtifactInspect({
           <Icon name="edit" size={15} />
         </span>
         <div className="min-w-0">
-          <h2 className="font-medium text-foreground text-sm">Inspect</h2>
+          <SectionTitle as="h2">Inspect</SectionTitle>
           <p className="text-2xs text-muted-foreground">Editing HTML safely</p>
         </div>
       </div>
@@ -121,10 +123,10 @@ function SceneInspect({
   return (
     <div data-testid="artifact-inspect-scene" className="mt-6 space-y-5">
       <div>
-        <p className="text-2xs text-muted-foreground uppercase tracking-wide">
+        <Eyebrow as="div">
           Scene {video.i + 1} of {video.total}
-        </p>
-        <h3 className="mt-1 font-medium text-foreground text-sm">Scene timing and flow</h3>
+        </Eyebrow>
+        <SectionTitle className="mt-1">Scene timing and flow</SectionTitle>
         <p className="mt-2 text-sm leading-6 text-muted-foreground">
           Edit words directly on the canvas. Scene controls stay here in the same editing session.
         </p>
@@ -257,10 +259,10 @@ function TextInspect({
 
   return (
     <div data-testid="artifact-inspect-text" className="mt-6">
-      <p className="text-2xs text-muted-foreground uppercase tracking-wide">{kind}</p>
-      <h3 className="mt-1 font-medium text-foreground text-sm">
+      <Eyebrow as="div">{kind}</Eyebrow>
+      <SectionTitle className="mt-1">
         {canFormat ? "Format the selection" : "Edit directly in the document"}
-      </h3>
+      </SectionTitle>
       <p className="mt-2 text-sm leading-6 text-muted-foreground">
         Type where the caret is. Select words to add emphasis or a link; every change joins the same
         undo history.
@@ -269,12 +271,12 @@ function TextInspect({
       {selectedText ? (
         <blockquote
           title={selectedText}
-          className="mt-4 truncate border-border border-y py-3 text-foreground text-sm"
+          className="mt-4 truncate rounded-md bg-secondary/40 px-3 py-2.5 text-foreground text-sm"
         >
           “{selectedText}”
         </blockquote>
       ) : (
-        <p className="mt-4 border-border border-y py-3 text-xs text-muted-foreground">
+        <p className="mt-4 rounded-md bg-secondary/40 px-3 py-2.5 text-xs text-muted-foreground">
           Select words in the document to enable formatting.
         </p>
       )}
@@ -386,13 +388,13 @@ function FormatButton({
 function ChooseInspect() {
   return (
     <div data-testid="artifact-inspect-choose" className="mt-6">
-      <h3 className="font-medium text-foreground text-sm">Choose content in the document</h3>
+      <SectionTitle>Choose content in the document</SectionTitle>
       <p className="mt-2 text-sm leading-6 text-muted-foreground">
         Click text to type in place, or select an image, media element, or marked box to adjust it
         with the surrounding layout visible.
       </p>
 
-      <ul className="mt-5 space-y-3 border-border border-y py-4 text-sm">
+      <ul className="mt-5 space-y-3 text-sm">
         <InspectCapability
           title="Text"
           detail="Type inline; select words for bold, italic, or link."
@@ -431,7 +433,7 @@ function SessionControls({
 }) {
   return (
     <div className="mt-auto pt-6">
-      <div className="flex items-center justify-between gap-3 border-border border-t pt-4">
+      <div className="flex items-center justify-between gap-3">
         <div>
           <p className="font-medium text-foreground text-xs">Edit history</p>
           <p className="mt-0.5 text-2xs text-muted-foreground">Text and elements share one stack</p>

--- a/apps/web/src/pages/artifact/deck-organizer.tsx
+++ b/apps/web/src/pages/artifact/deck-organizer.tsx
@@ -11,6 +11,7 @@ import {
 import { useEffect, useMemo, useRef, useState } from "react"
 import { type Artifact, api } from "@/api"
 import { ConfirmDialog } from "@/components/shared/confirm-dialog"
+import { SectionTitle } from "@/components/shared/section-title"
 import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
@@ -339,7 +340,7 @@ function OrganizerBody({ organizer, touch }: { organizer: Organizer; touch: bool
     <>
       <div className="flex items-center justify-between border-b border-border px-3 py-2.5">
         <div>
-          <h2 className="font-heading text-sm font-medium">Slides</h2>
+          <SectionTitle as="h2">Slides</SectionTitle>
           <p className="text-2xs text-muted-foreground">
             {organizer.slides.length} slide{organizer.slides.length === 1 ? "" : "s"} ·{" "}
             {organizer.dirty ? "Unsaved changes" : "No unsaved changes"}

--- a/apps/web/src/pages/artifact/export-job-list.tsx
+++ b/apps/web/src/pages/artifact/export-job-list.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query"
 import { api } from "@/api"
 import { Icon } from "@/components/icons"
+import { SectionTitle } from "@/components/shared/section-title"
 import { StatusPanel } from "@/components/shared/status-panel"
 import { Button } from "@/components/ui/button"
 import { useApiMutation } from "@/lib/use-api-mutation"
@@ -48,8 +49,8 @@ export function ExportJobList({ shortId, open }: { shortId: string; open: boolea
   if (!jobs.data?.jobs.length) return null
 
   return (
-    <div className="border-t border-border pt-4">
-      <div className="mb-2 text-sm font-medium">Recent exports</div>
+    <div className="flex flex-col gap-2">
+      <SectionTitle count={jobs.data.jobs.length}>Recent exports</SectionTitle>
       <div className="flex max-h-48 flex-col gap-2 overflow-y-auto">
         {jobs.data.jobs.map((job) => (
           <div

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -1632,14 +1632,14 @@ export function Artifact({ template = false }: { template?: boolean }) {
                     {!canPublish ? (
                       <div
                         data-testid="comment-suggestion-hint"
-                        className="border-b border-border-soft px-3 py-2 text-xs text-muted-foreground"
+                        className="px-3 py-2 text-xs text-muted-foreground"
                       >
                         You can comment on this document. Select any text to suggest a change.
                       </div>
                     ) : isLocked ? (
                       <div
                         data-testid="locked-suggestion-hint"
-                        className="border-b border-border-soft px-3 py-2 text-xs text-muted-foreground"
+                        className="px-3 py-2 text-xs text-muted-foreground"
                       >
                         Changes are locked. Suggest an edit as a comment, or unlock to publish.
                       </div>

--- a/apps/web/src/pages/artifact/inline-mention-menu.tsx
+++ b/apps/web/src/pages/artifact/inline-mention-menu.tsx
@@ -1,4 +1,5 @@
 import type { DirUser } from "@/api"
+import { Eyebrow } from "@/components/shared/section-eyebrow"
 import { cn } from "@/lib/utils"
 import type { InlineMentionMenuState } from "./use-inline-edit"
 
@@ -20,7 +21,9 @@ export function InlineMentionMenu({
       className="fixed z-50 w-72 overflow-hidden rounded-xl bg-popover p-1 shadow-[var(--shadow-pop)] ring-1 ring-foreground/10"
       style={{ left: menu.position.left, top: menu.position.top }}
     >
-      <div className="px-2.5 py-2 text-xs text-muted-foreground">Mention a collaborator</div>
+      <Eyebrow as="div" className="px-2.5 py-2">
+        Mention a collaborator
+      </Eyebrow>
       {menu.loading ? (
         <div className="px-2.5 py-2 text-sm text-muted-foreground">Finding people…</div>
       ) : menu.users.length ? (

--- a/apps/web/src/pages/artifact/linked-bundle-editor.tsx
+++ b/apps/web/src/pages/artifact/linked-bundle-editor.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react"
 import { api } from "@/api"
+import { Eyebrow } from "@/components/shared/section-eyebrow"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -200,12 +201,10 @@ export function LinkedBundleEditor({
             </span>
           </DialogDescription>
         </DialogHeader>
-        <div className="grid grid-cols-5 border-y border-border bg-muted/20">
+        <div className="grid grid-cols-5 bg-muted/20">
           {stats.map(([label, value], index) => (
             <div key={label} className={index ? "border-l border-border px-4 py-3" : "px-4 py-3"}>
-              <div className="font-mono text-2xs uppercase tracking-[0.1em] text-muted-foreground">
-                {label}
-              </div>
+              <Eyebrow as="div">{label}</Eyebrow>
               <div className="mt-1 text-lg font-semibold text-foreground">
                 {loading || inspection.problem ? "—" : value}
               </div>
@@ -214,12 +213,12 @@ export function LinkedBundleEditor({
         </div>
         <div className="px-6 pt-5">
           <div className="flex items-center justify-between rounded-t-lg border border-border bg-muted/30 px-3 py-2">
-            <div className="flex items-center gap-2 font-mono text-2xs uppercase tracking-[0.1em] text-muted-foreground">
+            <Eyebrow as="div" className="flex items-center gap-2">
               JSON source
               <span className={dirty ? "text-warning" : "text-success"}>
                 {dirty ? "Unsaved changes" : `Current v${version}`}
               </span>
-            </div>
+            </Eyebrow>
             <Button
               variant="ghost"
               size="sm"

--- a/apps/web/src/pages/artifact/linked-bundle-node-details-panel.tsx
+++ b/apps/web/src/pages/artifact/linked-bundle-node-details-panel.tsx
@@ -1,4 +1,5 @@
 import { Icon } from "@/components/icons"
+import { Eyebrow } from "@/components/shared/section-eyebrow"
 import { Button } from "@/components/ui/button"
 import type { LinkedBundleNodeNote } from "./linked-bundle-node-details"
 
@@ -12,14 +13,14 @@ export function LinkedBundleNodeDetailsPanel({
   return (
     <div className="mt-3 rounded-lg border border-border-soft bg-background/40 p-3 text-xs">
       <div className="flex items-start justify-between gap-3">
-        <div className="flex flex-wrap items-center gap-2 font-mono text-2xs uppercase tracking-[0.08em] text-muted-foreground">
+        <Eyebrow as="div" className="flex flex-wrap items-center gap-2">
           Note
           {note.source === "workflow" ? (
             <span className="rounded border border-border bg-muted/50 px-1.5 py-0.5 normal-case tracking-normal">
               Drafted from workflow
             </span>
           ) : null}
-        </div>
+        </Eyebrow>
         {onEdit ? (
           <Button
             variant="ghost"

--- a/apps/web/src/pages/artifact/linked-bundle-node-note-editor.tsx
+++ b/apps/web/src/pages/artifact/linked-bundle-node-note-editor.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react"
 import { api } from "@/api"
+import { Eyebrow } from "@/components/shared/section-eyebrow"
 import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
 import { useApiMutation } from "@/lib/use-api-mutation"
@@ -81,9 +82,7 @@ export function LinkedBundleNodeNoteEditor({
       data-testid="bundle-note-editor"
     >
       <label className="grid gap-2">
-        <span className="font-mono text-2xs uppercase tracking-[0.08em] text-muted-foreground">
-          Note
-        </span>
+        <Eyebrow as="span">Note</Eyebrow>
         <Textarea
           data-testid="bundle-note-input"
           value={note}

--- a/apps/web/src/pages/artifact/linked-bundle-now-workspace.tsx
+++ b/apps/web/src/pages/artifact/linked-bundle-now-workspace.tsx
@@ -1,5 +1,7 @@
 import { useMemo } from "react"
 import type { Artifact } from "@/api"
+import { Eyebrow } from "@/components/shared/section-eyebrow"
+import { SectionHeading, SectionTitle } from "@/components/shared/section-title"
 import { cn } from "@/lib/utils"
 import { type LinkedBundleWorkflowNode, linkedBundleNodeNote } from "./linked-bundle-node-details"
 import { linkedBundleNodeStateDot } from "./linked-bundle-node-state"
@@ -146,10 +148,8 @@ export function LinkedBundleNowWorkspace({
       >
         <span className="flex items-start justify-between gap-3">
           <span className="min-w-0">
-            <span className="font-mono text-2xs uppercase tracking-[0.1em] text-muted-foreground">
-              {diagram.title}
-            </span>
-            <span className="mt-1 block text-sm font-semibold text-foreground">{node.label}</span>
+            <Eyebrow as="span">{diagram.title}</Eyebrow>
+            <span className="mt-1 block text-sm font-medium text-foreground">{node.label}</span>
           </span>
           <span className="shrink-0 text-2xs text-muted-foreground">Open in Advanced →</span>
         </span>
@@ -214,8 +214,10 @@ export function LinkedBundleNowWorkspace({
   return (
     <div className="grid gap-5" data-testid="bundle-now-view">
       <section className="rounded-xl border border-border bg-card p-4 sm:p-6">
-        <div className="font-mono text-2xs uppercase tracking-[0.12em] text-primary">Now</div>
-        <h2 className="mt-2 max-w-3xl text-lg font-semibold tracking-tight text-foreground sm:text-2xl">
+        <Eyebrow as="div" className="text-primary">
+          Now
+        </Eyebrow>
+        <h2 className="mt-2 max-w-3xl text-balance text-lg font-medium tracking-tight text-foreground sm:text-2xl">
           {linkedBundleNowHeadline(summary)}
         </h2>
         <p className="mt-2 hidden max-w-3xl text-sm leading-relaxed text-muted-foreground sm:block">
@@ -251,7 +253,7 @@ export function LinkedBundleNowWorkspace({
       {diagrams.length ? (
         <section data-testid="bundle-now-topology">
           <div className="mb-2">
-            <h2 className="text-sm font-semibold text-foreground">{topologyTitle}</h2>
+            <SectionHeading>{topologyTitle}</SectionHeading>
             <p className="mt-0.5 text-xs text-muted-foreground">
               A compact view of the authored topology. Open a relationship for the full canvas.
             </p>
@@ -267,13 +269,11 @@ export function LinkedBundleNowWorkspace({
                 >
                   <div className="flex flex-wrap items-start justify-between gap-2">
                     <div>
-                      <div className="font-mono text-2xs uppercase tracking-[0.12em] text-primary">
+                      <Eyebrow as="div" className="text-primary">
                         {diagram.type} · {diagram.nodes.length}{" "}
                         {diagram.type === "loop" ? "steps" : "nodes"}
-                      </div>
-                      <h3 className="mt-1 text-sm font-semibold text-foreground">
-                        {diagram.title}
-                      </h3>
+                      </Eyebrow>
+                      <SectionTitle className="mt-1">{diagram.title}</SectionTitle>
                     </div>
                     <span className="font-mono text-2xs text-muted-foreground">
                       {diagram.edges.length}{" "}
@@ -338,7 +338,7 @@ export function LinkedBundleNowWorkspace({
       {summary.needsHelp.length ? (
         <section data-testid="bundle-now-needs-help">
           <div className="mb-2">
-            <h2 className="text-sm font-semibold text-destructive">Needs you</h2>
+            <SectionHeading>Needs you</SectionHeading>
             <p className="mt-0.5 text-xs text-muted-foreground">
               Only explicit agent help requests appear here.
             </p>
@@ -352,7 +352,7 @@ export function LinkedBundleNowWorkspace({
       {moving.length ? (
         <section>
           <div className="mb-2">
-            <h2 className="text-sm font-semibold text-foreground">Current work</h2>
+            <SectionHeading>Current work</SectionHeading>
             <p className="mt-0.5 text-xs text-muted-foreground">
               Active, waiting, and blocked work—without the graph mechanics.
             </p>
@@ -366,7 +366,7 @@ export function LinkedBundleNowWorkspace({
       {summary.next.length ? (
         <section>
           <div className="mb-2">
-            <h2 className="text-sm font-semibold text-foreground">Likely next</h2>
+            <SectionHeading>Likely next</SectionHeading>
             <p className="mt-0.5 text-xs text-muted-foreground">
               Pending work directly downstream from what is current.
             </p>
@@ -380,7 +380,7 @@ export function LinkedBundleNowWorkspace({
       {loops.length ? (
         <section>
           <div className="mb-2">
-            <h2 className="text-sm font-semibold text-foreground">Improvement attempts</h2>
+            <SectionHeading>Improvement attempts</SectionHeading>
             <p className="mt-0.5 text-xs text-muted-foreground">
               Loops read as goals, current attempts, and stop conditions here.
             </p>
@@ -398,10 +398,8 @@ export function LinkedBundleNowWorkspace({
                 >
                   <span className="flex items-start justify-between gap-3">
                     <span>
-                      <span className="font-mono text-2xs uppercase tracking-[0.1em] text-muted-foreground">
-                        Improvement loop
-                      </span>
-                      <span className="mt-1 block text-sm font-semibold text-foreground">
+                      <Eyebrow as="span">Improvement loop</Eyebrow>
+                      <span className="mt-1 block text-sm font-medium text-foreground">
                         {loop.title}
                       </span>
                     </span>
@@ -420,20 +418,18 @@ export function LinkedBundleNowWorkspace({
                   </span>
                   <dl className="mt-3 grid gap-2 text-xs sm:grid-cols-3 xl:grid-cols-1 2xl:grid-cols-3">
                     <div>
-                      <dt className="font-mono text-2xs uppercase text-muted-foreground">Goal</dt>
+                      <Eyebrow as="dt">Goal</Eyebrow>
                       <dd className="mt-1 text-foreground">{loop.goal ?? "Not stated"}</dd>
                     </div>
                     <div>
-                      <dt className="font-mono text-2xs uppercase text-muted-foreground">
-                        Current attempt
-                      </dt>
+                      <Eyebrow as="dt">Current attempt</Eyebrow>
                       <dd className="mt-1 text-foreground">
                         {current.map((node) => node.label).join(", ") ||
                           (complete ? "Completed" : "Not stated")}
                       </dd>
                     </div>
                     <div>
-                      <dt className="font-mono text-2xs uppercase text-muted-foreground">Stop</dt>
+                      <Eyebrow as="dt">Stop</Eyebrow>
                       <dd className="mt-1 text-foreground">{loop.stop ?? "Not stated"}</dd>
                     </div>
                   </dl>

--- a/apps/web/src/pages/artifact/linked-bundle-panel.tsx
+++ b/apps/web/src/pages/artifact/linked-bundle-panel.tsx
@@ -1,6 +1,7 @@
 import type { Artifact, Comment } from "@/api"
 import { Icon } from "@/components/icons"
-import { Count } from "@/components/shared/section-eyebrow"
+import { Count, Eyebrow } from "@/components/shared/section-eyebrow"
+import { SectionTitle } from "@/components/shared/section-title"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 import { parseAnchor } from "./types"
@@ -101,14 +102,12 @@ function DiagramCard({
   return (
     <section className="overflow-hidden rounded-lg border border-border bg-card">
       <div className="border-b border-border-soft px-3 py-3">
-        <div className="font-mono text-2xs uppercase tracking-[0.12em] text-muted-foreground">
-          {diagram.type}
-        </div>
-        <h3 className="mt-1 text-sm font-semibold leading-snug text-foreground">{diagram.title}</h3>
+        <Eyebrow as="div">{diagram.type}</Eyebrow>
+        <SectionTitle className="mt-1">{diagram.title}</SectionTitle>
       </div>
 
       {diagram.type === "loop" ? (
-        <div className="border-b border-border-soft bg-muted/20">
+        <div className="bg-muted/20">
           {(["goal", "evaluate", "stop"] as const).map((key) => {
             const target = linkedBundleReviewTarget(diagram.id, "policy", key)
             const value = diagram[key] ?? "Not stated"
@@ -126,10 +125,10 @@ function DiagramCard({
         </div>
       ) : null}
 
-      <div className="px-3 pb-1 pt-3 font-mono text-2xs uppercase tracking-[0.12em] text-muted-foreground">
+      <Eyebrow as="div" className="px-3 pb-1 pt-3">
         {diagram.nodes.length} {nodeKind.toLowerCase()}
         {diagram.nodes.length === 1 ? "" : "s"}
-      </div>
+      </Eyebrow>
       <div>
         {diagram.nodes.map((node) => {
           const target = linkedBundleReviewTarget(diagram.id, "node", node.id)
@@ -166,14 +165,14 @@ function DiagramCard({
       </div>
 
       {diagram.edges.length ? (
-        <details className="border-t border-border-soft">
+        <details className="pt-1">
           <summary className="cursor-pointer px-3 py-2.5 text-xs font-medium text-muted-foreground hover:text-foreground">
             {diagram.edges.length}{" "}
             {diagram.type === "loop"
               ? `transition${diagram.edges.length === 1 ? "" : "s"}`
               : `relationship${diagram.edges.length === 1 ? "" : "s"}`}
           </summary>
-          <div className="border-t border-border-soft">
+          <div>
             {diagram.edges.map((edge, index) => {
               const local = `${index}-${edge.from}-${edge.to}`
               const target = linkedBundleReviewTarget(diagram.id, "edge", local)
@@ -221,7 +220,7 @@ export function LinkedBundlePanel({
       <div className="border-b border-border px-3 py-3">
         <div className="flex items-start gap-2">
           <div className="min-w-0 flex-1">
-            <div className="text-sm font-semibold text-foreground">Bundle map</div>
+            <SectionTitle as="h2">Bundle map</SectionTitle>
             <div className="mt-1 font-mono text-2xs text-muted-foreground">
               {bundle.members.length} artifacts · {loops} loop{loops === 1 ? "" : "s"} · {graphs}{" "}
               graph{graphs === 1 ? "" : "s"}
@@ -252,12 +251,10 @@ export function LinkedBundlePanel({
       <div className="grid gap-3 p-3">
         <section className="overflow-hidden rounded-lg border border-border bg-card">
           <div className="border-b border-border-soft px-3 py-3">
-            <div className="font-mono text-2xs uppercase tracking-[0.12em] text-muted-foreground">
-              Artifacts
-            </div>
-            <h3 className="mt-1 text-sm font-semibold leading-snug text-foreground">
+            <Eyebrow as="div">Artifacts</Eyebrow>
+            <SectionTitle className="mt-1">
               {bundle.members.length} living artifact{bundle.members.length === 1 ? "" : "s"}
-            </h3>
+            </SectionTitle>
           </div>
           <div>
             {bundle.members.map((member) => {

--- a/apps/web/src/pages/artifact/linked-bundle-workspace.tsx
+++ b/apps/web/src/pages/artifact/linked-bundle-workspace.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from "react"
 import type { Artifact, Comment, DirUser } from "@/api"
 import { Icon } from "@/components/icons"
-import { Count } from "@/components/shared/section-eyebrow"
+import { Count, Eyebrow } from "@/components/shared/section-eyebrow"
+import { SectionHeading, SectionTitle } from "@/components/shared/section-title"
 import { Button } from "@/components/ui/button"
 import { ago } from "@/lib/time"
 import { cn } from "@/lib/utils"
@@ -400,10 +401,10 @@ function DiagramWorkspace({
     <section className="overflow-hidden rounded-xl border border-border bg-card">
       <div className="flex flex-wrap items-start justify-between gap-3 border-b border-border-soft px-4 py-3.5">
         <div>
-          <div className="font-mono text-2xs uppercase tracking-[0.12em] text-muted-foreground">
+          <Eyebrow as="div">
             {diagram.type} · {diagram.nodes.length} {diagram.type === "loop" ? "steps" : "nodes"}
-          </div>
-          <h3 className="mt-1 text-base font-semibold text-foreground">{diagram.title}</h3>
+          </Eyebrow>
+          <SectionTitle className="mt-1">{diagram.title}</SectionTitle>
         </div>
         <div className="flex items-center gap-3">
           <span className="text-xs text-muted-foreground">
@@ -478,9 +479,7 @@ function DiagramWorkspace({
                   active && "bg-primary/5",
                 )}
               >
-                <span className="font-mono text-2xs uppercase tracking-[0.1em] text-muted-foreground">
-                  {key}
-                </span>
+                <Eyebrow as="span">{key}</Eyebrow>
                 <span className="mt-1 block line-clamp-2 text-xs text-foreground">
                   {diagram[key] ?? "Not stated"}
                 </span>
@@ -493,9 +492,9 @@ function DiagramWorkspace({
 
       {currentNodes.length ? (
         <div className="flex items-center gap-2 overflow-x-auto border-b border-border-soft bg-muted/15 px-3 py-2 sm:hidden">
-          <span className="shrink-0 font-mono text-2xs uppercase tracking-[0.1em] text-muted-foreground">
+          <Eyebrow as="span" className="shrink-0">
             Current
-          </span>
+          </Eyebrow>
           {currentNodes.map((node) => (
             <button
               key={node.id}
@@ -656,11 +655,11 @@ function DiagramWorkspace({
                   >
                     <span className="flex min-w-0 items-center gap-2">
                       <span className={cn("size-2 shrink-0 rounded-full", stateDot(node.state))} />
-                      <span className="truncate text-sm font-semibold text-foreground">
+                      <span className="truncate text-sm font-medium text-foreground">
                         {node.label}
                       </span>
                       {node.help?.needed ? (
-                        <span className="ml-auto shrink-0 rounded border border-destructive/40 bg-destructive/10 px-1.5 py-0.5 font-mono text-2xs font-semibold uppercase tracking-[0.08em] text-destructive">
+                        <span className="ml-auto shrink-0 rounded border border-destructive/40 bg-destructive/10 px-1.5 py-0.5 font-mono text-2xs font-semibold text-destructive">
                           Needs help
                         </span>
                       ) : null}
@@ -702,11 +701,9 @@ function DiagramWorkspace({
           {selection ? (
             <div data-testid="bundle-selection" className="grid items-start gap-4">
               <div className="min-w-0">
-                <div className="font-mono text-2xs uppercase tracking-[0.12em] text-muted-foreground">
-                  {selection.eyebrow}
-                </div>
+                <Eyebrow as="div">{selection.eyebrow}</Eyebrow>
                 <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1">
-                  <h4 className="text-base font-semibold text-foreground">{selection.title}</h4>
+                  <SectionTitle as="h4">{selection.title}</SectionTitle>
                   {selection.state ? (
                     <span className="flex items-center gap-1.5 text-xs">
                       <span className={cn("size-2 rounded-full", stateDot(selection.state))} />
@@ -824,14 +821,9 @@ function ArtifactShelf({
       )}
       data-testid="bundle-artifact-shelf"
     >
-      <div className="mb-2 flex items-baseline justify-between gap-3">
-        <div>
-          <h2 className="text-sm font-semibold text-foreground">Living artifacts</h2>
-          <p className="mt-0.5 text-2xs text-muted-foreground">Always in this workspace</p>
-        </div>
-        <span className="shrink-0 font-mono text-2xs text-muted-foreground">
-          {members.length} total
-        </span>
+      <div className="mb-2">
+        <SectionHeading count={members.length}>Living artifacts</SectionHeading>
+        <p className="mt-0.5 text-2xs text-muted-foreground">Always in this workspace</p>
       </div>
       <div className="flex gap-2 overflow-x-auto pb-2 lg:grid lg:overflow-visible lg:pb-0">
         {members.map((member) => (
@@ -1014,9 +1006,9 @@ export function LinkedBundleWorkspace({
       <div className="sticky top-0 z-30 border-b border-border bg-background/95 px-4 py-3 backdrop-blur sm:px-6">
         <div className="mx-auto grid max-w-[90rem] gap-3">
           <div className="min-w-0">
-            <div className="font-mono text-2xs uppercase tracking-[0.12em] text-primary">
+            <Eyebrow as="div" className="text-primary">
               Linked bundle workspace
-            </div>
+            </Eyebrow>
             <p className="mt-1 max-w-3xl text-sm text-muted-foreground">{bundle.purpose}</p>
             <div className="mt-2 font-mono text-2xs text-muted-foreground">
               {bundle.members.length} artifacts · {loops} loop{loops === 1 ? "" : "s"} · {graphs}{" "}
@@ -1132,12 +1124,10 @@ export function LinkedBundleWorkspace({
           ) : diagrams.length ? (
             <div className="grid gap-4" data-testid="bundle-advanced-view">
               <div className="rounded-xl border border-border bg-card p-4">
-                <div className="font-mono text-2xs uppercase tracking-[0.12em] text-muted-foreground">
-                  Advanced
-                </div>
-                <h2 className="mt-1 text-base font-semibold text-foreground">
+                <Eyebrow as="div">Advanced</Eyebrow>
+                <SectionTitle as="h2" className="mt-1">
                   Full graph and authored state
-                </h2>
+                </SectionTitle>
                 <p className="mt-1 text-xs text-muted-foreground">
                   Inspect exact relationships, tiers, confidence, help state, and loop policy.
                 </p>

--- a/apps/web/src/pages/artifact/public-viewer.tsx
+++ b/apps/web/src/pages/artifact/public-viewer.tsx
@@ -4,6 +4,7 @@ import { type ReactNode, useState } from "react"
 import type { Artifact, Viewer } from "@/api"
 import { Icon } from "@/components/icons"
 import { Logo } from "@/components/shared/logo"
+import { Eyebrow } from "@/components/shared/section-eyebrow"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -207,9 +208,7 @@ export function PublicViewer({
           data-testid="template-strip"
           className="flex shrink-0 flex-wrap items-center gap-x-4 gap-y-2 border-b border-border bg-muted/40 px-4 py-2 text-sm max-sm:px-3"
         >
-          <span className="font-mono text-2xs uppercase tracking-wider text-muted-foreground">
-            Template
-          </span>
+          <Eyebrow>Template</Eyebrow>
           <span className="min-w-0 flex-1 text-muted-foreground">
             Make a copy to start from it, or hand it to your agent.
           </span>

--- a/apps/web/src/pages/artifact/share-dialog.tsx
+++ b/apps/web/src/pages/artifact/share-dialog.tsx
@@ -14,7 +14,8 @@ import {
   type WorkspaceAccess,
 } from "@/api"
 import { Icon } from "@/components/icons"
-import { Eyebrow, SectionEyebrow } from "@/components/shared/section-eyebrow"
+import { Eyebrow } from "@/components/shared/section-eyebrow"
+import { SectionTitle } from "@/components/shared/section-title"
 import {
   accessIcon,
   accessSummary,
@@ -487,7 +488,7 @@ export function ShareButton({
               onPasswordSet: setPassword,
             }}
             workspaceChildren={
-              <div className="mt-3 flex items-center justify-between gap-3 border-t border-border-soft pt-3">
+              <div className="mt-3 flex items-center justify-between gap-3">
                 <div className="min-w-0">
                   <div className="text-sm text-foreground">Show in the workspace library</div>
                   <div className="text-xs text-muted-foreground">
@@ -505,7 +506,7 @@ export function ShareButton({
             }
             worldChildren={
               <>
-                <div className="mt-3 flex items-center justify-between gap-3 border-t border-border-soft pt-3">
+                <div className="mt-3 flex items-center justify-between gap-3">
                   <div className="min-w-0">
                     <div className="text-sm text-foreground">List in the public directory</div>
                     <div className="text-xs text-muted-foreground">
@@ -570,9 +571,9 @@ export function ShareButton({
               not per-person rows. */}
           {grants.length > 0 && (
             <div>
-              <SectionEyebrow count={grants.length > 1 ? grants.length : undefined}>
+              <SectionTitle count={grants.length > 1 ? grants.length : undefined}>
                 Reachable through collections
-              </SectionEyebrow>
+              </SectionTitle>
               <div className="-mx-2 mt-1 flex flex-col">
                 {grants.map((g) => (
                   <div

--- a/apps/web/src/pages/artifact/workflow-preview.tsx
+++ b/apps/web/src/pages/artifact/workflow-preview.tsx
@@ -1,4 +1,6 @@
 import type { Artifact } from "@/api"
+import { Eyebrow } from "@/components/shared/section-eyebrow"
+import { SectionHeading, SectionTitle } from "@/components/shared/section-title"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 import { WorkflowRunHistory } from "./workflow-run-history"
@@ -18,16 +20,16 @@ const Section = ({
   if (!items.length) return null
   return (
     <section className="min-w-0">
-      <h3
+      <Eyebrow
+        as="h3"
         className={cn(
-          "font-mono text-2xs font-semibold uppercase tracking-[0.11em] text-muted-foreground",
           tone === "pause" && "text-warning",
           tone === "effect" && "text-insights",
           tone === "limit" && "text-destructive",
         )}
       >
         {title}
-      </h3>
+      </Eyebrow>
       <ul className="mt-2 grid gap-2">
         {items.map((item) => (
           <li key={item} className="flex min-w-0 gap-2 text-sm leading-relaxed text-foreground">
@@ -56,7 +58,7 @@ export const workflowTriggerLabel = (startsWhen: string): string => {
 
 const RunPath = ({ diagram }: { diagram: PreviewDiagram }) => (
   <section className="min-w-0">
-    <h3 className="text-sm font-semibold text-foreground">The run</h3>
+    <SectionTitle>The run</SectionTitle>
     <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
       One Agent session per step attempt. Later steps start only when their stated condition is met.
     </p>
@@ -68,12 +70,12 @@ const RunPath = ({ diagram }: { diagram: PreviewDiagram }) => (
               key={session.node_id}
               className="flex min-w-0 gap-3 rounded-lg border border-border-soft bg-background/45 p-3"
             >
-              <span className="grid size-6 shrink-0 place-items-center rounded-full bg-primary/10 font-mono text-2xs font-semibold text-primary">
+              <span className="grid size-6 shrink-0 place-items-center rounded-full bg-primary/10 font-mono text-2xs font-medium text-primary">
                 {index + 1}
               </span>
               <div className="min-w-0 flex-1">
                 <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
-                  <span className="break-words text-sm font-semibold text-foreground">
+                  <span className="break-words text-sm font-medium text-foreground">
                     {session.label}
                   </span>
                   <span className="max-w-full break-all rounded-md bg-muted/60 px-1.5 py-0.5 font-mono text-2xs text-muted-foreground">
@@ -101,7 +103,7 @@ const RunPath = ({ diagram }: { diagram: PreviewDiagram }) => (
 
 const RunConsiderations = ({ diagram }: { diagram: PreviewDiagram }) => (
   <aside className="min-w-0 rounded-lg border border-border-soft bg-muted/20 p-4">
-    <h3 className="text-sm font-semibold text-foreground">Things to know</h3>
+    <SectionTitle>Things to know</SectionTitle>
     <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
       The choices, pauses, and limits that can change the path.
     </p>
@@ -124,7 +126,7 @@ const RunConsiderations = ({ diagram }: { diagram: PreviewDiagram }) => (
 const ScenarioChecks = ({ scenarios }: { scenarios: PreviewDiagram["scenarios"] }) => {
   if (!scenarios.length) return null
   return (
-    <details className="border-t border-border-soft px-4 py-3 sm:px-5">
+    <details className="px-4 pb-4 sm:px-5">
       <summary className="cursor-pointer text-xs font-medium text-foreground">
         Checks passed · {scenarios.length} scenario{scenarios.length === 1 ? "" : "s"}
       </summary>
@@ -134,9 +136,7 @@ const ScenarioChecks = ({ scenarios }: { scenarios: PreviewDiagram["scenarios"] 
             key={`${scenario.kind}-${scenario.outcome}`}
             className="rounded-lg border border-border-soft p-3"
           >
-            <div className="font-mono text-2xs uppercase text-muted-foreground">
-              {scenario.kind}
-            </div>
+            <Eyebrow as="div">{scenario.kind}</Eyebrow>
             <div className="mt-1 break-words text-xs leading-relaxed text-foreground">
               {scenario.outcome}
             </div>
@@ -164,10 +164,12 @@ const DiagramPreview = ({
   >
     <header className="flex flex-wrap items-center justify-between gap-3 border-b border-border-soft px-4 py-3 sm:px-5">
       <div className="min-w-0">
-        <div className="font-mono text-2xs uppercase tracking-[0.12em] text-primary">Workflow</div>
-        <h2 className="mt-1 break-words text-base font-semibold text-foreground">
+        <Eyebrow as="div" className="text-primary">
+          Workflow
+        </Eyebrow>
+        <SectionTitle as="h2" className="mt-1">
           {diagram.title}
-        </h2>
+        </SectionTitle>
       </div>
       {onRun ? (
         <Button
@@ -226,7 +228,7 @@ export function WorkflowPreview({
         <div className="flex flex-wrap items-center gap-2">
           <span
             className={cn(
-              "inline-flex items-center gap-2 rounded-full border px-2.5 py-1 font-mono text-2xs font-semibold uppercase tracking-[0.08em]",
+              "inline-flex items-center gap-2 rounded-full border px-2.5 py-1 font-mono text-2xs font-medium",
               ready
                 ? "border-success/25 bg-success/10 text-success"
                 : "border-destructive/25 bg-destructive/10 text-destructive",
@@ -237,9 +239,9 @@ export function WorkflowPreview({
           </span>
           <span className="text-xs text-muted-foreground">Preview only · nothing has started</span>
         </div>
-        <h2 className="mt-3 text-lg font-semibold text-foreground">
+        <SectionHeading as="h2" className="mt-3">
           {ready ? "Review the run before it starts" : "Fix these blockers before run"}
-        </h2>
+        </SectionHeading>
         {preview.purpose ? (
           <p className="mt-1 max-w-3xl text-sm leading-relaxed text-muted-foreground">
             {preview.purpose}

--- a/apps/web/src/pages/artifact/workflow-run-history.tsx
+++ b/apps/web/src/pages/artifact/workflow-run-history.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query"
 import { api, type WorkflowRunSummary } from "@/api"
+import { Eyebrow } from "@/components/shared/section-eyebrow"
 import { ago } from "@/lib/time"
 import { cn } from "@/lib/utils"
 
@@ -68,7 +69,7 @@ const WorkflowAttemptTimeline = ({ attempts }: { attempts: WorkflowAttempt[] }) 
           <div className="min-w-0">
             <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1">
               <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
-                <span className="break-all font-mono text-xs font-semibold text-foreground">
+                <span className="break-all font-mono text-xs font-medium text-foreground">
                   {attempt.nodeId}
                 </span>
                 <span className="text-2xs text-muted-foreground">
@@ -113,31 +114,27 @@ export function WorkflowRunHistory({ shortId, diagramId }: { shortId: string; di
 
   if (query.isPending) {
     return (
-      <div className="border-t border-border-soft px-4 py-3 text-xs text-muted-foreground sm:px-5">
+      <div className="px-4 pb-4 text-xs text-muted-foreground sm:px-5" role="status">
         Checking recent runs…
       </div>
     )
   }
   if (query.isError) {
     return (
-      <div className="border-t border-border-soft px-4 py-3 text-xs text-destructive sm:px-5">
-        Couldn’t load recent runs.
-      </div>
+      <div className="px-4 pb-4 text-xs text-destructive sm:px-5">Couldn’t load recent runs.</div>
     )
   }
   if (query.data.runs.length === 0) {
     return (
-      <div className="border-t border-border-soft px-4 py-3 text-xs text-muted-foreground sm:px-5">
+      <div className="px-4 pb-4 text-xs text-muted-foreground sm:px-5">
         No runs yet. Starting this workflow creates a separate, version-pinned run.
       </div>
     )
   }
 
   return (
-    <section className="border-t border-border-soft px-4 py-3 sm:px-5" data-testid="workflow-runs">
-      <div className="font-mono text-2xs uppercase tracking-[0.12em] text-muted-foreground">
-        Recent runs
-      </div>
+    <section className="px-4 pb-4 sm:px-5" data-testid="workflow-runs">
+      <Eyebrow as="div">Recent runs</Eyebrow>
       <div className="mt-2 grid gap-2">
         {query.data.runs.map((run, index) => (
           <article

--- a/apps/web/src/pages/brandprint/brandprint-section.tsx
+++ b/apps/web/src/pages/brandprint/brandprint-section.tsx
@@ -5,6 +5,7 @@ import { useRef, useState } from "react"
 import { api, type OrgSettings } from "@/api"
 import { Icon } from "@/components/icons"
 import { LoadError } from "@/components/shared/load-error"
+import { SectionTitle } from "@/components/shared/section-title"
 import { SettingRow } from "@/components/shared/setting-row"
 import { SettingsGroup } from "@/components/shared/settings-group"
 import { Badge } from "@/components/ui/badge"
@@ -632,7 +633,7 @@ function BrandprintDocs({
   })
   return (
     <div className="flex flex-col gap-2 py-3.5">
-      <p className="text-sm font-medium text-foreground">Documents</p>
+      <SectionTitle>Documents</SectionTitle>
       {isError ? (
         <p className="text-sm text-muted-foreground">
           Couldn't load the docs.{" "}

--- a/apps/web/src/pages/brandprint/profile-panel.tsx
+++ b/apps/web/src/pages/brandprint/profile-panel.tsx
@@ -3,6 +3,7 @@ import { Link } from "@tanstack/react-router"
 import { useState } from "react"
 import { API_BASE, ApiError, api, type DirUser } from "@/api"
 import { ConnectAgentButton, PromptBlock, publicUrl } from "@/components/shared/connect-agent"
+import { SectionTitle } from "@/components/shared/section-title"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
 import { toast } from "@/components/ui/sonner"
@@ -49,7 +50,7 @@ export function ProfilePanel({ profileId }: { profileId: string }) {
       <section className="flex flex-col gap-3" data-testid="brandprint-profile-live">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
-            <h2 className="text-base font-medium text-foreground">Brand profile</h2>
+            <SectionTitle as="h2">Brand profile</SectionTitle>
             <p className="text-sm text-muted-foreground">
               Live. Every agent connected to this workspace reads it before authoring. An agent's
               change to it always opens a review round for you on the document.
@@ -129,9 +130,7 @@ function HandoffCard({ profileId, onDismiss }: { profileId: string; onDismiss?: 
         className="flex flex-col gap-1 rounded-lg border bg-secondary/40 px-4 py-3"
         data-testid="brandprint-generate-queued"
       >
-        <h2 className="text-base font-medium text-foreground">
-          Your agent is building your Brandprint
-        </h2>
+        <SectionTitle as="h2">Your agent is building your Brandprint</SectionTitle>
         <p className="text-sm text-pretty text-muted-foreground">
           The build brief is queued. The built profile will appear here after your agent's next
           session. You can leave this page open or come back later.
@@ -146,9 +145,9 @@ function HandoffCard({ profileId, onDismiss }: { profileId: string; onDismiss?: 
     >
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
-          <h2 className="text-base font-medium text-foreground">
+          <SectionTitle as="h2">
             {regenerating ? "Regenerate your brand profile" : "Finish with your agent"}
-          </h2>
+          </SectionTitle>
           <p className="text-sm text-pretty text-muted-foreground">
             {regenerating
               ? "Give your agent the brief again to rebuild the profile from the current sources. The new version will appear here for review."

--- a/apps/web/src/pages/context/builder.tsx
+++ b/apps/web/src/pages/context/builder.tsx
@@ -6,6 +6,7 @@ import { ChatThread } from "@/components/chat/chat-thread"
 import { useChatSession } from "@/components/chat/use-chat-session"
 import { Icon } from "@/components/icons"
 import { PageShell } from "@/components/shared/page-shell"
+import { SectionTitle } from "@/components/shared/section-title"
 import { StatusPanel } from "@/components/shared/status-panel"
 import { Button } from "@/components/ui/button"
 import { copyText } from "@/lib/clipboard"
@@ -24,7 +25,9 @@ function AgentDoor() {
     >
       <div className="flex items-center gap-2">
         <Icon name="sparkles" className="size-4 text-muted-foreground" />
-        <h2 className="text-sm font-medium text-foreground">{BUILDER_COPY.agentDoorTitle}</h2>
+        <SectionTitle as="h2" className="min-w-0 flex-1">
+          {BUILDER_COPY.agentDoorTitle}
+        </SectionTitle>
       </div>
       <p className="text-sm text-muted-foreground">{BUILDER_COPY.agentDoorBody}</p>
       <div className="flex items-start gap-2">
@@ -146,7 +149,7 @@ export function AgentBuilderPage() {
         </div>
       )}
 
-      <div className="flex flex-col gap-3 border-t border-border-soft pt-4">
+      <div className="flex flex-col gap-3">
         <button
           type="button"
           data-testid="builder-expert-door"

--- a/apps/web/src/pages/context/console.tsx
+++ b/apps/web/src/pages/context/console.tsx
@@ -1,6 +1,6 @@
 import { useInfiniteQuery, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Link, useParams } from "@tanstack/react-router"
-import { Copy as CopyIcon, Cpu, Plug, TriangleAlert } from "lucide-react"
+import { Copy as CopyIcon, TriangleAlert } from "lucide-react"
 import { useEffect, useState } from "react"
 import {
   ApiError,
@@ -17,7 +17,8 @@ import { EmptyState } from "@/components/shared/empty-state"
 import { LoadError } from "@/components/shared/load-error"
 import { PageShell } from "@/components/shared/page-shell"
 import { PersonSearchInput } from "@/components/shared/person-search-input"
-import { Eyebrow, SectionEyebrow } from "@/components/shared/section-eyebrow"
+import { Eyebrow } from "@/components/shared/section-eyebrow"
+import { SectionTitle } from "@/components/shared/section-title"
 import { Spinner } from "@/components/shared/spinner"
 import { StatusPanel } from "@/components/shared/status-panel"
 import { Badge, type badgeVariants } from "@/components/ui/badge"
@@ -345,7 +346,7 @@ function Console({ id }: { id: string }) {
             {sourcesCount > 0 && <SourcesCard count={sourcesCount} />}
             {isOwner && (
               <div className="rounded-xl border bg-card p-3.5">
-                <SectionEyebrow className="mb-2.5">Access</SectionEyebrow>
+                <SectionTitle className="mb-2.5">Access</SectionTitle>
                 <ContextAccess id={id} name={context.name} policy={context.ask_policy} />
               </div>
             )}
@@ -473,7 +474,7 @@ function ContextStatusWorkspace({
     >
       <div className="rounded-xl border bg-card p-4">
         <Eyebrow>Now</Eyebrow>
-        <h2 className="mt-2 text-base font-semibold tracking-tight text-foreground">
+        <h2 className="mt-2 text-base font-medium tracking-tight text-foreground">
           {summary.headline}
         </h2>
         <div className="mt-3 flex flex-wrap items-center gap-1.5 font-mono text-2xs">
@@ -537,7 +538,7 @@ function ContextStatusWorkspace({
       <div className="min-w-0 rounded-xl border bg-card p-4" data-testid="context-artifact-shelf">
         <div className="mb-2 flex items-baseline justify-between gap-3">
           <div>
-            <h2 className="text-sm font-semibold text-foreground">Living artifacts</h2>
+            <SectionTitle as="h2">Living artifacts</SectionTitle>
             <p className="mt-0.5 text-2xs text-muted-foreground">
               Latest results stay visible as they evolve
             </p>
@@ -652,9 +653,9 @@ function ContextAccess({
 
         <div className="flex flex-col gap-6">
           <div>
-            <SectionEyebrow action={policyMut.isPending && <Spinner className="size-3" />}>
+            <SectionTitle action={policyMut.isPending && <Spinner className="size-3" />}>
               Who can ask
-            </SectionEyebrow>
+            </SectionTitle>
             <div className="mt-2 flex flex-col">
               <AccessSegmentToggle
                 segments={CONTEXT_SEGMENTS}
@@ -673,7 +674,7 @@ function ContextAccess({
 
           {policy === "invited" && (
             <div>
-              <SectionEyebrow count={roster?.length}>Invited to ask</SectionEyebrow>
+              <SectionTitle count={roster?.length}>Invited to ask</SectionTitle>
               <form onSubmit={add} className="mt-2 flex items-center gap-2">
                 <PersonSearchInput
                   value={email}
@@ -719,7 +720,7 @@ function ContextAccess({
             </div>
           )}
 
-          <div className="flex items-center gap-2 border-t border-border-soft pt-3 text-xs text-muted-foreground">
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
             <Icon name="lock" className="size-3.5" />
             Workspace members only. People outside this workspace cannot use the Agent.
           </div>
@@ -805,7 +806,7 @@ function RunnerCard({
       className="flex flex-col gap-2.5 rounded-xl border bg-card p-3.5"
       data-testid="rail-runner"
     >
-      <SectionEyebrow icon={<Cpu className="size-3" />}>Doing work</SectionEyebrow>
+      <SectionTitle>Doing work</SectionTitle>
       <div className="flex items-center gap-1.5 text-xs text-foreground">
         <span className={cn("size-1.5 rounded-full", dot)} aria-hidden />
         {status}
@@ -818,7 +819,8 @@ function RunnerCard({
           : "None is connected right now, so tasks wait in line and run once one is."}
       </p>
       {isOwner && (
-        <div className="flex flex-col gap-2 border-t border-border-soft pt-2.5">
+        <div className="flex flex-col gap-2">
+          <Eyebrow as="h4">Run it yourself</Eyebrow>
           <div>
             <p className="text-2xs text-muted-foreground">
               Ask it to do something in Chat above or from your own coding session:
@@ -924,7 +926,7 @@ function SkillsCard({
 }) {
   return (
     <div className="flex flex-col gap-2 rounded-xl border bg-card p-3.5" data-testid="rail-skills">
-      <SectionEyebrow>Skills · {skills.length}</SectionEyebrow>
+      <SectionTitle count={skills.length}>Skills</SectionTitle>
       <ul className="flex flex-col gap-1.5">
         {skills.slice(0, 6).map((s) => (
           <li key={s.short_id} className="flex items-center gap-2 text-sm text-foreground">
@@ -962,7 +964,7 @@ function SourcesCard({ count }: { count: number }) {
       className="flex flex-col gap-1.5 rounded-xl border bg-card p-3.5"
       data-testid="rail-sources"
     >
-      <SectionEyebrow icon={<Plug className="size-3" />}>Sources · {count}</SectionEyebrow>
+      <SectionTitle count={count}>Sources</SectionTitle>
       <p className="text-xs text-muted-foreground">
         {count === 1 ? "One connection" : `${count} connections`} this Agent may use as tools.
       </p>
@@ -1007,7 +1009,7 @@ function ManifestTab({ context }: { context: ContextDetail }) {
 
       {skills.length > 0 && (
         <div className="flex flex-col gap-2.5">
-          <SectionEyebrow
+          <SectionTitle
             action={
               staleCount > 0 ? (
                 <span className="font-mono text-2xs text-warning">
@@ -1019,7 +1021,7 @@ function ManifestTab({ context }: { context: ContextDetail }) {
             }
           >
             Skills · {skills.length}
-          </SectionEyebrow>
+          </SectionTitle>
           <div className="overflow-x-auto rounded-xl border">
             <table className="w-full text-sm">
               <thead>
@@ -1091,7 +1093,7 @@ function ManifestTab({ context }: { context: ContextDetail }) {
 
       {context.repos && context.repos.length > 0 && (
         <div className="flex flex-col gap-2">
-          <SectionEyebrow>Repos · {context.repos.length}</SectionEyebrow>
+          <SectionTitle count={context.repos.length}>Repos</SectionTitle>
           <ul className="flex flex-col gap-1">
             {context.repos.map((r) => (
               <li key={r.url} className="flex items-center gap-2 font-mono text-sm text-foreground">
@@ -1104,8 +1106,8 @@ function ManifestTab({ context }: { context: ContextDetail }) {
         </div>
       )}
 
-      <div className="border-t pt-5">
-        <SectionEyebrow className="mb-3">Document</SectionEyebrow>
+      <div className="flex flex-col gap-3">
+        <SectionTitle>Document</SectionTitle>
         <div
           className={ANSWER_PROSE}
           // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized in answerMdToHtml (xss whitelist).
@@ -1362,9 +1364,9 @@ function SessionThread({
       </div>
 
       {session.state === "closed" ? (
-        <p className="border-t pt-3 text-sm text-muted-foreground">This conversation is closed.</p>
+        <p className="text-sm text-muted-foreground">This conversation is closed.</p>
       ) : isMine ? (
-        <div className="flex flex-col gap-2 border-t pt-3">
+        <div className="flex flex-col gap-2">
           <Textarea
             data-testid="console-followup-input"
             aria-label="Follow-up"
@@ -1397,7 +1399,7 @@ function SessionThread({
           </div>
         </div>
       ) : (
-        <div className="flex items-center border-t pt-3">
+        <div className="flex items-center">
           <Button
             variant="ghost"
             size="sm"

--- a/apps/web/src/pages/library/collections-view.tsx
+++ b/apps/web/src/pages/library/collections-view.tsx
@@ -3,6 +3,7 @@ import type { Collection } from "@/api"
 import { Icon } from "@/components/icons"
 import { EmptyState } from "@/components/shared/empty-state"
 import { Eyebrow } from "@/components/shared/section-eyebrow"
+import { SectionHeading } from "@/components/shared/section-title"
 import { Thumb } from "@/components/shared/thumb"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -143,7 +144,9 @@ export function CollectionsView({
         <>
           {digest.length > 0 && (
             <section data-testid="collections-digest">
-              <SectionRule label={week ? "Recent work" : "Latest activity"} />
+              <SectionHeading className="mb-3">
+                {week ? "Recent work" : "Latest activity"}
+              </SectionHeading>
               <div>
                 {digest.map((c) => (
                   <DigestEntry key={c.id} col={c} />
@@ -153,7 +156,9 @@ export function CollectionsView({
           )}
 
           <section data-testid="collections-index">
-            <SectionRule label="All collections · A–Z" />
+            <SectionHeading className="mb-3" action={<Eyebrow>A–Z</Eyebrow>}>
+              All collections
+            </SectionHeading>
             {/* The header names the columns; the columns hold. */}
             <Eyebrow as="div" className="flex h-6 items-center gap-3 border-b border-border px-1">
               <span className="min-w-0 flex-1">Name</span>
@@ -170,15 +175,6 @@ export function CollectionsView({
           </section>
         </>
       )}
-    </div>
-  )
-}
-
-function SectionRule({ label }: { label: string }) {
-  return (
-    <div className="mb-3 flex items-center gap-3">
-      <Eyebrow>{label}</Eyebrow>
-      <span className="h-px flex-1 bg-border-soft" />
     </div>
   )
 }

--- a/apps/web/src/pages/library/folder-header.tsx
+++ b/apps/web/src/pages/library/folder-header.tsx
@@ -1,5 +1,6 @@
 import { ChevronRight } from "lucide-react"
 import type { ReactNode } from "react"
+import { Eyebrow } from "@/components/shared/section-eyebrow"
 import { cn } from "@/lib/utils"
 
 // The one header a folder group wears, in both folder views (a manual collection's
@@ -52,20 +53,25 @@ export function FolderHeader({
           )}
           aria-hidden
         />
-        <span
-          className={cn(
-            "truncate font-mono",
-            path ? "text-xs" : "text-2xs uppercase tracking-wide",
-            muted ? "text-muted-foreground/70" : "text-muted-foreground",
-          )}
-        >
-          {label}
-        </span>
+        {path ? (
+          <span
+            className={cn(
+              "truncate font-mono text-xs",
+              muted ? "text-muted-foreground/70" : "text-muted-foreground",
+            )}
+          >
+            {label}
+          </span>
+        ) : (
+          <Eyebrow as="span" className={cn("truncate", muted && "text-muted-foreground/70")}>
+            {label}
+          </Eyebrow>
+        )}
         <span className="shrink-0 font-mono text-2xs tabular-nums text-muted-foreground/70">
           {count}
         </span>
       </button>
-      <span className="h-px min-w-4 flex-1 bg-border-soft" />
+      <span className="min-w-4 flex-1" />
       {trailing}
     </div>
   )

--- a/apps/web/src/pages/library/how-it-works.tsx
+++ b/apps/web/src/pages/library/how-it-works.tsx
@@ -9,7 +9,7 @@ export function HowItWorks() {
         later.
       </p>
 
-      <dl className="mt-5 grid divide-y border-y sm:grid-cols-3 sm:divide-x sm:divide-y-0">
+      <dl className="mt-5 grid gap-5 sm:grid-cols-3 sm:gap-8">
         <Step
           title="Publish the result"
           blurb="Give a report, plan, deck, or site a lasting URL outside the chat."
@@ -29,7 +29,7 @@ export function HowItWorks() {
 
 function Step({ title, blurb }: { title: string; blurb: string }) {
   return (
-    <div className="py-4 sm:px-5 sm:first:pl-0 sm:last:pr-0">
+    <div>
       <dt className="text-sm font-medium text-foreground">{title}</dt>
       <dd className="mt-1.5 text-base/7 text-pretty text-muted-foreground sm:text-sm/6">{blurb}</dd>
     </div>

--- a/apps/web/src/pages/library/public-collection.tsx
+++ b/apps/web/src/pages/library/public-collection.tsx
@@ -62,7 +62,7 @@ export function PublicCollection() {
   return (
     <main className="min-h-dvh bg-background">
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-5 py-8 sm:px-8 sm:py-12">
-        <header className="flex flex-wrap items-end gap-4 border-b border-border-soft pb-6">
+        <header className="flex flex-wrap items-end gap-4">
           <div className="min-w-0 flex-1">
             <div className="mb-2 flex items-center gap-2 text-sm text-muted-foreground">
               <Icon name="collection" /> Collection

--- a/apps/web/src/pages/people.tsx
+++ b/apps/web/src/pages/people.tsx
@@ -7,7 +7,7 @@ import { EmptyState } from "@/components/shared/empty-state"
 import { FollowButton } from "@/components/shared/follow-button"
 import { LoadError } from "@/components/shared/load-error"
 import { SearchField } from "@/components/shared/search-field"
-import { SectionEyebrow } from "@/components/shared/section-eyebrow"
+import { SectionHeading } from "@/components/shared/section-title"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -174,9 +174,9 @@ function PeopleGroup({
 }) {
   return (
     <section>
-      <SectionEyebrow className="mb-3" count={people.length}>
+      <SectionHeading className="mb-3" count={people.length}>
         {label}
-      </SectionEyebrow>
+      </SectionHeading>
       <ul
         role="list"
         data-testid={testId}
@@ -254,7 +254,7 @@ function PersonCard({
 function ActivityPreview({ items }: { items: Artifact[] }) {
   return (
     <section>
-      <SectionEyebrow
+      <SectionHeading
         className="mb-3"
         count={items.length}
         action={
@@ -268,7 +268,7 @@ function ActivityPreview({ items }: { items: Artifact[] }) {
         }
       >
         Recent activity
-      </SectionEyebrow>
+      </SectionHeading>
       <ul
         role="list"
         data-testid="people-activity"

--- a/apps/web/src/pages/profile/index.tsx
+++ b/apps/web/src/pages/profile/index.tsx
@@ -10,7 +10,7 @@ import { FollowButton } from "@/components/shared/follow-button"
 import { LoadError } from "@/components/shared/load-error"
 import { PageShell } from "@/components/shared/page-shell"
 import { PublicFrame } from "@/components/shared/public-frame"
-import { SectionEyebrow } from "@/components/shared/section-eyebrow"
+import { SectionHeading } from "@/components/shared/section-title"
 import { Spinner } from "@/components/shared/spinner"
 import { UsernameForm } from "@/components/shared/username-form"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
@@ -264,7 +264,7 @@ function ProfileWork({
   return (
     <section className="flex flex-col gap-3">
       <div className="flex items-center justify-between gap-3">
-        <SectionEyebrow className="flex-1">Work</SectionEyebrow>
+        <SectionHeading className="flex-1">Work</SectionHeading>
         {/* The grid/list toggle only earns its place once there's work to reshape. */}
         {!isPending && !isError && items.length > 0 && (
           <ToggleGroup

--- a/apps/web/src/pages/profile/skeleton.tsx
+++ b/apps/web/src/pages/profile/skeleton.tsx
@@ -1,6 +1,6 @@
 import { CardGrid } from "@/components/shared/card-grid"
 import { PageShell } from "@/components/shared/page-shell"
-import { SectionEyebrow } from "@/components/shared/section-eyebrow"
+import { SectionHeading } from "@/components/shared/section-title"
 import { Skeleton } from "@/components/ui/skeleton"
 import { CardSkeletonCell } from "../library/library-skeleton"
 
@@ -59,10 +59,10 @@ export function ProfilePending() {
         </div>
       </section>
 
-      {/* The Work section: the real static eyebrow (always "Work") over the grid
+      {/* The Work section: the real static heading (always "Work") over the grid
           silhouette, matching ProfileWork's own `flex flex-col gap-3` section. */}
       <section className="flex flex-col gap-3">
-        <SectionEyebrow>Work</SectionEyebrow>
+        <SectionHeading>Work</SectionHeading>
         <ProfileWorkSkeleton />
       </section>
     </PageShell>

--- a/apps/web/src/pages/roadmap.tsx
+++ b/apps/web/src/pages/roadmap.tsx
@@ -17,7 +17,7 @@ export function Roadmap() {
   return (
     <div className="dark min-h-dvh bg-background text-foreground">
       <div className="mx-auto max-w-5xl px-6 py-5">
-        <header className="flex items-center gap-2.5 border-b border-border/70 pb-5">
+        <header className="flex items-center gap-2.5 pb-5">
           <Link to="/" className="flex items-center gap-2.5">
             <Logo size={19} />
             <span className="text-sm font-semibold tracking-tight">Derive</span>
@@ -33,9 +33,7 @@ export function Roadmap() {
         </header>
 
         <div className="pt-10 pb-7">
-          <p className="font-mono text-2xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
-            Living document
-          </p>
+          <Eyebrow as="div">Living document</Eyebrow>
           <h1 className="mt-3 text-3xl font-semibold tracking-tight sm:text-4xl">
             Where Derive is going
           </h1>

--- a/apps/web/src/pages/templates/add-entry-dialog.tsx
+++ b/apps/web/src/pages/templates/add-entry-dialog.tsx
@@ -2,6 +2,7 @@ import { useReducer } from "react"
 import { type Artifact, api } from "@/api"
 import { Icon } from "@/components/icons"
 import { FormField } from "@/components/shared/form-field"
+import { Eyebrow } from "@/components/shared/section-eyebrow"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -78,9 +79,9 @@ export function AddEntryDialog({
     >
       <DialogContent className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-xl">
         <DialogHeader>
-          <p className="font-mono text-2xs uppercase tracking-wider text-muted-foreground">
+          <Eyebrow as="div">
             {step === "source" ? "1 of 2 · Choose source" : "2 of 2 · Describe starter"}
-          </p>
+          </Eyebrow>
           <DialogTitle>
             {step === "source" ? "Choose reusable work" : "Name the starter"}
           </DialogTitle>

--- a/apps/web/src/pages/templates/agent-template-dialog.tsx
+++ b/apps/web/src/pages/templates/agent-template-dialog.tsx
@@ -1,5 +1,7 @@
 import { Icon } from "@/components/icons"
 import { FormField } from "@/components/shared/form-field"
+import { Eyebrow } from "@/components/shared/section-eyebrow"
+import { SectionTitle } from "@/components/shared/section-title"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -56,9 +58,9 @@ function AgentTemplateDialogInner({
         aria-describedby={descriptionId}
       >
         <DialogHeader className="pr-7">
-          <p className="mb-1 font-mono text-2xs uppercase tracking-wider text-muted-foreground">
+          <Eyebrow as="div" className="mb-1">
             {target.kind === "context" ? "Context" : target.category}
-          </p>
+          </Eyebrow>
           <DialogTitle className="font-serif text-2xl tracking-tight [overflow-wrap:anywhere]">
             Use {target.title}
           </DialogTitle>
@@ -72,11 +74,8 @@ function AgentTemplateDialogInner({
             {target.description}
           </p>
           {target.sections?.length ? (
-            <div
-              className="mt-2.5 border-t pt-2.5"
-              data-testid="template-agent-inheritance-preview"
-            >
-              <p className="text-xs font-medium text-muted-foreground">Included sections</p>
+            <div className="mt-3" data-testid="template-agent-inheritance-preview">
+              <SectionTitle as="h4">Included sections</SectionTitle>
               <div className="mt-1.5 flex flex-wrap gap-1.5">
                 {target.sections.slice(0, 6).map((section) => (
                   <p
@@ -127,7 +126,7 @@ function AgentTemplateDialogInner({
 
           {showHandoff ? (
             <div className="grid gap-2" data-testid="template-agent-handoff-preview">
-              <p className="text-xs font-medium text-foreground">Prepared task</p>
+              <SectionTitle as="h4">Prepared task</SectionTitle>
               <Textarea
                 readOnly
                 value={handoff}

--- a/apps/web/src/pages/templates/derive-source.tsx
+++ b/apps/web/src/pages/templates/derive-source.tsx
@@ -2,6 +2,7 @@ import { useState } from "react"
 import { type Artifact, api } from "@/api"
 import { Icon } from "@/components/icons"
 import { fieldError } from "@/components/shared/field-error"
+import { SectionHeading } from "@/components/shared/section-title"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { parseRef } from "@/pages/artifact/parse-ref"
@@ -61,7 +62,7 @@ export function DeriveSource({
       <div className="flex min-w-0 flex-col gap-2">
         <div className="flex items-center gap-2">
           <Icon name="derive" className="text-muted-foreground" />
-          <h2 className="text-base font-medium text-foreground">Start from an artifact</h2>
+          <SectionHeading>Start from an artifact</SectionHeading>
         </div>
         <p className="max-w-2xl text-base/7 text-pretty text-muted-foreground sm:text-sm/6">
           Paste a Derive link, then tell the agent what you need. It will reuse the artifact’s

--- a/apps/web/src/pages/templates/index.tsx
+++ b/apps/web/src/pages/templates/index.tsx
@@ -10,6 +10,7 @@ import { PageHeader } from "@/components/shared/page-header"
 import { PageShell } from "@/components/shared/page-shell"
 import { PublicFrame } from "@/components/shared/public-frame"
 import { SearchField } from "@/components/shared/search-field"
+import { SectionHeading } from "@/components/shared/section-title"
 import { StatusPanel } from "@/components/shared/status-panel"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
@@ -104,9 +105,7 @@ export function Templates() {
   const shelfFor = (title: string, rows: TemplateArtifact[], testId: string) =>
     rows.length ? (
       <section className="flex flex-col gap-3" data-testid={testId}>
-        <h2 className="font-mono text-2xs uppercase tracking-wider text-muted-foreground">
-          {title}
-        </h2>
+        <SectionHeading count={rows.length}>{title}</SectionHeading>
         <CardGrid>
           {rows.map((template) => (
             <TemplateArtifactCard
@@ -202,10 +201,7 @@ export function Templates() {
             hotkey
           />
           {shelfState.isPending ? (
-            <div
-              className="grid min-h-64 place-items-center border-y py-12 text-center"
-              role="status"
-            >
+            <div className="grid min-h-64 place-items-center py-12 text-center" role="status">
               <div className="flex max-w-sm flex-col items-center gap-3 text-muted-foreground">
                 <Icon name="derive" size={24} className="animate-pulse" />
                 <p className="text-sm">Loading templates…</p>

--- a/apps/web/src/pages/templates/library-detail.tsx
+++ b/apps/web/src/pages/templates/library-detail.tsx
@@ -6,6 +6,7 @@ import { CardGrid } from "@/components/shared/card-grid"
 import { ConfirmDialog } from "@/components/shared/confirm-dialog"
 import { EmptyState } from "@/components/shared/empty-state"
 import { SearchField } from "@/components/shared/search-field"
+import { Eyebrow } from "@/components/shared/section-eyebrow"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { useApiMutation } from "@/lib/use-api-mutation"
@@ -38,7 +39,7 @@ export function LibraryDetail({
   })
   if (detail.isPending)
     return (
-      <div className="grid min-h-64 place-items-center border-y text-sm text-muted-foreground">
+      <div className="grid min-h-64 place-items-center text-sm text-muted-foreground" role="status">
         Opening library…
       </div>
     )
@@ -71,7 +72,7 @@ export function LibraryDetail({
   )
   return (
     <section className="flex flex-col gap-5" data-testid="template-library-detail">
-      <div className="flex flex-wrap items-start gap-3 border-b pb-5">
+      <div className="flex flex-wrap items-start gap-3">
         <Button size="sm" variant="ghost" onClick={onBack} data-testid="template-library-back">
           <Icon name="chevron-left" /> Libraries
         </Button>
@@ -81,9 +82,7 @@ export function LibraryDetail({
               <Icon name={scopeCopy[library.scope].icon} size={12} />{" "}
               {scopeCopy[library.scope].label}
             </Badge>
-            <span className="font-mono text-2xs uppercase tracking-wider text-muted-foreground">
-              {library.entry_count} starters · immutable versions
-            </span>
+            <Eyebrow>{library.entry_count} starters · immutable versions</Eyebrow>
           </div>
           <h2 className="mt-3 font-serif text-3xl font-medium tracking-tight text-foreground [overflow-wrap:anywhere]">
             {library.title}

--- a/apps/web/src/pages/templates/library-shelf.tsx
+++ b/apps/web/src/pages/templates/library-shelf.tsx
@@ -41,7 +41,6 @@ export function LibraryShelf({
   return (
     <section className="flex flex-col gap-5" data-testid="template-libraries">
       <PageHeader
-        className="border-y py-5"
         eyebrow="A shareable starting point"
         title="Libraries make useful work reusable."
         subtitle="Publish the version you trust. Others start from an independent copy, with source provenance intact."
@@ -87,7 +86,10 @@ export function LibraryShelf({
         </Button>
       </div>
       {libraries.isPending || libraries.isPlaceholderData ? (
-        <div className="grid min-h-64 place-items-center border-y text-sm text-muted-foreground">
+        <div
+          className="grid min-h-64 place-items-center text-sm text-muted-foreground"
+          role="status"
+        >
           {libraries.isPlaceholderData ? "Searching libraries…" : "Loading libraries…"}
         </div>
       ) : schemaPending ? (

--- a/apps/web/src/pages/templates/public-library.tsx
+++ b/apps/web/src/pages/templates/public-library.tsx
@@ -11,6 +11,7 @@ import { PageHeader } from "@/components/shared/page-header"
 import { PageShell } from "@/components/shared/page-shell"
 import { PublicFrame } from "@/components/shared/public-frame"
 import { SearchField } from "@/components/shared/search-field"
+import { Eyebrow } from "@/components/shared/section-eyebrow"
 import { StatusPanel } from "@/components/shared/status-panel"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -67,7 +68,6 @@ function PublicTemplateLibraryCatalogInner() {
   return (
     <PageShell width="wide" className="flex flex-col gap-8">
       <PageHeader
-        className="border-b pb-7"
         eyebrow="Public template libraries"
         title="Useful beginnings, shared openly."
         subtitle="Browse version-pinned starters from the Derive community, then tell your agent what to make with one."
@@ -82,7 +82,10 @@ function PublicTemplateLibraryCatalogInner() {
         testId="public-template-libraries-search"
       />
       {libraries.isPlaceholderData ? (
-        <div className="grid min-h-48 place-items-center border-y text-sm text-muted-foreground">
+        <div
+          className="grid min-h-48 place-items-center text-sm text-muted-foreground"
+          role="status"
+        >
           Searching libraries…
         </div>
       ) : publicLibraries.length ? (
@@ -188,14 +191,12 @@ function PublicTemplateLibraryInner({ id }: { id: string }) {
   }
   return (
     <PageShell width="wide" className="flex flex-col gap-8">
-      <section className="border-b pb-7">
+      <section>
         <div className="flex flex-wrap items-center gap-2">
           <Badge variant="outline" shape="pill">
             <Icon name={scopeIcon} size={12} /> {scopeLabel}
           </Badge>
-          <span className="font-mono text-2xs uppercase tracking-wider text-muted-foreground">
-            {data.entry_count} pinned starters
-          </span>
+          <Eyebrow>{data.entry_count} pinned starters</Eyebrow>
         </div>
         <h1 className="mt-4 max-w-3xl font-serif text-4xl font-medium leading-tight tracking-tight text-foreground sm:text-5xl">
           {data.title}

--- a/apps/web/src/pages/templates/template-entry-card.tsx
+++ b/apps/web/src/pages/templates/template-entry-card.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react"
 import type { TemplateLibraryEntry } from "@/api"
+import { Eyebrow } from "@/components/shared/section-eyebrow"
 import { Badge } from "@/components/ui/badge"
 import {
   Card,
@@ -43,9 +44,9 @@ export function TemplateEntryCard({
           </p>
         ) : null}
         {entry.sections.length > 0 ? (
-          <p className="line-clamp-1 font-mono text-2xs uppercase tracking-wider text-muted-foreground [overflow-wrap:anywhere]">
+          <Eyebrow as="div" className="line-clamp-1 [overflow-wrap:anywhere]">
             {entry.sections.join(" · ")}
-          </p>
+          </Eyebrow>
         ) : null}
       </CardContent>
       <CardFooter className="mt-auto flex-wrap gap-2">{actions}</CardFooter>

--- a/apps/web/src/pages/templates/template-library-card.tsx
+++ b/apps/web/src/pages/templates/template-library-card.tsx
@@ -2,6 +2,7 @@ import { Link } from "@tanstack/react-router"
 import type { TemplateLibrary } from "@/api"
 import { Icon } from "@/components/icons"
 import { AuthorChip } from "@/components/shared/author-chip"
+import { Eyebrow } from "@/components/shared/section-eyebrow"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -22,9 +23,7 @@ function LibraryCardContent({ library }: { library: TemplateLibrary }) {
           <Badge variant="outline" shape="pill">
             <Icon name={scopeCopy[library.scope].icon} size={12} /> {scopeCopy[library.scope].label}
           </Badge>
-          <span className="font-mono text-2xs uppercase tracking-wider text-muted-foreground">
-            {library.entry_count} starters
-          </span>
+          <Eyebrow>{library.entry_count} starters</Eyebrow>
         </div>
         <CardTitle className="font-serif text-xl tracking-tight [overflow-wrap:anywhere]">
           {library.title}

--- a/apps/web/src/pages/welcome.tsx
+++ b/apps/web/src/pages/welcome.tsx
@@ -245,10 +245,7 @@ function DoneRow({ children, testId }: { children: React.ReactNode; testId: stri
 // Replaced by DoneRow when the polling query sees the expected state.
 function WatchRow({ children, testId }: { children: React.ReactNode; testId: string }) {
   return (
-    <p
-      data-testid={testId}
-      className="flex items-center gap-2.5 border-t pt-4 text-sm text-muted-foreground"
-    >
+    <p data-testid={testId} className="flex items-center gap-2.5 text-sm text-muted-foreground">
       <span className="relative flex size-2">
         <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-muted-foreground opacity-50" />
         <span className="relative inline-flex size-2 rounded-full bg-muted-foreground" />

--- a/apps/web/src/pages/workflows/automated-workflows.tsx
+++ b/apps/web/src/pages/workflows/automated-workflows.tsx
@@ -8,6 +8,7 @@ import { ConfirmDialog } from "@/components/shared/confirm-dialog"
 import { ListRow } from "@/components/shared/list-row"
 import { LoadError } from "@/components/shared/load-error"
 import { Eyebrow } from "@/components/shared/section-eyebrow"
+import { SectionHeading } from "@/components/shared/section-title"
 import { SettingsEmpty } from "@/components/shared/settings-empty"
 import { SettingsGroup } from "@/components/shared/settings-group"
 import { StatusBadge } from "@/components/shared/status-badge"
@@ -52,7 +53,7 @@ export function AutomatedWorkflows() {
   return (
     <section className="flex flex-col gap-4">
       <div className="flex flex-col gap-1">
-        <h2 className="text-base font-semibold text-foreground">Single-agent workflows</h2>
+        <SectionHeading>Single-agent workflows</SectionHeading>
         <p className="text-sm text-muted-foreground">
           Give one Agent a standing instruction, then run it on demand, on a schedule, or after an
           event. Each start creates a separate run.

--- a/apps/web/src/pages/workflows/index.tsx
+++ b/apps/web/src/pages/workflows/index.tsx
@@ -6,6 +6,7 @@ import { ListRow } from "@/components/shared/list-row"
 import { LoadError } from "@/components/shared/load-error"
 import { PageHeader } from "@/components/shared/page-header"
 import { PageShell } from "@/components/shared/page-shell"
+import { SectionHeading } from "@/components/shared/section-title"
 import { StatusBadge } from "@/components/shared/status-badge"
 import { Skeleton } from "@/components/ui/skeleton"
 import { workflowsQuery } from "@/lib/queries"
@@ -58,7 +59,7 @@ export function Workflows() {
 
       <section className="flex flex-col gap-4" data-testid="workflow-directory">
         <div className="flex flex-col gap-1">
-          <h2 className="text-base font-semibold text-foreground">Coordinated workflows</h2>
+          <SectionHeading>Coordinated workflows</SectionHeading>
           <p className="text-sm text-muted-foreground">
             Versioned graphs and loops made from Agent steps, branches, and human pauses.
           </p>

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -145,7 +145,7 @@ Rules:
 - Headings: `font-medium` or `font-semibold`, never `font-bold`; `tracking-tight` above
   `text-xl` (globals.css already tightens h1–h6 letter-spacing); no `leading-*` overrides
   on headings; `text-balance` on headings, `text-pretty` on paragraphs.
-- `uppercase` only on mono eyebrows, always with `tracking-wide` (the `SectionEyebrow`
+- `uppercase` only on mono eyebrows, always with `tracking-wide` (the `Eyebrow`
   grammar).
 - Numbers that change (counts, stats, timers): `tabular-nums`.
 - Voice moments are set per call-site (`font-serif font-medium tracking-tight` —
@@ -172,6 +172,26 @@ Rules:
   in dark).
 - Never a heavy mid-gray divider; edges are the low-contrast hairline tokens
   (`border-border`, `border-border-soft`).
+- **Lines mark positions and structure, never groups — and no label ever carries a rule.**
+  At page scale a section is separated by whitespace and by its heading being the
+  second-largest type on the page (`SectionHeading`); inside a bounded container (dialog, card,
+  rail, console column) the title steps down one size (`SectionTitle`) and the container's own
+  edges are the only lines; a sub-group, a day or a column label is a bare mono `Eyebrow` with
+  air above it. The hairlines that remain are structural — a container's edge, a table's column
+  row, the row separators of a dense list — or positional — the activity "New" line, the login
+  "or". Never a hairline between two sibling blocks to say "new section", and never a label with
+  a rule trailing to the edge (that idiom, the old `SectionEyebrow`, is gone). Four levels, four
+  signals: page title, heading, title, eyebrow; one line-system per surface.
+  The lines that are allowed, precisely: **bars** — a container's header bar (title, tabs,
+  actions), footer or action bar, composer dock, toolbar, a card's cover-to-body edge, and a
+  vertical `w-px` between control groups inside a bar; **tables** — column-header rows and the
+  row separators of a dense list (`divide-y`, `border-t first:border-t-0`); **positions** — the
+  unread marker, the login "or", a `border-l-2` indent rail. A block that needs containment gets
+  a well (`rounded-md bg-secondary/40`) or spacing, not a rule; a loading state is a `Skeleton`,
+  not a boxed line.
+  On narrative surfaces (welcome, how-it-works, public heroes) a section heading may speak in the
+  voice register (`font-serif text-xl font-medium tracking-tight`) — a register, not a fifth
+  level — and it still carries no rule.
 - Images/screenshots/thumbnails: no borders — `outline-1 -outline-offset-1
   outline-foreground/10`.
 
@@ -351,20 +371,24 @@ variants.
   muted keeps it quiet — and matches the stock menu/select/command group labels, so the register
   reads identically everywhere. Use `Eyebrow` for card step-labels, popover section headers, and
   inline dividers instead of re-typing the class string.
-- **SectionEyebrow** — `Eyebrow` **re-inked to `text-foreground`** (a section header should be
-  seen) + tabular count (kept muted) + hairline rule to the edge. The section-level header; pairs
-  with **PageHeader**, the page-level one.
-- **SectionTitle** (`shared/section-title.tsx`) — the quiet **sans** sub-block heading (`text-sm
-  font-medium text-foreground` `<h3>` + optional right-aligned `action`): for control/card
-  sub-groups nested inside a section (Settings "Role"/"Discoverability"/"Slack", a card title)
-  where the mono eyebrow reads too technical. The warm counterpart to `SectionEyebrow`'s mono.
+- **SectionHeading** (`shared/section-title.tsx`) — the page-level section heading in the
+  chrome register (`text-base font-medium text-foreground` `<h2>`, the machine-register `Count`,
+  an optional trailing `action`, **no rule**). One step below **PageHeader**, one above
+  **SectionTitle**; Activity, People, Profile "Work" and the Collections index lead their
+  sections with it, and sections separate by whitespace. Under it, a sub-group or day label is a
+  bare `Eyebrow as="h3"` — never a label with a rule.
+- **SectionTitle** (`shared/section-title.tsx`) — the **sans** title inside a bounded container
+  (`text-sm font-medium text-foreground` `<h3>`, the machine-register `Count`, an optional
+  right-aligned `action`, no rule): Settings groups, dialog sections ("Who can open this",
+  "People with access"), the context console's cards and columns, a card title. Same anatomy as
+  `SectionHeading` one step down.
 - **LabeledDivider** (`shared/section-eyebrow.tsx`) — a label centered between two hairline rules
   (the login "or", a mid-page voice break). Owns only the flanking-rule layout; pass the label in
   whatever register fits (a mono `Eyebrow`, a voice `<h2>`), so nothing hand-rolls the two-sided
   `<Separator className="flex-1" />` pair.
 - **Count** (`shared/section-eyebrow.tsx`) — the machine-register count beside a label
   ("Members · 12"): mono `text-2xs` tabular muted, led by an aria-hidden middle dot (SRs read just
-  the number). `SectionEyebrow` bakes the same in; use `Count` for standalone label + count rows.
+  the number). `SectionHeading` and `SectionTitle` bake the same in; use `Count` for standalone label + count rows.
 - **PageHeader** (`shared/page-header.tsx`) — the ONE page title band, so screens stop
   diverging: an optional mono `Eyebrow`, the title in the house **voice** (`font-serif`
   alias + `text-2xl font-medium tracking-tight text-balance`), an optional muted subtitle,


### PR DESCRIPTION
## Summary

One header grammar for the whole app: **lines mark structure and position, never groups — and no label ever carries a rule.**

The Activity page drew three heading levels with one primitive, the mono eyebrow, told apart only by whether a hairline trailed it to the edge. The eyebrow is the smallest type on a page; heading a section with it inverts the scale, and the rule was the crutch. This replaces the crutch with headings, and applies the result everywhere so a section reads the same on every screen.

### The grammar
| Level | Primitive | Heads | Look |
|---|---|---|---|
| 1 | `PageHeader` | the page | voice register, never a rule |
| 2 | `SectionHeading` (new) | a section of a page | Geist 16px medium, mono count, optional action; whitespace between sections |
| 3 | `SectionTitle` | a section inside a dialog / card / aside / rail / settings pane | same anatomy at 14px; the container's edges are the only lines |
| 4 | `Eyebrow` | sub-group, day, column, step, popover group | mono caps, muted — the one uppercase level, always bare |
| — | lines | structure and position only | a bar's edge (header/footer/composer/toolbar), table rows, a vertical rule between control groups inside a bar, the unread marker, the login "or" |

### What changed
- `SectionEyebrow` (eyebrow + rule) is **deleted**; its sites move to `SectionTitle` (share dialog, context console cards and columns) or `SectionHeading` (Activity, People, Profile, Collections). `SectionTitle` gains `count`/`as`; `Eyebrow` gains `as="p" | "dt"`.
- Page headers and heroes lose the rules they wore (Templates, template libraries, library detail, public collection, roadmap, folder labels).
- ~30 hairlines between content blocks become spacing or a well (context console — its session thread had three stacked rules — builder, welcome, how-it-works, inspect rail, export list, share-dialog switches, artifact hints, workflow cards, run history, Templates loading boxes, which are now `role="status"`).
- ~90 hand-rolled headings and caps labels move onto the primitives (linked-bundle family, workflow preview, inspect rail, Templates cards and dialogs, brandprint, palette), retiring `font-semibold` headings and three different caps tracking values.
- Kept deliberately: bar edges, table rows, toolbar vertical rules, position markers, and voice-register headings on narrative pages.
- The showcase "Headings" row is the living reference; `docs/design-system.md` carries the doctrine and the exact list of allowed lines.

## Test plan
- [x] `pnpm verify` (ci 34/34, typecheck, all suites) — the pre-push gate.
- [x] Web unit 152/152; no testid changes.
- [x] Screens harnesses re-run for the activity page and rail; ~15 swept surfaces captured and reviewed (workflows, brandprint, template libraries, agents, welcome, roadmap, share dialog, collections, profile, showcase).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/853"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790509026&installation_model_id=428097&pr_number=853&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F853&signature=2ee8acb2804a909c37e838893641cb9f65104600d4f35c85505412d31d3b9416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->