### PR TITLE
Fix GitHub App reconnect redirect

### DIFF
--- a/apps/api/src/github-app-setup.ts
+++ b/apps/api/src/github-app-setup.ts
@@ -45,6 +45,9 @@ export const buildManifest = (baseUrl: string, host: string) => ({
   // Where GitHub sends the browser after the App is INSTALLED — our callback
   // starts a user-authorization proof before any installation is persisted.
   setup_url: new URL("/v1/github/callback", baseUrl).toString(),
+  // An already-installed App opens GitHub's repository-selection screen. Return to the
+  // same callback after that update too, or Derive never receives the installation id.
+  setup_on_update: true,
   callback_urls: [new URL("/v1/github/authorize", baseUrl).toString()],
   request_oauth_on_install: false,
   // Public so it can be installed on organizations too, not just the owner's

--- a/apps/api/test/github-manifest.test.ts
+++ b/apps/api/test/github-manifest.test.ts
@@ -26,6 +26,7 @@ describe("GitHub App manifest", () => {
 
   it("uses setup + authorization callbacks without automatic OAuth-on-install", () => {
     expect(m.setup_url).toBe("https://derive.example.com/v1/github/callback")
+    expect(m.setup_on_update).toBe(true)
     expect(m.callback_urls).toEqual(["https://derive.example.com/v1/github/authorize"])
     expect(m.request_oauth_on_install).toBe(false)
     expect(m.redirect_url).toBe("https://derive.example.com/settings/github/app/created")


### PR DESCRIPTION
## Summary

- Enable GitHub App setup redirects after repository-access updates.
- Return existing installations to Derive so the workspace binding can finish.
- Lock the setting with a manifest regression test.

## Cause

GitHub redirects a new installation to the setup URL by default. It only redirects an existing installation after an update when setup-on-update is enabled. Without that flag, GitHub shows the App as installed but Derive never receives the installation ID.

## Validation

- 15 focused GitHub integration tests passed.
- API type checks passed.
- Full API suite passed: 1,683 tests.
- 34 of 34 guardrails passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/865"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790723497&installation_model_id=428097&pr_number=865&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F865&signature=4170ce48a5f84b8770f57caf7245621b23a419cfd1644da063a4636d0176e419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->