### PR TITLE
Simplify the Workflows browser

### DIFF
--- a/apps/web/src/components/shared/run-receipt.tsx
+++ b/apps/web/src/components/shared/run-receipt.tsx
@@ -58,13 +58,15 @@ export function RunReceipt({
         <StatusBadge tone={runStatusTone(status)} shape="pill">
           {runStatusLabel(status)}
         </StatusBadge>
-        <span className="min-w-0 truncate text-sm font-medium text-foreground">{title}</span>
+        <span className="w-full min-w-0 break-words text-sm font-medium text-foreground sm:w-auto sm:truncate">
+          {title}
+        </span>
         <span className="font-mono text-2xs text-muted-foreground">{id.slice(-8)}</span>
         <span className="ml-auto shrink-0 font-mono text-2xs text-muted-foreground">
           {ago(createdAt)}
         </span>
       </div>
-      <p className="mt-1.5 text-xs leading-relaxed text-muted-foreground">{summary}</p>
+      <p className="mt-1.5 break-words text-xs leading-relaxed text-muted-foreground">{summary}</p>
       {facts.length > 0 ? (
         <div className="mt-1.5 flex flex-wrap gap-x-3 gap-y-1 font-mono text-2xs text-muted-foreground">
           {facts.map((fact) => (

--- a/apps/web/src/pages/workflows/automated-workflows.tsx
+++ b/apps/web/src/pages/workflows/automated-workflows.tsx
@@ -149,14 +149,15 @@ function AutomationRow({
   return (
     <ListRow
       data-testid={`automation-row-${automation.id}`}
+      className="[&>div:first-child]:flex-wrap [&>div:first-child>div:last-child]:w-full sm:[&>div:first-child>div:last-child]:w-auto"
       leading={
         <div className="flex size-7 shrink-0 items-center justify-center rounded-full bg-accent">
           <Zap className="size-4 text-muted-foreground" aria-hidden />
         </div>
       }
       title={
-        <span className="flex items-center gap-1.5">
-          <span className="truncate">{automation.instruction}</span>
+        <span className="flex min-w-0 flex-wrap items-center gap-1.5">
+          <span className="min-w-0 max-w-full truncate">{automation.instruction}</span>
           <Badge variant="outline">
             {automation.provider === "codex" ? "Codex" : "Claude Code"}
           </Badge>

--- a/apps/web/src/pages/workflows/index.test.ts
+++ b/apps/web/src/pages/workflows/index.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest"
+import type { WorkflowDirectoryItem } from "@/api"
+import { visibleWorkflows } from "./index"
+import { workflowBuilderPrompt } from "./workflow-builder-dialog"
+
+const workflow = (
+  shortId: string,
+  status: WorkflowDirectoryItem["status"],
+  updatedAt: string,
+): WorkflowDirectoryItem => ({
+  shortId,
+  title: shortId,
+  version: 1,
+  updatedAt,
+  purpose: null,
+  status,
+  diagrams: [],
+})
+
+describe("workflow browser", () => {
+  const ready = workflow("ready", "ready", "2026-08-30T10:00:00.000Z")
+  const blocked = workflow("blocked", "needs-changes", "2026-08-30T11:00:00.000Z")
+
+  it("sorts newest first and filters without dropping the blocked definition", () => {
+    expect(visibleWorkflows([ready, blocked], "all").map((item) => item.shortId)).toEqual([
+      "blocked",
+      "ready",
+    ])
+    expect(visibleWorkflows([ready, blocked], "needs-changes")).toEqual([blocked])
+  })
+})
+
+describe("workflow builder handoff", () => {
+  it("builds a bounded draft request and never starts the workflow", () => {
+    const prompt = workflowBuilderPrompt({
+      outcome: "  Verify a pull request and publish the evidence.  ",
+      shape: "loop",
+      maxAttempts: 3,
+      testOnly: true,
+      gateExternalEffects: true,
+      finalReview: false,
+    })
+    expect(prompt).toContain("Outcome: Verify a pull request and publish the evidence.")
+    expect(prompt).toContain("Stop after at most 3 attempts.")
+    expect(prompt).toContain("Do not run it yet.")
+  })
+})

--- a/apps/web/src/pages/workflows/index.tsx
+++ b/apps/web/src/pages/workflows/index.tsx
@@ -1,143 +1,231 @@
 import { useQuery } from "@tanstack/react-query"
-import { Link } from "@tanstack/react-router"
+import { useState } from "react"
 import type { WorkflowDirectoryItem } from "@/api"
+import { useShell } from "@/components/chrome/shell-context"
 import { Icon } from "@/components/icons"
-import { ListRow } from "@/components/shared/list-row"
+import { EmptyState } from "@/components/shared/empty-state"
 import { LoadError } from "@/components/shared/load-error"
 import { PageHeader } from "@/components/shared/page-header"
 import { PageShell } from "@/components/shared/page-shell"
-import { SectionHeading } from "@/components/shared/section-title"
-import { StatusBadge } from "@/components/shared/status-badge"
+import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { workflowsQuery } from "@/lib/queries"
-import { ago } from "@/lib/time"
 import { useDocumentTitle } from "@/lib/use-document-title"
+import { cn } from "@/lib/utils"
 import { SettingsListSkeleton } from "../settings/settings-list-skeleton"
 import { AutomatedWorkflows } from "./automated-workflows"
+import { WorkflowBuilderDialog } from "./workflow-builder-dialog"
+import { WorkflowDirectoryHeader, WorkflowDirectoryRow } from "./workflow-directory"
 
-const countLabel = (count: number, singular: string, plural = `${singular}s`): string =>
-  `${count} ${count === 1 ? singular : plural}`
+export type WorkflowFilter = "all" | WorkflowDirectoryItem["status"]
 
-const workflowMeta = (workflow: WorkflowDirectoryItem): string => {
-  const counts = workflow.diagrams.reduce(
-    (total, diagram) => ({
-      contextSteps: total.contextSteps + diagram.contextSteps,
-      humanPauses: total.humanPauses + diagram.humanPauses,
-      branches: total.branches + diagram.branches,
-      loops: total.loops + diagram.loops,
-    }),
-    { contextSteps: 0, humanPauses: 0, branches: 0, loops: 0 },
+export const visibleWorkflows = (
+  workflows: WorkflowDirectoryItem[],
+  filter: WorkflowFilter,
+): WorkflowDirectoryItem[] =>
+  [...(filter === "all" ? workflows : workflows.filter((item) => item.status === filter))].sort(
+    (a, b) => b.updatedAt.localeCompare(a.updatedAt),
   )
-  return [
-    countLabel(counts.contextSteps, "Context step"),
-    counts.humanPauses ? countLabel(counts.humanPauses, "human pause") : "No human pauses",
-    counts.loops
-      ? countLabel(counts.loops, "bounded loop")
-      : counts.branches
-        ? countLabel(counts.branches, "possible branch", "possible branches")
-        : "Linear",
-    `v${workflow.version}`,
-    ago(workflow.updatedAt),
-  ].join(" · ")
-}
 
 export function Workflows() {
   useDocumentTitle("Workflows")
+  const { openAssistant } = useShell()
   const { data, isPending, isError, refetch } = useQuery(workflowsQuery())
+  const [view, setView] = useState("browse")
+  const [filter, setFilter] = useState<WorkflowFilter>("all")
+  const [builderOpen, setBuilderOpen] = useState(false)
+  const all = data ?? []
+  const ready = all.filter((item) => item.status === "ready").length
+  const needsChanges = all.length - ready
+  const visible = visibleWorkflows(all, filter)
 
   return (
-    <PageShell className="flex flex-col gap-10">
+    <PageShell width="wide" className="flex flex-col gap-6">
       <PageHeader
+        eyebrow="Workspace"
         title="Workflows"
-        subtitle={
-          <>
-            Reusable work. A workflow may coordinate several Context steps or run one instruction on
-            a schedule. Every start creates a fresh run.
-          </>
+        subtitle="Browse repeatable agent work like you browse artifacts. Open one to understand it. Use the guide when you want to build."
+        actions={
+          <Button size="sm" data-testid="workflows-new" onClick={() => setBuilderOpen(true)}>
+            <Icon name="plus" /> New workflow
+          </Button>
         }
       />
 
-      <section className="flex flex-col gap-4" data-testid="workflow-directory">
-        <div className="flex flex-col gap-1">
-          <SectionHeading>Coordinated workflows</SectionHeading>
-          <p className="text-sm text-muted-foreground">
-            Versioned graphs and loops made from Context steps, branches, and human pauses.
-          </p>
-        </div>
-        {isPending ? (
-          <SettingsListSkeleton rows={3} trailing={false} />
-        ) : isError ? (
-          <LoadError
-            title="Couldn’t load workflows"
-            testId="workflows-retry"
-            layout="inline"
-            onRetry={() => refetch()}
-          />
-        ) : !data?.length ? (
-          <p className="py-3.5 text-sm text-muted-foreground">
-            No coordinated workflows yet. They appear here when an Artifact carries a workflow
-            definition.
-          </p>
-        ) : (
-          <div className="flex flex-col divide-y divide-border-soft">
-            {data.map((workflow) => (
-              <Link
-                key={workflow.shortId}
-                to="/artifacts/$ref"
-                params={{ ref: workflow.shortId }}
-                data-testid="workflow-row"
-                className="rounded-md px-2 transition-colors hover:bg-accent"
-              >
-                <ListRow
-                  leading={
-                    <span className="grid size-7 shrink-0 place-items-center rounded-full bg-accent">
-                      <Icon name="workflow" className="text-muted-foreground" />
-                    </span>
-                  }
-                  title={
-                    <span className="flex min-w-0 items-center gap-2">
-                      <span className="truncate">{workflow.title}</span>
-                      {workflow.status === "needs-changes" ? (
-                        <StatusBadge tone="attention">Needs changes</StatusBadge>
-                      ) : null}
-                    </span>
-                  }
-                  meta={workflow.purpose ?? workflowMeta(workflow)}
-                  below={
-                    workflow.purpose ? (
-                      <p className="pl-10 font-mono text-2xs text-muted-foreground">
-                        {workflowMeta(workflow)}
-                      </p>
-                    ) : undefined
-                  }
-                />
-              </Link>
-            ))}
-          </div>
-        )}
-      </section>
+      <Tabs value={view} onValueChange={setView}>
+        <TabsList variant="line" aria-label="Workflow views">
+          <TabsTrigger value="browse" data-testid="workflows-view-browse">
+            Browse
+          </TabsTrigger>
+          <TabsTrigger value="schedules" data-testid="workflows-view-schedules">
+            Schedules and runs
+          </TabsTrigger>
+        </TabsList>
 
-      <AutomatedWorkflows />
+        <TabsContent value="browse" className="flex flex-col gap-5 pt-5">
+          {isPending ? (
+            <div
+              className="grid gap-2 sm:grid-cols-3"
+              role="status"
+              aria-label="Loading workflow summary"
+            >
+              <Skeleton className="h-14 rounded-xl" />
+              <Skeleton className="h-14 rounded-xl" />
+              <Skeleton className="h-14 rounded-xl" />
+            </div>
+          ) : (
+            <div className="grid gap-2 sm:grid-cols-3" data-testid="workflow-summary">
+              <Summary number={all.length} label="in this workspace" tone="primary" />
+              <Summary number={ready} label="ready to use" tone="success" />
+              <Summary number={needsChanges} label="need changes" tone="warning" />
+            </div>
+          )}
+
+          <fieldset className="flex flex-wrap items-center gap-2">
+            <legend className="sr-only">Filter workflows</legend>
+            {(
+              [
+                ["all", "All", all.length],
+                ["ready", "Ready", ready],
+                ["needs-changes", "Needs changes", needsChanges],
+              ] as const
+            ).map(([value, label, count]) => (
+              <Button
+                key={value}
+                variant={filter === value ? "secondary" : "ghost"}
+                size="sm"
+                aria-pressed={filter === value}
+                data-testid={`workflows-filter-${value}`}
+                onClick={() => setFilter(value)}
+              >
+                {label}
+                <span className="font-mono text-2xs text-muted-foreground">{count}</span>
+              </Button>
+            ))}
+            <span className="ml-auto font-mono text-2xs text-muted-foreground">
+              Updated recently
+            </span>
+          </fieldset>
+
+          <section data-testid="workflow-directory">
+            {isPending ? (
+              <SettingsListSkeleton rows={4} trailing={false} />
+            ) : isError ? (
+              <LoadError
+                title="Couldn’t load workflows"
+                testId="workflows-retry"
+                layout="inline"
+                onRetry={() => refetch()}
+              />
+            ) : visible.length ? (
+              <div
+                className="overflow-hidden rounded-xl border bg-card"
+                data-testid="workflow-list"
+              >
+                <WorkflowDirectoryHeader />
+                {visible.map((workflow) => (
+                  <WorkflowDirectoryRow key={workflow.shortId} workflow={workflow} />
+                ))}
+              </div>
+            ) : (
+              <EmptyState
+                icon={<Icon name="workflow" />}
+                title={filter === "all" ? "No workflows yet" : `No ${filter} workflows`}
+                description={
+                  filter === "all"
+                    ? "Describe the outcome. Derive will suggest the smallest workflow that fits."
+                    : "Choose another filter, or create a new workflow."
+                }
+                action={
+                  <Button
+                    size="sm"
+                    data-testid="workflows-empty-new"
+                    onClick={() => setBuilderOpen(true)}
+                  >
+                    <Icon name="plus" /> New workflow
+                  </Button>
+                }
+              />
+            )}
+          </section>
+
+          {!isPending && !isError && visible.length ? (
+            <div className="flex flex-col gap-3 rounded-xl border border-dashed bg-secondary/20 p-4 sm:flex-row sm:items-center">
+              <span className="grid size-9 shrink-0 place-items-center rounded-lg bg-card text-muted-foreground ring-1 ring-border">
+                <Icon name="sparkles" />
+              </span>
+              <div>
+                <p className="text-sm font-medium">Not sure where to start?</p>
+                <p className="text-xs text-muted-foreground">
+                  Describe the outcome. Derive will suggest the smallest workflow that fits.
+                </p>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                className="sm:ml-auto"
+                data-testid="workflows-guided-start"
+                onClick={() => setBuilderOpen(true)}
+              >
+                Start guided
+              </Button>
+            </div>
+          ) : null}
+        </TabsContent>
+
+        <TabsContent value="schedules" className="pt-5">
+          <AutomatedWorkflows />
+        </TabsContent>
+      </Tabs>
+
+      <WorkflowBuilderDialog
+        open={builderOpen}
+        onOpenChange={setBuilderOpen}
+        onBuild={(prompt) => openAssistant(prompt)}
+      />
     </PageShell>
+  )
+}
+
+function Summary({
+  number,
+  label,
+  tone,
+}: {
+  number: number
+  label: string
+  tone: "primary" | "success" | "warning"
+}) {
+  return (
+    <div className="flex items-center gap-3 rounded-xl border bg-card px-4 py-3">
+      <span
+        className={cn(
+          "size-2 rounded-full",
+          tone === "primary" ? "bg-primary" : tone === "success" ? "bg-success" : "bg-warning",
+        )}
+        aria-hidden
+      />
+      <strong className="font-mono text-lg font-medium tabular-nums">{number}</strong>
+      <span className="text-xs text-muted-foreground">{label}</span>
+    </div>
   )
 }
 
 export function WorkflowsPending() {
   return (
-    <PageShell className="flex flex-col gap-10">
+    <PageShell width="wide" className="flex flex-col gap-6">
       <header className="flex flex-col gap-2">
         <Skeleton className="h-7 w-32" />
         <Skeleton className="h-4 w-full max-w-2xl" />
       </header>
-      {["coordinated", "single-agent"].map((section) => (
-        <section key={section} className="flex flex-col gap-4">
-          <div className="flex flex-col gap-2">
-            <Skeleton className="h-5 w-44" />
-            <Skeleton className="h-4 w-full max-w-xl" />
-          </div>
-          <SettingsListSkeleton rows={3} />
-        </section>
-      ))}
+      <Skeleton className="h-8 w-56" />
+      <div className="grid gap-2 sm:grid-cols-3">
+        <Skeleton className="h-14 rounded-xl" />
+        <Skeleton className="h-14 rounded-xl" />
+        <Skeleton className="h-14 rounded-xl" />
+      </div>
+      <SettingsListSkeleton rows={4} trailing={false} />
     </PageShell>
   )
 }

--- a/apps/web/src/pages/workflows/workflow-builder-dialog.tsx
+++ b/apps/web/src/pages/workflows/workflow-builder-dialog.tsx
@@ -171,7 +171,7 @@ export function WorkflowBuilderDialog({
           </DialogDescription>
         </DialogHeader>
         <StepRail current={step} />
-        <div className="min-h-72 py-2">
+        <div className="min-h-0 py-2 sm:min-h-72">
           {step === 0 ? (
             <div className="flex flex-col gap-4" data-testid="workflow-builder-outcome">
               <div>
@@ -212,7 +212,7 @@ export function WorkflowBuilderDialog({
                     aria-pressed={draft.shape === shape.id}
                     onClick={() => setDraft({ ...draft, shape: shape.id })}
                     className={cn(
-                      "flex min-h-32 flex-col items-start gap-2 rounded-xl border bg-card p-3 text-left outline-none hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring",
+                      "flex min-h-0 flex-col items-start gap-2 rounded-xl border bg-card p-3 text-left outline-none hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring sm:min-h-32",
                       draft.shape === shape.id && "border-primary ring-2 ring-primary/20",
                     )}
                   >

--- a/apps/web/src/pages/workflows/workflow-builder-dialog.tsx
+++ b/apps/web/src/pages/workflows/workflow-builder-dialog.tsx
@@ -1,0 +1,355 @@
+import { useMemo, useState } from "react"
+import { Icon, type IconName } from "@/components/icons"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { cn } from "@/lib/utils"
+
+export type WorkflowShape = "handoff" | "loop" | "decision"
+
+export interface WorkflowDraft {
+  outcome: string
+  shape: WorkflowShape
+  maxAttempts: number
+  testOnly: boolean
+  gateExternalEffects: boolean
+  finalReview: boolean
+}
+
+const DEFAULT_DRAFT: WorkflowDraft = {
+  outcome: "",
+  shape: "loop",
+  maxAttempts: 2,
+  testOnly: true,
+  gateExternalEffects: true,
+  finalReview: false,
+}
+
+const SHAPES: Array<{
+  id: WorkflowShape
+  icon: IconName
+  title: string
+  description: string
+}> = [
+  { id: "handoff", icon: "arrow", title: "Handoff", description: "One step follows another." },
+  {
+    id: "loop",
+    icon: "workflow",
+    title: "Improve until ready",
+    description: "Try, check, and revise within a bound.",
+  },
+  {
+    id: "decision",
+    icon: "review",
+    title: "Human decision",
+    description: "Pause before a key branch or action.",
+  },
+]
+
+export const workflowBuilderPrompt = (draft: WorkflowDraft): string => {
+  const shape =
+    draft.shape === "handoff"
+      ? "Use the smallest useful linear handoff."
+      : draft.shape === "decision"
+        ? "Include one explicit human decision with clear options."
+        : "Use a bounded evaluator and improvement loop."
+  const boundaries = [
+    draft.testOnly ? "Keep all writes in test or draft surfaces." : null,
+    draft.gateExternalEffects
+      ? "Require a human decision before consequential effects outside Derive."
+      : null,
+    draft.finalReview ? "Add a final human review before the terminal result." : null,
+  ].filter(Boolean)
+
+  return [
+    "Create a new workflow in this Derive workspace.",
+    `Outcome: ${draft.outcome.trim()}`,
+    shape,
+    draft.shape === "loop" ? `Stop after at most ${draft.maxAttempts} attempts.` : null,
+    boundaries.length ? `Boundaries: ${boundaries.join(" ")}` : null,
+    "Show one workflow Preview, repair any blockers, then create the workflow as a draft.",
+    "Do not run it yet.",
+  ]
+    .filter(Boolean)
+    .join("\n")
+}
+
+function StepRail({ current }: { current: number }) {
+  return (
+    <ol className="grid grid-cols-4 gap-2" aria-label="Workflow builder progress">
+      {["Outcome", "Shape", "Safety", "Preview"].map((label, index) => (
+        <li
+          key={label}
+          className={cn(
+            "flex min-w-0 flex-col gap-1 font-mono text-2xs text-muted-foreground",
+            index <= current && "text-foreground",
+          )}
+          aria-current={index === current ? "step" : undefined}
+        >
+          <span
+            aria-hidden
+            className={cn("h-0.5 rounded-full bg-border", index <= current && "bg-primary")}
+          />
+          <span className="truncate">
+            {index + 1}. {label}
+          </span>
+        </li>
+      ))}
+    </ol>
+  )
+}
+
+function SafetyRow({
+  checked,
+  onChange,
+  title,
+  description,
+  testId,
+}: {
+  checked: boolean
+  onChange: (checked: boolean) => void
+  title: string
+  description: string
+  testId: string
+}) {
+  return (
+    <label className="flex cursor-pointer items-start gap-3 rounded-xl border bg-card p-3 hover:bg-accent">
+      <Checkbox
+        checked={checked}
+        onCheckedChange={(value) => onChange(value === true)}
+        data-testid={testId}
+        className="mt-0.5"
+      />
+      <span>
+        <span className="block text-sm font-medium">{title}</span>
+        <span className="mt-0.5 block text-xs text-muted-foreground">{description}</span>
+      </span>
+    </label>
+  )
+}
+
+export function WorkflowBuilderDialog({
+  open,
+  onOpenChange,
+  onBuild,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onBuild: (prompt: string) => void
+}) {
+  const [step, setStep] = useState(0)
+  const [draft, setDraft] = useState<WorkflowDraft>(DEFAULT_DRAFT)
+  const prompt = useMemo(() => workflowBuilderPrompt(draft), [draft])
+  const close = (next: boolean) => {
+    onOpenChange(next)
+    if (!next) {
+      setStep(0)
+      setDraft(DEFAULT_DRAFT)
+    }
+  }
+  const finish = () => {
+    onBuild(prompt)
+    close(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={close}>
+      <DialogContent className="sm:max-w-2xl" data-testid="workflow-builder-dialog">
+        <DialogHeader>
+          <DialogTitle>Create a workflow</DialogTitle>
+          <DialogDescription>
+            Start with the result. You can inspect and edit the draft before anything runs.
+          </DialogDescription>
+        </DialogHeader>
+        <StepRail current={step} />
+        <div className="min-h-72 py-2">
+          {step === 0 ? (
+            <div className="flex flex-col gap-4" data-testid="workflow-builder-outcome">
+              <div>
+                <h2 className="font-serif text-xl font-medium tracking-tight">
+                  What should happen?
+                </h2>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Describe a result as if you were briefing a teammate.
+                </p>
+              </div>
+              <Textarea
+                autoFocus
+                value={draft.outcome}
+                onChange={(event) => setDraft({ ...draft, outcome: event.target.value })}
+                placeholder="For example: Review a pull request, fix material issues, and verify that it is ready."
+                aria-label="Workflow outcome"
+                data-testid="workflow-builder-outcome-input"
+                className="min-h-32"
+              />
+            </div>
+          ) : null}
+          {step === 1 ? (
+            <div className="flex flex-col gap-4" data-testid="workflow-builder-shape">
+              <div>
+                <h2 className="font-serif text-xl font-medium tracking-tight">
+                  Choose a simple shape
+                </h2>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Derive will turn this into explicit steps and routes.
+                </p>
+              </div>
+              <div className="grid gap-2 sm:grid-cols-3">
+                {SHAPES.map((shape) => (
+                  <button
+                    key={shape.id}
+                    type="button"
+                    data-testid={`workflow-builder-shape-${shape.id}`}
+                    aria-pressed={draft.shape === shape.id}
+                    onClick={() => setDraft({ ...draft, shape: shape.id })}
+                    className={cn(
+                      "flex min-h-32 flex-col items-start gap-2 rounded-xl border bg-card p-3 text-left outline-none hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring",
+                      draft.shape === shape.id && "border-primary ring-2 ring-primary/20",
+                    )}
+                  >
+                    <span className="grid size-8 place-items-center rounded-lg bg-secondary">
+                      <Icon name={shape.icon} />
+                    </span>
+                    <span className="font-medium">{shape.title}</span>
+                    <span className="text-xs text-muted-foreground">{shape.description}</span>
+                  </button>
+                ))}
+              </div>
+              {draft.shape === "loop" ? (
+                <label className="flex items-center gap-3 rounded-xl border bg-secondary/30 p-3 text-sm">
+                  <span className="font-medium">Maximum attempts</span>
+                  <Input
+                    type="number"
+                    min={1}
+                    max={10}
+                    value={draft.maxAttempts}
+                    onChange={(event) =>
+                      setDraft({
+                        ...draft,
+                        maxAttempts: Math.max(1, Math.min(10, Number(event.target.value) || 1)),
+                      })
+                    }
+                    aria-label="Maximum attempts"
+                    data-testid="workflow-builder-attempts"
+                    className="ml-auto w-20"
+                  />
+                </label>
+              ) : null}
+            </div>
+          ) : null}
+          {step === 2 ? (
+            <div className="flex flex-col gap-4" data-testid="workflow-builder-safety">
+              <div>
+                <h2 className="font-serif text-xl font-medium tracking-tight">
+                  Set the boundaries
+                </h2>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  These rules become part of the workflow draft.
+                </p>
+              </div>
+              <div className="flex flex-col gap-2">
+                <SafetyRow
+                  checked={draft.testOnly}
+                  onChange={(testOnly) => setDraft({ ...draft, testOnly })}
+                  title="Use test or draft surfaces"
+                  description="Keep writes away from production and final delivery surfaces."
+                  testId="workflow-builder-test-only"
+                />
+                <SafetyRow
+                  checked={draft.gateExternalEffects}
+                  onChange={(gateExternalEffects) => setDraft({ ...draft, gateExternalEffects })}
+                  title="Ask before consequential actions"
+                  description="Pause before messages, spending, access changes, or production writes."
+                  testId="workflow-builder-gate-effects"
+                />
+                <SafetyRow
+                  checked={draft.finalReview}
+                  onChange={(finalReview) => setDraft({ ...draft, finalReview })}
+                  title="Request final human review"
+                  description="Add an explicit decision before the terminal result."
+                  testId="workflow-builder-final-review"
+                />
+              </div>
+            </div>
+          ) : null}
+          {step === 3 ? (
+            <div className="flex flex-col gap-4" data-testid="workflow-builder-preview">
+              <div>
+                <h2 className="font-serif text-xl font-medium tracking-tight">
+                  Preview before you create
+                </h2>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Derive will validate the full definition before it creates the draft.
+                </p>
+              </div>
+              <div className="rounded-xl border bg-secondary/30 p-4">
+                <div className="flex items-start gap-3">
+                  <span className="grid size-9 shrink-0 place-items-center rounded-lg bg-card ring-1 ring-border">
+                    <Icon
+                      name={
+                        draft.shape === "loop"
+                          ? "workflow"
+                          : draft.shape === "decision"
+                            ? "review"
+                            : "arrow"
+                      }
+                    />
+                  </span>
+                  <div className="min-w-0">
+                    <p className="font-medium">{draft.outcome.trim()}</p>
+                    <p className="mt-1 font-mono text-2xs text-muted-foreground">
+                      {SHAPES.find((shape) => shape.id === draft.shape)?.title}
+                      {draft.shape === "loop" ? ` · ${draft.maxAttempts} attempts maximum` : ""}
+                    </p>
+                  </div>
+                  <span className="ml-auto shrink-0 rounded-full bg-success/10 px-2 py-1 font-mono text-2xs text-success">
+                    Ready to draft
+                  </span>
+                </div>
+                <pre className="mt-4 max-h-40 overflow-y-auto whitespace-pre-wrap rounded-lg border bg-card p-3 font-mono text-2xs text-muted-foreground">
+                  {prompt}
+                </pre>
+              </div>
+            </div>
+          ) : null}
+        </div>
+        <DialogFooter>
+          {step > 0 ? (
+            <Button
+              variant="outline"
+              onClick={() => setStep((current) => current - 1)}
+              data-testid="workflow-builder-back"
+            >
+              Back
+            </Button>
+          ) : null}
+          <span className="mr-auto self-center text-xs text-muted-foreground">
+            Nothing runs until you choose Run.
+          </span>
+          {step < 3 ? (
+            <Button
+              onClick={() => setStep((current) => current + 1)}
+              disabled={step === 0 && draft.outcome.trim().length < 9}
+              data-testid="workflow-builder-next"
+            >
+              Continue
+            </Button>
+          ) : (
+            <Button onClick={finish} data-testid="workflow-builder-finish">
+              <Icon name="sparkles" /> Build with Derive
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/pages/workflows/workflow-directory.tsx
+++ b/apps/web/src/pages/workflows/workflow-directory.tsx
@@ -1,0 +1,86 @@
+import { Link } from "@tanstack/react-router"
+import type { WorkflowDirectoryItem } from "@/api"
+import { Icon } from "@/components/icons"
+import { Badge } from "@/components/ui/badge"
+import { ago } from "@/lib/time"
+import { cn } from "@/lib/utils"
+
+const COL = {
+  icon: "w-10 shrink-0",
+  name: "min-w-0 flex-1",
+  structure: "w-40 shrink-0 max-md:hidden",
+  state: "w-28 shrink-0 max-sm:hidden",
+  when: "w-20 shrink-0 text-right",
+}
+
+const workflowCounts = (item: WorkflowDirectoryItem) =>
+  item.diagrams.reduce(
+    (total, diagram) => ({
+      contextSteps: total.contextSteps + diagram.contextSteps,
+      humanPauses: total.humanPauses + diagram.humanPauses,
+      loops: total.loops + diagram.loops,
+    }),
+    { contextSteps: 0, humanPauses: 0, loops: 0 },
+  )
+
+export function WorkflowDirectoryHeader() {
+  return (
+    <div className="flex h-8 items-center border-b bg-secondary/40 px-3 font-mono text-2xs uppercase tracking-wide text-muted-foreground">
+      <span className={COL.icon} />
+      <span className={COL.name}>Name</span>
+      <span className={COL.structure}>Structure</span>
+      <span className={COL.state}>State</span>
+      <span className={COL.when}>Updated</span>
+    </div>
+  )
+}
+
+export function WorkflowDirectoryRow({ workflow: item }: { workflow: WorkflowDirectoryItem }) {
+  const counts = workflowCounts(item)
+  const ready = item.status === "ready"
+  const structure = [
+    `${counts.contextSteps} ${counts.contextSteps === 1 ? "step" : "steps"}`,
+    counts.humanPauses ? `${counts.humanPauses} human` : null,
+    counts.loops ? `${counts.loops} ${counts.loops === 1 ? "loop" : "loops"}` : null,
+  ]
+    .filter(Boolean)
+    .join(" · ")
+
+  return (
+    <Link
+      to="/artifacts/$ref"
+      params={{ ref: item.shortId }}
+      data-testid={`workflow-row-${item.shortId}`}
+      className="group flex min-h-16 items-center border-b border-border-soft px-3 outline-none transition-colors last:border-b-0 hover:bg-secondary/60 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+    >
+      <span className={COL.icon}>
+        <span className="grid size-8 place-items-center rounded-lg bg-secondary text-muted-foreground ring-1 ring-border-soft">
+          <Icon name="workflow" />
+        </span>
+      </span>
+      <span className={cn(COL.name, "flex flex-col gap-0.5 pr-5")}>
+        <span className="truncate text-sm font-medium tracking-tight text-foreground">
+          {item.title}
+        </span>
+        <span className="line-clamp-1 text-xs text-muted-foreground">
+          {item.purpose ?? "Reusable coordinated work with a versioned definition."}
+        </span>
+      </span>
+      <span className={cn(COL.structure, "font-mono text-2xs text-muted-foreground")}>
+        {structure || "No Context steps"}
+      </span>
+      <span className={COL.state}>
+        <Badge variant={ready ? "success" : "warning"} shape="pill">
+          <span
+            aria-hidden
+            className={cn("size-1.5 rounded-full", ready ? "bg-success" : "bg-warning")}
+          />
+          {ready ? "Ready" : "Needs changes"}
+        </Badge>
+      </span>
+      <span className={cn(COL.when, "font-mono text-2xs tabular-nums text-muted-foreground")}>
+        {ago(item.updatedAt)}
+      </span>
+    </Link>
+  )
+}


### PR DESCRIPTION
## Summary

- present coordinated workflows as a compact artifact-style directory
- separate browsing from schedules and run activity
- add a four-step guided workflow builder that hands a safe draft request to Derive
- keep all execution behind the existing explicit Run action

## Verification

- `pnpm verify`
- 34/34 guardrails
- all package typechecks
- all repository tests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/868"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790731670&installation_model_id=428097&pr_number=868&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F868&signature=52d33ffef3f94b5407dda51adfff13a37c86ad292cfae99ca3d79ba769103570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->