### PR TITLE
Recover operator GitHub installations without OAuth

### DIFF
--- a/apps/api/src/lib/github-app.ts
+++ b/apps/api/src/lib/github-app.ts
@@ -209,6 +209,41 @@ export async function getAppInstallation(
   }
 }
 
+/** List every installation for the App with App-JWT auth. Instance operators use this only to
+ * recover the shared App they administer; workspace managers still prove access with OAuth. */
+export async function listAppInstallations(
+  appId: string,
+  privateKeyPem: string,
+): Promise<AppInstallation[]> {
+  const result: AppInstallation[] = []
+  const jwt = appJwt(appId, privateKeyPem)
+  for (let page = 1; page <= 10; page++) {
+    const res = await fetch(`${API}/app/installations?per_page=100&page=${page}`, {
+      headers: ghHeaders(`Bearer ${jwt}`),
+    })
+    if (!res.ok) return raise(res, "listing the GitHub App installations")
+    const installations = (await res.json()) as {
+      id?: number
+      account?: { login?: string; type?: string }
+      html_url?: string
+      permissions?: Record<string, string>
+    }[]
+    for (const installation of installations) {
+      if (!installation.id || !Number.isSafeInteger(installation.id)) continue
+      result.push({
+        id: installation.id,
+        account: installation.account
+          ? { login: installation.account.login ?? "", type: installation.account.type ?? "" }
+          : null,
+        htmlUrl: installation.html_url ?? null,
+        permissions: installation.permissions ?? {},
+      })
+    }
+    if (installations.length < 100) break
+  }
+  return result
+}
+
 /** Exchange GitHub's one-time web-flow code. The token exists only long enough to prove that
  * the signed-in installer can access the installation they are binding; it is never persisted. */
 export async function exchangeGithubUserCode(input: {

--- a/apps/api/src/routes/github.ts
+++ b/apps/api/src/routes/github.ts
@@ -16,6 +16,7 @@ import {
   getAppInfo,
   getAppInstallation,
   getUserInstallation,
+  listAppInstallations,
   listUserInstallations,
 } from "../lib/github-app"
 import { upsertGithubConnection } from "../lib/github-connection"
@@ -110,6 +111,28 @@ export const githubRoutes = (ctx: AppContext) => {
     authorize.searchParams.set("prompt", "select_account")
     return authorize.toString()
   }
+
+  const selectionPage = (
+    org: string,
+    uid: string,
+    installations: Awaited<ReturnType<typeof listAppInstallations>>,
+    encryptionKey: string,
+  ): string =>
+    installationPickerHTML({
+      installations: installations.map((installation) => ({
+        login: installation.account?.login || `Installation ${installation.id}`,
+        state: signState(
+          {
+            kind: "github-install-select",
+            org,
+            uid,
+            installationId: String(installation.id),
+          },
+          encryptionKey,
+        ),
+      })),
+      installUrl: "/v1/github/install/new",
+    })
 
   const Account = z.object({
     installation_id: z.string(),
@@ -296,6 +319,30 @@ export const githubRoutes = (ctx: AppContext) => {
     if (me instanceof Response) return me
     const loaded = await loadApp()
     if (!loaded || !deps.encryptionKey) return fail(c, 404, "GitHub is not configured")
+    if (await isSuperAdmin(c)) {
+      try {
+        const installations = await listAppInstallations(loaded.app.app_id, loaded.pem)
+        if (!installations.length) return c.redirect("/v1/github/install/new")
+        if (installations.length === 1) {
+          const installation = installations[0]
+          if (!installation) return c.redirect(settingsRedirect("save"))
+          await upsertGithubConnection(meta, {
+            orgId: org,
+            userId: me.id,
+            installationId: String(installation.id),
+            accountLogin: installation.account?.login ?? null,
+          })
+          return c.redirect(settingsRedirect("connected"))
+        }
+        return c.html(selectionPage(org, me.id, installations, deps.encryptionKey))
+      } catch (err) {
+        log.warn("github operator installation recovery failed", {
+          user_id: me.id,
+          error: err instanceof Error ? err.message : String(err),
+        })
+        return c.redirect(settingsRedirect("save"))
+      }
+    }
     const state = signState(
       { kind: "github-install-discover", org, uid: me.id },
       deps.encryptionKey,
@@ -427,23 +474,7 @@ export const githubRoutes = (ctx: AppContext) => {
           })
           return c.redirect(settingsRedirect("connected"))
         }
-        return c.html(
-          installationPickerHTML({
-            installations: installations.map((installation) => ({
-              login: installation.account?.login || `Installation ${installation.id}`,
-              state: signState(
-                {
-                  kind: "github-install-select",
-                  org: state.org,
-                  uid: me.id,
-                  installationId: String(installation.id),
-                },
-                encryptionKey,
-              ),
-            })),
-            installUrl: "/v1/github/install/new",
-          }),
-        )
+        return c.html(selectionPage(state.org, me.id, installations, encryptionKey))
       }
       const installation = await getUserInstallation(userToken, state.installationId)
       if (!installation) {

--- a/apps/api/test/github-integration.test.ts
+++ b/apps/api/test/github-integration.test.ts
@@ -282,6 +282,42 @@ describe("standard GitHub integration", () => {
     ).toHaveLength(1)
   })
 
+  it("recovers the shared App for an instance operator without GitHub OAuth", async () => {
+    const { app, meta } = makeAuthedApp("gh-standard-operator", [owner], "editor", {
+      deps: { encryptionKey: KEY },
+      operatorIds: [owner.id],
+    })
+    await seedApp(meta)
+    let installations = [
+      {
+        id: 56001,
+        account: { login: "derive-operator", type: "Organization" },
+        permissions: { actions: "write", metadata: "read", pull_requests: "write" },
+      },
+    ]
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL) => {
+        const parsed = new URL(String(url))
+        if (parsed.pathname === "/app/installations")
+          return new Response(JSON.stringify(installations), { status: 200 })
+        return new Response("not found", { status: 404 })
+      }),
+    )
+
+    const recovered = await app.request("/v1/github/install", { headers: as(owner.email) })
+    expect(recovered.headers.get("location")).toContain("github_connected=1")
+    expect(
+      (await meta.listConnections("default", undefined, "workspace")).filter(
+        (connection) => connection.kind === "github_app",
+      ),
+    ).toMatchObject([{ broker_ref: "56001", scopes_label: "derive-operator", status: "active" }])
+
+    installations = []
+    const fresh = await app.request("/v1/github/install", { headers: as(owner.email) })
+    expect(fresh.headers.get("location")).toBe("/v1/github/install/new")
+  })
+
   it("lets a manager choose between existing installations without an install callback", async () => {
     const { app, meta } = makeAuthedApp("gh-standard-existing", [owner], "editor", {
       deps: { encryptionKey: KEY },


### PR DESCRIPTION
## Summary

- let an instance operator discover installations with the shared App credentials
- bind a sole existing installation without GitHub user OAuth
- reuse the signed account picker when the App has several installations
- retain GitHub OAuth proof for ordinary workspace managers

## Why

A transferred or legacy GitHub App can lack a user authorization callback URL. GitHub rejects OAuth before Derive can recover its existing installation. The instance operator already administers the shared App and its encrypted private key, so Derive can use App-JWT authentication for this bounded recovery path without weakening workspace-admin isolation.

## Validation

- `pnpm run ci` — 34/34 guardrails
- `pnpm typecheck`
- `pnpm test` — full workspace pass
- `pnpm verify:affected` — pass
- focused operator recovery, no-install, workspace-manager OAuth, multi-install, and forged-state coverage

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/869"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790732022&installation_model_id=428097&pr_number=869&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F869&signature=a43458ac94b205ac3f9598961c073bb40018eae27c7bf2b91a9ce9ce9f9ae841"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->