### PR TITLE
Fix GitHub App owner link

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -2038,9 +2038,10 @@
             ],
             "description": "Whether the instance App has every current permission; null when no live App exists"
           },
-          "app_settings_url": {
+          "app_url": {
             "type": "string",
-            "nullable": true
+            "nullable": true,
+            "description": "Public GitHub App page. This URL does not assume the caller manages the App"
           },
           "can_manage_app": {
             "type": "boolean",
@@ -2100,7 +2101,7 @@
           "app_slug",
           "app_owner_login",
           "app_permissions_state",
-          "app_settings_url",
+          "app_url",
           "can_manage_app",
           "accounts"
         ]

--- a/apps/api/src/routes/github.ts
+++ b/apps/api/src/routes/github.ts
@@ -156,7 +156,10 @@ export const githubRoutes = (ctx: AppContext) => {
         .describe(
           "Whether the instance App has every current permission; null when no live App exists",
         ),
-      app_settings_url: z.string().nullable(),
+      app_url: z
+        .string()
+        .nullable()
+        .describe("Public GitHub App page. This URL does not assume the caller manages the App"),
       can_manage_app: z
         .boolean()
         .describe("Whether the caller is an instance operator who can configure the shared App"),
@@ -191,7 +194,6 @@ export const githubRoutes = (ctx: AppContext) => {
       let available = !!loaded
       let slug = loaded?.app.slug ?? null
       let appOwnerLogin: string | null = null
-      let appOwnerType: string | null = null
       let basePermissionsMissing = false
       // Null means GitHub could not be checked. Do not turn a transient outage into a false
       // permission-upgrade prompt.
@@ -204,7 +206,6 @@ export const githubRoutes = (ctx: AppContext) => {
           const live = await getAppInfo(loaded.app.app_id, loaded.pem)
           slug = live.slug || slug
           appOwnerLogin = live.owner?.login || null
-          appOwnerType = live.owner?.type || null
           if (slug && slug !== loaded.app.slug) await meta.setGithubApp({ ...loaded.app, slug })
           basePermissionsMissing = Object.entries(REQUIRED_PERMISSIONS).some(
             ([permission, level]) =>
@@ -299,11 +300,7 @@ export const githubRoutes = (ctx: AppContext) => {
         app_slug: slug,
         app_owner_login: appOwnerLogin,
         app_permissions_state: appPermissionsState,
-        app_settings_url: slug
-          ? appOwnerType === "Organization" && appOwnerLogin
-            ? `https://github.com/organizations/${encodeURIComponent(appOwnerLogin)}/settings/apps/${encodeURIComponent(slug)}/permissions`
-            : `https://github.com/settings/apps/${encodeURIComponent(slug)}/permissions`
-          : null,
+        app_url: slug ? `https://github.com/apps/${encodeURIComponent(slug)}` : null,
         can_manage_app: canManageApp,
         accounts,
       })

--- a/apps/api/test/github-integration.test.ts
+++ b/apps/api/test/github-integration.test.ts
@@ -199,8 +199,7 @@ describe("standard GitHub integration", () => {
       connected: true,
       app_owner_login: "derive-to",
       app_permissions_state: "ready",
-      app_settings_url:
-        "https://github.com/organizations/derive-to/settings/apps/derive-test/permissions",
+      app_url: "https://github.com/apps/derive-test",
       can_manage_app: false,
       accounts: [
         {

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -7476,7 +7476,8 @@ export interface components {
              * @enum {string|null}
              */
             app_permissions_state: "ready" | "update_required" | "unknown" | null;
-            app_settings_url: string | null;
+            /** @description Public GitHub App page. This URL does not assume the caller manages the App */
+            app_url: string | null;
             /** @description Whether the caller is an instance operator who can configure the shared App */
             can_manage_app: boolean;
             accounts: {

--- a/apps/web/src/pages/settings/integrations-section.tsx
+++ b/apps/web/src/pages/settings/integrations-section.tsx
@@ -312,9 +312,9 @@ export function IntegrationsSection() {
               actions={
                 github.app_permissions_state === "update_required" &&
                 github.can_manage_app &&
-                github.app_settings_url ? (
+                github.app_url ? (
                   <Button data-testid="github-update-app" variant="ghost" size="sm" asChild>
-                    <a href={github.app_settings_url}>Open App settings</a>
+                    <a href={github.app_url}>View App on GitHub</a>
                   </Button>
                 ) : undefined
               }


### PR DESCRIPTION
## Summary

- replace the owner-only GitHub App settings URL with the public App page
- explain that the reported owner or an App manager must update permissions
- keep the API schema and generated client types aligned

## Validation

- full API test suite: 1685 passed, 3 skipped
- `pnpm typecheck`
- `pnpm run ci`: 34/34 guardrails
- public App URL returns HTTP 200

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/870"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790732966&installation_model_id=428097&pr_number=870&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F870&signature=306f03e931a0a0c7f3db3b7a3802184e55314b38ae4a1a8410dcafd8948ca807"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->