### PR TITLE
Recover existing GitHub App installations

### DIFF
--- a/apps/api/src/github-app-setup.ts
+++ b/apps/api/src/github-app-setup.ts
@@ -59,6 +59,28 @@ export const buildManifest = (baseUrl: string, host: string) => ({
   default_events: REQUIRED_EVENTS,
 })
 
+export function installationPickerHTML(props: {
+  installations: { login: string; state: string }[]
+  installUrl: string
+}): string {
+  const choices = props.installations
+    .map(
+      (installation) => `<form class="field" method="post" action="/v1/github/select">
+        <input type="hidden" name="state" value="${esc(installation.state)}"/>
+        <button class="btn ghost" type="submit">${esc(installation.login)}</button>
+      </form>`,
+    )
+    .join("")
+  return SHELL(
+    "Choose GitHub account",
+    "",
+    `<h1>Choose a GitHub account</h1>
+    <p class="sub">Choose the existing App installation to connect to this Derive workspace.</p>
+    ${choices}
+    <p class="foot"><a href="${esc(props.installUrl)}">Install the App on another account</a></p>`,
+  )
+}
+
 /** The manifest form page. The operator chooses who owns the App before GitHub creates it.
  * GitHub shows that owner as the developer, so silently defaulting to the signed-in person's
  * account is both surprising and difficult to repair after installations exist. */

--- a/apps/api/src/lib/github-app.ts
+++ b/apps/api/src/lib/github-app.ts
@@ -236,12 +236,10 @@ export async function exchangeGithubUserCode(input: {
   return data.access_token
 }
 
-/** GitHub's documented defense against a spoofed setup `installation_id`: use the temporary
- * user access token to confirm the installer is associated with that installation. */
-export async function getUserInstallation(
-  userToken: string,
-  installationId: string,
-): Promise<AppInstallation | null> {
+/** List installations this App's temporary user token can access. GitHub scopes this endpoint
+ * to the App that issued the token, so it is safe to use for existing-install discovery. */
+export async function listUserInstallations(userToken: string): Promise<AppInstallation[]> {
+  const result: AppInstallation[] = []
   for (let page = 1; page <= 10; page++) {
     const res = await fetch(`${API}/user/installations?per_page=100&page=${page}`, {
       headers: ghHeaders(`Bearer ${userToken}`),
@@ -256,19 +254,30 @@ export async function getUserInstallation(
       }[]
     }
     const installations = data.installations ?? []
-    const found = installations.find((installation) => String(installation.id) === installationId)
-    if (found)
-      return {
-        id: found.id ?? Number(installationId),
-        account: found.account
-          ? { login: found.account.login ?? "", type: found.account.type ?? "" }
+    for (const installation of installations) {
+      if (!installation.id || !Number.isSafeInteger(installation.id)) continue
+      result.push({
+        id: installation.id,
+        account: installation.account
+          ? { login: installation.account.login ?? "", type: installation.account.type ?? "" }
           : null,
-        htmlUrl: found.html_url ?? null,
-        permissions: found.permissions ?? {},
-      }
+        htmlUrl: installation.html_url ?? null,
+        permissions: installation.permissions ?? {},
+      })
+    }
     if (installations.length < 100) break
   }
-  return null
+  return result
+}
+
+/** GitHub's documented defense against a spoofed setup `installation_id`: use the temporary
+ * user access token to confirm the installer is associated with that installation. */
+export async function getUserInstallation(
+  userToken: string,
+  installationId: string,
+): Promise<AppInstallation | null> {
+  const installations = await listUserInstallations(userToken)
+  return installations.find((installation) => String(installation.id) === installationId) ?? null
 }
 
 export interface AppInstallation {

--- a/apps/api/src/routes/github.ts
+++ b/apps/api/src/routes/github.ts
@@ -4,7 +4,11 @@ import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import type { Handler } from "hono"
 import type { BlankEnv } from "hono/types"
 import type { AppContext } from "../context"
-import { MANIFEST_PERMISSIONS, REQUIRED_PERMISSIONS } from "../github-app-setup"
+import {
+  installationPickerHTML,
+  MANIFEST_PERMISSIONS,
+  REQUIRED_PERMISSIONS,
+} from "../github-app-setup"
 import { decryptSecret, signState, verifyState } from "../lib/crypto"
 import {
   exchangeGithubUserCode,
@@ -12,6 +16,7 @@ import {
   getAppInfo,
   getAppInstallation,
   getUserInstallation,
+  listUserInstallations,
 } from "../lib/github-app"
 import { upsertGithubConnection } from "../lib/github-connection"
 import { bail, fail } from "../lib/http"
@@ -26,6 +31,21 @@ interface InstallState {
 
 interface AuthorizationState {
   kind: "github-install-authorize"
+  org: string
+  uid: string
+  installationId: string
+  iat: number
+}
+
+interface DiscoveryState {
+  kind: "github-install-discover"
+  org: string
+  uid: string
+  iat: number
+}
+
+interface SelectionState {
+  kind: "github-install-select"
   org: string
   uid: string
   installationId: string
@@ -72,6 +92,24 @@ export const githubRoutes = (ctx: AppContext) => {
 
   const codeChallenge = (verifier: string): string =>
     createHash("sha256").update(verifier).digest("base64url")
+
+  const authorizationUrl = (clientId: string, state: string): string => {
+    if (!deps.encryptionKey) throw new Error("GitHub authorization is not configured")
+    const authorize = new URL("https://github.com/login/oauth/authorize")
+    authorize.searchParams.set("client_id", clientId)
+    authorize.searchParams.set(
+      "redirect_uri",
+      new URL("/v1/github/authorize", deps.baseUrl).toString(),
+    )
+    authorize.searchParams.set("state", state)
+    authorize.searchParams.set(
+      "code_challenge",
+      codeChallenge(codeVerifier(state, deps.encryptionKey)),
+    )
+    authorize.searchParams.set("code_challenge_method", "S256")
+    authorize.searchParams.set("prompt", "select_account")
+    return authorize.toString()
+  }
 
   const Account = z.object({
     installation_id: z.string(),
@@ -249,8 +287,25 @@ export const githubRoutes = (ctx: AppContext) => {
     },
   )
 
-  // One navigation, like Slack: admin → GitHub login/SSO/repository selection → callback.
+  // Start with GitHub user authorization. This lets Derive discover an existing installation
+  // even when an older App does not redirect installation updates to its setup URL.
   app.get("/v1/github/install", async (c) => {
+    const org = await requireWorkspace(c, "manage")
+    if (org instanceof Response) return org
+    const me = await requireUser(c)
+    if (me instanceof Response) return me
+    const loaded = await loadApp()
+    if (!loaded || !deps.encryptionKey) return fail(c, 404, "GitHub is not configured")
+    const state = signState(
+      { kind: "github-install-discover", org, uid: me.id },
+      deps.encryptionKey,
+    )
+    return c.redirect(authorizationUrl(loaded.app.client_id, state))
+  })
+
+  // No accessible installation exists yet. GitHub returns through the setup callback after the
+  // manager chooses an account and repositories.
+  app.get("/v1/github/install/new", async (c) => {
     const org = await requireWorkspace(c, "manage")
     if (org instanceof Response) return org
     const me = await requireUser(c)
@@ -316,16 +371,7 @@ export const githubRoutes = (ctx: AppContext) => {
       { kind: "github-install-authorize", org, uid, installationId },
       deps.encryptionKey,
     )
-    const verifier = codeVerifier(authorizationState, deps.encryptionKey)
-    const redirectUri = new URL("/v1/github/authorize", deps.baseUrl).toString()
-    const authorize = new URL("https://github.com/login/oauth/authorize")
-    authorize.searchParams.set("client_id", loaded.app.client_id)
-    authorize.searchParams.set("redirect_uri", redirectUri)
-    authorize.searchParams.set("state", authorizationState)
-    authorize.searchParams.set("code_challenge", codeChallenge(verifier))
-    authorize.searchParams.set("code_challenge_method", "S256")
-    authorize.searchParams.set("prompt", "select_account")
-    return c.redirect(authorize.toString())
+    return c.redirect(authorizationUrl(loaded.app.client_id, authorizationState))
   }
 
   app.get("/v1/github/callback", handleInstallCallback)
@@ -339,8 +385,13 @@ export const githubRoutes = (ctx: AppContext) => {
     const stateRaw = c.req.query("state") ?? ""
     if (c.req.query("error") === "access_denied") return c.redirect(settingsRedirect("canceled"))
     if (!deps.encryptionKey || !code) return c.redirect(settingsRedirect("config"))
-    const state = verifyState<AuthorizationState>(stateRaw, deps.encryptionKey)
-    if (state?.kind !== "github-install-authorize" || !installationIdIsValid(state.installationId))
+    const encryptionKey = deps.encryptionKey
+    const state = verifyState<AuthorizationState | DiscoveryState>(stateRaw, encryptionKey)
+    if (
+      !state ||
+      (state.kind !== "github-install-discover" &&
+        (state.kind !== "github-install-authorize" || !installationIdIsValid(state.installationId)))
+    )
       return c.redirect(settingsRedirect("expired"))
 
     const me = await currentUser(c)
@@ -357,11 +408,43 @@ export const githubRoutes = (ctx: AppContext) => {
     try {
       const userToken = await exchangeGithubUserCode({
         clientId: loaded.app.client_id,
-        clientSecret: decryptSecret(loaded.app.client_secret, deps.encryptionKey),
+        clientSecret: decryptSecret(loaded.app.client_secret, encryptionKey),
         code,
         redirectUri: new URL("/v1/github/authorize", deps.baseUrl).toString(),
-        codeVerifier: codeVerifier(stateRaw, deps.encryptionKey),
+        codeVerifier: codeVerifier(stateRaw, encryptionKey),
       })
+      if (state.kind === "github-install-discover") {
+        const installations = await listUserInstallations(userToken)
+        if (!installations.length) return c.redirect("/v1/github/install/new")
+        if (installations.length === 1) {
+          const installation = installations[0]
+          if (!installation) return c.redirect(settingsRedirect("save"))
+          await upsertGithubConnection(meta, {
+            orgId: state.org,
+            userId: me.id,
+            installationId: String(installation.id),
+            accountLogin: installation.account?.login ?? null,
+          })
+          return c.redirect(settingsRedirect("connected"))
+        }
+        return c.html(
+          installationPickerHTML({
+            installations: installations.map((installation) => ({
+              login: installation.account?.login || `Installation ${installation.id}`,
+              state: signState(
+                {
+                  kind: "github-install-select",
+                  org: state.org,
+                  uid: me.id,
+                  installationId: String(installation.id),
+                },
+                encryptionKey,
+              ),
+            })),
+            installUrl: "/v1/github/install/new",
+          }),
+        )
+      }
       const installation = await getUserInstallation(userToken, state.installationId)
       if (!installation) {
         log.warn("github installer cannot access installation", {
@@ -380,6 +463,47 @@ export const githubRoutes = (ctx: AppContext) => {
       return c.redirect(settingsRedirect("connected"))
     } catch (err) {
       log.warn("github integration save failed", {
+        installation_id:
+          state.kind === "github-install-authorize" ? state.installationId : "discovery",
+        error: err instanceof Error ? err.message : String(err),
+      })
+      return c.redirect(settingsRedirect("save"))
+    }
+  })
+
+  app.post("/v1/github/select", async (c) => {
+    const org = await requireWorkspace(c, "manage")
+    if (org instanceof Response) return org
+    const me = await requireUser(c)
+    if (me instanceof Response) return me
+    if (!deps.encryptionKey) return c.redirect(settingsRedirect("config"))
+    const body = await c.req.parseBody()
+    const stateRaw = typeof body.state === "string" ? body.state : ""
+    const state = verifyState<SelectionState>(stateRaw, deps.encryptionKey)
+    if (
+      state?.kind !== "github-install-select" ||
+      !installationIdIsValid(state.installationId) ||
+      state.org !== org ||
+      state.uid !== me.id
+    )
+      return c.redirect(settingsRedirect("expired"))
+    const loaded = await loadApp()
+    if (!loaded) return c.redirect(settingsRedirect("config"))
+    try {
+      const installation = await getAppInstallation(
+        loaded.app.app_id,
+        loaded.pem,
+        state.installationId,
+      )
+      await upsertGithubConnection(meta, {
+        orgId: org,
+        userId: me.id,
+        installationId: state.installationId,
+        accountLogin: installation.account?.login ?? null,
+      })
+      return c.redirect(settingsRedirect("connected"))
+    } catch (err) {
+      log.warn("github installation selection failed", {
         installation_id: state.installationId,
         error: err instanceof Error ? err.message : String(err),
       })

--- a/apps/api/test/github-integration.test.ts
+++ b/apps/api/test/github-integration.test.ts
@@ -51,7 +51,11 @@ describe("standard GitHub integration", () => {
     expect(generic.status).toBe(400)
     const install = await app.request("/v1/github/install", { headers: as(owner.email) })
     expect(install.status).toBe(302)
-    expect(install.headers.get("location")).toContain(
+    expect(new URL(install.headers.get("location") ?? "").pathname).toBe("/login/oauth/authorize")
+    const freshInstall = await app.request("/v1/github/install/new", {
+      headers: as(owner.email),
+    })
+    expect(freshInstall.headers.get("location")).toContain(
       "https://github.com/apps/derive-test/installations/new?state=",
     )
     expect((await app.request("/v1/github/install", { headers: as(member.email) })).status).toBe(
@@ -268,14 +272,91 @@ describe("standard GitHub integration", () => {
     expect(disconnected.status).toBe(204)
     expect(await meta.getConnection(created?.id ?? "")).toMatchObject({ status: "revoked" })
 
-    const finalSetup = await callback("44001")
-    await authorize(finalSetup.headers.get("location"), "reconnect")
+    const recovered = await authorize(install.headers.get("location"), "reconnect")
+    expect(recovered.headers.get("location")).toContain("github_connected=1")
     expect(await meta.getConnection(created?.id ?? "")).toMatchObject({ status: "active" })
     expect(
       (await meta.listConnections("default", undefined, "workspace")).filter(
         (connection) => connection.kind === "github_app",
       ),
     ).toHaveLength(1)
+  })
+
+  it("lets a manager choose between existing installations without an install callback", async () => {
+    const { app, meta } = makeAuthedApp("gh-standard-existing", [owner], "editor", {
+      deps: { encryptionKey: KEY },
+    })
+    await seedApp(meta)
+    let installations = [
+      { id: 55001, account: { login: "derive-one", type: "Organization" } },
+      { id: 55002, account: { login: "derive-two", type: "Organization" } },
+    ]
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL) => {
+        const parsed = new URL(String(url))
+        if (parsed.host === "github.com" && parsed.pathname === "/login/oauth/access_token")
+          return new Response(JSON.stringify({ access_token: "ghu_existing" }), { status: 200 })
+        if (parsed.pathname === "/user/installations")
+          return new Response(JSON.stringify({ installations }), { status: 200 })
+        if (parsed.pathname === "/app/installations/55002")
+          return new Response(
+            JSON.stringify({
+              id: 55002,
+              account: { login: "derive-two", type: "Organization" },
+              permissions: { actions: "write", metadata: "read", pull_requests: "write" },
+            }),
+            { status: 200 },
+          )
+        return new Response("not found", { status: 404 })
+      }),
+    )
+
+    const install = await app.request("/v1/github/install", { headers: as(owner.email) })
+    const oauth = new URL(install.headers.get("location") ?? "")
+    const picker = await app.request(
+      `/v1/github/authorize?code=existing&state=${encodeURIComponent(oauth.searchParams.get("state") ?? "")}`,
+      { headers: as(owner.email) },
+    )
+    expect(picker.status).toBe(200)
+    const html = await picker.text()
+    expect(html).toContain("Choose a GitHub account")
+    expect(html).toContain("derive-one")
+    expect(html).toContain("derive-two")
+    expect(html).toContain("/v1/github/install/new")
+    const selectionStates = [...html.matchAll(/name="state" value="([^"]+)"/g)].map(
+      (match) => match[1] ?? "",
+    )
+    expect(selectionStates).toHaveLength(2)
+
+    const forged = await app.request("/v1/github/select", {
+      method: "POST",
+      headers: { ...as(owner.email), "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({ state: "forged" }),
+    })
+    expect(forged.headers.get("location")).toContain("github_error=expired")
+    expect(await meta.listConnections("default", undefined, "workspace")).toEqual([])
+
+    const selected = await app.request("/v1/github/select", {
+      method: "POST",
+      headers: { ...as(owner.email), "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({ state: selectionStates[1] ?? "" }),
+    })
+    expect(selected.headers.get("location")).toContain("github_connected=1")
+    expect(
+      (await meta.listConnections("default", undefined, "workspace")).filter(
+        (connection) => connection.kind === "github_app",
+      ),
+    ).toMatchObject([{ broker_ref: "55002", scopes_label: "derive-two", status: "active" }])
+
+    installations = []
+    const emptyInstall = await app.request("/v1/github/install", { headers: as(owner.email) })
+    const emptyOauth = new URL(emptyInstall.headers.get("location") ?? "")
+    const noExisting = await app.request(
+      `/v1/github/authorize?code=empty&state=${encodeURIComponent(emptyOauth.searchParams.get("state") ?? "")}`,
+      { headers: as(owner.email) },
+    )
+    expect(noExisting.headers.get("location")).toBe("/v1/github/install/new")
   })
 
   it("rejects a forged standard callback before it records an installation", async () => {

--- a/apps/web/src/pages/settings/integrations-section.tsx
+++ b/apps/web/src/pages/settings/integrations-section.tsx
@@ -389,7 +389,7 @@ export function IntegrationsSection() {
             {github.app_permissions_state !== "update_required" && (
               <ListRow
                 title={github.accounts.length ? "Another GitHub account" : "GitHub account"}
-                meta="Choose the repositories that this workspace's contexts and automations may use."
+                meta="Connect an existing App installation or install it on another GitHub account."
                 actions={
                   isAdmin ? (
                     <Button


### PR DESCRIPTION
## Summary

- authorize the workspace manager before GitHub installation setup
- discover and bind an existing App installation without a setup redirect
- show the shared Derive account picker when several installations are available
- keep the repository-selection path for a fresh installation

## Why

Older GitHub Apps can be installed without `Redirect on update`. GitHub then shows the App as installed but never returns the installation ID to Derive. The user access token can securely list only this App’s installations that the manager can access, so Derive can recover the existing installation directly.

## Validation

- `pnpm run ci`
- `pnpm typecheck`
- `pnpm test`
- pre-push `pnpm verify:affected`
- existing-install, multi-install selection, empty-install, replay, and forged-state coverage

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/867"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790724951&installation_model_id=428097&pr_number=867&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F867&signature=7d7a8fdcb02e50ac6114160e3174feeee5151d8b2f22eb4e7e2cbe5165823996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->