### PR TITLE
Make Artifacts the product front door

### DIFF
--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -350,14 +350,20 @@ test("settings destinations and their retired paths resolve", async ({ owner }) 
   await expect(owner.getByTestId("toggle-github-preview-link")).toHaveCount(0)
 })
 
-test("Archived lives inside the Library filter rather than the primary rail", async ({ owner }) => {
+test("Artifacts is the front door and Archived remains one of its filters", async ({ owner }) => {
   await owner.goto("/")
+  await expect(owner.getByTestId("sidebar-all")).toContainText("Artifacts")
+  await expect(owner.getByRole("heading", { name: /^Artifacts\b/ })).toBeVisible()
+  await expect(owner.getByTestId("library-view")).toHaveAttribute("aria-label", "Artifact views")
+  await expect(owner.getByTestId("library-view-artifacts")).toHaveText("All")
+  await expect(owner.getByTestId("library-view-collections")).toHaveText("Collections")
+  await expect(owner).toHaveTitle("Artifacts · Derive")
   await expect(owner.getByTestId("nav-archived")).toHaveCount(0)
 
   await owner.getByTestId("library-filter").click()
   await owner.getByTestId("library-filter-archived").click()
   await expect(owner).toHaveURL(/\/archived$/)
-  await expect(owner.getByRole("heading", { name: /Library/ })).toBeVisible()
+  await expect(owner.getByRole("heading", { name: /^Artifacts\b/ })).toBeVisible()
   await expect(owner.getByTestId("library-filter")).toHaveAttribute(
     "aria-label",
     "Filter: Archived",
@@ -410,6 +416,7 @@ test("Collections is a digest of the week, then an alphabetical index", async ({
   const colId = new URL(owner.url()).searchParams.get("collection")
 
   await owner.goto("/?view=collections")
+  await expect(owner).toHaveTitle("Collections · Derive")
   // A brand-new empty collection is one index line — never a digest entry (no activity),
   // and never an apology about its contents.
   await expect(owner.getByTestId("collections-index")).toBeVisible()
@@ -431,9 +438,10 @@ test("Collections is a digest of the week, then an alphabetical index", async ({
   await owner.reload()
   await expect(owner.getByTestId("collections-index")).toBeVisible()
 
-  // Switching back to Artifacts leaves the Collections view entirely.
+  // Switching back to All leaves the Collections view entirely.
   await owner.getByTestId("library-view-artifacts").click()
   await expect(owner.getByTestId("collections-index")).toHaveCount(0)
+  await expect(owner).toHaveTitle("Artifacts · Derive")
 })
 
 test("a card states three facts, not nine", async ({ owner }) => {
@@ -548,7 +556,7 @@ test("a collection says where you are, and the way back is the trail", async ({ 
   // first, with the way out an `×` chip over in the toolbar.
   await owner.goto(`/?collection=${colId}`)
   const home = owner.getByTestId("crumb-0")
-  await expect(home).toHaveText("Library")
+  await expect(home).toHaveText("Artifacts")
   await home.click()
   await expect(owner).toHaveURL(/\/$|\/\?/)
   await expect(owner.getByTestId("collection-share")).toHaveCount(0)
@@ -556,7 +564,7 @@ test("a collection says where you are, and the way back is the trail", async ({ 
   await expect(owner.getByTestId("library-clear-filter")).toHaveCount(0)
 })
 
-test("the library is a drop target, and + New never hides", async ({ owner }) => {
+test("Artifacts is a drop target, and + New never hides", async ({ owner }) => {
   await owner.goto("/")
   // The one primary action is STABLE: visible even while the connect-agent card shows
   // (a fresh workspace used to have no visible way to create anything by hand).

--- a/apps/web/src/components/chrome/app-shell.tsx
+++ b/apps/web/src/components/chrome/app-shell.tsx
@@ -326,7 +326,7 @@ function MobileTopBar({
 // Where am I, for the mobile navbar (the sidebar is hidden behind the drawer).
 // A pathname switch, not route metadata — labels are chrome, not content.
 function PageLabel({ pathname }: { pathname: string }) {
-  if (pathname === "/") return "Library"
+  if (pathname === "/") return "Artifacts"
   if (pathname === "/favorites") return "Favorites"
   if (pathname === "/following") return "Following"
   if (pathname === "/archived") return "Archived"

--- a/apps/web/src/components/chrome/nav-rail.tsx
+++ b/apps/web/src/components/chrome/nav-rail.tsx
@@ -397,8 +397,8 @@ export function NavRail() {
   const brandprintIds = useBrandprintCollectionIds()
   const visibleCollections = collections.filter((col) => !brandprintIds.has(col.id))
 
-  // Only starred collections reach the rail; the rest live in the library's Collections
-  // view. Every collection used to be listed here, which grew unbounded.
+  // Only starred collections reach the rail; the rest live in the Artifacts page's
+  // Collections view. Every collection used to be listed here, which grew unbounded.
   //
   const starredCollections = visibleCollections.filter((col) => col.starred)
 
@@ -417,7 +417,7 @@ export function NavRail() {
             <SidebarMenu>
               <FilterItem
                 icon="all"
-                label="Library"
+                label="Artifacts"
                 count={summary?.total}
                 search={{}}
                 active={isAll}

--- a/apps/web/src/components/showcase/showcase.tsx
+++ b/apps/web/src/components/showcase/showcase.tsx
@@ -856,7 +856,7 @@ function RowStatesDemo() {
             <SidebarMenuItem>
               <SidebarMenuButton isActive>
                 <Icon name="all" size={16} />
-                <span>Library</span>
+                <span>Artifacts</span>
               </SidebarMenuButton>
             </SidebarMenuItem>
           </SidebarMenu>

--- a/apps/web/src/pages/activity.tsx
+++ b/apps/web/src/pages/activity.tsx
@@ -27,7 +27,7 @@ const NEEDS_CAP = 5
 /**
  * The Activity page's two sections — the workspace's "Needs you" and its "Recent
  * activity" — from one request (lib/queries.ts workspaceActivityQuery). Its own place,
- * beside Notifications: the Library stays the library (the grid is what that page is),
+ * beside Notifications: the Artifacts page stays the document grid,
  * the bell stays what was addressed to you, and this is what is happening.
  *
  * Needs you: the review rounds pending FOR this person across the workspace, and the open

--- a/apps/web/src/pages/library/index.tsx
+++ b/apps/web/src/pages/library/index.tsx
@@ -100,8 +100,8 @@ function LibraryBody({ view }: { view: LibraryView }) {
   // one IS the `collection` filter, so the switch would be offering you the place you
   // are already standing.
   const showCollections = view === "all" && search.view === "collections" && !search.collection
-  // Archived is a lifecycle shelf within the library, not a separate destination. It keeps
-  // the library header and controls while its route preserves deep links and loader caching.
+  // Archived is a lifecycle shelf within Artifacts, not a separate destination. It keeps
+  // the Artifacts header and controls while its route preserves deep links and loader caching.
   const onLibrarySurface = view === "all" || view === "archived"
   // Brandprint-pointed collections take artifacts through Settings, not the shelves.
   const brandprintIds = useBrandprintCollectionIds()
@@ -321,7 +321,7 @@ function LibraryBody({ view }: { view: LibraryView }) {
   }
   const { follows, unfollow } = useFollows()
 
-  const collectionAncestors = [{ label: "Library" }]
+  const collectionAncestors = [{ label: "Artifacts" }]
 
   const collectionTitle =
     activeCollection?.title ?? feed.data?.pages?.[0]?.collection?.title ?? "Collection"
@@ -349,9 +349,14 @@ function LibraryBody({ view }: { view: LibraryView }) {
                 : filter.kind === "mine"
                   ? "Created by me"
                   : collectionTitle
-  // The tab names the view — a collection, Favorites, Created by me… —
-  // while the unfiltered home stays plain "Derive".
-  useDocumentTitle(filter.kind === "all" ? null : heading)
+  // The browser title follows the visible place. Collections is a view of Artifacts;
+  // named feeds and open collections keep their own more specific title.
+  const documentTitle = showCollections
+    ? "Collections"
+    : filter.kind === "all"
+      ? "Artifacts"
+      : heading
+  useDocumentTitle(documentTitle)
   // Only the counts the server can state authoritatively (preloaded summary / the
   // collection's own count) get a number; the follow/shared/feedback feeds show none
   // rather than a misleading "loaded-so-far" count that grows as you scroll.
@@ -466,7 +471,7 @@ function LibraryBody({ view }: { view: LibraryView }) {
           <div className="flex min-h-10 flex-wrap items-center gap-1.5">
             <h1 className="flex min-w-0 items-baseline gap-2">
               <span className="truncate font-serif text-lg font-semibold tracking-tight text-foreground">
-                {onLibrarySurface ? "Library" : heading}
+                {onLibrarySurface ? "Artifacts" : heading}
               </span>
               {identityCount !== undefined && (
                 <span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
@@ -506,8 +511,8 @@ function LibraryBody({ view }: { view: LibraryView }) {
               showPublish && <NewArtifactButton />
             )}
           </div>
-          {/* Artifacts and Collections are views of the library. The filter menu narrows
-              the artifact view, including its archived shelf; named activity feeds remain
+          {/* All and Collections are views of Artifacts. The filter menu narrows
+              All, including its archived shelf; named activity feeds remain
               separate routes and therefore do not render these controls. */}
           {onLibrarySurface && !search.collection ? (
             <div className="mb-5 flex items-center gap-4 border-b border-border-soft">

--- a/apps/web/src/pages/library/types.ts
+++ b/apps/web/src/pages/library/types.ts
@@ -62,7 +62,7 @@ export const LIBRARY_SEARCH_PARAMS = [
 ] as const
 
 export type LibrarySearch = {
-  /** Which of the library's two views is showing. Absent = Artifacts. Collections is
+  /** Which of the Artifact page's two views is showing. Absent = All. Collections is
    *  a view of the same page rather than its own route: it shares the toolbar, and
    *  opening a shelf from it is just the `collection` filter below. */
   view?: "collections"

--- a/apps/web/src/pages/library/view-switch.tsx
+++ b/apps/web/src/pages/library/view-switch.tsx
@@ -2,7 +2,7 @@ import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 
 export type LibraryViewMode = "artifacts" | "collections"
 
-// Artifacts ⇄ Collections, as underline tabs beneath the page's name — they are views
+// All ⇄ Collections, as underline tabs beneath the Artifacts heading — they are views
 // of one place, which is what tabs say. The boxed segmented control fought the search
 // box for the toolbar's attention; tabs sit where Linear puts them, small and quiet.
 //
@@ -19,10 +19,10 @@ export function ViewSwitch({
     <ToggleGroup
       type="single"
       value={value}
-      // Radix emits "" when you press the active segment; ignore it so the library
+      // Radix emits "" when you press the active segment; ignore it so Artifacts
       // always has a view rather than flickering to neither.
       onValueChange={(v) => v && onChange(v as LibraryViewMode)}
-      aria-label="Library view"
+      aria-label="Artifact views"
       data-testid="library-view"
       className="gap-5"
     >
@@ -31,7 +31,7 @@ export function ViewSwitch({
         data-testid="library-view-artifacts"
         className="relative h-9 rounded-none bg-transparent px-0.5 text-sm text-muted-foreground hover:bg-transparent hover:text-foreground data-[state=on]:bg-transparent data-[state=on]:text-foreground after:absolute after:inset-x-0 after:-bottom-px after:h-0.5 after:rounded-full data-[state=on]:after:bg-foreground"
       >
-        Artifacts
+        All
       </ToggleGroupItem>
       <ToggleGroupItem
         value="collections"

--- a/apps/web/src/routes/activity.tsx
+++ b/apps/web/src/routes/activity.tsx
@@ -5,7 +5,7 @@ import { useDocumentTitle } from "@/lib/use-document-title"
 import { WorkspaceActivity } from "@/pages/activity"
 
 // What is happening in the workspace, and what needs you — its own page beside
-// Notifications. Not the Library (the grid is what that page is) and not the bell (what
+// Notifications. Not the Artifacts page (the document grid) and not the bell (what
 // was addressed to you); the third question, answered in one place.
 function ActivityPage() {
   useDocumentTitle("Activity")


### PR DESCRIPTION
## What changed

- Makes Artifacts the primary navigation label, home heading, mobile label, and collection breadcrumb root.
- Names the two subordinate views All and Collections.
- Gives the home and Collections views matching browser titles.
- Keeps the / route, Library components and types, query keys, storage, and APIs unchanged.

## Why

Artifact is one of Derive’s three public nouns. Calling its front door Library and then presenting an Artifacts tab forced users to learn two names for the same place. Now an Artifact is the thing and a Collection is a shelf beneath it.

## Verification

- pnpm verify: 34/34 guardrails, all workspace typechecks, 2,904 package tests
- Focused Playwright: Artifact front door, Collections transition, Archived filter, and collection breadcrumb
- pnpm verify:affected via the pre-push hook

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790514278&installation_model_id=428097&pr_number=854&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F854&signature=ec41dd24682ed6bf0986e2e2e77b4433d20f579e75f85d347c9ac2b5398039ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->