### PR TITLE
Hide non-blocking preview errors from readers

### DIFF
--- a/apps/web/e2e/render-fidelity/render-fidelity.spec.ts
+++ b/apps/web/e2e/render-fidelity/render-fidelity.spec.ts
@@ -34,6 +34,17 @@ async function withErrorCapture(page: Page, fn: () => Promise<void>): Promise<st
   return errors
 }
 
+async function openRuntimeDiagnostics(page: Page, code: string) {
+  // A usable artifact never advertises authored runtime noise to its reader.
+  await expect(page.getByTestId("render-degraded")).toHaveCount(0)
+  await page.getByTestId("artifact-inline-edit").click()
+  const advanced = page.getByTestId("artifact-runtime-diagnostics")
+  await expect(advanced).toBeVisible()
+  await advanced.locator("summary").click()
+  await expect(advanced).toContainText(code)
+  return advanced
+}
+
 test.describe("render fidelity — pinning what the sandbox CSP permits", () => {
   test("an iframe-based visualization with an authored CSP reaches Ready", async ({
     owner: page,
@@ -41,7 +52,9 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
     const html = readFileSync(join(FIXTURES, "startup-csp-visualization-shell.html"), "utf8")
     const shortId = await publishArtifact(page, "index.html", html, "text/html")
 
-    const errors = await withErrorCapture(page, () => page.goto(`/artifacts/${shortId}`))
+    const errors = await withErrorCapture(page, async () => {
+      await page.goto(`/artifacts/${shortId}`)
+    })
     expect(errors).toEqual([])
     await expect(page.getByTestId("render-degraded")).toHaveCount(0)
     await expect(page.getByText("This artifact couldn’t start")).toHaveCount(0)
@@ -86,9 +99,12 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
     const html = readFileSync(join(FIXTURES, "startup-fail-soft.html"), "utf8")
     const shortId = await publishArtifact(page, "index.html", html, "text/html")
 
-    const wrapperErrors = await withErrorCapture(page, () => page.goto(`/artifacts/${shortId}`))
+    const wrapperErrors = await withErrorCapture(page, async () => {
+      await page.goto(`/artifacts/${shortId}`)
+    })
     expect(wrapperErrors).toEqual([])
-    await expect(page.getByTestId("render-degraded")).toBeVisible()
+    const diagnostics = await openRuntimeDiagnostics(page, "script-error")
+    await expect(diagnostics).toContainText("Hidden from readers")
     await expect(page.getByText("This artifact couldn’t start")).toHaveCount(0)
 
     const frame = page.locator('iframe[title="index"]')
@@ -97,8 +113,6 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
     await expect(artifact.locator("#rows tr")).toHaveCount(30)
     await artifact.locator("#control").click()
     await expect(artifact.locator("#count")).toHaveText("1")
-    await page.getByTestId("render-degraded-dismiss").click()
-    await expect(page.getByTestId("render-degraded")).toHaveCount(0)
     await expect(artifact.locator("#rows tr")).toHaveCount(30)
 
     // The public wrapper has its own chrome/layout path. Exercise the same shared
@@ -107,7 +121,8 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
     const publicPage = await publicContext.newPage()
     try {
       await publicPage.goto(`/artifacts/${shortId}`)
-      await expect(publicPage.getByTestId("render-degraded")).toBeVisible()
+      await expect(publicPage.getByTestId("render-degraded")).toHaveCount(0)
+      await expect(publicPage.getByTestId("artifact-runtime-diagnostics")).toHaveCount(0)
       await expect(publicPage.getByText("This artifact couldn’t start")).toHaveCount(0)
       const publicArtifact = publicPage.frameLocator('iframe[title="index"]')
       await expect(publicArtifact.locator("#rows tr")).toHaveCount(30)
@@ -125,7 +140,7 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
     const shortId = await publishArtifact(page, "index.html", html, "text/html")
 
     await page.goto(`/artifacts/${shortId}`)
-    await expect(page.getByTestId("render-degraded")).toBeVisible()
+    await expect(page.getByTestId("render-degraded")).toHaveCount(0)
     await expect(page.getByText("Artifact script stopped")).toHaveCount(0)
     const artifact = page.frameLocator('iframe[title="index"]')
     await expect(
@@ -145,7 +160,7 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
     await page.goto(`/artifacts/${shortId}`)
     await expect(page.getByText("Loading preview…")).toBeVisible()
     await expect(page.getByTestId("render-degraded")).toHaveCount(0)
-    await expect(page.getByTestId("render-degraded")).toBeVisible()
+    await expect(page.getByTestId("render-degraded")).toHaveCount(0)
     const artifact = page.frameLocator('iframe[title="index"]')
     await expect(artifact.locator("#rows tr")).toHaveCount(30)
     await artifact.locator("#control").click()
@@ -156,7 +171,7 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
     try {
       await publicPage.goto(`/artifacts/${shortId}`)
       await expect(publicPage.getByText("Loading preview…")).toBeVisible()
-      await expect(publicPage.getByTestId("render-degraded")).toBeVisible()
+      await expect(publicPage.getByTestId("render-degraded")).toHaveCount(0)
       const publicArtifact = publicPage.frameLocator('iframe[title="index"]')
       await expect(publicArtifact.locator("#rows tr")).toHaveCount(30)
     } finally {
@@ -177,7 +192,7 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
         artifact.getByRole("heading", { name: "Useful controls reached Ready" }),
       ).toBeVisible()
       await artifact.locator(`#${action}-control`).click()
-      await expect(page.getByTestId("render-degraded")).toBeVisible()
+      await expect(page.getByTestId("render-degraded")).toHaveCount(0)
       await expect(page.getByText("Artifact script stopped")).toHaveCount(0)
       await artifact.locator("#working-control").click()
       await expect(artifact.locator("#count")).toHaveText("1")
@@ -247,40 +262,22 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
     await expect(artifact.locator("#count")).toHaveText("1")
   })
 
-  test("a distinct post-ready failure reopens recovery after dismissal", async ({
-    browser,
+  test("a distinct post-ready failure updates the hidden Inspect diagnostic", async ({
     owner: page,
   }) => {
     const html = readFileSync(join(FIXTURES, "startup-sequential-errors.html"), "utf8")
     const shortId = await publishArtifact(page, "index.html", html, "text/html")
 
     await page.goto(`/artifacts/${shortId}`)
-    await expect(page.getByTestId("render-degraded")).toBeVisible()
-    await page.getByTestId("render-degraded-dismiss").click()
-    await expect(page.getByTestId("render-degraded")).toHaveCount(0)
+    const diagnostics = await openRuntimeDiagnostics(page, "resource-error")
 
     const artifact = page.frameLocator('iframe[title="index"]')
     await artifact.locator("#throw-control").click()
-    await expect(page.getByTestId("render-degraded")).toBeVisible()
-    await expect(
-      page.getByText("A script failed after meaningful content", { exact: false }),
-    ).toBeVisible()
+    await expect(page.getByTestId("render-degraded")).toHaveCount(0)
+    await expect(diagnostics).toContainText("script-error")
+    await expect(diagnostics).not.toContainText("resource-error")
     await artifact.locator("#working-control").click()
     await expect(artifact.locator("#count")).toHaveText("1")
-
-    const mobileContext = await browser.newContext({ viewport: { width: 390, height: 844 } })
-    const mobile = await mobileContext.newPage()
-    try {
-      await mobile.goto(`/artifacts/${shortId}`)
-      await expect(mobile.getByTestId("render-degraded")).toContainText("resource-error")
-      await mobile.getByTestId("render-degraded-dismiss").click()
-      const mobileArtifact = mobile.frameLocator('iframe[title="index"]')
-      await mobileArtifact.locator("#throw-control").click()
-      await expect(mobile.getByTestId("render-degraded")).toContainText("script-error")
-      await expect(mobile.getByTestId("render-degraded")).not.toContainText("resource-error")
-    } finally {
-      await mobileContext.close()
-    }
   })
 
   test("visible meaningful content in an open shadow root reaches Ready", async ({
@@ -336,19 +333,17 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
     await expect(artifact.locator("#count")).toHaveText("1")
   })
 
-  test("degraded dismissal is scoped to one artifact instance", async ({ owner: page }) => {
+  test("hidden diagnostics are scoped to one artifact instance", async ({ owner: page }) => {
     const html = readFileSync(join(FIXTURES, "startup-fail-soft.html"), "utf8")
     const firstId = await publishArtifact(page, "index.html", html, "text/html")
     const secondId = await publishArtifact(page, "index.html", html, "text/html")
 
     await page.goto(`/artifacts/${firstId}`)
-    await expect(page.getByTestId("render-degraded")).toBeVisible()
-    await page.getByTestId("render-degraded-dismiss").click()
     await expect(page.getByTestId("render-degraded")).toHaveCount(0)
 
     await page.goto(`/artifacts/${secondId}`)
-    await expect(page.getByTestId("render-degraded")).toBeVisible()
-    await expect(page.getByTestId("render-degraded")).toContainText("script-error")
+    await expect(page.getByTestId("render-degraded")).toHaveCount(0)
+    await openRuntimeDiagnostics(page, "script-error")
   })
 
   for (const scenario of [
@@ -397,7 +392,7 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
     const shortId = await publishArtifact(page, "index.html", html, "text/html")
 
     await page.goto(`/artifacts/${shortId}`)
-    await expect(page.getByTestId("render-degraded")).toBeVisible()
+    await expect(page.getByTestId("render-degraded")).toHaveCount(0)
     const artifact = page.frameLocator('iframe[title="index"]')
     await artifact.locator("#control").click()
     await expect(artifact.locator("#count")).toHaveText("1")
@@ -475,31 +470,30 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
     await expect(page.getByTestId("render-retry")).toHaveCount(0)
   })
 
-  test("a dismissed degraded warning returns after a full reload", async ({ owner: page }) => {
+  test("a non-blocking failure stays off the viewer surface after reload", async ({
+    owner: page,
+  }) => {
     const html = readFileSync(join(FIXTURES, "startup-fail-soft.html"), "utf8")
     const shortId = await publishArtifact(page, "index.html", html, "text/html")
     await page.goto(`/artifacts/${shortId}`)
-    await expect(page.getByTestId("render-degraded")).toBeVisible()
-    await page.getByTestId("render-degraded-dismiss").click()
     await expect(page.getByTestId("render-degraded")).toHaveCount(0)
     await page.reload()
-    await expect(page.getByTestId("render-degraded")).toBeVisible()
+    await expect(page.getByTestId("render-degraded")).toHaveCount(0)
     await expect(page.frameLocator('iframe[title="index"]').locator("#rows tr")).toHaveCount(30)
   })
 
-  test("Retry on a degraded artifact creates one fresh usable iframe", async ({ owner: page }) => {
+  test("a degraded artifact offers no unnecessary viewer recovery action", async ({
+    owner: page,
+  }) => {
     const html = readFileSync(join(FIXTURES, "startup-fail-soft.html"), "utf8")
     const shortId = await publishArtifact(page, "index.html", html, "text/html")
     await page.goto(`/artifacts/${shortId}`)
     const artifact = page.frameLocator('iframe[title="index"]')
     await artifact.locator("#control").click()
     await expect(artifact.locator("#count")).toHaveText("1")
-    await page.getByTestId("render-retry").click()
+    await expect(page.getByTestId("render-retry")).toHaveCount(0)
     await expect(page.locator('iframe[title="index"]')).toHaveCount(1)
-    await expect(page.getByTestId("render-degraded")).toBeVisible()
-    await expect(artifact.locator("#count")).toHaveText("0")
-    await artifact.locator("#control").click()
-    await expect(artifact.locator("#count")).toHaveText("1")
+    await expect(page.getByTestId("render-degraded")).toHaveCount(0)
   })
 
   test("two blocked Retry attempts never duplicate recovery or iframes", async ({
@@ -541,7 +535,7 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
     await expect(artifact.locator("#control")).toHaveAttribute("data-clicked", "true")
   })
 
-  test("navigating from Degraded to a clean sibling clears the warning rail", async ({
+  test("navigating from Degraded to a clean sibling keeps the surface quiet", async ({
     owner: page,
   }) => {
     const degraded = await publishArtifact(
@@ -557,7 +551,7 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
       "text/html",
     )
     await page.goto(`/artifacts/${degraded}`)
-    await expect(page.getByTestId("render-degraded")).toBeVisible()
+    await expect(page.getByTestId("render-degraded")).toHaveCount(0)
     await page.goto(`/artifacts/${clean}`)
     await expect(page.getByTestId("render-degraded")).toHaveCount(0)
     const artifact = page.frameLocator('iframe[title="index"]')

--- a/apps/web/e2e/render-fidelity/render-fidelity.spec.ts
+++ b/apps/web/e2e/render-fidelity/render-fidelity.spec.ts
@@ -103,8 +103,6 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
       await page.goto(`/artifacts/${shortId}`)
     })
     expect(wrapperErrors).toEqual([])
-    const diagnostics = await openRuntimeDiagnostics(page, "script-error")
-    await expect(diagnostics).toContainText("Hidden from readers")
     await expect(page.getByText("This artifact couldn’t start")).toHaveCount(0)
 
     const frame = page.locator('iframe[title="index"]')
@@ -114,6 +112,10 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
     await artifact.locator("#control").click()
     await expect(artifact.locator("#count")).toHaveText("1")
     await expect(artifact.locator("#rows tr")).toHaveCount(30)
+    // Inspect is edit mode, which intentionally owns canvas clicks. Prove the
+    // authored control works before entering it, then inspect the hidden issue.
+    const diagnostics = await openRuntimeDiagnostics(page, "script-error")
+    await expect(diagnostics).toContainText("Hidden from readers")
 
     // The public wrapper has its own chrome/layout path. Exercise the same shared
     // artifact anonymously so a workbench-only fix cannot masquerade as complete.
@@ -269,15 +271,16 @@ test.describe("render fidelity — pinning what the sandbox CSP permits", () => 
     const shortId = await publishArtifact(page, "index.html", html, "text/html")
 
     await page.goto(`/artifacts/${shortId}`)
-    const diagnostics = await openRuntimeDiagnostics(page, "resource-error")
-
     const artifact = page.frameLocator('iframe[title="index"]')
     await artifact.locator("#throw-control").click()
     await expect(page.getByTestId("render-degraded")).toHaveCount(0)
-    await expect(diagnostics).toContainText("script-error")
-    await expect(diagnostics).not.toContainText("resource-error")
     await artifact.locator("#working-control").click()
     await expect(artifact.locator("#count")).toHaveText("1")
+    // Trigger the newer authored failure before entering Inspect: edit mode
+    // captures canvas clicks by design, so it is not a valid interaction harness.
+    const diagnostics = await openRuntimeDiagnostics(page, "script-error")
+    await expect(diagnostics).toContainText("script-error")
+    await expect(diagnostics).not.toContainText("resource-error")
   })
 
   test("visible meaningful content in an open shadow root reaches Ready", async ({

--- a/apps/web/src/pages/artifact/artifact-inspect.tsx
+++ b/apps/web/src/pages/artifact/artifact-inspect.tsx
@@ -5,6 +5,7 @@ import { SectionTitle } from "@/components/shared/section-title"
 import { Button } from "@/components/ui/button"
 import { Kbd } from "@/components/ui/kbd"
 import { cn } from "@/lib/utils"
+import type { RuntimeDiagnostic } from "./render-stage"
 
 type FormatKind = "b" | "i" | "a"
 
@@ -26,6 +27,7 @@ export function ArtifactInspect({
   textKind,
   selectedText,
   video,
+  runtimeDiagnostic,
   onSceneEdit,
   onUndo,
   onRedo,
@@ -50,6 +52,9 @@ export function ArtifactInspect({
     transitionMs: number
     caption: string
   } | null
+  /** Non-blocking render diagnostics stay out of the viewer and live behind the
+   * collapsed Advanced section of the editor-only Inspect rail. */
+  runtimeDiagnostic?: RuntimeDiagnostic | null
   onSceneEdit?: (edit: Record<string, unknown>) => void
   onUndo: () => void
   onRedo: () => void
@@ -87,6 +92,8 @@ export function ArtifactInspect({
         <ChooseInspect />
       )}
 
+      {runtimeDiagnostic && <RuntimeDiagnostics diagnostic={runtimeDiagnostic} />}
+
       <SessionControls
         dirty={dirty}
         saving={saving}
@@ -98,6 +105,39 @@ export function ArtifactInspect({
         onDone={onDone}
       />
     </section>
+  )
+}
+
+function RuntimeDiagnostics({ diagnostic }: { diagnostic: RuntimeDiagnostic }) {
+  return (
+    <details
+      data-testid="artifact-runtime-diagnostics"
+      className="mt-6 rounded-lg border border-border bg-secondary/20"
+    >
+      <summary className="cursor-pointer px-3 py-2.5 text-xs font-medium text-muted-foreground marker:text-muted-foreground">
+        Advanced
+      </summary>
+      <div className="space-y-3 border-t border-border px-3 py-3">
+        <div>
+          <Eyebrow as="div">Preview diagnostics</Eyebrow>
+          <p className="mt-1 text-sm font-medium text-foreground">{diagnostic.title}</p>
+          <p className="mt-1 text-xs leading-5 text-muted-foreground">{diagnostic.description}</p>
+        </div>
+        <dl className="grid gap-2 rounded-md bg-secondary/40 p-2.5 font-mono text-3xs text-muted-foreground">
+          <div className="grid grid-cols-[4.5rem_minmax(0,1fr)] gap-2">
+            <dt>Type</dt>
+            <dd className="min-w-0 break-all text-foreground">{diagnostic.code}</dd>
+          </div>
+          <div className="grid grid-cols-[4.5rem_minmax(0,1fr)] gap-2">
+            <dt>Reference</dt>
+            <dd className="min-w-0 break-all text-foreground">{diagnostic.reference}</dd>
+          </div>
+        </dl>
+        <p className="text-3xs leading-4 text-muted-foreground">
+          Hidden from readers because the artifact reached a usable state.
+        </p>
+      </div>
+    </details>
   )
 }
 

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -66,6 +66,7 @@ import { parseRef, refFor } from "./parse-ref"
 import { PasswordGate } from "./password-gate"
 import { PublicViewer } from "./public-viewer"
 import { Presence } from "./rail-deck"
+import { runtimeDiagnosticFor } from "./render-stage"
 import type { ArtifactSearch } from "./route-config"
 import { SharedStateAuthDialog } from "./shared-state-auth-dialog"
 import { SourceEditor } from "./source-editor"
@@ -973,6 +974,7 @@ export function Artifact({ template = false }: { template?: boolean }) {
     seeded || (rawTokenStale && !pinnedForShown) ? null : rawArtifactUrl(shortId, shown, rawToken)
   // Direct publishing is a workbench capability.
   const canPublish = !isGuest && (art.my_role === "editor" || art.my_role === "owner")
+  const runtimeDiagnostic = canPublish ? runtimeDiagnosticFor(runtimeError, shortId, shown) : null
   // md vs html drives syntax highlighting + how the live preview renders.
   const format = formatOf(art)
   // Lock: any editor can toggle it (advanced menu). While locked, nothing
@@ -1616,6 +1618,7 @@ export function Artifact({ template = false }: { template?: boolean }) {
                     textKind={inlineEdit.tools.textKind}
                     selectedText={inlineEdit.tools.selectedText}
                     video={video}
+                    runtimeDiagnostic={runtimeDiagnostic}
                     onSceneEdit={(edit) => post({ type: "video-edit", ...edit })}
                     onUndo={inlineEdit.undo}
                     onRedo={inlineEdit.redo}

--- a/apps/web/src/pages/artifact/render-stage.test.ts
+++ b/apps/web/src/pages/artifact/render-stage.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import {
+  runtimeDiagnosticFor,
   runtimeDisposition,
   runtimeFailureCopy,
   type UpdateCueState,
@@ -75,11 +76,22 @@ describe("runtimeFailureCopy", () => {
     expect(runtimeFailureCopy("script-error", "blocked", false).description).not.toContain("stack")
   })
 
-  it("keeps optional and post-ready failures visible with neutral reader copy", () => {
+  it("classifies optional and post-ready failures as degraded", () => {
     expect(runtimeDisposition({ code: "resource-error", phase: "loading" })).toBe("degraded")
     expect(runtimeDisposition({ code: "script-error", phase: "ready" })).toBe("degraded")
     expect(runtimeDisposition({ code: "script-error", phase: "loading" })).toBe("blocked")
     expect(runtimeFailureCopy("script-error", "degraded", false).title).toContain("unavailable")
+  })
+
+  it("keeps degraded diagnostics in authoring surfaces only", () => {
+    expect(runtimeDiagnosticFor({ code: "script-error", phase: "loading" }, "memo", 3)).toBeNull()
+    expect(runtimeDiagnosticFor({ code: "script-error", phase: "ready" }, "memo", 3)).toEqual({
+      code: "script-error",
+      reference: "memo-v3-script-error",
+      title: "Non-blocking preview issue",
+      description:
+        "A script failed after meaningful content appeared. The rendered content is still available; check the source before republishing.",
+    })
   })
 
   it("never lets a queued optional warning downgrade a bootstrap failure", () => {

--- a/apps/web/src/pages/artifact/render-stage.tsx
+++ b/apps/web/src/pages/artifact/render-stage.tsx
@@ -59,6 +59,13 @@ export const updateCue = (
  * storage case. The runtime sends only this coarse code, never exception text. */
 export type RuntimeDisposition = "blocked" | "degraded"
 
+export type RuntimeDiagnostic = {
+  code: ArtifactRuntimeErrorCode
+  reference: string
+  title: string
+  description: string
+}
+
 /** Resource failures are optional by default. Script/storage failures block only
  * before meaningful content exists; after ready they degrade without replacing the
  * last good frame. This is the viewer's small, explicit startup state machine. */
@@ -73,7 +80,7 @@ export const runtimeFailureCopy = (
   if (disposition === "degraded")
     return canFix
       ? {
-          title: "Preview kept running after an artifact error",
+          title: "Non-blocking preview issue",
           description:
             code === "resource-error"
               ? "An optional image, font, or stylesheet failed to load. The rendered content is still available."
@@ -105,6 +112,24 @@ export const runtimeFailureCopy = (
         title: "This artifact couldn’t start",
         description: "Its author needs to fix a script error.",
       }
+}
+
+/** Non-blocking failures are authoring diagnostics, not viewer warnings. Keep
+ * them off the artifact surface and expose them only from the editor's Inspect
+ * rail. Blocking failures still own the render because the artifact is unusable. */
+export const runtimeDiagnosticFor = (
+  error: ArtifactRuntimeError | null | undefined,
+  subject: string,
+  version: number | undefined,
+): RuntimeDiagnostic | null => {
+  if (!error || runtimeDisposition(error) !== "degraded") return null
+  const copy = runtimeFailureCopy(error.code, "degraded", true)
+  return {
+    code: error.code,
+    reference: `${subject}${version == null ? "" : `-v${version}`}-${error.code}`,
+    title: copy.title,
+    description: copy.description,
+  }
 }
 
 export function RenderStage({
@@ -195,11 +220,6 @@ export function RenderStage({
   const runtimeFailure = runtimeError
     ? runtimeFailureCopy(runtimeError.code, disposition ?? "blocked", canFixRuntimeError)
     : null
-  const incidentReference = runtimeError
-    ? `${subject}${version == null ? "" : `-v${version}`}-${runtimeError.code}`
-    : null
-  const incidentInstance = incidentReference ? `${incidentReference}-${attempt}` : null
-  const [dismissedIncident, setDismissedIncident] = useState<string | null>(null)
 
   // "Updated" cue: when the shown version steps up IN PLACE (a peer published a new
   // version of the document being watched), flash a soft, non-blocking badge instead
@@ -227,46 +247,6 @@ export function RenderStage({
   return (
     <div className={cn("relative flex min-h-0 flex-1 flex-col", className)}>
       {banner}
-      {/* A warning must never obscure authored content. Keep degraded recovery in
-          the stage flow, outside the iframe/cursor coordinate system. */}
-      {phase === "ready" &&
-        runtimeError &&
-        runtimeFailure &&
-        disposition === "degraded" &&
-        incidentInstance !== dismissedIncident && (
-          <div
-            role="status"
-            aria-live="polite"
-            data-testid="render-degraded"
-            className="flex shrink-0 items-center gap-3 border-b border-warning/30 bg-card px-3 py-2"
-          >
-            <Icon name="report" className="size-4 shrink-0 text-warning" strokeWidth={1.75} />
-            <div className="min-w-0 flex-1">
-              <p className="text-sm font-medium text-foreground">{runtimeFailure.title}</p>
-              <p className="hidden text-xs text-muted-foreground sm:block">
-                {runtimeFailure.description}
-              </p>
-              <p className="mt-0.5 truncate font-mono text-3xs text-muted-foreground">
-                {runtimeError.code}
-                <span className="hidden sm:inline"> · Reference: {incidentReference}</span>
-              </p>
-            </div>
-            <div className="flex shrink-0 items-center gap-1">
-              <Button variant="outline" size="sm" data-testid="render-retry" onClick={retry}>
-                Try again
-              </Button>
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                aria-label="Dismiss preview warning"
-                data-testid="render-degraded-dismiss"
-                onClick={() => setDismissedIncident(incidentInstance)}
-              >
-                <Icon name="close" size={14} />
-              </Button>
-            </div>
-          </div>
-        )}
       {/* The render fills edge-to-edge; the content card's rounded overflow-hidden
           clips it, and the header above carries its top edge. bg-background (the app
           canvas, NEVER bg-white) is the backdrop the boot state paints on — so a dark


### PR DESCRIPTION
## Summary
- remove non-blocking runtime warnings from the artifact surface
- keep diagnostics editor-only under Inspect → Advanced
- preserve prominent recovery for failures that prevent rendering

## Verification
- pnpm verify
- affected pre-push gate
- real-browser check of viewer and Inspect states

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/858"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790550790&installation_model_id=428097&pr_number=858&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F858&signature=33ce4922f93a44118173f5a089279a4394b10bb4270901fb2904be7521e27a35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->