### PR TITLE
Harden GitHub App ownership flow

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -2023,14 +2023,28 @@
             "type": "string",
             "nullable": true
           },
-          "permissions_ready": {
-            "type": "boolean",
-            "nullable": true,
-            "description": "Whether the configured App and its connected installations have every current permission; null when GitHub could not be checked"
-          },
-          "permissions_url": {
+          "app_owner_login": {
             "type": "string",
             "nullable": true
+          },
+          "app_permissions_state": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "ready",
+              "update_required",
+              "unknown",
+              null
+            ],
+            "description": "Whether the instance App has every current permission; null when no live App exists"
+          },
+          "app_settings_url": {
+            "type": "string",
+            "nullable": true
+          },
+          "can_manage_app": {
+            "type": "boolean",
+            "description": "Whether the caller is an instance operator who can configure the shared App"
           },
           "accounts": {
             "type": "array",
@@ -2055,13 +2069,27 @@
                     "disconnected",
                     "needs_reauth"
                   ]
+                },
+                "permissions_state": {
+                  "type": "string",
+                  "enum": [
+                    "ready",
+                    "approval_required",
+                    "unknown"
+                  ]
+                },
+                "permissions_url": {
+                  "type": "string",
+                  "nullable": true
                 }
               },
               "required": [
                 "installation_id",
                 "account_login",
                 "connection_id",
-                "state"
+                "state",
+                "permissions_state",
+                "permissions_url"
               ]
             }
           }
@@ -2070,8 +2098,10 @@
           "available",
           "connected",
           "app_slug",
-          "permissions_ready",
-          "permissions_url",
+          "app_owner_login",
+          "app_permissions_state",
+          "app_settings_url",
+          "can_manage_app",
           "accounts"
         ]
       },

--- a/apps/api/src/brand-page.ts
+++ b/apps/api/src/brand-page.ts
@@ -30,6 +30,12 @@ const STYLE = `<style>
     border:1px solid var(--accent);background:var(--accent);color:var(--accent-fg);text-decoration:none}
   .btn:hover{filter:brightness(1.07)}
   .btn.ghost{background:transparent;color:var(--ink);border-color:var(--line)}
+  .field{display:flex;flex-direction:column;gap:6px;margin:0 0 16px}
+  .field label{font-size:13px;font-weight:600;color:var(--ink)}
+  .field input{width:100%;border:1px solid var(--line);border-radius:10px;background:var(--paper);
+    color:var(--ink);padding:10px 12px;font:14px var(--sans);outline:none}
+  .field input:focus{border-color:var(--accent);box-shadow:0 0 0 3px color-mix(in srgb,var(--accent) 16%,transparent)}
+  .hint{color:var(--muted);font-size:12.5px;margin:0}
   .foot{color:var(--muted);font-size:12.5px;line-height:1.5;margin:20px 0 0}
   .err{color:var(--bad);font-size:14px;margin:0 0 4px;font-weight:500}
   code{font-family:var(--mono);font-size:.9em;background:rgba(0,0,0,.05);padding:1px 5px;border-radius:5px}

--- a/apps/api/src/github-app-setup.ts
+++ b/apps/api/src/github-app-setup.ts
@@ -2,7 +2,7 @@
 // a self-hoster to hand-create an App and paste five secrets, we POST a manifest
 // to GitHub; they click "Create GitHub App" once and GitHub redirects back with a
 // temporary code we trade for the App's permanent credentials (see lib/github-app
-// convertManifestCode). Two pages: the auto-submitting manifest form, and a
+// convertManifestCode). Two pages: the owner-selection manifest form, and a
 // success/failure landing. Styled like the CLI callback so setup feels like Derive.
 import { esc, brandShell as SHELL } from "./brand-page"
 
@@ -56,11 +56,9 @@ export const buildManifest = (baseUrl: string, host: string) => ({
   default_events: REQUIRED_EVENTS,
 })
 
-/**
- * The manifest form page. Auto-POSTs to GitHub's App-creation endpoint with the
- * manifest + our signed `state`; GitHub shows a "Create GitHub App" confirmation,
- * then redirects to the created-callback. A no-JS button is the fallback.
- */
+/** The manifest form page. The operator chooses who owns the App before GitHub creates it.
+ * GitHub shows that owner as the developer, so silently defaulting to the signed-in person's
+ * account is both surprising and difficult to repair after installations exist. */
 export function manifestFormHTML(props: { baseUrl: string; state: string }): string {
   const { baseUrl } = props
   const host = (() => {
@@ -70,19 +68,39 @@ export function manifestFormHTML(props: { baseUrl: string; state: string }): str
       return "self-hosted"
     }
   })()
-  const action = `https://github.com/settings/apps/new?state=${encodeURIComponent(props.state)}`
+  const personalAction = `https://github.com/settings/apps/new?state=${encodeURIComponent(props.state)}`
   const manifestJson = JSON.stringify(buildManifest(baseUrl, host))
   return SHELL(
     "Set up GitHub App",
     "",
     `<h1>Create your GitHub App</h1>
-    <p class="sub">This opens GitHub to create a Derive app for your account. Select the repositories agents may read — no tokens to paste and no repository mirror.</p>
-    <form id="f" method="post" action="${esc(action)}">
+    <p class="sub">Create the App under the organization that operates this Derive instance. GitHub shows that account as the App developer.</p>
+    <form id="f" method="post" action="${esc(personalAction)}">
+      <div class="field">
+        <label for="owner">GitHub organization</label>
+        <input id="owner" name="owner" autocomplete="organization" placeholder="derive-to" pattern="[A-Za-z0-9-]{1,39}"/>
+        <p class="hint">Leave this blank only if a personal account should own the App.</p>
+      </div>
       <input type="hidden" name="manifest" value="${esc(manifestJson)}"/>
-      <button class="btn" type="submit">Continue to GitHub</button>
+      <div class="row">
+        <button class="btn" type="submit">Continue to GitHub</button>
+        <button class="btn ghost" type="submit" formnovalidate data-personal>Use personal account</button>
+      </div>
     </form>
     <p class="foot">Derive asks for <strong>Metadata: read</strong>, <strong>Pull requests: write</strong>, and <strong>Actions: write</strong>. Server-side policies limit these to PR reads, one top-level PR comment, workflow status, and dispatch of workflows named <strong>derive-*.yml</strong>.</p>
-    <script>setTimeout(function(){document.getElementById("f").submit()},400)</script>`,
+    <script>
+      (function(){
+        var form=document.getElementById("f"),owner=document.getElementById("owner"),personal=${JSON.stringify(personalAction)};
+        form.addEventListener("submit",function(event){
+          if(event.submitter&&event.submitter.hasAttribute("data-personal")){form.action=personal;return}
+          var value=owner.value.trim();
+          if(!value){event.preventDefault();owner.setCustomValidity("Enter the GitHub organization that should own this App, or choose personal account.");owner.reportValidity();return}
+          owner.setCustomValidity("");
+          form.action="https://github.com/organizations/"+encodeURIComponent(value)+"/settings/apps/new?state="+${JSON.stringify(encodeURIComponent(props.state))};
+        });
+        owner.addEventListener("input",function(){owner.setCustomValidity("")});
+      })()
+    </script>`,
   )
 }
 

--- a/apps/api/src/lib/github-app.ts
+++ b/apps/api/src/lib/github-app.ts
@@ -98,6 +98,7 @@ export async function getAppInfo(
 ): Promise<{
   slug: string
   html_url: string
+  owner: { login: string; type: string } | null
   permissions: Record<string, string>
   events: string[]
 }> {
@@ -108,12 +109,14 @@ export async function getAppInfo(
   const d = (await res.json()) as {
     slug?: string
     html_url?: string
+    owner?: { login?: string; type?: string } | null
     permissions?: Record<string, string>
     events?: string[]
   }
   return {
     slug: d.slug ?? "",
     html_url: d.html_url ?? "",
+    owner: d.owner ? { login: d.owner.login ?? "", type: d.owner.type ?? "" } : null,
     permissions: d.permissions ?? {},
     events: d.events ?? [],
   }

--- a/apps/api/src/routes/github-app.ts
+++ b/apps/api/src/routes/github-app.ts
@@ -6,14 +6,14 @@ import { convertManifestCode } from "../lib/github-app"
 import { log } from "../log"
 
 /**
- * One-click GitHub App registration (the manifest flow). /new renders the auto-submitting
- * manifest form (admins only); GitHub creates the App and redirects to /created with a
+ * One-click GitHub App registration (the manifest flow). /new lets the instance operator
+ * choose the App owner; GitHub creates the App and redirects to /created with a
  * temporary code we trade for the App's credentials. Both are top-level navigations (not
  * the /v1 API), bound by a signed `state` carrying the initiating user. Needs an
  * encryptionKey — App secrets are never stored in the clear.
  */
 export const githubAppRoutes = (ctx: AppContext) => {
-  const { deps, meta, workspaceCan, currentUser } = ctx
+  const { deps, meta, isSuperAdmin, currentUser } = ctx
   const app = new Hono()
 
   app.get("/settings/github/app/new", async (c) => {
@@ -22,9 +22,25 @@ export const githubAppRoutes = (ctx: AppContext) => {
         setupResultHTML({ ok: false, error: "Server is missing an encryption key." }),
         500,
       )
-    if (!(await workspaceCan(c, "manage")))
-      return c.redirect("/login?return_to=/settings/github/app/new")
-    const uid = (await currentUser(c))?.id ?? "anon"
+    const me = await currentUser(c)
+    if (!me) return c.redirect("/login?return_to=/settings/github/app/new")
+    if (!(await isSuperAdmin(c)))
+      return c.html(
+        setupResultHTML({
+          ok: false,
+          error: "Only an instance operator can configure the shared GitHub App.",
+        }),
+        403,
+      )
+    if (await meta.getGithubApp())
+      return c.html(
+        setupResultHTML({
+          ok: false,
+          error: "This Derive instance already has a GitHub App. It cannot be replaced here.",
+        }),
+        409,
+      )
+    const uid = me.id
     const state = signState({ kind: "app-manifest", uid }, deps.encryptionKey)
     return c.html(manifestFormHTML({ baseUrl: deps.baseUrl, state }))
   })
@@ -34,13 +50,32 @@ export const githubAppRoutes = (ctx: AppContext) => {
     const stateRaw = c.req.query("state") ?? ""
     if (!deps.encryptionKey || !code)
       return c.html(setupResultHTML({ ok: false, error: "Missing setup code." }), 400)
-    const state = verifyState<{ kind?: string }>(stateRaw, deps.encryptionKey)
-    if (state?.kind !== "app-manifest")
+    const state = verifyState<{ kind?: string; uid?: string }>(
+      stateRaw,
+      deps.encryptionKey,
+      60 * 60 * 1000,
+    )
+    const me = await currentUser(c)
+    if (
+      state?.kind !== "app-manifest" ||
+      !state.uid ||
+      !me ||
+      state.uid !== me.id ||
+      !(await isSuperAdmin(c))
+    )
       return c.html(setupResultHTML({ ok: false, error: "This setup link has expired." }), 400)
+    if (await meta.getGithubApp())
+      return c.html(
+        setupResultHTML({
+          ok: false,
+          error: "Another operator already configured the GitHub App. No changes were made.",
+        }),
+        409,
+      )
     try {
       const conv = await convertManifestCode(code)
       const key = deps.encryptionKey
-      await meta.setGithubApp({
+      const created = await meta.createGithubApp({
         id: "default",
         app_id: conv.app_id,
         slug: conv.slug,
@@ -49,6 +84,14 @@ export const githubAppRoutes = (ctx: AppContext) => {
         private_key: encryptSecret(conv.pem, key),
         created_at: new Date().toISOString(),
       })
+      if (!created)
+        return c.html(
+          setupResultHTML({
+            ok: false,
+            error: `Another operator completed setup first. Delete the unused ${conv.slug} App on GitHub.`,
+          }),
+          409,
+        )
       return c.html(setupResultHTML({ ok: true, slug: conv.slug }))
     } catch (err) {
       const detail = err instanceof Error ? err.message : String(err)

--- a/apps/api/src/routes/github.ts
+++ b/apps/api/src/routes/github.ts
@@ -36,8 +36,16 @@ const installationIdIsValid = (value: string | undefined): value is string =>
   !!value && /^[1-9][0-9]*$/.test(value)
 
 export const githubRoutes = (ctx: AppContext) => {
-  const { meta, deps, requireUser, requireWorkspace, workspaceCan, activeWorkspace, currentUser } =
-    ctx
+  const {
+    meta,
+    deps,
+    requireUser,
+    requireWorkspace,
+    workspaceCan,
+    activeWorkspace,
+    currentUser,
+    isSuperAdmin,
+  } = ctx
   const app = new OpenAPIHono<BlankEnv>()
 
   const loadApp = async (): Promise<{ app: GitHubAppRecord; pem: string } | null> => {
@@ -70,6 +78,8 @@ export const githubRoutes = (ctx: AppContext) => {
     account_login: z.string().nullable(),
     connection_id: z.string().nullable(),
     state: z.enum(["active", "disconnected", "needs_reauth"]),
+    permissions_state: z.enum(["ready", "approval_required", "unknown"]),
+    permissions_url: z.string().nullable(),
   })
   const GithubStatus = z
     .object({
@@ -78,13 +88,17 @@ export const githubRoutes = (ctx: AppContext) => {
         .boolean()
         .describe("Whether this workspace has at least one active GitHub connection"),
       app_slug: z.string().nullable(),
-      permissions_ready: z
-        .boolean()
+      app_owner_login: z.string().nullable(),
+      app_permissions_state: z
+        .enum(["ready", "update_required", "unknown"])
         .nullable()
         .describe(
-          "Whether the configured App and its connected installations have every current permission; null when GitHub could not be checked",
+          "Whether the instance App has every current permission; null when no live App exists",
         ),
-      permissions_url: z.string().nullable(),
+      app_settings_url: z.string().nullable(),
+      can_manage_app: z
+        .boolean()
+        .describe("Whether the caller is an instance operator who can configure the shared App"),
       accounts: z.array(Account),
     })
     .openapi("GithubStatus")
@@ -107,132 +121,129 @@ export const githubRoutes = (ctx: AppContext) => {
       if (me instanceof Response) return bail(me)
       const org = await requireWorkspace(c, "read")
       if (org instanceof Response) return bail(org)
-      const [loaded, installs, connections] = await Promise.all([
+      const [loaded, connections, canManageApp] = await Promise.all([
         loadApp(),
-        meta.listGithubInstallations(org),
         meta.listConnections(org, undefined, "workspace"),
+        isSuperAdmin(c),
       ])
 
       let available = !!loaded
       let slug = loaded?.app.slug ?? null
+      let appOwnerLogin: string | null = null
+      let appOwnerType: string | null = null
       let basePermissionsMissing = false
       // Null means GitHub could not be checked. Do not turn a transient outage into a false
       // permission-upgrade prompt.
-      let appPermissionsReady: boolean | null = null
+      let appPermissionsState: "ready" | "update_required" | "unknown" | null = loaded
+        ? "unknown"
+        : null
       const rank: Record<string, number> = { read: 1, write: 2, admin: 3 }
       if (loaded) {
         try {
           const live = await getAppInfo(loaded.app.app_id, loaded.pem)
           slug = live.slug || slug
+          appOwnerLogin = live.owner?.login || null
+          appOwnerType = live.owner?.type || null
           if (slug && slug !== loaded.app.slug) await meta.setGithubApp({ ...loaded.app, slug })
           basePermissionsMissing = Object.entries(REQUIRED_PERMISSIONS).some(
             ([permission, level]) =>
               !live.permissions[permission] ||
               (rank[live.permissions[permission] ?? ""] ?? 0) < (rank[level] ?? 0),
           )
-          appPermissionsReady = Object.entries(MANIFEST_PERMISSIONS).every(
+          appPermissionsState = Object.entries(MANIFEST_PERMISSIONS).every(
             ([permission, level]) =>
               !!live.permissions[permission] &&
               (rank[live.permissions[permission] ?? ""] ?? 0) >= (rank[level] ?? 0),
           )
+            ? "ready"
+            : "update_required"
         } catch (err) {
           // Deleted/revoked is definitive. A network/5xx failure must not hide a working App.
-          if (err instanceof GitHubError && (err.status === 401 || err.status === 404))
+          if (err instanceof GitHubError && (err.status === 401 || err.status === 404)) {
             available = false
+            appPermissionsState = null
+          }
         }
       }
 
       const githubConnections = connections.filter((cn) => cn.kind === "github_app")
-      const byInstallation = new Map(githubConnections.map((cn) => [cn.broker_ref, cn]))
-      const installIds = new Set(installs.map((installation) => installation.installation_id))
-      // A stored row is not proof the installation still exists. Check each account live so
+      // A connection row is not proof the installation still exists. Check each account live so
       // Settings can distinguish a working connection from an App GitHub has removed. Treat
       // only definitive auth/not-found responses as stale; a transient GitHub outage must not
       // make healthy connections disappear.
       const staleInstallations = new Set<string>()
-      const installationPermissions = new Map<string, boolean>()
-      let installationPermissionsUrl: string | null = null
+      const installationPermissions = new Map<
+        string,
+        { state: "ready" | "approval_required"; url: string | null }
+      >()
       if (loaded && available) {
         await Promise.all(
-          installs.map(async (installation) => {
+          githubConnections.map(async (connection) => {
             try {
               const live = await getAppInstallation(
                 loaded.app.app_id,
                 loaded.pem,
-                installation.installation_id,
+                connection.broker_ref,
               )
               const permissionsReady = Object.entries(MANIFEST_PERMISSIONS).every(
                 ([permission, level]) =>
                   !!live.permissions[permission] &&
                   (rank[live.permissions[permission] ?? ""] ?? 0) >= (rank[level] ?? 0),
               )
-              installationPermissions.set(installation.installation_id, permissionsReady)
-              if (!permissionsReady && !installationPermissionsUrl && live.htmlUrl)
-                installationPermissionsUrl = live.htmlUrl
+              installationPermissions.set(connection.broker_ref, {
+                state: permissionsReady ? "ready" : "approval_required",
+                url: permissionsReady ? null : live.htmlUrl,
+              })
             } catch (err) {
               if (
                 err instanceof GitHubError &&
                 (err.status === 401 || err.status === 403 || err.status === 404)
               )
-                staleInstallations.add(installation.installation_id)
+                staleInstallations.add(connection.broker_ref)
             }
           }),
         )
-      }
-      const liveInstallationIds = installs
-        .map((installation) => installation.installation_id)
-        .filter((id) => !staleInstallations.has(id))
-      let permissionsReady = appPermissionsReady
-      if (appPermissionsReady === true && liveInstallationIds.length > 0) {
-        if (liveInstallationIds.some((id) => installationPermissions.get(id) === false))
-          permissionsReady = false
-        else if (liveInstallationIds.some((id) => !installationPermissions.has(id)))
-          permissionsReady = null
       }
       const accounts: {
         installation_id: string
         account_login: string | null
         connection_id: string | null
         state: "active" | "disconnected" | "needs_reauth"
-      }[] = installs.map((installation) => {
-        const connection = byInstallation.get(installation.installation_id)
+        permissions_state: "ready" | "approval_required" | "unknown"
+        permissions_url: string | null
+      }[] = githubConnections.map((connection) => {
+        const permissions = installationPermissions.get(connection.broker_ref)
         const usable =
-          connection?.status === "active" &&
+          connection.status === "active" &&
           available &&
           !basePermissionsMissing &&
-          !staleInstallations.has(installation.installation_id)
+          !staleInstallations.has(connection.broker_ref)
         return {
-          installation_id: installation.installation_id,
-          account_login: installation.account_login ?? connection?.scopes_label ?? null,
-          connection_id: connection?.id ?? null,
+          installation_id: connection.broker_ref,
+          account_login: connection.scopes_label,
+          connection_id: connection.id,
+          permissions_state: permissions?.state ?? "unknown",
+          permissions_url: permissions?.url ?? null,
           state: usable
             ? ("active" as const)
-            : connection?.status === "active"
+            : connection.status === "active"
               ? ("needs_reauth" as const)
               : ("disconnected" as const),
         }
       })
-      for (const connection of githubConnections) {
-        if (installIds.has(connection.broker_ref)) continue
-        accounts.push({
-          installation_id: connection.broker_ref,
-          account_login: connection.scopes_label,
-          connection_id: connection.id,
-          state: "needs_reauth",
-        })
-      }
 
       return c.json({
         available,
         connected: accounts.some((account) => account.state === "active"),
         app_slug: slug,
-        permissions_ready: permissionsReady,
-        permissions_url:
-          appPermissionsReady === true && installationPermissionsUrl
-            ? installationPermissionsUrl
-            : slug
-              ? `https://github.com/settings/apps/${encodeURIComponent(slug)}/permissions`
-              : null,
+        app_owner_login: appOwnerLogin,
+        app_permissions_state: appPermissionsState,
+        app_settings_url: slug
+          ? appOwnerType === "Organization" && appOwnerLogin
+            ? `https://github.com/organizations/${encodeURIComponent(appOwnerLogin)}/settings/apps/${encodeURIComponent(slug)}/permissions`
+            : `https://github.com/settings/apps/${encodeURIComponent(slug)}/permissions`
+          : null,
+        can_manage_app: canManageApp,
         accounts,
       })
     },
@@ -360,13 +371,6 @@ export const githubRoutes = (ctx: AppContext) => {
         return c.redirect(settingsRedirect("save"))
       }
       const accountLogin = installation.account?.login ?? null
-      await meta.upsertGithubInstallation({
-        installation_id: state.installationId,
-        org_id: state.org,
-        account_login: accountLogin,
-        created_by: me.id,
-        created_at: new Date().toISOString(),
-      })
       await upsertGithubConnection(meta, {
         orgId: state.org,
         userId: me.id,

--- a/apps/api/test/github-app.test.ts
+++ b/apps/api/test/github-app.test.ts
@@ -1,6 +1,7 @@
 import { createVerify, generateKeyPairSync } from "node:crypto"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { appJwt, installationToken } from "../src/lib/github-app"
+import { as, makeAuthedApp, type TestUser } from "./helpers"
 
 // A throwaway RSA keypair, PKCS#1 PEM — the exact format GitHub's manifest
 // conversion hands back, so this also proves createPrivateKey accepts it.
@@ -13,6 +14,102 @@ const { privateKey, publicKey } = generateKeyPairSync("rsa", {
 const decode = (seg: string) => JSON.parse(Buffer.from(seg, "base64url").toString("utf8"))
 
 afterEach(() => vi.unstubAllGlobals())
+
+describe("GitHub App registration", () => {
+  const operator: TestUser = {
+    id: "u_github_app_operator",
+    email: "github-operator@derive.test",
+    name: "Operator",
+  }
+  const secondOperator: TestUser = {
+    id: "u_github_app_operator_two",
+    email: "github-operator-two@derive.test",
+    name: "Second operator",
+  }
+
+  it("keeps instance App setup away from ordinary workspace owners", async () => {
+    const { app } = makeAuthedApp("github-app-operator-gate", [operator], "editor", {
+      deps: { encryptionKey: "github-app-registration-key" },
+    })
+    const res = await app.request("/settings/github/app/new", {
+      headers: as(operator.email),
+    })
+    expect(res.status).toBe(403)
+    expect(await res.text()).toContain("Only an instance operator")
+  })
+
+  it("asks the operator who should own the App instead of defaulting to their account", async () => {
+    const { app } = makeAuthedApp("github-app-owner-choice", [operator], "editor", {
+      deps: { encryptionKey: "github-app-registration-key" },
+      operatorIds: [operator.id],
+    })
+    const res = await app.request("/settings/github/app/new", {
+      headers: as(operator.email),
+    })
+    const html = await res.text()
+    expect(res.status).toBe(200)
+    expect(html).toContain("GitHub organization")
+    expect(html).toContain("GitHub shows that account as the App developer")
+    expect(html).toContain("https://github.com/organizations/")
+    expect(html).toContain("Use personal account")
+    expect(html).not.toContain("setTimeout")
+  })
+
+  it("binds conversion to the initiating operator and never replaces the shared App", async () => {
+    const { app, meta } = makeAuthedApp(
+      "github-app-insert-only",
+      [operator, secondOperator],
+      "owner",
+      {
+        deps: { encryptionKey: "github-app-registration-key" },
+        operatorIds: [operator.id, secondOperator.id],
+      },
+    )
+    const setup = await app.request("/settings/github/app/new", {
+      headers: as(operator.email),
+    })
+    const html = await setup.text()
+    const state = html.match(/settings\/apps\/new\?state=([A-Za-z0-9_.-]+)/)?.[1]
+    expect(state).toBeTruthy()
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              id: 991,
+              slug: "derive-owned",
+              client_id: "Iv1.owned",
+              client_secret: "secret",
+              pem: privateKey,
+            }),
+            { status: 201 },
+          ),
+      ),
+    )
+    const wrongUser = await app.request(
+      `/settings/github/app/created?code=wrong&state=${encodeURIComponent(state ?? "")}`,
+      { headers: as(secondOperator.email) },
+    )
+    expect(wrongUser.status).toBe(400)
+    expect(await meta.getGithubApp()).toBeNull()
+
+    const created = await app.request(
+      `/settings/github/app/created?code=right&state=${encodeURIComponent(state ?? "")}`,
+      { headers: as(operator.email) },
+    )
+    expect(created.status).toBe(200)
+    expect(await meta.getGithubApp()).toMatchObject({ app_id: "991", slug: "derive-owned" })
+
+    const replay = await app.request(
+      `/settings/github/app/created?code=replay&state=${encodeURIComponent(state ?? "")}`,
+      { headers: as(operator.email) },
+    )
+    expect(replay.status).toBe(409)
+    expect(await meta.getGithubApp()).toMatchObject({ app_id: "991", slug: "derive-owned" })
+  })
+})
 
 describe("appJwt", () => {
   it("signs a verifiable RS256 JWT with the App id as issuer", () => {

--- a/apps/api/test/github-integration.test.ts
+++ b/apps/api/test/github-integration.test.ts
@@ -1,6 +1,7 @@
 import { generateKeyPairSync } from "node:crypto"
 import { describe, expect, it, vi } from "vitest"
 import { encryptSecret, signState } from "../src/lib/crypto"
+import { upsertGithubConnection } from "../src/lib/github-connection"
 import { as, jsonAs, makeAuthedApp, type quotaApp, type TestUser } from "./helpers"
 
 // A real RSA key (PKCS#1, as GitHub's manifest returns) so appJwt/getAppInfo can
@@ -109,6 +110,7 @@ describe("standard GitHub integration", () => {
           return new Response(
             JSON.stringify({
               slug: "derive-test",
+              owner: { login: "derive-to", type: "Organization" },
               permissions: {
                 ...(actionsPermission ? { actions: actionsPermission } : {}),
                 metadata: "read",
@@ -149,7 +151,7 @@ describe("standard GitHub integration", () => {
     const [firstSetup, concurrentSetup] = await Promise.all([callback("44001"), callback("44001")])
     expect(firstSetup.status).toBe(302)
     expect(concurrentSetup.status).toBe(302)
-    expect(await meta.getGithubInstallation("44001")).toBeNull()
+    expect(await meta.listConnections("default", undefined, "workspace")).toEqual([])
 
     const [first, concurrentReplay] = await Promise.all([
       authorize(firstSetup.headers.get("location"), "first"),
@@ -177,8 +179,6 @@ describe("standard GitHub integration", () => {
     expect(new URL(legacySetup.headers.get("location") ?? "").pathname).toBe(
       "/login/oauth/authorize",
     )
-    expect(await meta.listGithubInstallations("default")).toHaveLength(1)
-
     const reconnectSetup = await callback("44001")
     const replay = await authorize(reconnectSetup.headers.get("location"), "replay")
     expect(replay.headers.get("location")).toContain("github_connected=1")
@@ -193,46 +193,64 @@ describe("standard GitHub integration", () => {
     expect(await status.json()).toMatchObject({
       available: true,
       connected: true,
-      permissions_ready: true,
+      app_owner_login: "derive-to",
+      app_permissions_state: "ready",
+      app_settings_url:
+        "https://github.com/organizations/derive-to/settings/apps/derive-test/permissions",
+      can_manage_app: false,
       accounts: [
         {
           installation_id: "44001",
           account_login: "derive-to",
           connection_id: created?.id,
           state: "active",
+          permissions_state: "ready",
+          permissions_url: null,
         },
       ],
     })
     pullPermission = "read"
     expect(
       await (await app.request("/v1/github", { headers: as(owner.email) })).json(),
-    ).toMatchObject({ permissions_ready: false })
+    ).toMatchObject({ app_permissions_state: "update_required" })
     pullPermission = "write"
     actionsPermission = undefined
     expect(
       await (await app.request("/v1/github", { headers: as(owner.email) })).json(),
-    ).toMatchObject({ permissions_ready: false, connected: true })
+    ).toMatchObject({ app_permissions_state: "update_required", connected: true })
     actionsPermission = "write"
     installationActionsPermission = undefined
     expect(
       await (await app.request("/v1/github", { headers: as(owner.email) })).json(),
     ).toMatchObject({
-      permissions_ready: false,
-      permissions_url: "https://github.com/organizations/derive-to/settings/installations/44001",
+      app_permissions_state: "ready",
+      accounts: [
+        {
+          permissions_state: "approval_required",
+          permissions_url:
+            "https://github.com/organizations/derive-to/settings/installations/44001",
+        },
+      ],
     })
     installationActionsPermission = "write"
     installationPullPermission = undefined
     expect(
       await (await app.request("/v1/github", { headers: as(owner.email) })).json(),
     ).toMatchObject({
-      permissions_ready: false,
-      permissions_url: "https://github.com/organizations/derive-to/settings/installations/44001",
+      app_permissions_state: "ready",
+      accounts: [
+        {
+          permissions_state: "approval_required",
+          permissions_url:
+            "https://github.com/organizations/derive-to/settings/installations/44001",
+        },
+      ],
     })
     installationPullPermission = "write"
     appStatus = 500
     expect(
       await (await app.request("/v1/github", { headers: as(owner.email) })).json(),
-    ).toMatchObject({ permissions_ready: null, available: true, connected: true })
+    ).toMatchObject({ app_permissions_state: "unknown", available: true, connected: true })
     appStatus = 200
     installationStatus = 404
     expect(
@@ -270,7 +288,6 @@ describe("standard GitHub integration", () => {
     })
     expect(res.status).toBe(302)
     expect(res.headers.get("location")).toContain("github_error=expired")
-    expect(await meta.getGithubInstallation("44002")).toBeNull()
     expect(await meta.listConnections("default", undefined, "workspace")).toEqual([])
 
     const legacy = await app.request(
@@ -278,8 +295,6 @@ describe("standard GitHub integration", () => {
       { headers: as(owner.email) },
     )
     expect(legacy.headers.get("location")).toContain("github_error=expired")
-    expect(await meta.getGithubInstallation("44002")).toBeNull()
-
     const ownerState = signState(
       { kind: "github-install-setup", org: "default", uid: owner.id },
       KEY,
@@ -289,7 +304,7 @@ describe("standard GitHub integration", () => {
       { headers: as(member.email) },
     )
     expect(wrongSession.headers.get("location")).toContain("github_error=expired")
-    expect(await meta.getGithubInstallation("44002")).toBeNull()
+    expect(await meta.listConnections("default", undefined, "workspace")).toEqual([])
   })
 
   it("allows a direct GitHub install only after manager login and user-access proof", async () => {
@@ -326,23 +341,23 @@ describe("standard GitHub integration", () => {
     })
     const oauth = new URL(ownerResult.headers.get("location") ?? "")
     expect(oauth.pathname).toBe("/login/oauth/authorize")
-    expect(await meta.getGithubInstallation("44003")).toBeNull()
+    expect(await meta.listConnections("default", undefined, "workspace")).toEqual([])
     const authorized = await app.request(
       `/v1/github/authorize?code=direct&state=${encodeURIComponent(oauth.searchParams.get("state") ?? "")}`,
       { headers: as(owner.email) },
     )
     expect(authorized.headers.get("location")).toContain("github_connected=1")
-    expect(await meta.getGithubInstallation("44003")).toMatchObject({ org_id: "default" })
+    expect(await meta.listConnections("default", undefined, "workspace")).toEqual([
+      expect.objectContaining({ broker_ref: "44003", org_id: "default" }),
+    ])
 
     const memberResult = await app.request("/v1/github/callback?installation_id=44004", {
       headers: as(member.email),
     })
     expect(memberResult.headers.get("location")).toContain("github_error=expired")
-    expect(await meta.getGithubInstallation("44004")).toBeNull()
 
     const anonymousResult = await app.request("/v1/github/callback?installation_id=44005")
     expect(anonymousResult.headers.get("location")).toContain("/login?return_to=")
-    expect(await meta.getGithubInstallation("44005")).toBeNull()
 
     const anonymousLegacyResult = await app.request(
       "/v1/sync/github/callback?installation_id=44005&setup_action=install",
@@ -350,7 +365,6 @@ describe("standard GitHub integration", () => {
     expect(anonymousLegacyResult.headers.get("location")).toContain(
       "return_to=%2Fv1%2Fsync%2Fgithub%2Fcallback",
     )
-    expect(await meta.getGithubInstallation("44005")).toBeNull()
   })
 
   it("refuses an installation the authorizing GitHub user cannot access", async () => {
@@ -385,7 +399,38 @@ describe("standard GitHub integration", () => {
       { headers: as(owner.email) },
     )
     expect(authorized.headers.get("location")).toContain("github_error=save")
-    expect(await meta.getGithubInstallation("44006")).toBeNull()
     expect(await meta.listConnections("default", undefined, "workspace")).toEqual([])
+  })
+
+  it("binds one GitHub installation independently to multiple Derive workspaces", async () => {
+    const { meta } = makeAuthedApp("gh-standard-multi-workspace", [owner], "editor")
+    await meta.setWorkspace("second", "Second workspace")
+    await meta.setMembership({
+      id: "m_gh_second",
+      org_id: "second",
+      user_id: owner.id,
+      role: "owner",
+    })
+
+    const first = await upsertGithubConnection(meta, {
+      orgId: "default",
+      userId: owner.id,
+      installationId: "44007",
+      accountLogin: "derive-to",
+    })
+    const second = await upsertGithubConnection(meta, {
+      orgId: "second",
+      userId: owner.id,
+      installationId: "44007",
+      accountLogin: "derive-to",
+    })
+
+    expect(first.id).not.toBe(second.id)
+    expect(await meta.listConnections("default", undefined, "workspace")).toEqual([
+      expect.objectContaining({ id: first.id, broker_ref: "44007" }),
+    ])
+    expect(await meta.listConnections("second", undefined, "workspace")).toEqual([
+      expect.objectContaining({ id: second.id, broker_ref: "44007" }),
+    ])
   })
 })

--- a/apps/api/test/hosted-tools.test.ts
+++ b/apps/api/test/hosted-tools.test.ts
@@ -545,13 +545,6 @@ describe("hosted tool injection — least privilege (WO4)", () => {
       private_key: encryptSecret(GITHUB_APP_PEM, key),
       created_at: new Date().toISOString(),
     })
-    await h.meta.upsertGithubInstallation({
-      installation_id: "99002",
-      org_id: "default",
-      account_login: "derive-to",
-      created_by: owner.id,
-      created_at: new Date().toISOString(),
-    })
     const connection = await upsertGithubConnection(h.meta, {
       orgId: "default",
       userId: owner.id,

--- a/apps/docs/content/self-hosting/configuration.md
+++ b/apps/docs/content/self-hosting/configuration.md
@@ -298,6 +298,29 @@ Linking is per-user and optional: without it, DMs fall back to matching a member
 The manifest is served (filled) at `/v1/slack/manifest.json`; the setup page is the copy-paste
 front end for it. Bot tokens are stored per workspace, encrypted at rest with `DERIVE_AUTH_SECRET`.
 
+### GitHub App (optional)
+
+Create one GitHub App for each Derive instance. The instance operator creates and owns the
+shared App. Workspace owners then install that App on a GitHub account and select the
+repositories that their workspace can use. One GitHub installation can connect to more than
+one Derive workspace. Each workspace keeps an independent connection.
+
+1. Sign in as the instance operator. Open **Settings → Integrations → Set up App**.
+2. Enter the GitHub organization that operates the Derive instance. GitHub shows this account
+   as the App developer. Use a personal account only when that account should own the App.
+3. Review the generated manifest on GitHub and create the App. Derive stores the App credentials
+   encrypted with `DERIVE_AUTH_SECRET`.
+4. Return to **Settings → Integrations**. Workspace owners can now connect GitHub accounts and
+   select repositories.
+
+Derive requests **Metadata: read**, **Pull requests: write**, and **Actions: write**. It uses
+these permissions for pull request reads, top-level pull request comments, workflow status, and
+workflow dispatch. Derive limits dispatch to workflow files named `derive-*.yml`.
+
+If a release adds an App permission, an App owner or manager must first update the shared App.
+Each connected GitHub account owner must then approve the permission update for that
+installation. Derive shows these as separate actions in **Settings → Integrations**.
+
 ---
 
 ## Node Basic: containers + Postgres + S3/R2

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -7470,15 +7470,24 @@ export interface components {
             /** @description Whether this workspace has at least one active GitHub connection */
             connected: boolean;
             app_slug: string | null;
-            /** @description Whether the configured App and its connected installations have every current permission; null when GitHub could not be checked */
-            permissions_ready: boolean | null;
-            permissions_url: string | null;
+            app_owner_login: string | null;
+            /**
+             * @description Whether the instance App has every current permission; null when no live App exists
+             * @enum {string|null}
+             */
+            app_permissions_state: "ready" | "update_required" | "unknown" | null;
+            app_settings_url: string | null;
+            /** @description Whether the caller is an instance operator who can configure the shared App */
+            can_manage_app: boolean;
             accounts: {
                 installation_id: string;
                 account_login: string | null;
                 connection_id: string | null;
                 /** @enum {string} */
                 state: "active" | "disconnected" | "needs_reauth";
+                /** @enum {string} */
+                permissions_state: "ready" | "approval_required" | "unknown";
+                permissions_url: string | null;
             }[];
         };
         SlackStatus: {

--- a/apps/web/src/pages/settings/integrations-section.tsx
+++ b/apps/web/src/pages/settings/integrations-section.tsx
@@ -4,9 +4,11 @@ import { useEffect, useState } from "react"
 import { api, type GithubIntegrationAccount, type OrgSettings } from "@/api"
 import { AdminNote } from "@/components/shared/admin-note"
 import { ConfirmDialog } from "@/components/shared/confirm-dialog"
+import { ListRow } from "@/components/shared/list-row"
 import { LoadError } from "@/components/shared/load-error"
 import { SettingRow } from "@/components/shared/setting-row"
 import { SettingsGroup } from "@/components/shared/settings-group"
+import { StatusBadge } from "@/components/shared/status-badge"
 import { StatusPanel } from "@/components/shared/status-panel"
 import { Button } from "@/components/ui/button"
 import { toast } from "@/components/ui/sonner"
@@ -232,22 +234,6 @@ export function IntegrationsSection() {
             }
           />
         )}
-        {github && github.permissions_ready === false && github.permissions_url && (
-          <StatusPanel
-            tone="warning"
-            layout="inline"
-            icon={<AlertTriangle aria-hidden />}
-            title="Your GitHub App needs more permissions"
-            description="Review the App permissions on GitHub, then approve the update for each connected account."
-            action={
-              isAdmin && (
-                <Button data-testid="github-update-permissions" variant="outline" size="sm" asChild>
-                  <a href={github.permissions_url}>Review permissions</a>
-                </Button>
-              )
-            }
-          />
-        )}
         {githubIsPending ? (
           <SettingsListSkeleton />
         ) : githubIsError ? (
@@ -258,19 +244,26 @@ export function IntegrationsSection() {
             onRetry={() => refetchGithub()}
           />
         ) : github && !github.available ? (
-          <div className="flex flex-col items-start gap-3 py-1">
-            <p className="text-sm text-muted-foreground">
-              GitHub isn't configured on this Derive instance yet. Create the App once, then install
-              it on the repositories agents may read.
-            </p>
-            {isAdmin ? (
-              <Button data-testid="github-setup" variant="default" asChild>
-                <a href="/settings/github/app/new">Set up GitHub App</a>
-              </Button>
-            ) : (
-              <AdminNote can="set up the GitHub App" />
-            )}
-          </div>
+          <ListRow
+            title={
+              <span className="flex flex-wrap items-center gap-2">
+                GitHub App
+                <StatusBadge tone="muted">Not configured</StatusBadge>
+              </span>
+            }
+            meta={
+              github.can_manage_app
+                ? "Create the shared App once for this Derive instance."
+                : "Ask an instance operator to configure the shared GitHub App."
+            }
+            actions={
+              github.can_manage_app ? (
+                <Button data-testid="github-setup" variant="ghost" size="sm" asChild>
+                  <a href="/settings/github/app/new">Set up App</a>
+                </Button>
+              ) : undefined
+            }
+          />
         ) : githubInstallResult?.connected && !github?.connected ? (
           <StatusPanel
             tone={githubIsFetching ? "neutral" : "danger"}
@@ -294,28 +287,81 @@ export function IntegrationsSection() {
               )
             }
           />
-        ) : github?.accounts.length ? (
+        ) : github ? (
           <>
-            <div className="divide-y">
-              {github.accounts.map((account) => (
-                <div
-                  key={account.installation_id}
-                  className="flex flex-wrap items-center justify-between gap-3 py-3.5"
-                >
-                  <div>
-                    <p className="text-sm font-medium">
-                      {account.account_login ?? `Installation ${account.installation_id}`}
-                    </p>
-                    <p className="text-xs text-muted-foreground">
-                      {account.state === "active"
-                        ? "Available to this workspace's contexts and automations"
-                        : account.state === "needs_reauth"
-                          ? "The GitHub installation is missing or was removed"
-                          : "Installed, but disconnected from agent use"}
-                    </p>
-                  </div>
-                  {isAdmin && (
-                    <div className="flex flex-wrap items-center gap-2">
+            <ListRow
+              title={
+                <span className="flex flex-wrap items-center gap-2">
+                  GitHub App
+                  {github.app_permissions_state === "update_required" ? (
+                    <StatusBadge tone="attention">Update required</StatusBadge>
+                  ) : github.app_permissions_state === "ready" ? (
+                    <StatusBadge tone="ok">Ready</StatusBadge>
+                  ) : (
+                    <StatusBadge tone="muted">Status unknown</StatusBadge>
+                  )}
+                </span>
+              }
+              meta={
+                github.app_permissions_state === "update_required"
+                  ? `${github.app_owner_login ? `@${github.app_owner_login} owns this App. ` : ""}An App owner or manager must grant Actions read and write before Derive can run workflows.`
+                  : github.app_permissions_state === "ready"
+                    ? `${github.app_owner_login ? `Owned by @${github.app_owner_login}. ` : ""}The App permissions are current.`
+                    : "Derive could not confirm the App permissions. Existing connections remain available."
+              }
+              actions={
+                github.app_permissions_state === "update_required" &&
+                github.can_manage_app &&
+                github.app_settings_url ? (
+                  <Button data-testid="github-update-app" variant="ghost" size="sm" asChild>
+                    <a href={github.app_settings_url}>Open App settings</a>
+                  </Button>
+                ) : undefined
+              }
+            />
+            {github.accounts.map((account) => (
+              <ListRow
+                key={account.installation_id}
+                title={
+                  <span className="flex flex-wrap items-center gap-2">
+                    {account.account_login ?? `Installation ${account.installation_id}`}
+                    {account.state === "needs_reauth" ? (
+                      <StatusBadge tone="attention">Needs reconnect</StatusBadge>
+                    ) : github.app_permissions_state === "ready" &&
+                      account.permissions_state === "approval_required" ? (
+                      <StatusBadge tone="attention">Approval required</StatusBadge>
+                    ) : account.state === "active" ? (
+                      <StatusBadge tone="ok">Connected</StatusBadge>
+                    ) : (
+                      <StatusBadge tone="muted">Disconnected</StatusBadge>
+                    )}
+                  </span>
+                }
+                meta={
+                  account.state === "needs_reauth"
+                    ? "The GitHub installation is missing or was removed."
+                    : github.app_permissions_state === "ready" &&
+                        account.permissions_state === "approval_required"
+                      ? "A GitHub account owner must approve the App's updated permissions."
+                      : account.state === "active"
+                        ? "Available to this workspace's contexts and automations."
+                        : "Installed, but disconnected from agent use."
+                }
+                actions={
+                  isAdmin ? (
+                    <>
+                      {github.app_permissions_state === "ready" &&
+                        account.permissions_state === "approval_required" &&
+                        account.permissions_url && (
+                          <Button
+                            data-testid={`github-approve-${account.installation_id}`}
+                            variant="ghost"
+                            size="sm"
+                            asChild
+                          >
+                            <a href={account.permissions_url}>Review update</a>
+                          </Button>
+                        )}
                       {account.state === "active" && account.connection_id ? (
                         <Button
                           data-testid={`github-disconnect-${account.installation_id}`}
@@ -328,42 +374,41 @@ export function IntegrationsSection() {
                       ) : (
                         <Button
                           data-testid={`github-reconnect-${account.installation_id}`}
-                          variant="default"
+                          variant="ghost"
                           size="sm"
                           asChild
                         >
                           <a href="/v1/github/install">Reconnect</a>
                         </Button>
                       )}
-                    </div>
-                  )}
-                </div>
-              ))}
-            </div>
-            {isAdmin && (
-              <div className="py-2">
-                <Button data-testid="github-add-account" variant="outline" size="sm" asChild>
-                  <a href="/v1/github/install">Connect another account</a>
-                </Button>
-              </div>
+                    </>
+                  ) : undefined
+                }
+              />
+            ))}
+            {github.app_permissions_state !== "update_required" && (
+              <ListRow
+                title={github.accounts.length ? "Another GitHub account" : "GitHub account"}
+                meta="Choose the repositories that this workspace's contexts and automations may use."
+                actions={
+                  isAdmin ? (
+                    <Button
+                      data-testid={github.accounts.length ? "github-add-account" : "github-connect"}
+                      variant="ghost"
+                      size="sm"
+                      asChild
+                    >
+                      <a href="/v1/github/install">
+                        {github.accounts.length ? "Connect account" : "Connect"}
+                      </a>
+                    </Button>
+                  ) : undefined
+                }
+              />
             )}
             {!isAdmin && <AdminNote can="manage the GitHub connection" />}
           </>
-        ) : (
-          <div className="flex flex-col items-start gap-3 py-1">
-            <p className="text-sm text-muted-foreground">
-              Install the GitHub App, sign in or complete SSO if GitHub asks, and choose the
-              repositories agents may read.
-            </p>
-            {isAdmin ? (
-              <Button data-testid="github-connect" variant="default" asChild>
-                <a href="/v1/github/install">Connect GitHub</a>
-              </Button>
-            ) : (
-              <AdminNote can="connect GitHub" />
-            )}
-          </div>
-        )}
+        ) : null}
         <ConfirmDialog
           open={!!disconnectingGithub}
           onOpenChange={(open) => !open && setDisconnectingGithub(null)}

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -656,14 +656,6 @@ CREATE TABLE IF NOT EXISTS github_app (
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
 );
 
-CREATE TABLE IF NOT EXISTS github_installation (
-  installation_id TEXT PRIMARY KEY,
-  org_id TEXT NOT NULL,
-  account_login TEXT,
-  created_by TEXT NOT NULL,
-  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
-);
-
 CREATE TABLE IF NOT EXISTS domain (
   host TEXT PRIMARY KEY,
   artifact_id TEXT,

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -1397,13 +1397,10 @@ export interface IntegrationStore {
   // ---- GitHub App (instance credentials + per-workspace installations) -----
   /** The instance's GitHub App credentials, or null before the manifest setup. */
   getGithubApp(): Promise<GitHubAppRecord | null>
+  /** Insert the instance App only when none exists. False means another operator won setup. */
+  createGithubApp(a: GitHubAppRecord): Promise<boolean>
   /** Upsert the single instance App row (id = "default"). */
   setGithubApp(a: GitHubAppRecord): Promise<void>
-  /** Record (or refresh) a workspace's App installation. */
-  upsertGithubInstallation(i: GitHubInstallationRecord): Promise<GitHubInstallationRecord>
-  getGithubInstallation(installationId: string): Promise<GitHubInstallationRecord | null>
-  /** A workspace's installations, newest first. */
-  listGithubInstallations(orgId: string): Promise<GitHubInstallationRecord[]>
   // ---- Workspace integration settings (enable/disable each channel) --------
   /** The workspace's integration preferences, merged over defaults (so a workspace
    *  that never saved any returns all-enabled). */
@@ -4036,18 +4033,6 @@ export interface GitHubAppRecord {
   client_secret: string
   /** PEM private key (encrypted at rest). */
   private_key: string
-  created_at: string
-}
-
-/** A GitHub App installation a workspace connected: the binding between a GitHub
- *  account's selected repos and a Derive workspace. */
-export interface GitHubInstallationRecord {
-  /** Numeric GitHub installation id, stored as text (PK). */
-  installation_id: string
-  org_id: string
-  /** The GitHub account (org/user login) the App is installed on. */
-  account_login: string | null
-  created_by: string
   created_at: string
 }
 

--- a/packages/db/src/parity.ts
+++ b/packages/db/src/parity.ts
@@ -33,7 +33,6 @@ import type {
   FolderRecord,
   FollowRecord,
   GitHubAppRecord,
-  GitHubInstallationRecord,
   InvitationRecord,
   MembershipRecord,
   NotificationRecord,
@@ -101,7 +100,6 @@ export interface TypedTables {
   templateLibrary: TemplateLibraryRecord
   templateLibraryEntry: TemplateLibraryEntryRecord
   githubApp: GitHubAppRecord
-  githubInstallation: GitHubInstallationRecord
   domain: DomainRecord
   report: ReportRecord
   auditLog: AuditLogRecord

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -883,13 +883,6 @@ export const githubApp = pgTable("github_app", {
   private_key: text("private_key").notNull(),
   created_at: text("created_at").notNull().$defaultFn(isoNow),
 })
-export const githubInstallation = pgTable("github_installation", {
-  installation_id: text("installation_id").primaryKey(),
-  org_id: text("org_id").notNull(),
-  account_login: text("account_login"),
-  created_by: text("created_by").notNull(),
-  created_at: text("created_at").notNull().$defaultFn(isoNow),
-})
 export const domain = pgTable("domain", {
   host: text("host").primaryKey(),
   artifact_id: text("artifact_id").references(() => artifact.id),
@@ -1182,7 +1175,6 @@ const TABLES = [
   userNotificationPref,
   activitySeen,
   githubApp,
-  githubInstallation,
   domain,
   reviewRound,
   context,

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -35,7 +35,6 @@ import type {
   FollowKind,
   FollowRecord,
   GitHubAppRecord,
-  GitHubInstallationRecord,
   GithubUserMapping,
   InvitationRecord,
   LinkRole,
@@ -206,7 +205,6 @@ import {
   folder,
   follow,
   githubApp,
-  githubInstallation,
   instanceOperator,
   invitation,
   membership,
@@ -301,7 +299,6 @@ export const schema = {
   templateLibrary,
   templateLibraryEntry,
   githubApp,
-  githubInstallation,
   domain,
   report,
   auditLog,
@@ -351,7 +348,6 @@ const _schemaShapes: Shapes<typeof schema> = {
   templateLibrary: true,
   templateLibraryEntry: true,
   githubApp: true,
-  githubInstallation: true,
   domain: true,
   report: true,
   auditLog: true,
@@ -3858,6 +3854,14 @@ export class PgMetaStore implements MetaStore {
     const rows = await this.db.select().from(githubApp).where(eq(githubApp.id, "default"))
     return rows[0] ?? null
   }
+  async createGithubApp(a: GitHubAppRecord): Promise<boolean> {
+    const rows = await this.db
+      .insert(githubApp)
+      .values(a)
+      .onConflictDoNothing()
+      .returning({ id: githubApp.id })
+    return rows.length > 0
+  }
   async setGithubApp(a: GitHubAppRecord): Promise<void> {
     const { id: _id, created_at: _created, ...set } = a
     await this.db.insert(githubApp).values(a).onConflictDoUpdate({ target: githubApp.id, set })
@@ -4195,32 +4199,6 @@ export class PgMetaStore implements MetaStore {
         set,
       })
   }
-  async upsertGithubInstallation(i: GitHubInstallationRecord): Promise<GitHubInstallationRecord> {
-    const rows = await this.db
-      .insert(githubInstallation)
-      .values(i)
-      .onConflictDoUpdate({
-        target: githubInstallation.installation_id,
-        set: { org_id: i.org_id, account_login: i.account_login, created_by: i.created_by },
-      })
-      .returning()
-    return one(rows)
-  }
-  async getGithubInstallation(installationId: string): Promise<GitHubInstallationRecord | null> {
-    const rows = await this.db
-      .select()
-      .from(githubInstallation)
-      .where(eq(githubInstallation.installation_id, installationId))
-    return rows[0] ?? null
-  }
-  async listGithubInstallations(orgId: string): Promise<GitHubInstallationRecord[]> {
-    return this.db
-      .select()
-      .from(githubInstallation)
-      .where(eq(githubInstallation.org_id, orgId))
-      .orderBy(desc(githubInstallation.created_at))
-  }
-
   // ---- Domains (hostname → artifact) -------------------------------------
   async getDomain(host: string): Promise<DomainRecord | null> {
     const rows = await this.db.select().from(domain).where(eq(domain.host, host))

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -30,7 +30,6 @@ import type {
   FollowKind,
   FollowRecord,
   GitHubAppRecord,
-  GitHubInstallationRecord,
   InvitationRecord,
   LinkRole,
   ListArtifactsOpts,
@@ -193,7 +192,6 @@ import {
   folder,
   follow,
   githubApp,
-  githubInstallation,
   instanceOperator,
   invitation,
   membership,
@@ -423,7 +421,6 @@ export const schema = {
   templateLibrary,
   templateLibraryEntry,
   githubApp,
-  githubInstallation,
   domain,
   report,
   auditLog,
@@ -473,7 +470,6 @@ const _schemaShapes: Shapes<typeof schema> = {
   templateLibrary: true,
   templateLibraryEntry: true,
   githubApp: true,
-  githubInstallation: true,
   domain: true,
   report: true,
   auditLog: true,
@@ -3015,6 +3011,13 @@ export function makeRepos(db: SqliteDb) {
   // ---- GitHub App (instance credentials + per-workspace installations) -----
   const getGithubApp = async (): Promise<GitHubAppRecord | null> =>
     (await db.select().from(githubApp).where(eq(githubApp.id, "default")).get()) ?? null
+  const createGithubApp = async (a: GitHubAppRecord): Promise<boolean> =>
+    !!(await db
+      .insert(githubApp)
+      .values(a)
+      .onConflictDoNothing()
+      .returning({ id: githubApp.id })
+      .get())
   const setGithubApp = async (a: GitHubAppRecord): Promise<void> => {
     const { id: _id, created_at: _created, ...set } = a
     await db.insert(githubApp).values(a).onConflictDoUpdate({ target: githubApp.id, set }).run()
@@ -3337,33 +3340,6 @@ export function makeRepos(db: SqliteDb) {
       })
       .run()
   }
-  const upsertGithubInstallation = async (
-    i: GitHubInstallationRecord,
-  ): Promise<GitHubInstallationRecord> =>
-    (await db
-      .insert(githubInstallation)
-      .values(i)
-      .onConflictDoUpdate({
-        target: githubInstallation.installation_id,
-        set: { org_id: i.org_id, account_login: i.account_login, created_by: i.created_by },
-      })
-      .returning()
-      .get()) as GitHubInstallationRecord
-  const getGithubInstallation = async (
-    installationId: string,
-  ): Promise<GitHubInstallationRecord | null> =>
-    (await db
-      .select()
-      .from(githubInstallation)
-      .where(eq(githubInstallation.installation_id, installationId))
-      .get()) ?? null
-  const listGithubInstallations = async (orgId: string): Promise<GitHubInstallationRecord[]> =>
-    db
-      .select()
-      .from(githubInstallation)
-      .where(eq(githubInstallation.org_id, orgId))
-      .orderBy(desc(githubInstallation.created_at))
-      .all()
   // ---- Domains (hostname → artifact) -------------------------------------
   const getDomain = async (host: string): Promise<DomainRecord | null> =>
     (await db.select().from(domain).where(eq(domain.host, host)).get()) ?? null
@@ -5628,6 +5604,7 @@ export function makeRepos(db: SqliteDb) {
     countTemplateLibraryEntries,
     deleteTemplateLibraryEntry,
     getGithubApp,
+    createGithubApp,
     setGithubApp,
     getOrgSettings,
     setOrgSettings,
@@ -5659,9 +5636,6 @@ export function makeRepos(db: SqliteDb) {
     deleteSlackUserLink,
     getUserNotificationPref,
     setUserNotificationPref,
-    upsertGithubInstallation,
-    getGithubInstallation,
-    listGithubInstallations,
     getDomain,
     setDomain,
     getArtifactDomains,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1081,17 +1081,6 @@ export const githubApp = sqliteTable("github_app", {
   created_at: text("created_at").notNull().default(now),
 })
 
-// A GitHub App installation a workspace connected — the binding between a GitHub
-// account's selected repos and a Derive workspace. Agent source calls mint
-// short-lived installation tokens against installation_id.
-export const githubInstallation = sqliteTable("github_installation", {
-  installation_id: text("installation_id").primaryKey(),
-  org_id: text("org_id").notNull(),
-  account_login: text("account_login"),
-  created_by: text("created_by").notNull(),
-  created_at: text("created_at").notNull().default(now),
-})
-
 // Domain mode: a hostname that serves an artifact at the root of its own origin.
 // `host` is globally unique (one host → one artifact); `kind` separates a platform
 // subdomain (name.derived.app) from a customer's own domain.
@@ -1404,7 +1393,6 @@ const TABLES = [
   userNotificationPref,
   activitySeen,
   githubApp,
-  githubInstallation,
   domain,
   reviewRound,
   context,

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -1774,32 +1774,9 @@ export function runStoreContract(
   })
 
   describe(`${label}: github app`, () => {
-    it("stores a workspace installation", async () => {
-      const inst = await store.upsertGithubInstallation({
-        installation_id: "4242",
-        org_id: ORG,
-        account_login: "acme",
-        created_by: "amy",
-        created_at: "2026-06-15T00:00:00.000Z",
-      })
-      expect(inst.account_login).toBe("acme")
-      // Upsert is idempotent on installation_id (re-install refreshes, no dupe).
-      await store.upsertGithubInstallation({
-        installation_id: "4242",
-        org_id: ORG,
-        account_login: "acme-renamed",
-        created_by: "amy",
-        created_at: "2026-06-15T00:00:00.000Z",
-      })
-      expect(await store.getGithubInstallation("4242")).toMatchObject({
-        account_login: "acme-renamed",
-      })
-      expect(await store.listGithubInstallations(ORG)).toHaveLength(1)
-    })
-
-    it("stores the instance GitHub App credentials as a single upserted row", async () => {
+    it("creates the instance GitHub App once and only updates that App in place", async () => {
       expect(await store.getGithubApp()).toBeNull()
-      await store.setGithubApp({
+      const first = {
         id: "default",
         app_id: "111",
         slug: "derive-on-acme",
@@ -1807,19 +1784,27 @@ export function runStoreContract(
         client_secret: "enc-secret",
         private_key: "enc-pem",
         created_at: "2026-06-15T00:00:00.000Z",
-      })
+      }
+      expect(await store.createGithubApp(first)).toBe(true)
       expect(await store.getGithubApp()).toMatchObject({ app_id: "111", slug: "derive-on-acme" })
-      // Re-setup overwrites in place (still one row).
+      expect(
+        await store.createGithubApp({
+          ...first,
+          app_id: "222",
+          slug: "derive-on-acme-2",
+        }),
+      ).toBe(false)
+      expect(await store.getGithubApp()).toMatchObject({ app_id: "111", slug: "derive-on-acme" })
+      // A live rename may refresh metadata without replacing the credentials.
       await store.setGithubApp({
+        ...first,
         id: "default",
-        app_id: "222",
-        slug: "derive-on-acme-2",
-        client_id: "Iv1.def",
-        client_secret: "enc-secret-2",
-        private_key: "enc-pem-2",
-        created_at: "2026-06-15T00:00:00.000Z",
+        slug: "derive-on-acme-renamed",
       })
-      expect(await store.getGithubApp()).toMatchObject({ app_id: "222" })
+      expect(await store.getGithubApp()).toMatchObject({
+        app_id: "111",
+        slug: "derive-on-acme-renamed",
+      })
     })
   })
 


### PR DESCRIPTION
## Summary

- Make the instance operator choose the GitHub App owner before setup.
- Show App and installation permission states with standard settings rows.
- Use the correct settings URL for organization-owned Apps.
- Use workspace connections as the only installation binding.
- Document the hosted and self-hosted App model.

## Product model

Hosted Derive uses one App owned by the Derive GitHub organization. A self-hosted deployment uses one App owned by that deployment operator. Workspace owners install the shared App, select repositories, and bind each installation independently to their Derive workspace.

The existing production App still needs a GitHub-side ownership transfer or recreation under the Derive organization. This PR prevents the setup mistake for future Apps and shows the current owner in Settings.

## Validation

- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm run ci: 34 of 34 guardrails
- pnpm --filter @derive/docs build
- pnpm --filter @derive/docs typecheck
- Browser-checked desktop and mobile integration settings.