### PR TITLE
Fix GitHub permission upgrade flow

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -2023,13 +2023,10 @@
             "type": "string",
             "nullable": true
           },
-          "needs_permissions": {
-            "type": "boolean"
-          },
-          "actions_available": {
+          "permissions_ready": {
             "type": "boolean",
             "nullable": true,
-            "description": "Whether the configured App and its connected installations can dispatch GitHub Actions workflows; null when GitHub could not be checked"
+            "description": "Whether the configured App and its connected installations have every current permission; null when GitHub could not be checked"
           },
           "permissions_url": {
             "type": "string",
@@ -2073,8 +2070,7 @@
           "available",
           "connected",
           "app_slug",
-          "needs_permissions",
-          "actions_available",
+          "permissions_ready",
           "permissions_url",
           "accounts"
         ]

--- a/apps/api/src/routes/github.ts
+++ b/apps/api/src/routes/github.ts
@@ -1,6 +1,7 @@
 import { createHash, createHmac } from "node:crypto"
 import type { GitHubAppRecord } from "@derive/core"
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
+import type { Handler } from "hono"
 import type { BlankEnv } from "hono/types"
 import type { AppContext } from "../context"
 import { ACTIONS_PERMISSION, REQUIRED_PERMISSIONS } from "../github-app-setup"
@@ -256,7 +257,7 @@ export const githubRoutes = (ctx: AppContext) => {
   // GitHub warns that installation_id on a setup callback is attacker-controlled. This first
   // callback therefore verifies the App + Derive manager, then starts GitHub's user OAuth proof.
   // Nothing is persisted until /authorize confirms this user can access this installation.
-  app.get("/v1/github/callback", async (c) => {
+  const handleInstallCallback: Handler<BlankEnv> = async (c) => {
     const installationId = c.req.query("installation_id")
     const stateRaw = c.req.query("state") ?? ""
     if (c.req.query("setup_action") === "request") return c.redirect(settingsRedirect("canceled"))
@@ -316,7 +317,13 @@ export const githubRoutes = (ctx: AppContext) => {
     authorize.searchParams.set("code_challenge_method", "S256")
     authorize.searchParams.set("prompt", "select_account")
     return c.redirect(authorize.toString())
-  })
+  }
+
+  app.get("/v1/github/callback", handleInstallCallback)
+  // Apps created before GitHub became a standard integration still have this setup URL on
+  // GitHub. GitHub does not expose an API that can rewrite a live App's configuration, so keep
+  // the old browser callback as an alias to the same signed, workspace-scoped install flow.
+  app.get("/v1/sync/github/callback", handleInstallCallback)
 
   app.get("/v1/github/authorize", async (c) => {
     const code = c.req.query("code")

--- a/apps/api/src/routes/github.ts
+++ b/apps/api/src/routes/github.ts
@@ -4,7 +4,7 @@ import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import type { Handler } from "hono"
 import type { BlankEnv } from "hono/types"
 import type { AppContext } from "../context"
-import { ACTIONS_PERMISSION, REQUIRED_PERMISSIONS } from "../github-app-setup"
+import { MANIFEST_PERMISSIONS, REQUIRED_PERMISSIONS } from "../github-app-setup"
 import { decryptSecret, signState, verifyState } from "../lib/crypto"
 import {
   exchangeGithubUserCode,
@@ -78,12 +78,11 @@ export const githubRoutes = (ctx: AppContext) => {
         .boolean()
         .describe("Whether this workspace has at least one active GitHub connection"),
       app_slug: z.string().nullable(),
-      needs_permissions: z.boolean(),
-      actions_available: z
+      permissions_ready: z
         .boolean()
         .nullable()
         .describe(
-          "Whether the configured App and its connected installations can dispatch GitHub Actions workflows; null when GitHub could not be checked",
+          "Whether the configured App and its connected installations have every current permission; null when GitHub could not be checked",
         ),
       permissions_url: z.string().nullable(),
       accounts: z.array(Account),
@@ -116,22 +115,22 @@ export const githubRoutes = (ctx: AppContext) => {
 
       let available = !!loaded
       let slug = loaded?.app.slug ?? null
-      let needsPermissions = false
+      let basePermissionsMissing = false
       // Null means GitHub could not be checked. Do not turn a transient outage into a false
       // permission-upgrade prompt.
-      let appActionsAvailable: boolean | null = null
+      let appPermissionsReady: boolean | null = null
       const rank: Record<string, number> = { read: 1, write: 2, admin: 3 }
       if (loaded) {
         try {
           const live = await getAppInfo(loaded.app.app_id, loaded.pem)
           slug = live.slug || slug
           if (slug && slug !== loaded.app.slug) await meta.setGithubApp({ ...loaded.app, slug })
-          needsPermissions = Object.entries(REQUIRED_PERMISSIONS).some(
+          basePermissionsMissing = Object.entries(REQUIRED_PERMISSIONS).some(
             ([permission, level]) =>
               !live.permissions[permission] ||
               (rank[live.permissions[permission] ?? ""] ?? 0) < (rank[level] ?? 0),
           )
-          appActionsAvailable = Object.entries(ACTIONS_PERMISSION).every(
+          appPermissionsReady = Object.entries(MANIFEST_PERMISSIONS).every(
             ([permission, level]) =>
               !!live.permissions[permission] &&
               (rank[live.permissions[permission] ?? ""] ?? 0) >= (rank[level] ?? 0),
@@ -151,7 +150,7 @@ export const githubRoutes = (ctx: AppContext) => {
       // only definitive auth/not-found responses as stale; a transient GitHub outage must not
       // make healthy connections disappear.
       const staleInstallations = new Set<string>()
-      const installationActions = new Map<string, boolean>()
+      const installationPermissions = new Map<string, boolean>()
       let installationPermissionsUrl: string | null = null
       if (loaded && available) {
         await Promise.all(
@@ -162,13 +161,13 @@ export const githubRoutes = (ctx: AppContext) => {
                 loaded.pem,
                 installation.installation_id,
               )
-              const actions = Object.entries(ACTIONS_PERMISSION).every(
+              const permissionsReady = Object.entries(MANIFEST_PERMISSIONS).every(
                 ([permission, level]) =>
                   !!live.permissions[permission] &&
                   (rank[live.permissions[permission] ?? ""] ?? 0) >= (rank[level] ?? 0),
               )
-              installationActions.set(installation.installation_id, actions)
-              if (!actions && !installationPermissionsUrl && live.htmlUrl)
+              installationPermissions.set(installation.installation_id, permissionsReady)
+              if (!permissionsReady && !installationPermissionsUrl && live.htmlUrl)
                 installationPermissionsUrl = live.htmlUrl
             } catch (err) {
               if (
@@ -183,12 +182,12 @@ export const githubRoutes = (ctx: AppContext) => {
       const liveInstallationIds = installs
         .map((installation) => installation.installation_id)
         .filter((id) => !staleInstallations.has(id))
-      let actionsAvailable = appActionsAvailable
-      if (appActionsAvailable === true && liveInstallationIds.length > 0) {
-        if (liveInstallationIds.some((id) => installationActions.get(id) === false))
-          actionsAvailable = false
-        else if (liveInstallationIds.some((id) => !installationActions.has(id)))
-          actionsAvailable = null
+      let permissionsReady = appPermissionsReady
+      if (appPermissionsReady === true && liveInstallationIds.length > 0) {
+        if (liveInstallationIds.some((id) => installationPermissions.get(id) === false))
+          permissionsReady = false
+        else if (liveInstallationIds.some((id) => !installationPermissions.has(id)))
+          permissionsReady = null
       }
       const accounts: {
         installation_id: string
@@ -200,7 +199,7 @@ export const githubRoutes = (ctx: AppContext) => {
         const usable =
           connection?.status === "active" &&
           available &&
-          !needsPermissions &&
+          !basePermissionsMissing &&
           !staleInstallations.has(installation.installation_id)
         return {
           installation_id: installation.installation_id,
@@ -227,10 +226,9 @@ export const githubRoutes = (ctx: AppContext) => {
         available,
         connected: accounts.some((account) => account.state === "active"),
         app_slug: slug,
-        needs_permissions: needsPermissions,
-        actions_available: actionsAvailable,
+        permissions_ready: permissionsReady,
         permissions_url:
-          appActionsAvailable === true && installationPermissionsUrl
+          appPermissionsReady === true && installationPermissionsUrl
             ? installationPermissionsUrl
             : slug
               ? `https://github.com/settings/apps/${encodeURIComponent(slug)}/permissions`

--- a/apps/api/test/github-integration.test.ts
+++ b/apps/api/test/github-integration.test.ts
@@ -123,6 +123,11 @@ describe("standard GitHub integration", () => {
       app.request(`/v1/github/callback?installation_id=${id}&state=${encodeURIComponent(state)}`, {
         headers: as(owner.email),
       })
+    const legacyCallback = (id: string) =>
+      app.request(
+        `/v1/sync/github/callback?installation_id=${id}&setup_action=install&state=${encodeURIComponent(state)}`,
+        { headers: as(owner.email) },
+      )
     const authorize = (location: string | null, code: string) => {
       const oauth = new URL(location ?? "")
       expect(oauth.origin).toBe("https://github.com")
@@ -163,6 +168,13 @@ describe("standard GitHub integration", () => {
       secret_enc: null,
     })
     expect(await meta.listCollections("default")).toEqual([])
+
+    const legacySetup = await legacyCallback("44001")
+    expect(legacySetup.status).toBe(302)
+    expect(new URL(legacySetup.headers.get("location") ?? "").pathname).toBe(
+      "/login/oauth/authorize",
+    )
+    expect(await meta.listGithubInstallations("default")).toHaveLength(1)
 
     const reconnectSetup = await callback("44001")
     const replay = await authorize(reconnectSetup.headers.get("location"), "replay")
@@ -251,6 +263,13 @@ describe("standard GitHub integration", () => {
     expect(await meta.getGithubInstallation("44002")).toBeNull()
     expect(await meta.listConnections("default", undefined, "workspace")).toEqual([])
 
+    const legacy = await app.request(
+      "/v1/sync/github/callback?installation_id=44002&setup_action=install&state=forged",
+      { headers: as(owner.email) },
+    )
+    expect(legacy.headers.get("location")).toContain("github_error=expired")
+    expect(await meta.getGithubInstallation("44002")).toBeNull()
+
     const ownerState = signState(
       { kind: "github-install-setup", org: "default", uid: owner.id },
       KEY,
@@ -313,6 +332,14 @@ describe("standard GitHub integration", () => {
 
     const anonymousResult = await app.request("/v1/github/callback?installation_id=44005")
     expect(anonymousResult.headers.get("location")).toContain("/login?return_to=")
+    expect(await meta.getGithubInstallation("44005")).toBeNull()
+
+    const anonymousLegacyResult = await app.request(
+      "/v1/sync/github/callback?installation_id=44005&setup_action=install",
+    )
+    expect(anonymousLegacyResult.headers.get("location")).toContain(
+      "return_to=%2Fv1%2Fsync%2Fgithub%2Fcallback",
+    )
     expect(await meta.getGithubInstallation("44005")).toBeNull()
   })
 

--- a/apps/api/test/github-integration.test.ts
+++ b/apps/api/test/github-integration.test.ts
@@ -59,6 +59,7 @@ describe("standard GitHub integration", () => {
     let pullPermission = "write"
     let actionsPermission: string | undefined = "write"
     let installationActionsPermission: string | undefined = "write"
+    let installationPullPermission: string | undefined = "write"
     let appStatus = 200
     let installationStatus = 200
     const oauthCodes: string[] = []
@@ -79,7 +80,9 @@ describe("standard GitHub integration", () => {
                   ? { actions: installationActionsPermission }
                   : {}),
                 metadata: "read",
-                pull_requests: "write",
+                ...(installationPullPermission
+                  ? { pull_requests: installationPullPermission }
+                  : {}),
               },
             }),
             { status: installationStatus },
@@ -190,8 +193,7 @@ describe("standard GitHub integration", () => {
     expect(await status.json()).toMatchObject({
       available: true,
       connected: true,
-      actions_available: true,
-      needs_permissions: false,
+      permissions_ready: true,
       accounts: [
         {
           installation_id: "44001",
@@ -204,25 +206,33 @@ describe("standard GitHub integration", () => {
     pullPermission = "read"
     expect(
       await (await app.request("/v1/github", { headers: as(owner.email) })).json(),
-    ).toMatchObject({ needs_permissions: true })
+    ).toMatchObject({ permissions_ready: false })
     pullPermission = "write"
     actionsPermission = undefined
     expect(
       await (await app.request("/v1/github", { headers: as(owner.email) })).json(),
-    ).toMatchObject({ actions_available: false, connected: true, needs_permissions: false })
+    ).toMatchObject({ permissions_ready: false, connected: true })
     actionsPermission = "write"
     installationActionsPermission = undefined
     expect(
       await (await app.request("/v1/github", { headers: as(owner.email) })).json(),
     ).toMatchObject({
-      actions_available: false,
+      permissions_ready: false,
       permissions_url: "https://github.com/organizations/derive-to/settings/installations/44001",
     })
     installationActionsPermission = "write"
+    installationPullPermission = undefined
+    expect(
+      await (await app.request("/v1/github", { headers: as(owner.email) })).json(),
+    ).toMatchObject({
+      permissions_ready: false,
+      permissions_url: "https://github.com/organizations/derive-to/settings/installations/44001",
+    })
+    installationPullPermission = "write"
     appStatus = 500
     expect(
       await (await app.request("/v1/github", { headers: as(owner.email) })).json(),
-    ).toMatchObject({ actions_available: null, available: true, connected: true })
+    ).toMatchObject({ permissions_ready: null, available: true, connected: true })
     appStatus = 200
     installationStatus = 404
     expect(

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -7470,9 +7470,8 @@ export interface components {
             /** @description Whether this workspace has at least one active GitHub connection */
             connected: boolean;
             app_slug: string | null;
-            needs_permissions: boolean;
-            /** @description Whether the configured App and its connected installations can dispatch GitHub Actions workflows; null when GitHub could not be checked */
-            actions_available: boolean | null;
+            /** @description Whether the configured App and its connected installations have every current permission; null when GitHub could not be checked */
+            permissions_ready: boolean | null;
             permissions_url: string | null;
             accounts: {
                 installation_id: string;

--- a/apps/web/src/lib/one-shot-params.ts
+++ b/apps/web/src/lib/one-shot-params.ts
@@ -1,5 +1,5 @@
 // Pure core of the one-shot URL-param handshake (?checkout=success,
-// ?slack_error=…, ?gh_install=…): take the named params out of a search string,
+// ?slack_error=…, ?github_connected=…): take the named params out of a search string,
 // returning what was taken and the search that should remain. Pure so the
 // take-and-strip semantics are unit-testable; the browser wiring (history,
 // mount-once) lives in use-one-shot-params.tsx.

--- a/apps/web/src/pages/settings/integrations-section.tsx
+++ b/apps/web/src/pages/settings/integrations-section.tsx
@@ -232,29 +232,22 @@ export function IntegrationsSection() {
             }
           />
         )}
-        {github &&
-          (github.needs_permissions || github.actions_available === false) &&
-          github.permissions_url && (
-            <StatusPanel
-              tone="warning"
-              layout="inline"
-              icon={<AlertTriangle aria-hidden />}
-              title="Your GitHub App needs more permissions"
-              description="Review the App permissions on GitHub, then approve the update for each connected account."
-              action={
-                isAdmin && (
-                  <Button
-                    data-testid="github-update-permissions"
-                    variant="outline"
-                    size="sm"
-                    asChild
-                  >
-                    <a href={github.permissions_url}>Review permissions</a>
-                  </Button>
-                )
-              }
-            />
-          )}
+        {github && github.permissions_ready === false && github.permissions_url && (
+          <StatusPanel
+            tone="warning"
+            layout="inline"
+            icon={<AlertTriangle aria-hidden />}
+            title="Your GitHub App needs more permissions"
+            description="Review the App permissions on GitHub, then approve the update for each connected account."
+            action={
+              isAdmin && (
+                <Button data-testid="github-update-permissions" variant="outline" size="sm" asChild>
+                  <a href={github.permissions_url}>Review permissions</a>
+                </Button>
+              )
+            }
+          />
+        )}
         {githubIsPending ? (
           <SettingsListSkeleton />
         ) : githubIsError ? (

--- a/apps/web/src/pages/settings/integrations-section.tsx
+++ b/apps/web/src/pages/settings/integrations-section.tsx
@@ -238,11 +238,17 @@ export function IntegrationsSection() {
             <StatusPanel
               tone="warning"
               layout="inline"
+              icon={<AlertTriangle aria-hidden />}
               title="Your GitHub App needs more permissions"
               description="Review the App permissions on GitHub, then approve the update for each connected account."
               action={
                 isAdmin && (
-                  <Button data-testid="github-update-permissions" size="sm" asChild>
+                  <Button
+                    data-testid="github-update-permissions"
+                    variant="outline"
+                    size="sm"
+                    asChild
+                  >
                     <a href={github.permissions_url}>Review permissions</a>
                   </Button>
                 )

--- a/apps/web/src/pages/settings/integrations-section.tsx
+++ b/apps/web/src/pages/settings/integrations-section.tsx
@@ -232,34 +232,18 @@ export function IntegrationsSection() {
             }
           />
         )}
-        {github?.needs_permissions && github.permissions_url && (
-          <StatusPanel
-            tone="danger"
-            layout="inline"
-            title="GitHub needs updated pull request access"
-            description="Update the App permission, then approve it for each connected account."
-            action={
-              isAdmin && (
-                <Button data-testid="github-update-permissions" size="sm" asChild>
-                  <a href={github.permissions_url}>Update permissions</a>
-                </Button>
-              )
-            }
-          />
-        )}
         {github &&
-          !github.needs_permissions &&
-          github.actions_available === false &&
+          (github.needs_permissions || github.actions_available === false) &&
           github.permissions_url && (
             <StatusPanel
               tone="warning"
               layout="inline"
-              title="Enable GitHub Actions"
-              description="Complete the GitHub permission step to let Derive discover and follow workflows, and start adapter workflows named derive-*.yml in selected repositories. Pull request tools continue to work without it."
+              title="Your GitHub App needs more permissions"
+              description="Review the App permissions on GitHub, then approve the update for each connected account."
               action={
                 isAdmin && (
-                  <Button data-testid="github-enable-actions" size="sm" asChild>
-                    <a href={github.permissions_url}>Enable Actions</a>
+                  <Button data-testid="github-update-permissions" size="sm" asChild>
+                    <a href={github.permissions_url}>Review permissions</a>
                   </Button>
                 )
               }


### PR DESCRIPTION
## Summary

- Accept the retired `/v1/sync/github/callback` URL that remains on the live GitHub App.
- Route it through the same signed, workspace-scoped OAuth proof as the canonical callback.
- Replace two competing permission alerts with one generic GitHub App permission state.
- Use one **Review permissions** action for App-level and installation-level updates.

## Cause

The live GitHub App still uses the callback URL from the former repository sync integration. GitHub redirects permission approvals to that URL. The standard integration removed the route, so the browser received a 404 before Derive could verify or save the installation. The callback URL is GitHub App configuration. It is not stored in a workspace database row, and GitHub does not provide an API to rewrite it.

## Safety

- The compatibility route runs the canonical callback handler.
- Signed state still binds the request to one user and workspace.
- Derive still verifies the installation belongs to this App.
- Derive still requires the GitHub user access proof before persistence.
- Forged, expired, logged-out, and unauthorized requests do not write installation or connection rows.

## Verification

- [x] Exact legacy URL shape with `setup_action=install`
- [x] Canonical callback
- [x] Forged state rejection
- [x] Logged-out return path
- [x] OAuth user-access proof
- [x] No persistence before proof
- [x] `pnpm run ci` — 34/34 checks
- [x] `pnpm typecheck`
- [x] `pnpm test` — 3,026 tests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/863"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790717479&installation_model_id=428097&pr_number=863&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F863&signature=86d303fb1e10c6c456ebc1b22b77f492e08fb475255a8b05d7b27c7e6d6bf15f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->