### PR TITLE
Add GitHub Actions runner adapter

### DIFF
--- a/.github/workflows/derive-runner-canary.yml
+++ b/.github/workflows/derive-runner-canary.yml
@@ -20,8 +20,11 @@ on:
         required: false
         type: string
 
-permissions:
-  contents: read
+permissions: {}
+
+concurrency:
+  group: derive-runner-${{ inputs.derive_run_id }}
+  cancel-in-progress: false
 
 jobs:
   canary:
@@ -34,6 +37,7 @@ jobs:
           SUITE: ${{ inputs.suite }}
           PAYLOAD: ${{ inputs.payload }}
         run: |
+          set -euo pipefail
           jq -n \
             --arg derive_run_id "$DERIVE_RUN_ID" \
             --arg suite "$SUITE" \
@@ -56,14 +60,13 @@ jobs:
           {
             echo "## Derive runner canary"
             echo
-            echo "- Derive run: \`$DERIVE_RUN_ID\`"
-            echo "- Suite: \`$SUITE\`"
             echo "- GitHub run: \`$GITHUB_RUN_ID\`"
+            echo "- Result: \`derive-result-$GITHUB_RUN_ID\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload result
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: derive-result-${{ inputs.derive_run_id }}
+          name: derive-result-${{ github.run_id }}
           path: derive-result.json
           retention-days: 7

--- a/.github/workflows/derive-runner-canary.yml
+++ b/.github/workflows/derive-runner-canary.yml
@@ -1,0 +1,69 @@
+name: derive runner canary
+
+# A small workflow for testing Derive's outbound runner adapter. It accepts the same
+# correlation data that a real test suite can accept, emits a machine-readable result,
+# and makes no external calls.
+on:
+  workflow_dispatch:
+    inputs:
+      derive_run_id:
+        description: Correlation id from the Derive run
+        required: true
+        type: string
+      suite:
+        description: Test suite name
+        required: true
+        default: baseline
+        type: string
+      payload:
+        description: Optional adapter payload
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Write result
+        env:
+          DERIVE_RUN_ID: ${{ inputs.derive_run_id }}
+          SUITE: ${{ inputs.suite }}
+          PAYLOAD: ${{ inputs.payload }}
+        run: |
+          jq -n \
+            --arg derive_run_id "$DERIVE_RUN_ID" \
+            --arg suite "$SUITE" \
+            --arg payload "$PAYLOAD" \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg ref "$GITHUB_REF" \
+            --arg sha "$GITHUB_SHA" \
+            --arg run_id "$GITHUB_RUN_ID" \
+            '{
+              derive_run_id: $derive_run_id,
+              suite: $suite,
+              payload: $payload,
+              repository: $repository,
+              ref: $ref,
+              sha: $sha,
+              github_run_id: $run_id,
+              conclusion: "success"
+            }' > derive-result.json
+
+          {
+            echo "## Derive runner canary"
+            echo
+            echo "- Derive run: \`$DERIVE_RUN_ID\`"
+            echo "- Suite: \`$SUITE\`"
+            echo "- GitHub run: \`$GITHUB_RUN_ID\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload result
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: derive-result-${{ inputs.derive_run_id }}
+          path: derive-result.json
+          retention-days: 7

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -2028,7 +2028,8 @@
           },
           "actions_available": {
             "type": "boolean",
-            "description": "Whether the configured App can discover and dispatch GitHub Actions workflows"
+            "nullable": true,
+            "description": "Whether the configured App and its connected installations can dispatch GitHub Actions workflows; null when GitHub could not be checked"
           },
           "permissions_url": {
             "type": "string",

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -2026,6 +2026,10 @@
           "needs_permissions": {
             "type": "boolean"
           },
+          "actions_available": {
+            "type": "boolean",
+            "description": "Whether the configured App can discover and dispatch GitHub Actions workflows"
+          },
           "permissions_url": {
             "type": "string",
             "nullable": true
@@ -2069,6 +2073,7 @@
           "connected",
           "app_slug",
           "needs_permissions",
+          "actions_available",
           "permissions_url",
           "accounts"
         ]

--- a/apps/api/src/github-app-setup.ts
+++ b/apps/api/src/github-app-setup.ts
@@ -81,7 +81,7 @@ export function manifestFormHTML(props: { baseUrl: string; state: string }): str
       <input type="hidden" name="manifest" value="${esc(manifestJson)}"/>
       <button class="btn" type="submit">Continue to GitHub</button>
     </form>
-    <p class="foot">Derive asks for <strong>Metadata: read</strong>, <strong>Pull requests: write</strong>, and <strong>Actions: write</strong>. Server-side policies limit these to PR reads, one top-level PR comment, and workflow discovery, dispatch, status, artifacts, and cancellation.</p>
+    <p class="foot">Derive asks for <strong>Metadata: read</strong>, <strong>Pull requests: write</strong>, and <strong>Actions: write</strong>. Server-side policies limit these to PR reads, one top-level PR comment, workflow status, and dispatch of workflows named <strong>derive-*.yml</strong>.</p>
     <script>setTimeout(function(){document.getElementById("f").submit()},400)</script>`,
   )
 }

--- a/apps/api/src/github-app-setup.ts
+++ b/apps/api/src/github-app-setup.ts
@@ -25,6 +25,11 @@ export const REQUIRED_PERMISSIONS: Record<string, string> = {
   metadata: "read",
   pull_requests: "write",
 }
+export const ACTIONS_PERMISSION = { actions: "write" } as const
+export const MANIFEST_PERMISSIONS: Record<string, string> = {
+  ...REQUIRED_PERMISSIONS,
+  ...ACTIONS_PERMISSION,
+}
 // Scheduled/manual runs query GitHub directly. No webhook collection is part of this path.
 export const REQUIRED_EVENTS: string[] = []
 
@@ -47,7 +52,7 @@ export const buildManifest = (baseUrl: string, host: string) => ({
   // server-narrowed to PR reads plus top-level comments, and only matters once bound via our
   // signed-state callback, so a stray direct install is inert.
   public: true,
-  default_permissions: REQUIRED_PERMISSIONS,
+  default_permissions: MANIFEST_PERMISSIONS,
   default_events: REQUIRED_EVENTS,
 })
 
@@ -76,7 +81,7 @@ export function manifestFormHTML(props: { baseUrl: string; state: string }): str
       <input type="hidden" name="manifest" value="${esc(manifestJson)}"/>
       <button class="btn" type="submit">Continue to GitHub</button>
     </form>
-    <p class="foot">Derive asks for <strong>Metadata: read</strong> and <strong>Pull requests: write</strong>. The write level is required to add a top-level PR conversation comment; Derive permits no other GitHub write.</p>
+    <p class="foot">Derive asks for <strong>Metadata: read</strong>, <strong>Pull requests: write</strong>, and <strong>Actions: write</strong>. Server-side policies limit these to PR reads, one top-level PR comment, and workflow discovery, dispatch, status, artifacts, and cancellation.</p>
     <script>setTimeout(function(){document.getElementById("f").submit()},400)</script>`,
   )
 }

--- a/apps/api/src/lib/broker.ts
+++ b/apps/api/src/lib/broker.ts
@@ -2,7 +2,7 @@ import type { BrokerToolDef, ToolBroker } from "@derive/broker"
 import { type McpAuthResolver, makeBroker, quietReason, refRouter } from "@derive/broker"
 import type { ConnectionKind, ConnectionRecord, MetaStore } from "@derive/core"
 import { decryptSecret } from "./crypto"
-import { GitHubError, installationToken } from "./github-app"
+import { GitHubError, type GitHubTokenProfile, installationToken } from "./github-app"
 import { githubSourcePolicy } from "./github-source-policy"
 import { liveBearer } from "./mcp-oauth"
 
@@ -235,7 +235,7 @@ export const httpTools = (toolkit: string): BrokerToolDef[] => [
     name: `${toolkit}.get`,
     description:
       toolkit === "github"
-        ? "Read installation repositories, pull requests, changed files, or PR conversation comments from GitHub."
+        ? "Read installation repositories, pull requests, workflow definitions, workflow runs, jobs, or result-artifact metadata from GitHub."
         : `GET a path on the ${toolkit} API (authenticated server-side).`,
     params: { path: { type: "string", description: "Path starting with /" } },
   },
@@ -243,7 +243,7 @@ export const httpTools = (toolkit: string): BrokerToolDef[] => [
     name: `${toolkit}.post`,
     description:
       toolkit === "github"
-        ? "Add one top-level GitHub pull request conversation comment. Other writes are refused."
+        ? "Dispatch or cancel a GitHub Actions workflow, or add one top-level pull request conversation comment. Other writes are refused."
         : `POST JSON to a path on the ${toolkit} API (authenticated server-side).`,
     params: { path: { type: "string" }, body: { type: "object" } },
   },
@@ -266,6 +266,8 @@ export const bearerFor = async (
   meta: MetaStore,
   cn: ConnectionRecord,
   encryptionKey: string,
+  githubProfile: GitHubTokenProfile = "standard-pr",
+  githubRepository?: string,
 ): Promise<string> => {
   if (cn.kind === "secret") {
     if (!cn.secret_enc) throw new Error("secret connection is missing its secret")
@@ -279,17 +281,25 @@ export const bearerFor = async (
         app.app_id,
         decryptSecret(app.private_key, encryptionKey),
         cn.broker_ref,
+        githubProfile,
+        githubRepository,
       )
     } catch (err) {
       // Installation removal/suspension must stop being advertised after the first live call.
       // Transient 5xx/rate failures leave the source active so a later run can recover.
       if (
         err instanceof GitHubError &&
-        (err.status === 401 || err.status === 403 || err.status === 404)
+        (err.status === 401 ||
+          err.status === 404 ||
+          (err.status === 403 && githubProfile === "standard-pr"))
       ) {
         await meta.setConnectionStatus(cn.id, cn.org_id, "revoked")
         throw new Error("GitHub is no longer authorized; reconnect it in Settings → Integrations")
       }
+      if (err instanceof GitHubError && err.status === 403 && githubProfile === "workflow-dispatch")
+        throw new Error(
+          "GitHub Actions is not enabled for this App; update its permissions in Settings → Integrations",
+        )
       throw err
     }
   }
@@ -338,14 +348,20 @@ export const executeHttpTool = async (
   // effective surface before minting that token, so a prompt can never turn github.post into
   // a branch/PR mutation. Other direct integrations retain the generic confined HTTP surface.
   const githubPolicy = cn.kind === "github_app" ? githubSourcePolicy(tool, url, a.body) : null
-  const bearer = await bearerFor(meta, cn, encryptionKey)
+  const bearer = await bearerFor(
+    meta,
+    cn,
+    encryptionKey,
+    githubPolicy?.tokenProfile,
+    githubPolicy?.repository,
+  )
   const headers = {
     authorization: `Bearer ${bearer}`,
     ...(cn.kind === "github_app"
       ? {
           accept: "application/vnd.github+json",
           "user-agent": "derive-source/1",
-          "x-github-api-version": "2022-11-28",
+          "x-github-api-version": githubPolicy?.apiVersion ?? "2022-11-28",
         }
       : {}),
     ...(verb === "POST" ? { "content-type": "application/json" } : {}),

--- a/apps/api/src/lib/broker.ts
+++ b/apps/api/src/lib/broker.ts
@@ -243,7 +243,7 @@ export const httpTools = (toolkit: string): BrokerToolDef[] => [
     name: `${toolkit}.post`,
     description:
       toolkit === "github"
-        ? "Dispatch or cancel a GitHub Actions workflow, or add one top-level pull request conversation comment. Other writes are refused."
+        ? "Dispatch an opted-in derive-*.yml GitHub Actions workflow, or add one top-level pull request conversation comment. Other writes are refused."
         : `POST JSON to a path on the ${toolkit} API (authenticated server-side).`,
     params: { path: { type: "string" }, body: { type: "object" } },
   },
@@ -266,7 +266,7 @@ export const bearerFor = async (
   meta: MetaStore,
   cn: ConnectionRecord,
   encryptionKey: string,
-  githubProfile: GitHubTokenProfile = "standard-pr",
+  githubProfile: GitHubTokenProfile = "standard-read",
   githubRepository?: string,
 ): Promise<string> => {
   if (cn.kind === "secret") {
@@ -286,17 +286,30 @@ export const bearerFor = async (
       )
     } catch (err) {
       // Installation removal/suspension must stop being advertised after the first live call.
-      // Transient 5xx/rate failures leave the source active so a later run can recover.
-      if (
-        err instanceof GitHubError &&
-        (err.status === 401 ||
-          err.status === 404 ||
-          (err.status === 403 && githubProfile === "standard-pr"))
-      ) {
+      // A 403 can also mean a primary or secondary rate limit. It must never revoke a healthy
+      // installation. Only invalid credentials and a missing installation are definitive.
+      if (err instanceof GitHubError && (err.status === 401 || err.status === 404)) {
         await meta.setConnectionStatus(cn.id, cn.org_id, "revoked")
         throw new Error("GitHub is no longer authorized; reconnect it in Settings → Integrations")
       }
-      if (err instanceof GitHubError && err.status === 403 && githubProfile === "workflow-dispatch")
+      if (
+        err instanceof GitHubError &&
+        (err.status === 429 ||
+          (err.status === 403 && (err.retryAfter !== null || err.rateLimitRemaining === "0")))
+      ) {
+        const reset = Number(err.rateLimitReset)
+        const retry = err.retryAfter
+          ? ` Retry after ${err.retryAfter} seconds.`
+          : Number.isFinite(reset) && reset > 0
+            ? ` Retry after ${new Date(reset * 1_000).toISOString()}.`
+            : " Retry later."
+        throw new Error(`GitHub rate limit reached.${retry}`)
+      }
+      if (
+        err instanceof GitHubError &&
+        (err.status === 403 || err.status === 422) &&
+        (githubProfile === "workflow-read" || githubProfile === "workflow-dispatch")
+      )
         throw new Error(
           "GitHub Actions is not enabled for this App; update its permissions in Settings → Integrations",
         )
@@ -310,6 +323,40 @@ export const bearerFor = async (
     return decryptSecret(install.bot_token, encryptionKey)
   }
   throw new Error(`connection kind ${cn.kind} has no direct credential`)
+}
+
+const MAX_GITHUB_RESPONSE_BYTES = 4 * 1_024 * 1_024
+
+const responseText = async (res: Response, maxBytes?: number): Promise<string> => {
+  if (!maxBytes) return res.text()
+  const declared = Number(res.headers.get("content-length"))
+  if (Number.isFinite(declared) && declared > maxBytes)
+    throw new Error("GitHub response is too large; request a smaller page")
+  if (!res.body) return ""
+  const reader = res.body.getReader()
+  const chunks: Uint8Array[] = []
+  let total = 0
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      total += value.byteLength
+      if (total > maxBytes) {
+        await reader.cancel()
+        throw new Error("GitHub response is too large; request a smaller page")
+      }
+      chunks.push(value)
+    }
+  } finally {
+    reader.releaseLock()
+  }
+  const bytes = new Uint8Array(total)
+  let offset = 0
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return new TextDecoder().decode(bytes)
 }
 
 /**
@@ -384,7 +431,10 @@ export const executeHttpTool = async (
     body: verb === "POST" ? JSON.stringify(a.body ?? {}) : undefined,
     signal: AbortSignal.timeout(20_000),
   })
-  const text = await res.text()
+  const text = await responseText(
+    res,
+    cn.kind === "github_app" ? MAX_GITHUB_RESPONSE_BYTES : undefined,
+  )
   let body: unknown = text
   try {
     body = JSON.parse(text)

--- a/apps/api/src/lib/github-app.ts
+++ b/apps/api/src/lib/github-app.ts
@@ -64,6 +64,13 @@ export interface InstallationToken {
   expiresAt: string
 }
 
+export type GitHubTokenProfile = "standard-pr" | "workflow-dispatch"
+
+const PROFILE_PERMISSIONS: Record<GitHubTokenProfile, Record<string, string>> = {
+  "standard-pr": { metadata: "read", pull_requests: "write" },
+  "workflow-dispatch": { actions: "write", metadata: "read" },
+}
+
 /**
  * Fetch the App's own record (GET /app, App-JWT auth). Used to confirm a stored
  * App still exists on GitHub — if it was deleted, this 404s, and the caller treats
@@ -106,8 +113,10 @@ export async function installationToken(
   appId: string,
   privateKeyPem: string,
   installationId: string,
+  profile: GitHubTokenProfile = "standard-pr",
+  repository?: string,
 ): Promise<string> {
-  const cacheKey = `${appId}:${installationId}`
+  const cacheKey = `${appId}:${installationId}:${profile}:${repository ?? "*"}`
   const cached = tokenCache.get(cacheKey)
   if (cached && Date.parse(cached.expiresAt) - 60_000 > Date.now()) return cached.token
 
@@ -118,7 +127,10 @@ export async function installationToken(
       ...ghHeaders(`Bearer ${jwt}`),
       "content-type": "application/json",
     },
-    body: JSON.stringify({ permissions: { metadata: "read", pull_requests: "write" } }),
+    body: JSON.stringify({
+      permissions: PROFILE_PERMISSIONS[profile],
+      ...(repository ? { repositories: [repository] } : {}),
+    }),
   })
   if (!res.ok) return raise(res, "minting an installation token")
   const data = (await res.json()) as { token: string; expires_at: string }

--- a/apps/api/src/lib/github-app.ts
+++ b/apps/api/src/lib/github-app.ts
@@ -15,6 +15,9 @@ export class GitHubError extends Error {
   constructor(
     readonly status: number,
     message: string,
+    readonly retryAfter: string | null = null,
+    readonly rateLimitRemaining: string | null = null,
+    readonly rateLimitReset: string | null = null,
   ) {
     super(message)
     this.name = "GitHubError"
@@ -33,7 +36,13 @@ const ghHeaders = (auth?: string): Record<string, string> => ({
 
 const raise = async (res: Response, what: string): Promise<never> => {
   const body = await res.text().catch(() => "")
-  throw new GitHubError(res.status, `${what}: ${body.slice(0, 200) || res.statusText}`)
+  throw new GitHubError(
+    res.status,
+    `${what}: ${body.slice(0, 200) || res.statusText}`,
+    res.headers.get("retry-after"),
+    res.headers.get("x-ratelimit-remaining"),
+    res.headers.get("x-ratelimit-reset"),
+  )
 }
 
 /**
@@ -64,10 +73,16 @@ export interface InstallationToken {
   expiresAt: string
 }
 
-export type GitHubTokenProfile = "standard-pr" | "workflow-dispatch"
+export type GitHubTokenProfile =
+  | "standard-read"
+  | "pr-comment"
+  | "workflow-read"
+  | "workflow-dispatch"
 
 const PROFILE_PERMISSIONS: Record<GitHubTokenProfile, Record<string, string>> = {
-  "standard-pr": { metadata: "read", pull_requests: "write" },
+  "standard-read": { metadata: "read", pull_requests: "read" },
+  "pr-comment": { metadata: "read", pull_requests: "write" },
+  "workflow-read": { actions: "read", metadata: "read" },
   "workflow-dispatch": { actions: "write", metadata: "read" },
 }
 
@@ -107,15 +122,32 @@ export async function getAppInfo(
 // Per-isolate cache so a burst of source calls against one installation mints one token.
 // Re-minted 60s before expiry. Cleared implicitly when the isolate recycles.
 const tokenCache = new Map<string, InstallationToken>()
+const TOKEN_CACHE_MAX = 500
+
+const pruneTokenCache = (now: number): void => {
+  for (const [key, value] of tokenCache)
+    if (!Number.isFinite(Date.parse(value.expiresAt)) || Date.parse(value.expiresAt) <= now)
+      tokenCache.delete(key)
+  while (tokenCache.size >= TOKEN_CACHE_MAX) {
+    const oldest = tokenCache.keys().next().value
+    if (typeof oldest !== "string") break
+    tokenCache.delete(oldest)
+  }
+}
 
 /** Mint (or reuse) an installation access token for `installationId`. */
 export async function installationToken(
   appId: string,
   privateKeyPem: string,
   installationId: string,
-  profile: GitHubTokenProfile = "standard-pr",
+  profile: GitHubTokenProfile = "standard-read",
   repository?: string,
 ): Promise<string> {
+  if (!/^[1-9][0-9]{0,19}$/.test(installationId)) throw new Error("invalid GitHub installation id")
+  if ((profile === "workflow-read" || profile === "workflow-dispatch") && !repository)
+    throw new Error("a workflow token must name one repository")
+  if (repository && !/^[A-Za-z0-9_.-]{1,100}$/.test(repository))
+    throw new Error("invalid GitHub repository name")
   const cacheKey = `${appId}:${installationId}:${profile}:${repository ?? "*"}`
   const cached = tokenCache.get(cacheKey)
   if (cached && Date.parse(cached.expiresAt) - 60_000 > Date.now()) return cached.token
@@ -133,7 +165,16 @@ export async function installationToken(
     }),
   })
   if (!res.ok) return raise(res, "minting an installation token")
-  const data = (await res.json()) as { token: string; expires_at: string }
+  const data = (await res.json()) as { token?: unknown; expires_at?: unknown }
+  if (
+    typeof data.token !== "string" ||
+    !data.token ||
+    data.token.length > 2_048 ||
+    typeof data.expires_at !== "string" ||
+    !Number.isFinite(Date.parse(data.expires_at))
+  )
+    throw new Error("GitHub returned an invalid installation token")
+  pruneTokenCache(Date.now())
   tokenCache.set(cacheKey, { token: data.token, expiresAt: data.expires_at })
   return data.token
 }
@@ -152,12 +193,16 @@ export async function getAppInstallation(
   const data = (await res.json()) as {
     id?: number
     account?: { login?: string; type?: string }
+    html_url?: string
+    permissions?: Record<string, string>
   }
   return {
     id: data.id ?? Number(installationId),
     account: data.account
       ? { login: data.account.login ?? "", type: data.account.type ?? "" }
       : null,
+    htmlUrl: data.html_url ?? null,
+    permissions: data.permissions ?? {},
   }
 }
 
@@ -203,6 +248,8 @@ export async function getUserInstallation(
       installations?: {
         id?: number
         account?: { login?: string; type?: string }
+        html_url?: string
+        permissions?: Record<string, string>
       }[]
     }
     const installations = data.installations ?? []
@@ -213,6 +260,8 @@ export async function getUserInstallation(
         account: found.account
           ? { login: found.account.login ?? "", type: found.account.type ?? "" }
           : null,
+        htmlUrl: found.html_url ?? null,
+        permissions: found.permissions ?? {},
       }
     if (installations.length < 100) break
   }
@@ -222,6 +271,8 @@ export async function getUserInstallation(
 export interface AppInstallation {
   id: number
   account: { login: string; type: string } | null
+  htmlUrl: string | null
+  permissions: Record<string, string>
 }
 
 export interface ManifestConversion {

--- a/apps/api/src/lib/github-source-policy.ts
+++ b/apps/api/src/lib/github-source-policy.ts
@@ -1,5 +1,6 @@
 const REPO_PART = "[A-Za-z0-9_.-]+"
 const NUMBER = "[1-9][0-9]*"
+const WORKFLOW = `(?:${NUMBER}|[A-Za-z0-9_.-]+\\.ya?ml)`
 
 const listRepos = /^\/installation\/repositories$/
 const listPulls = new RegExp(`^/repos/${REPO_PART}/${REPO_PART}/pulls$`)
@@ -7,6 +8,24 @@ const getPull = new RegExp(`^/repos/${REPO_PART}/${REPO_PART}/pulls/${NUMBER}$`)
 const listPullFiles = new RegExp(`^/repos/${REPO_PART}/${REPO_PART}/pulls/${NUMBER}/files$`)
 const pullComments = new RegExp(
   `^/repos/(${REPO_PART})/(${REPO_PART})/issues/(${NUMBER})/comments$`,
+)
+const listWorkflows = new RegExp(`^/repos/(${REPO_PART})/(${REPO_PART})/actions/workflows$`)
+const getWorkflow = new RegExp(
+  `^/repos/(${REPO_PART})/(${REPO_PART})/actions/workflows/(${WORKFLOW})$`,
+)
+const workflowRuns = new RegExp(
+  `^/repos/(${REPO_PART})/(${REPO_PART})/actions/workflows/(${WORKFLOW})/runs$`,
+)
+const dispatchWorkflow = new RegExp(
+  `^/repos/(${REPO_PART})/(${REPO_PART})/actions/workflows/(${WORKFLOW})/dispatches$`,
+)
+const getRun = new RegExp(`^/repos/(${REPO_PART})/(${REPO_PART})/actions/runs/(${NUMBER})$`)
+const runJobs = new RegExp(`^/repos/(${REPO_PART})/(${REPO_PART})/actions/runs/(${NUMBER})/jobs$`)
+const runArtifacts = new RegExp(
+  `^/repos/(${REPO_PART})/(${REPO_PART})/actions/runs/(${NUMBER})/artifacts$`,
+)
+const cancelRun = new RegExp(
+  `^/repos/(${REPO_PART})/(${REPO_PART})/actions/runs/(${NUMBER})/cancel$`,
 )
 
 const queryKeys = (url: URL): Set<string> => new Set(url.searchParams.keys())
@@ -23,6 +42,32 @@ export interface GithubSourcePolicy {
   verb: "GET" | "POST"
   /** For comment writes, the PR endpoint used to prove the issue number is a PR. */
   prPreflightPath?: string
+  /** The permission-narrowed installation token this operation needs. */
+  tokenProfile: "standard-pr" | "workflow-dispatch"
+  /** Actions tokens are narrowed to this one repository at mint time. */
+  repository?: string
+  /** Workflow dispatch returns the run id under the current GitHub API version. */
+  apiVersion?: string
+}
+
+const standardPr = (extra: Omit<GithubSourcePolicy, "tokenProfile">): GithubSourcePolicy => ({
+  tokenProfile: "standard-pr",
+  ...extra,
+})
+
+const workflowAction = (
+  repository: string,
+  extra: Omit<GithubSourcePolicy, "repository" | "tokenProfile">,
+): GithubSourcePolicy => ({ repository, tokenProfile: "workflow-dispatch", ...extra })
+
+const workflowInputsAreValid = (value: unknown): boolean => {
+  if (value === undefined) return true
+  if (!plainObject(value) || Object.keys(value).length > 25) return false
+  return Object.entries(value).every(
+    ([key, input]) =>
+      /^[A-Za-z0-9_-]{1,100}$/.test(key) &&
+      (typeof input === "string" || typeof input === "number" || typeof input === "boolean"),
+  )
 }
 
 /**
@@ -41,23 +86,82 @@ export function githubSourcePolicy(tool: string, url: URL, body: unknown): Githu
   const path = url.pathname
 
   if (verb === "GET") {
-    if (listRepos.test(path) && onlyQueryKeys(url, ["page", "per_page"])) return { verb }
+    if (listRepos.test(path) && onlyQueryKeys(url, ["page", "per_page"]))
+      return standardPr({ verb })
     if (
       listPulls.test(path) &&
       onlyQueryKeys(url, ["base", "direction", "head", "page", "per_page", "sort", "state"])
     )
-      return { verb }
-    if (getPull.test(path) && queryKeys(url).size === 0) return { verb }
-    if (listPullFiles.test(path) && onlyQueryKeys(url, ["page", "per_page"])) return { verb }
+      return standardPr({ verb })
+    if (getPull.test(path) && queryKeys(url).size === 0) return standardPr({ verb })
+    if (listPullFiles.test(path) && onlyQueryKeys(url, ["page", "per_page"]))
+      return standardPr({ verb })
     const commentsMatch = pullComments.exec(path)
     if (commentsMatch && onlyQueryKeys(url, ["page", "per_page", "since"])) {
       const [, owner, repo, number] = commentsMatch
-      return { verb, prPreflightPath: `/repos/${owner}/${repo}/pulls/${number}` }
+      return standardPr({ verb, prPreflightPath: `/repos/${owner}/${repo}/pulls/${number}` })
     }
+    const workflowsMatch = listWorkflows.exec(path)
+    if (workflowsMatch && onlyQueryKeys(url, ["page", "per_page"]))
+      return workflowAction(workflowsMatch[2] as string, { verb })
+    const workflowMatch = getWorkflow.exec(path)
+    if (workflowMatch && queryKeys(url).size === 0)
+      return workflowAction(workflowMatch[2] as string, { verb })
+    const workflowRunsMatch = workflowRuns.exec(path)
+    if (
+      workflowRunsMatch &&
+      onlyQueryKeys(url, [
+        "actor",
+        "branch",
+        "check_suite_id",
+        "created",
+        "event",
+        "exclude_pull_requests",
+        "head_sha",
+        "page",
+        "per_page",
+        "status",
+      ])
+    )
+      return workflowAction(workflowRunsMatch[2] as string, { verb })
+    const runMatch = getRun.exec(path)
+    if (runMatch && queryKeys(url).size === 0)
+      return workflowAction(runMatch[2] as string, { verb })
+    const jobsMatch = runJobs.exec(path)
+    if (jobsMatch && onlyQueryKeys(url, ["filter", "page", "per_page"]))
+      return workflowAction(jobsMatch[2] as string, { verb })
+    const artifactsMatch = runArtifacts.exec(path)
+    if (artifactsMatch && onlyQueryKeys(url, ["name", "page", "per_page"]))
+      return workflowAction(artifactsMatch[2] as string, { verb })
     throw new Error(
-      "GitHub source only permits reading repositories, pull requests, and PR comments",
+      "GitHub source only permits reading repositories, pull requests, PR comments, and workflow runs",
     )
   }
+
+  const dispatchMatch = dispatchWorkflow.exec(path)
+  if (dispatchMatch && queryKeys(url).size === 0) {
+    if (
+      !plainObject(body) ||
+      Object.keys(body).some((key) => key !== "ref" && key !== "inputs") ||
+      typeof body.ref !== "string" ||
+      !body.ref.trim() ||
+      body.ref.length > 1_024 ||
+      !workflowInputsAreValid(body.inputs)
+    )
+      throw new Error("a GitHub workflow dispatch must contain a ref and at most 25 scalar inputs")
+    return workflowAction(dispatchMatch[2] as string, {
+      apiVersion: "2026-03-10",
+      verb,
+    })
+  }
+
+  const cancelMatch = cancelRun.exec(path)
+  if (
+    cancelMatch &&
+    queryKeys(url).size === 0 &&
+    (body === undefined || (plainObject(body) && Object.keys(body).length === 0))
+  )
+    return workflowAction(cancelMatch[2] as string, { verb })
 
   const match = pullComments.exec(path)
   if (!match || queryKeys(url).size !== 0)
@@ -68,5 +172,5 @@ export function githubSourcePolicy(tool: string, url: URL, body: unknown): Githu
   if (!comment || comment.length > 65_536)
     throw new Error("a GitHub pull request comment body must be 1–65,536 characters")
   const [, owner, repo, number] = match
-  return { verb, prPreflightPath: `/repos/${owner}/${repo}/pulls/${number}` }
+  return standardPr({ verb, prPreflightPath: `/repos/${owner}/${repo}/pulls/${number}` })
 }

--- a/apps/api/src/lib/github-source-policy.ts
+++ b/apps/api/src/lib/github-source-policy.ts
@@ -1,6 +1,14 @@
-const REPO_PART = "[A-Za-z0-9_.-]+"
-const NUMBER = "[1-9][0-9]*"
-const WORKFLOW = `(?:${NUMBER}|[A-Za-z0-9_.-]+\\.ya?ml)`
+import type { GitHubTokenProfile } from "./github-app"
+
+// Bound every attacker-controlled path component before token minting. GitHub names are much
+// shorter than these limits, but the explicit ceiling also prevents cache-key and URL abuse.
+const REPO_PART = "[A-Za-z0-9_.-]{1,100}"
+const NUMBER = "[1-9][0-9]{0,19}"
+const WORKFLOW_FILE = "[A-Za-z0-9_.-]{1,200}\\.ya?ml"
+const WORKFLOW = `(?:${NUMBER}|${WORKFLOW_FILE})`
+// Dispatch is opt-in by filename. Existing release and deployment workflows stay unreachable
+// unless their owner deliberately exposes a Derive adapter workflow.
+const DERIVE_WORKFLOW = "derive-[A-Za-z0-9_.-]{1,193}\\.ya?ml"
 
 const listRepos = /^\/installation\/repositories$/
 const listPulls = new RegExp(`^/repos/${REPO_PART}/${REPO_PART}/pulls$`)
@@ -17,6 +25,9 @@ const workflowRuns = new RegExp(
   `^/repos/(${REPO_PART})/(${REPO_PART})/actions/workflows/(${WORKFLOW})/runs$`,
 )
 const dispatchWorkflow = new RegExp(
+  `^/repos/(${REPO_PART})/(${REPO_PART})/actions/workflows/(${DERIVE_WORKFLOW})/dispatches$`,
+)
+const anyWorkflowDispatch = new RegExp(
   `^/repos/(${REPO_PART})/(${REPO_PART})/actions/workflows/(${WORKFLOW})/dispatches$`,
 )
 const getRun = new RegExp(`^/repos/(${REPO_PART})/(${REPO_PART})/actions/runs/(${NUMBER})$`)
@@ -24,14 +35,21 @@ const runJobs = new RegExp(`^/repos/(${REPO_PART})/(${REPO_PART})/actions/runs/(
 const runArtifacts = new RegExp(
   `^/repos/(${REPO_PART})/(${REPO_PART})/actions/runs/(${NUMBER})/artifacts$`,
 )
-const cancelRun = new RegExp(
-  `^/repos/(${REPO_PART})/(${REPO_PART})/actions/runs/(${NUMBER})/cancel$`,
-)
-
 const queryKeys = (url: URL): Set<string> => new Set(url.searchParams.keys())
 const onlyQueryKeys = (url: URL, allowed: readonly string[]): boolean => {
   const allowedSet = new Set(allowed)
-  return [...queryKeys(url)].every((key) => allowedSet.has(key))
+  const entries = [...url.searchParams.entries()]
+  if (
+    entries.length !== queryKeys(url).size ||
+    entries.some(([key, value]) => !allowedSet.has(key) || value.length > 256)
+  )
+    return false
+  const page = url.searchParams.get("page")
+  const perPage = url.searchParams.get("per_page")
+  return (
+    (!page || /^[1-9][0-9]{0,5}$/.test(page)) &&
+    (!perPage || /^(?:[1-9]|[1-9][0-9]|100)$/.test(perPage))
+  )
 }
 
 const plainObject = (value: unknown): value is Record<string, unknown> =>
@@ -43,31 +61,60 @@ export interface GithubSourcePolicy {
   /** For comment writes, the PR endpoint used to prove the issue number is a PR. */
   prPreflightPath?: string
   /** The permission-narrowed installation token this operation needs. */
-  tokenProfile: "standard-pr" | "workflow-dispatch"
+  tokenProfile: GitHubTokenProfile
   /** Actions tokens are narrowed to this one repository at mint time. */
   repository?: string
   /** Workflow dispatch returns the run id under the current GitHub API version. */
   apiVersion?: string
 }
 
-const standardPr = (extra: Omit<GithubSourcePolicy, "tokenProfile">): GithubSourcePolicy => ({
-  tokenProfile: "standard-pr",
+const standardRead = (extra: Omit<GithubSourcePolicy, "tokenProfile">): GithubSourcePolicy => ({
+  tokenProfile: "standard-read",
+  ...extra,
+})
+
+const prComment = (extra: Omit<GithubSourcePolicy, "tokenProfile">): GithubSourcePolicy => ({
+  tokenProfile: "pr-comment",
   ...extra,
 })
 
 const workflowAction = (
   repository: string,
-  extra: Omit<GithubSourcePolicy, "repository" | "tokenProfile">,
-): GithubSourcePolicy => ({ repository, tokenProfile: "workflow-dispatch", ...extra })
+  extra: Omit<GithubSourcePolicy, "repository">,
+): GithubSourcePolicy => ({ apiVersion: "2026-03-10", repository, ...extra })
 
 const workflowInputsAreValid = (value: unknown): boolean => {
   if (value === undefined) return true
   if (!plainObject(value) || Object.keys(value).length > 25) return false
-  return Object.entries(value).every(
-    ([key, input]) =>
-      /^[A-Za-z0-9_-]{1,100}$/.test(key) &&
-      (typeof input === "string" || typeof input === "number" || typeof input === "boolean"),
+  const entriesAreValid = Object.entries(value).every(([key, input]) => {
+    if (!/^[A-Za-z0-9_-]{1,100}$/.test(key)) return false
+    if (typeof input === "number") return Number.isFinite(input)
+    return typeof input === "string" || typeof input === "boolean"
+  })
+  // GitHub documents this as characters, not bytes. JSON is the exact payload representation
+  // and includes keys, quotes, and separators, so this refuses before GitHub's 65,535 limit.
+  return entriesAreValid && JSON.stringify(value).length <= 65_535
+}
+
+const workflowRefIsValid = (value: unknown): value is string => {
+  if (typeof value !== "string" || !value || value.length > 1_024 || value !== value.trim())
+    return false
+  const forbiddenCharacter = [...value].some((character) => {
+    const code = character.charCodeAt(0)
+    return code <= 0x20 || code === 0x7f || "~^:?*[\\".includes(character)
+  })
+  if (
+    value === "@" ||
+    value.startsWith("/") ||
+    value.endsWith("/") ||
+    value.endsWith(".") ||
+    value.includes("//") ||
+    value.includes("..") ||
+    value.includes("@{") ||
+    forbiddenCharacter
   )
+    return false
+  return value.split("/").every((part) => part && !part.startsWith(".") && !part.endsWith(".lock"))
 }
 
 /**
@@ -75,9 +122,10 @@ const workflowInputsAreValid = (value: unknown): boolean => {
  * PR conversation comment, but that vendor scope is broader than the product contract. This
  * policy is therefore checked before token minting and before any network request.
  *
- * Keep this list deliberately small: PR discovery/detail/files, PR conversation reads, and
- * one new top-level PR conversation comment. Repository contents, issues, reviews, branches,
- * merges, edits, and deletes are all outside the standard integration.
+ * Keep this list deliberately small: PR discovery/detail/files, PR conversation reads, one new
+ * top-level PR conversation comment, Actions reads, and dispatch of explicitly opted-in
+ * `derive-*.yml` workflows. Repository contents, issues, reviews, branches, merges, edits,
+ * deletes, reruns, and cancellation of unproven runs are all outside the standard integration.
  */
 export function githubSourcePolicy(tool: string, url: URL, body: unknown): GithubSourcePolicy {
   if (tool !== "github.get" && tool !== "github.post")
@@ -87,26 +135,26 @@ export function githubSourcePolicy(tool: string, url: URL, body: unknown): Githu
 
   if (verb === "GET") {
     if (listRepos.test(path) && onlyQueryKeys(url, ["page", "per_page"]))
-      return standardPr({ verb })
+      return standardRead({ verb })
     if (
       listPulls.test(path) &&
       onlyQueryKeys(url, ["base", "direction", "head", "page", "per_page", "sort", "state"])
     )
-      return standardPr({ verb })
-    if (getPull.test(path) && queryKeys(url).size === 0) return standardPr({ verb })
+      return standardRead({ verb })
+    if (getPull.test(path) && queryKeys(url).size === 0) return standardRead({ verb })
     if (listPullFiles.test(path) && onlyQueryKeys(url, ["page", "per_page"]))
-      return standardPr({ verb })
+      return standardRead({ verb })
     const commentsMatch = pullComments.exec(path)
     if (commentsMatch && onlyQueryKeys(url, ["page", "per_page", "since"])) {
       const [, owner, repo, number] = commentsMatch
-      return standardPr({ verb, prPreflightPath: `/repos/${owner}/${repo}/pulls/${number}` })
+      return standardRead({ verb, prPreflightPath: `/repos/${owner}/${repo}/pulls/${number}` })
     }
     const workflowsMatch = listWorkflows.exec(path)
     if (workflowsMatch && onlyQueryKeys(url, ["page", "per_page"]))
-      return workflowAction(workflowsMatch[2] as string, { verb })
+      return workflowAction(workflowsMatch[2] as string, { verb, tokenProfile: "workflow-read" })
     const workflowMatch = getWorkflow.exec(path)
     if (workflowMatch && queryKeys(url).size === 0)
-      return workflowAction(workflowMatch[2] as string, { verb })
+      return workflowAction(workflowMatch[2] as string, { verb, tokenProfile: "workflow-read" })
     const workflowRunsMatch = workflowRuns.exec(path)
     if (
       workflowRunsMatch &&
@@ -123,16 +171,22 @@ export function githubSourcePolicy(tool: string, url: URL, body: unknown): Githu
         "status",
       ])
     )
-      return workflowAction(workflowRunsMatch[2] as string, { verb })
+      return workflowAction(workflowRunsMatch[2] as string, {
+        verb,
+        tokenProfile: "workflow-read",
+      })
     const runMatch = getRun.exec(path)
     if (runMatch && queryKeys(url).size === 0)
-      return workflowAction(runMatch[2] as string, { verb })
+      return workflowAction(runMatch[2] as string, { verb, tokenProfile: "workflow-read" })
     const jobsMatch = runJobs.exec(path)
     if (jobsMatch && onlyQueryKeys(url, ["filter", "page", "per_page"]))
-      return workflowAction(jobsMatch[2] as string, { verb })
+      return workflowAction(jobsMatch[2] as string, { verb, tokenProfile: "workflow-read" })
     const artifactsMatch = runArtifacts.exec(path)
     if (artifactsMatch && onlyQueryKeys(url, ["name", "page", "per_page"]))
-      return workflowAction(artifactsMatch[2] as string, { verb })
+      return workflowAction(artifactsMatch[2] as string, {
+        verb,
+        tokenProfile: "workflow-read",
+      })
     throw new Error(
       "GitHub source only permits reading repositories, pull requests, PR comments, and workflow runs",
     )
@@ -143,25 +197,19 @@ export function githubSourcePolicy(tool: string, url: URL, body: unknown): Githu
     if (
       !plainObject(body) ||
       Object.keys(body).some((key) => key !== "ref" && key !== "inputs") ||
-      typeof body.ref !== "string" ||
-      !body.ref.trim() ||
-      body.ref.length > 1_024 ||
+      !workflowRefIsValid(body.ref) ||
       !workflowInputsAreValid(body.inputs)
     )
-      throw new Error("a GitHub workflow dispatch must contain a ref and at most 25 scalar inputs")
+      throw new Error(
+        "a GitHub workflow dispatch needs a valid ref and at most 25 scalar inputs (65,535 characters total)",
+      )
     return workflowAction(dispatchMatch[2] as string, {
-      apiVersion: "2026-03-10",
+      tokenProfile: "workflow-dispatch",
       verb,
     })
   }
-
-  const cancelMatch = cancelRun.exec(path)
-  if (
-    cancelMatch &&
-    queryKeys(url).size === 0 &&
-    (body === undefined || (plainObject(body) && Object.keys(body).length === 0))
-  )
-    return workflowAction(cancelMatch[2] as string, { verb })
+  if (anyWorkflowDispatch.test(path))
+    throw new Error("GitHub dispatch only permits adapter workflows named derive-*.yml")
 
   const match = pullComments.exec(path)
   if (!match || queryKeys(url).size !== 0)
@@ -172,5 +220,5 @@ export function githubSourcePolicy(tool: string, url: URL, body: unknown): Githu
   if (!comment || comment.length > 65_536)
     throw new Error("a GitHub pull request comment body must be 1–65,536 characters")
   const [, owner, repo, number] = match
-  return standardPr({ verb, prPreflightPath: `/repos/${owner}/${repo}/pulls/${number}` })
+  return prComment({ verb, prPreflightPath: `/repos/${owner}/${repo}/pulls/${number}` })
 }

--- a/apps/api/src/routes/github.ts
+++ b/apps/api/src/routes/github.ts
@@ -3,7 +3,7 @@ import type { GitHubAppRecord } from "@derive/core"
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import type { BlankEnv } from "hono/types"
 import type { AppContext } from "../context"
-import { REQUIRED_PERMISSIONS } from "../github-app-setup"
+import { ACTIONS_PERMISSION, REQUIRED_PERMISSIONS } from "../github-app-setup"
 import { decryptSecret, signState, verifyState } from "../lib/crypto"
 import {
   exchangeGithubUserCode,
@@ -78,6 +78,9 @@ export const githubRoutes = (ctx: AppContext) => {
         .describe("Whether this workspace has at least one active GitHub connection"),
       app_slug: z.string().nullable(),
       needs_permissions: z.boolean(),
+      actions_available: z
+        .boolean()
+        .describe("Whether the configured App can discover and dispatch GitHub Actions workflows"),
       permissions_url: z.string().nullable(),
       accounts: z.array(Account),
     })
@@ -110,6 +113,7 @@ export const githubRoutes = (ctx: AppContext) => {
       let available = !!loaded
       let slug = loaded?.app.slug ?? null
       let needsPermissions = false
+      let actionsAvailable = false
       if (loaded) {
         try {
           const live = await getAppInfo(loaded.app.app_id, loaded.pem)
@@ -120,6 +124,11 @@ export const githubRoutes = (ctx: AppContext) => {
             ([permission, level]) =>
               !live.permissions[permission] ||
               (rank[live.permissions[permission] ?? ""] ?? 0) < (rank[level] ?? 0),
+          )
+          actionsAvailable = Object.entries(ACTIONS_PERMISSION).every(
+            ([permission, level]) =>
+              !!live.permissions[permission] &&
+              (rank[live.permissions[permission] ?? ""] ?? 0) >= (rank[level] ?? 0),
           )
         } catch (err) {
           // Deleted/revoked is definitive. A network/5xx failure must not hide a working App.
@@ -189,6 +198,7 @@ export const githubRoutes = (ctx: AppContext) => {
         connected: accounts.some((account) => account.state === "active"),
         app_slug: slug,
         needs_permissions: needsPermissions,
+        actions_available: actionsAvailable,
         permissions_url: slug
           ? `https://github.com/settings/apps/${encodeURIComponent(slug)}/permissions`
           : null,

--- a/apps/api/src/routes/github.ts
+++ b/apps/api/src/routes/github.ts
@@ -80,7 +80,10 @@ export const githubRoutes = (ctx: AppContext) => {
       needs_permissions: z.boolean(),
       actions_available: z
         .boolean()
-        .describe("Whether the configured App can discover and dispatch GitHub Actions workflows"),
+        .nullable()
+        .describe(
+          "Whether the configured App and its connected installations can dispatch GitHub Actions workflows; null when GitHub could not be checked",
+        ),
       permissions_url: z.string().nullable(),
       accounts: z.array(Account),
     })
@@ -113,19 +116,21 @@ export const githubRoutes = (ctx: AppContext) => {
       let available = !!loaded
       let slug = loaded?.app.slug ?? null
       let needsPermissions = false
-      let actionsAvailable = false
+      // Null means GitHub could not be checked. Do not turn a transient outage into a false
+      // permission-upgrade prompt.
+      let appActionsAvailable: boolean | null = null
+      const rank: Record<string, number> = { read: 1, write: 2, admin: 3 }
       if (loaded) {
         try {
           const live = await getAppInfo(loaded.app.app_id, loaded.pem)
           slug = live.slug || slug
           if (slug && slug !== loaded.app.slug) await meta.setGithubApp({ ...loaded.app, slug })
-          const rank: Record<string, number> = { read: 1, write: 2, admin: 3 }
           needsPermissions = Object.entries(REQUIRED_PERMISSIONS).some(
             ([permission, level]) =>
               !live.permissions[permission] ||
               (rank[live.permissions[permission] ?? ""] ?? 0) < (rank[level] ?? 0),
           )
-          actionsAvailable = Object.entries(ACTIONS_PERMISSION).every(
+          appActionsAvailable = Object.entries(ACTIONS_PERMISSION).every(
             ([permission, level]) =>
               !!live.permissions[permission] &&
               (rank[live.permissions[permission] ?? ""] ?? 0) >= (rank[level] ?? 0),
@@ -145,11 +150,25 @@ export const githubRoutes = (ctx: AppContext) => {
       // only definitive auth/not-found responses as stale; a transient GitHub outage must not
       // make healthy connections disappear.
       const staleInstallations = new Set<string>()
+      const installationActions = new Map<string, boolean>()
+      let installationPermissionsUrl: string | null = null
       if (loaded && available) {
         await Promise.all(
           installs.map(async (installation) => {
             try {
-              await getAppInstallation(loaded.app.app_id, loaded.pem, installation.installation_id)
+              const live = await getAppInstallation(
+                loaded.app.app_id,
+                loaded.pem,
+                installation.installation_id,
+              )
+              const actions = Object.entries(ACTIONS_PERMISSION).every(
+                ([permission, level]) =>
+                  !!live.permissions[permission] &&
+                  (rank[live.permissions[permission] ?? ""] ?? 0) >= (rank[level] ?? 0),
+              )
+              installationActions.set(installation.installation_id, actions)
+              if (!actions && !installationPermissionsUrl && live.htmlUrl)
+                installationPermissionsUrl = live.htmlUrl
             } catch (err) {
               if (
                 err instanceof GitHubError &&
@@ -159,6 +178,16 @@ export const githubRoutes = (ctx: AppContext) => {
             }
           }),
         )
+      }
+      const liveInstallationIds = installs
+        .map((installation) => installation.installation_id)
+        .filter((id) => !staleInstallations.has(id))
+      let actionsAvailable = appActionsAvailable
+      if (appActionsAvailable === true && liveInstallationIds.length > 0) {
+        if (liveInstallationIds.some((id) => installationActions.get(id) === false))
+          actionsAvailable = false
+        else if (liveInstallationIds.some((id) => !installationActions.has(id)))
+          actionsAvailable = null
       }
       const accounts: {
         installation_id: string
@@ -199,9 +228,12 @@ export const githubRoutes = (ctx: AppContext) => {
         app_slug: slug,
         needs_permissions: needsPermissions,
         actions_available: actionsAvailable,
-        permissions_url: slug
-          ? `https://github.com/settings/apps/${encodeURIComponent(slug)}/permissions`
-          : null,
+        permissions_url:
+          appActionsAvailable === true && installationPermissionsUrl
+            ? installationPermissionsUrl
+            : slug
+              ? `https://github.com/settings/apps/${encodeURIComponent(slug)}/permissions`
+              : null,
         accounts,
       })
     },

--- a/apps/api/test/github-app.test.ts
+++ b/apps/api/test/github-app.test.ts
@@ -48,35 +48,71 @@ describe("installationToken", () => {
       }),
     )
 
-    const narrow = await installationToken("12345", privateKey, "profile-9001")
-    const narrowAgain = await installationToken("12345", privateKey, "profile-9001")
+    const narrow = await installationToken("12345", privateKey, "9001")
+    const narrowAgain = await installationToken("12345", privateKey, "9001")
+    const comment = await installationToken("12345", privateKey, "9001", "pr-comment")
+    const commentAgain = await installationToken("12345", privateKey, "9001", "pr-comment")
+    const read = await installationToken("12345", privateKey, "9001", "workflow-read", "derive")
+    const readAgain = await installationToken(
+      "12345",
+      privateKey,
+      "9001",
+      "workflow-read",
+      "derive",
+    )
     const actions = await installationToken(
       "12345",
       privateKey,
-      "profile-9001",
+      "9001",
       "workflow-dispatch",
       "derive",
     )
     const actionsAgain = await installationToken(
       "12345",
       privateKey,
-      "profile-9001",
+      "9001",
       "workflow-dispatch",
       "derive",
     )
 
     expect(narrow).toBe("installation-profile-1")
     expect(narrowAgain).toBe(narrow)
-    expect(actions).toBe("installation-profile-2")
+    expect(comment).toBe("installation-profile-2")
+    expect(commentAgain).toBe(comment)
+    expect(read).toBe("installation-profile-3")
+    expect(readAgain).toBe(read)
+    expect(actions).toBe("installation-profile-4")
     expect(actionsAgain).toBe(actions)
-    expect(calls).toHaveLength(2)
+    expect(calls).toHaveLength(4)
     expect(JSON.parse(String(calls[0]?.body))).toEqual({
-      permissions: { metadata: "read", pull_requests: "write" },
+      permissions: { metadata: "read", pull_requests: "read" },
     })
     expect(JSON.parse(String(calls[1]?.body))).toEqual({
+      permissions: { metadata: "read", pull_requests: "write" },
+    })
+    expect(JSON.parse(String(calls[2]?.body))).toEqual({
+      permissions: { actions: "read", metadata: "read" },
+      repositories: ["derive"],
+    })
+    expect(JSON.parse(String(calls[3]?.body))).toEqual({
       permissions: { actions: "write", metadata: "read" },
       repositories: ["derive"],
     })
     expect(new Headers(calls[0]?.headers).get("content-type")).toBe("application/json")
+  })
+
+  it("refuses malformed installation and repository scopes before calling GitHub", async () => {
+    const fetch = vi.fn()
+    vi.stubGlobal("fetch", fetch)
+    await expect(installationToken("12345", privateKey, "not-an-id")).rejects.toThrow(
+      /installation id/i,
+    )
+    await expect(installationToken("12345", privateKey, "9002", "workflow-read")).rejects.toThrow(
+      /name one repository/i,
+    )
+    await expect(
+      installationToken("12345", privateKey, "9002", "workflow-read", "bad/repo"),
+    ).rejects.toThrow(/repository name/i)
+    expect(fetch).not.toHaveBeenCalled()
   })
 })

--- a/apps/api/test/github-app.test.ts
+++ b/apps/api/test/github-app.test.ts
@@ -32,7 +32,7 @@ describe("appJwt", () => {
 })
 
 describe("installationToken", () => {
-  it("always down-scopes a token to the standard PR capability", async () => {
+  it("keeps permission profiles and repository scopes isolated in the token cache", async () => {
     const calls: RequestInit[] = []
     vi.stubGlobal(
       "fetch",
@@ -50,12 +50,32 @@ describe("installationToken", () => {
 
     const narrow = await installationToken("12345", privateKey, "profile-9001")
     const narrowAgain = await installationToken("12345", privateKey, "profile-9001")
+    const actions = await installationToken(
+      "12345",
+      privateKey,
+      "profile-9001",
+      "workflow-dispatch",
+      "derive",
+    )
+    const actionsAgain = await installationToken(
+      "12345",
+      privateKey,
+      "profile-9001",
+      "workflow-dispatch",
+      "derive",
+    )
 
     expect(narrow).toBe("installation-profile-1")
     expect(narrowAgain).toBe(narrow)
-    expect(calls).toHaveLength(1)
+    expect(actions).toBe("installation-profile-2")
+    expect(actionsAgain).toBe(actions)
+    expect(calls).toHaveLength(2)
     expect(JSON.parse(String(calls[0]?.body))).toEqual({
       permissions: { metadata: "read", pull_requests: "write" },
+    })
+    expect(JSON.parse(String(calls[1]?.body))).toEqual({
+      permissions: { actions: "write", metadata: "read" },
+      repositories: ["derive"],
     })
     expect(new Headers(calls[0]?.headers).get("content-type")).toBe("application/json")
   })

--- a/apps/api/test/github-integration.test.ts
+++ b/apps/api/test/github-integration.test.ts
@@ -57,6 +57,7 @@ describe("standard GitHub integration", () => {
       403,
     )
     let pullPermission = "write"
+    let actionsPermission: string | undefined = "write"
     let installationStatus = 200
     const oauthCodes: string[] = []
     const oauthVerifiers: string[] = []
@@ -92,7 +93,11 @@ describe("standard GitHub integration", () => {
           return new Response(
             JSON.stringify({
               slug: "derive-test",
-              permissions: { metadata: "read", pull_requests: pullPermission },
+              permissions: {
+                ...(actionsPermission ? { actions: actionsPermission } : {}),
+                metadata: "read",
+                pull_requests: pullPermission,
+              },
               events: [],
             }),
             { status: 200 },
@@ -160,6 +165,7 @@ describe("standard GitHub integration", () => {
     expect(await status.json()).toMatchObject({
       available: true,
       connected: true,
+      actions_available: true,
       needs_permissions: false,
       accounts: [
         {
@@ -175,6 +181,11 @@ describe("standard GitHub integration", () => {
       await (await app.request("/v1/github", { headers: as(owner.email) })).json(),
     ).toMatchObject({ needs_permissions: true })
     pullPermission = "write"
+    actionsPermission = undefined
+    expect(
+      await (await app.request("/v1/github", { headers: as(owner.email) })).json(),
+    ).toMatchObject({ actions_available: false, connected: true, needs_permissions: false })
+    actionsPermission = "write"
     installationStatus = 404
     expect(
       await (await app.request("/v1/github", { headers: as(owner.email) })).json(),

--- a/apps/api/test/github-integration.test.ts
+++ b/apps/api/test/github-integration.test.ts
@@ -58,6 +58,8 @@ describe("standard GitHub integration", () => {
     )
     let pullPermission = "write"
     let actionsPermission: string | undefined = "write"
+    let installationActionsPermission: string | undefined = "write"
+    let appStatus = 200
     let installationStatus = 200
     const oauthCodes: string[] = []
     const oauthVerifiers: string[] = []
@@ -68,7 +70,18 @@ describe("standard GitHub integration", () => {
         const path = parsed.pathname
         if (path === "/app/installations/44001")
           return new Response(
-            JSON.stringify({ id: 44001, account: { login: "derive-to", type: "Organization" } }),
+            JSON.stringify({
+              id: 44001,
+              account: { login: "derive-to", type: "Organization" },
+              html_url: "https://github.com/organizations/derive-to/settings/installations/44001",
+              permissions: {
+                ...(installationActionsPermission
+                  ? { actions: installationActionsPermission }
+                  : {}),
+                metadata: "read",
+                pull_requests: "write",
+              },
+            }),
             { status: installationStatus },
           )
         if (parsed.host === "github.com" && path === "/login/oauth/access_token") {
@@ -100,7 +113,7 @@ describe("standard GitHub integration", () => {
               },
               events: [],
             }),
-            { status: 200 },
+            { status: appStatus },
           )
         return new Response("not found", { status: 404 })
       }),
@@ -186,6 +199,19 @@ describe("standard GitHub integration", () => {
       await (await app.request("/v1/github", { headers: as(owner.email) })).json(),
     ).toMatchObject({ actions_available: false, connected: true, needs_permissions: false })
     actionsPermission = "write"
+    installationActionsPermission = undefined
+    expect(
+      await (await app.request("/v1/github", { headers: as(owner.email) })).json(),
+    ).toMatchObject({
+      actions_available: false,
+      permissions_url: "https://github.com/organizations/derive-to/settings/installations/44001",
+    })
+    installationActionsPermission = "write"
+    appStatus = 500
+    expect(
+      await (await app.request("/v1/github", { headers: as(owner.email) })).json(),
+    ).toMatchObject({ actions_available: null, available: true, connected: true })
+    appStatus = 200
     installationStatus = 404
     expect(
       await (await app.request("/v1/github", { headers: as(owner.email) })).json(),

--- a/apps/api/test/github-manifest.test.ts
+++ b/apps/api/test/github-manifest.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from "vitest"
 import { buildManifest } from "../src/github-app-setup"
 
 // Locks the standard-source manifest. New installs query GitHub on demand: no contents,
-// issues, webhook events, or sync callback may creep back into this contract.
+// issues, webhook events, or sync callback may creep back into this contract. Actions write is
+// server-narrowed to workflow discovery, dispatch, status, artifacts, and cancellation.
 describe("GitHub App manifest", () => {
   const m = buildManifest("https://derive.example.com", "derive.example.com")
 
@@ -15,8 +16,9 @@ describe("GitHub App manifest", () => {
     expect(m.public).toBe(true)
   })
 
-  it("requests metadata read + pull-request write, nothing more", () => {
+  it("requests only metadata, pull requests, and the bounded Actions capability", () => {
     expect(m.default_permissions).toEqual({
+      actions: "write",
       metadata: "read",
       pull_requests: "write",
     })

--- a/apps/api/test/hosted-tools.test.ts
+++ b/apps/api/test/hosted-tools.test.ts
@@ -227,7 +227,7 @@ describe("hosted tool injection — least privilege (WO4)", () => {
     ).rejects.toThrow(/reconnect/i)
   })
 
-  it("github_app: exposes only PR reads and new top-level PR comments", async () => {
+  it("github_app: exposes only bounded PR and workflow operations", async () => {
     const connection = {
       id: "conn_gh_policy",
       org_id: "default",
@@ -269,14 +269,21 @@ describe("hosted tool injection — least privilege (WO4)", () => {
       "https://api.github.com/repos/derive-to/derive/pulls/42",
       "https://api.github.com/repos/derive-to/derive/pulls/42/files?per_page=100&page=2",
     ])
-      expect(githubSourcePolicy("github.get", new URL(url), undefined)).toEqual({ verb: "GET" })
+      expect(githubSourcePolicy("github.get", new URL(url), undefined)).toEqual({
+        tokenProfile: "standard-pr",
+        verb: "GET",
+      })
     expect(
       githubSourcePolicy(
         "github.get",
         new URL("https://api.github.com/repos/derive-to/derive/issues/42/comments?per_page=100"),
         undefined,
       ),
-    ).toEqual({ verb: "GET", prPreflightPath: "/repos/derive-to/derive/pulls/42" })
+    ).toEqual({
+      tokenProfile: "standard-pr",
+      verb: "GET",
+      prPreflightPath: "/repos/derive-to/derive/pulls/42",
+    })
     expect(() =>
       githubSourcePolicy(
         "github.get",
@@ -297,13 +304,151 @@ describe("hosted tool injection — least privilege (WO4)", () => {
         new URL("https://api.github.com/repos/derive-to/derive/issues/42/comments"),
         { body: "One explicit PR comment." },
       ),
-    ).toEqual({ verb: "POST", prPreflightPath: "/repos/derive-to/derive/pulls/42" })
+    ).toEqual({
+      tokenProfile: "standard-pr",
+      verb: "POST",
+      prPreflightPath: "/repos/derive-to/derive/pulls/42",
+    })
+
+    for (const url of [
+      "https://api.github.com/repos/derive-to/derive/actions/workflows?per_page=100",
+      "https://api.github.com/repos/derive-to/derive/actions/workflows/agent-qa.yml",
+      "https://api.github.com/repos/derive-to/derive/actions/workflows/agent-qa.yml/runs?event=workflow_dispatch&status=in_progress",
+      "https://api.github.com/repos/derive-to/derive/actions/runs/9001",
+      "https://api.github.com/repos/derive-to/derive/actions/runs/9001/jobs?filter=latest",
+      "https://api.github.com/repos/derive-to/derive/actions/runs/9001/artifacts?name=derive-result",
+    ])
+      expect(githubSourcePolicy("github.get", new URL(url), undefined)).toMatchObject({
+        repository: "derive",
+        tokenProfile: "workflow-dispatch",
+        verb: "GET",
+      })
+    expect(
+      githubSourcePolicy(
+        "github.post",
+        new URL(
+          "https://api.github.com/repos/derive-to/derive/actions/workflows/agent-qa.yml/dispatches",
+        ),
+        { ref: "main", inputs: { derive_run_id: "run_123", deep: true } },
+      ),
+    ).toEqual({
+      apiVersion: "2026-03-10",
+      repository: "derive",
+      tokenProfile: "workflow-dispatch",
+      verb: "POST",
+    })
+    expect(
+      githubSourcePolicy(
+        "github.post",
+        new URL("https://api.github.com/repos/derive-to/derive/actions/runs/9001/cancel"),
+        {},
+      ),
+    ).toEqual({
+      repository: "derive",
+      tokenProfile: "workflow-dispatch",
+      verb: "POST",
+    })
+    expect(() =>
+      githubSourcePolicy(
+        "github.post",
+        new URL(
+          "https://api.github.com/repos/derive-to/derive/actions/workflows/agent-qa.yml/dispatches",
+        ),
+        { ref: "main", inputs: { nested: { unsafe: true } } },
+      ),
+    ).toThrow(/scalar inputs/i)
+    expect(() =>
+      githubSourcePolicy(
+        "github.post",
+        new URL("https://api.github.com/repos/derive-to/derive/actions/runs/9001/rerun"),
+        {},
+      ),
+    ).toThrow(/pull request comment/i)
 
     const defs = httpTools("github")
     expect(defs.find((tool) => tool.name === "github.get")?.description).toContain("pull requests")
+    expect(defs.find((tool) => tool.name === "github.get")?.description).toContain("workflow runs")
     expect(defs.find((tool) => tool.name === "github.post")?.description).toContain(
-      "Other writes are refused",
+      "Dispatch or cancel",
     )
+  })
+
+  it("github_app: dispatches with an Actions-only token narrowed to one repository", async () => {
+    const key = "github-actions-key"
+    const h = makeAuthedApp("conn-gh-actions", [owner], "editor", {
+      deps: { encryptionKey: key },
+    })
+    await h.meta.setGithubApp({
+      id: "default",
+      app_id: "553",
+      slug: "derive-test",
+      client_id: "Iv1.test",
+      client_secret: encryptSecret("client-secret", key),
+      private_key: encryptSecret(GITHUB_APP_PEM, key),
+      created_at: new Date().toISOString(),
+    })
+    const connection = await upsertGithubConnection(h.meta, {
+      orgId: "default",
+      userId: owner.id,
+      installationId: "99004",
+      accountLogin: "derive-to",
+    })
+    let tokenBody: unknown
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string | URL, init?: RequestInit) => {
+        tokenBody = JSON.parse(String(init?.body))
+        return new Response(
+          JSON.stringify({
+            token: "github-actions-token",
+            expires_at: new Date(Date.now() + 3_600_000).toISOString(),
+          }),
+          { status: 201 },
+        )
+      }),
+    )
+    const calls: { apiVersion: string | null; auth: string | null; body: string | null }[] = []
+    const githubFetch = (async (_url: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers)
+      calls.push({
+        apiVersion: headers.get("x-github-api-version"),
+        auth: headers.get("authorization"),
+        body: typeof init?.body === "string" ? init.body : null,
+      })
+      return new Response(
+        JSON.stringify({
+          workflow_run_id: 7788,
+          run_url: "https://api.github.com/repos/derive-to/derive/actions/runs/7788",
+          html_url: "https://github.com/derive-to/derive/actions/runs/7788",
+        }),
+        { status: 200 },
+      )
+    }) as typeof fetch
+
+    const out = await executeHttpTool(
+      h.meta,
+      connection,
+      "github.post",
+      {
+        path: "/repos/derive-to/derive/actions/workflows/agent-qa.yml/dispatches",
+        body: { ref: "main", inputs: { derive_run_id: "run_123" } },
+      },
+      key,
+      githubFetch,
+    )
+
+    expect(tokenBody).toEqual({
+      permissions: { actions: "write", metadata: "read" },
+      repositories: ["derive"],
+    })
+    expect(calls).toEqual([
+      {
+        apiVersion: "2026-03-10",
+        auth: "Bearer github-actions-token",
+        body: JSON.stringify({ ref: "main", inputs: { derive_run_id: "run_123" } }),
+      },
+    ])
+    expect(out).toMatchObject({ status: 200, body: { workflow_run_id: 7788 } })
   })
 
   it("github_app: verifies a comment target is a PR before posting", async () => {

--- a/apps/api/test/hosted-tools.test.ts
+++ b/apps/api/test/hosted-tools.test.ts
@@ -270,7 +270,7 @@ describe("hosted tool injection — least privilege (WO4)", () => {
       "https://api.github.com/repos/derive-to/derive/pulls/42/files?per_page=100&page=2",
     ])
       expect(githubSourcePolicy("github.get", new URL(url), undefined)).toEqual({
-        tokenProfile: "standard-pr",
+        tokenProfile: "standard-read",
         verb: "GET",
       })
     expect(
@@ -280,7 +280,7 @@ describe("hosted tool injection — least privilege (WO4)", () => {
         undefined,
       ),
     ).toEqual({
-      tokenProfile: "standard-pr",
+      tokenProfile: "standard-read",
       verb: "GET",
       prPreflightPath: "/repos/derive-to/derive/pulls/42",
     })
@@ -305,7 +305,7 @@ describe("hosted tool injection — least privilege (WO4)", () => {
         { body: "One explicit PR comment." },
       ),
     ).toEqual({
-      tokenProfile: "standard-pr",
+      tokenProfile: "pr-comment",
       verb: "POST",
       prPreflightPath: "/repos/derive-to/derive/pulls/42",
     })
@@ -319,15 +319,16 @@ describe("hosted tool injection — least privilege (WO4)", () => {
       "https://api.github.com/repos/derive-to/derive/actions/runs/9001/artifacts?name=derive-result",
     ])
       expect(githubSourcePolicy("github.get", new URL(url), undefined)).toMatchObject({
+        apiVersion: "2026-03-10",
         repository: "derive",
-        tokenProfile: "workflow-dispatch",
+        tokenProfile: "workflow-read",
         verb: "GET",
       })
     expect(
       githubSourcePolicy(
         "github.post",
         new URL(
-          "https://api.github.com/repos/derive-to/derive/actions/workflows/agent-qa.yml/dispatches",
+          "https://api.github.com/repos/derive-to/derive/actions/workflows/derive-agent-qa.yml/dispatches",
         ),
         { ref: "main", inputs: { derive_run_id: "run_123", deep: true } },
       ),
@@ -337,26 +338,54 @@ describe("hosted tool injection — least privilege (WO4)", () => {
       tokenProfile: "workflow-dispatch",
       verb: "POST",
     })
-    expect(
+    expect(() =>
+      githubSourcePolicy(
+        "github.post",
+        new URL(
+          "https://api.github.com/repos/derive-to/derive/actions/workflows/derive-agent-qa.yml/dispatches",
+        ),
+        { ref: "main", inputs: { nested: { unsafe: true } } },
+      ),
+    ).toThrow(/scalar inputs/i)
+    expect(() =>
+      githubSourcePolicy(
+        "github.post",
+        new URL(
+          "https://api.github.com/repos/derive-to/derive/actions/workflows/release.yml/dispatches",
+        ),
+        { ref: "main" },
+      ),
+    ).toThrow(/derive-\*\.yml/i)
+    expect(() =>
       githubSourcePolicy(
         "github.post",
         new URL("https://api.github.com/repos/derive-to/derive/actions/runs/9001/cancel"),
         {},
       ),
-    ).toEqual({
-      repository: "derive",
-      tokenProfile: "workflow-dispatch",
-      verb: "POST",
-    })
-    expect(() =>
-      githubSourcePolicy(
-        "github.post",
-        new URL(
-          "https://api.github.com/repos/derive-to/derive/actions/workflows/agent-qa.yml/dispatches",
-        ),
-        { ref: "main", inputs: { nested: { unsafe: true } } },
-      ),
-    ).toThrow(/scalar inputs/i)
+    ).toThrow(/pull request comment/i)
+    for (const [url, body] of [
+      [
+        "https://api.github.com/repos/derive-to/derive/actions/workflows/derive-agent-qa.yml/dispatches",
+        { ref: " bad ref", inputs: {} },
+      ],
+      [
+        "https://api.github.com/repos/derive-to/derive/actions/workflows/derive-agent-qa.yml/dispatches",
+        { ref: "main", inputs: { score: Number.NaN } },
+      ],
+      [
+        "https://api.github.com/repos/derive-to/derive/actions/workflows/derive-agent-qa.yml/dispatches",
+        { ref: "main", inputs: { payload: "x".repeat(65_536) } },
+      ],
+    ] as const)
+      expect(() => githubSourcePolicy("github.post", new URL(url), body)).toThrow(/valid ref/i)
+    for (const url of [
+      "https://api.github.com/repos/derive-to/derive/actions/workflows?per_page=101",
+      "https://api.github.com/repos/derive-to/derive/actions/workflows?per_page=10&per_page=20",
+      `https://api.github.com/repos/${"a".repeat(101)}/derive/actions/workflows`,
+    ])
+      expect(() => githubSourcePolicy("github.get", new URL(url), undefined)).toThrow(
+        /only permits reading/i,
+      )
     expect(() =>
       githubSourcePolicy(
         "github.post",
@@ -368,9 +397,7 @@ describe("hosted tool injection — least privilege (WO4)", () => {
     const defs = httpTools("github")
     expect(defs.find((tool) => tool.name === "github.get")?.description).toContain("pull requests")
     expect(defs.find((tool) => tool.name === "github.get")?.description).toContain("workflow runs")
-    expect(defs.find((tool) => tool.name === "github.post")?.description).toContain(
-      "Dispatch or cancel",
-    )
+    expect(defs.find((tool) => tool.name === "github.post")?.description).toContain("derive-*.yml")
   })
 
   it("github_app: dispatches with an Actions-only token narrowed to one repository", async () => {
@@ -430,7 +457,7 @@ describe("hosted tool injection — least privilege (WO4)", () => {
       connection,
       "github.post",
       {
-        path: "/repos/derive-to/derive/actions/workflows/agent-qa.yml/dispatches",
+        path: "/repos/derive-to/derive/actions/workflows/derive-agent-qa.yml/dispatches",
         body: { ref: "main", inputs: { derive_run_id: "run_123" } },
       },
       key,
@@ -449,6 +476,59 @@ describe("hosted tool injection — least privilege (WO4)", () => {
       },
     ])
     expect(out).toMatchObject({ status: 200, body: { workflow_run_id: 7788 } })
+  })
+
+  it("github_app: bounds workflow responses and uses a read-only Actions token", async () => {
+    const key = "github-actions-read-key"
+    const h = makeAuthedApp("conn-gh-actions-read", [owner], "editor", {
+      deps: { encryptionKey: key },
+    })
+    await h.meta.setGithubApp({
+      id: "default",
+      app_id: "555",
+      slug: "derive-test",
+      client_id: "Iv1.test",
+      client_secret: encryptSecret("client-secret", key),
+      private_key: encryptSecret(GITHUB_APP_PEM, key),
+      created_at: new Date().toISOString(),
+    })
+    const connection = await upsertGithubConnection(h.meta, {
+      orgId: "default",
+      userId: owner.id,
+      installationId: "99006",
+      accountLogin: "derive-to",
+    })
+    let tokenBody: unknown
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string | URL, init?: RequestInit) => {
+        tokenBody = JSON.parse(String(init?.body))
+        return new Response(
+          JSON.stringify({
+            token: "github-actions-read-token",
+            expires_at: new Date(Date.now() + 3_600_000).toISOString(),
+          }),
+          { status: 201 },
+        )
+      }),
+    )
+    const oversizedFetch = (async () =>
+      new Response("x".repeat(4 * 1_024 * 1_024 + 1), { status: 200 })) as typeof fetch
+
+    await expect(
+      executeHttpTool(
+        h.meta,
+        connection,
+        "github.get",
+        { path: "/repos/derive-to/derive/actions/workflows?per_page=1" },
+        key,
+        oversizedFetch,
+      ),
+    ).rejects.toThrow(/too large.*smaller page/i)
+    expect(tokenBody).toEqual({
+      permissions: { actions: "read", metadata: "read" },
+      repositories: ["derive"],
+    })
   })
 
   it("github_app: verifies a comment target is a PR before posting", async () => {
@@ -612,6 +692,56 @@ describe("hosted tool injection — least privilege (WO4)", () => {
     ).rejects.toThrow(/reconnect it in Settings → Integrations/i)
     expect(called).toBe(false)
     expect(await h.meta.getConnection(connection.id)).toMatchObject({ status: "revoked" })
+  })
+
+  it("github_app: preserves a healthy source when token minting is rate limited", async () => {
+    const key = "github-rate-limit-key"
+    const h = makeAuthedApp("conn-gh-rate-limit", [owner], "editor", {
+      deps: { encryptionKey: key },
+    })
+    await h.meta.setGithubApp({
+      id: "default",
+      app_id: "554",
+      slug: "derive-test",
+      client_id: "Iv1.test",
+      client_secret: encryptSecret("client-secret", key),
+      private_key: encryptSecret(GITHUB_APP_PEM, key),
+      created_at: new Date().toISOString(),
+    })
+    const connection = await upsertGithubConnection(h.meta, {
+      orgId: "default",
+      userId: owner.id,
+      installationId: "99005",
+      accountLogin: "derive-to",
+    })
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ message: "API rate limit exceeded" }), {
+            status: 403,
+            headers: { "retry-after": "30", "x-ratelimit-remaining": "0" },
+          }),
+      ),
+    )
+    let called = false
+    const apiFetch = (async () => {
+      called = true
+      return new Response("unexpected", { status: 500 })
+    }) as typeof fetch
+
+    await expect(
+      executeHttpTool(
+        h.meta,
+        connection,
+        "github.get",
+        { path: "/repos/derive-to/derive/actions/workflows?per_page=10" },
+        key,
+        apiFetch,
+      ),
+    ).rejects.toThrow(/rate limit.*30 seconds/i)
+    expect(called).toBe(false)
+    expect(await h.meta.getConnection(connection.id)).toMatchObject({ status: "active" })
   })
 
   it("a departed member's PERSONAL connection stops resolving; a workspace one survives", async () => {

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -7471,6 +7471,8 @@ export interface components {
             connected: boolean;
             app_slug: string | null;
             needs_permissions: boolean;
+            /** @description Whether the configured App can discover and dispatch GitHub Actions workflows */
+            actions_available: boolean;
             permissions_url: string | null;
             accounts: {
                 installation_id: string;

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -7471,8 +7471,8 @@ export interface components {
             connected: boolean;
             app_slug: string | null;
             needs_permissions: boolean;
-            /** @description Whether the configured App can discover and dispatch GitHub Actions workflows */
-            actions_available: boolean;
+            /** @description Whether the configured App and its connected installations can dispatch GitHub Actions workflows; null when GitHub could not be checked */
+            actions_available: boolean | null;
             permissions_url: string | null;
             accounts: {
                 installation_id: string;

--- a/apps/web/src/pages/settings/integrations-section.tsx
+++ b/apps/web/src/pages/settings/integrations-section.tsx
@@ -249,13 +249,13 @@ export function IntegrationsSection() {
         )}
         {github &&
           !github.needs_permissions &&
-          !github.actions_available &&
+          github.actions_available === false &&
           github.permissions_url && (
             <StatusPanel
               tone="warning"
               layout="inline"
               title="Enable GitHub Actions"
-              description="Approve Actions access once to let Derive discover, start, follow, and cancel workflows in selected repositories. Pull request tools continue to work without it."
+              description="Complete the GitHub permission step to let Derive discover and follow workflows, and start adapter workflows named derive-*.yml in selected repositories. Pull request tools continue to work without it."
               action={
                 isAdmin && (
                   <Button data-testid="github-enable-actions" size="sm" asChild>

--- a/apps/web/src/pages/settings/integrations-section.tsx
+++ b/apps/web/src/pages/settings/integrations-section.tsx
@@ -214,7 +214,7 @@ export function IntegrationsSection() {
 
       <SettingsGroup
         title="GitHub"
-        description="Read pull requests and add top-level PR conversation comments in repositories selected during installation. Derive does not mirror repository files or create collections."
+        description="Read pull requests, add top-level PR comments, and run selected GitHub Actions workflows. Derive does not mirror repository files or create collections."
       >
         {githubInstallError && githubInstallResult && !githubInstallResult.connected && (
           <StatusPanel
@@ -247,6 +247,24 @@ export function IntegrationsSection() {
             }
           />
         )}
+        {github &&
+          !github.needs_permissions &&
+          !github.actions_available &&
+          github.permissions_url && (
+            <StatusPanel
+              tone="warning"
+              layout="inline"
+              title="Enable GitHub Actions"
+              description="Approve Actions access once to let Derive discover, start, follow, and cancel workflows in selected repositories. Pull request tools continue to work without it."
+              action={
+                isAdmin && (
+                  <Button data-testid="github-enable-actions" size="sm" asChild>
+                    <a href={github.permissions_url}>Enable Actions</a>
+                  </Button>
+                )
+              }
+            />
+          )}
         {githubIsPending ? (
           <SettingsListSkeleton />
         ) : githubIsError ? (


### PR DESCRIPTION
## Summary

- Extend the standard GitHub source with a narrow GitHub Actions surface.
- Let an agent discover workflows, dispatch an opted-in adapter workflow, read its status and jobs, and inspect result-artifact metadata.
- Mint a separate installation token for each effect and repository:
  - PR and workflow reads use read-only tokens.
  - PR comments use a PR-write token.
  - Workflow dispatch uses an Actions-write token.
- Ask for Actions access when Derive creates a GitHub App.
- Detect App-level and installation-level permission approval for existing Apps, and link to the correct GitHub step.
- Add a harmless `derive-runner-canary.yml` workflow for the first end-to-end run.

This builds on #808. The Derive workflow remains runner-neutral. A Context defines the adapter and uses a bound source. GitHub Actions is the first adapter because the standard GitHub source can make it require no copied token or webhook setup.

## Safety boundary

- Dispatch only permits workflow filenames that match `derive-*.yml` or `derive-*.yaml`. Existing release and deployment workflows do not become callable by accident.
- Dispatch inputs permit at most 25 scalar values and 65,535 characters, which matches GitHub's current contract.
- Git refs, repository names, workflow names, pagination, response sizes, and token-cache growth are bounded before or during each call.
- Actions tokens are limited to one installed repository.
- Reads never receive Actions-write permission.
- Cancellation and reruns are refused. Derive cannot yet prove that it created an arbitrary run id, so it must not cancel that run.
- Rate limits remain retryable and never revoke a healthy connection.
- A transient GitHub status failure does not show a false permission prompt.

## Run path

1. Create a manual Derive workflow and bind its GitHub source.
2. Tell its Context which repository, `derive-*.yml` workflow, ref, inputs, and target artifact to use.
3. Press **Run now**.
4. The agent dispatches the workflow, follows the returned run id, and publishes the result into the target artifact.

## Test plan

- [x] `pnpm verify` — 34/34 guardrails, all typechecks, 3,026 tests.
- [x] Focused tests cover all four token profiles, exact repository scoping, App and installation permission upgrades, every allowed workflow read, denied workflow writes, dispatch response handling, malformed refs, oversized inputs and responses, duplicate or excessive pagination, rate limiting, and connection revocation.
- [ ] After merge, complete the Actions permission step in **Settings → Integrations**.
- [ ] Run `.github/workflows/derive-runner-canary.yml` from a manual Derive workflow.
- [ ] Confirm Derive follows the returned GitHub run, sees the uploaded `derive-result-*` artifact metadata, and updates the target Derive artifact.
