### PR TITLE
Make GitHub workflow runs seamless

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -2036,7 +2036,18 @@
               "unknown",
               null
             ],
-            "description": "Whether the instance App has every current permission; null when no live App exists"
+            "description": "Whether the instance App has every current permission and event; null when no live App exists"
+          },
+          "app_webhook_state": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "ready",
+              "update_required",
+              "unknown",
+              null
+            ],
+            "description": "Whether signed GitHub workflow completion events can reach this instance"
           },
           "app_settings_url": {
             "type": "string",
@@ -2100,6 +2111,7 @@
           "app_slug",
           "app_owner_login",
           "app_permissions_state",
+          "app_webhook_state",
           "app_settings_url",
           "can_manage_app",
           "accounts"

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -412,6 +412,7 @@ export function createApp(deps: AppDeps): Hono {
     /^\/v1\/slack\/interactivity$/, // Slack Block Kit actions — signing-secret signature is the gate
     /^\/v1\/slack\/commands$/, // Slack slash command (/derive) — signing-secret signature is the gate
     /^\/v1\/billing\/webhook$/, // Stripe webhook: the Stripe-Signature check is the gate
+    /^\/v1\/(?:sync\/)?github\/webhook$/, // GitHub App webhook — the HMAC signature is the gate
     /^\/v1\/assets\/t\/[^/]+$/, // MCP-minted upload URL — the signed expiring token is the gate
     /^\/v1\/artifacts\/t\/[^/]+$/, // MCP-minted publish URL (create) — signed token is the gate
     /^\/v1\/drafts$/, // anonymous draft mint (the claim flow) — anonymous is the point; draftPublish IP cap + publish limiter are the gate

--- a/apps/api/src/github-app-setup.ts
+++ b/apps/api/src/github-app-setup.ts
@@ -30,8 +30,9 @@ export const MANIFEST_PERMISSIONS: Record<string, string> = {
   ...REQUIRED_PERMISSIONS,
   ...ACTIONS_PERMISSION,
 }
-// Scheduled/manual runs query GitHub directly. No webhook collection is part of this path.
-export const REQUIRED_EVENTS: string[] = []
+// Completion events let Derive react when an external workflow finishes. The receiver accepts
+// only signed payloads and ignores every event except the narrow workflow-run contract.
+export const REQUIRED_EVENTS = ["workflow_run"]
 
 /** The GitHub App manifest: what permissions/events/URLs the new App is born with.
  *  Consumes REQUIRED_PERMISSIONS/REQUIRED_EVENTS so a fresh App is always current.
@@ -50,6 +51,10 @@ export const buildManifest = (baseUrl: string, host: string) => ({
   setup_on_update: true,
   callback_urls: [new URL("/v1/github/authorize", baseUrl).toString()],
   request_oauth_on_install: false,
+  hook_attributes: {
+    url: new URL("/v1/github/webhook", baseUrl).toString(),
+    active: true,
+  },
   // Public so it can be installed on organizations too, not just the owner's
   // personal account (GitHub restricts a private App to its owner account). It is
   // server-narrowed to PR reads plus top-level comments, and only matters once bound via our
@@ -112,7 +117,7 @@ export function manifestFormHTML(props: { baseUrl: string; state: string }): str
         <button class="btn ghost" type="submit" formnovalidate data-personal>Use personal account</button>
       </div>
     </form>
-    <p class="foot">Derive asks for <strong>Metadata: read</strong>, <strong>Pull requests: write</strong>, and <strong>Actions: write</strong>. Server-side policies limit these to PR reads, one top-level PR comment, workflow status, and dispatch of workflows named <strong>derive-*.yml</strong>.</p>
+    <p class="foot">Derive asks for <strong>Metadata: read</strong>, <strong>Pull requests: write</strong>, and <strong>Actions: write</strong>. Server-side policies limit these to PR reads, one top-level PR comment, workflow status, dispatch of workflows named <strong>derive-*.yml</strong>, and signed workflow completion events.</p>
     <script>
       (function(){
         var form=document.getElementById("f"),owner=document.getElementById("owner"),personal=${JSON.stringify(personalAction)};

--- a/apps/api/src/lib/github-app.ts
+++ b/apps/api/src/lib/github-app.ts
@@ -2,7 +2,7 @@
 // installation tokens, and handle App setup/installer authorization. Everything runs on the
 // Cloudflare Worker (node:crypto under nodejs_compat — same basis as ./crypto).
 
-import { createPrivateKey, createSign } from "node:crypto"
+import { createHmac, createPrivateKey, createSign } from "node:crypto"
 
 const API = "https://api.github.com"
 const WEB = "https://github.com"
@@ -10,6 +10,14 @@ const UA = "derive/1"
 const API_VERSION = "2022-11-28"
 
 const b64url = (b: Buffer | string): string => Buffer.from(b).toString("base64url")
+
+/** Stable per-App webhook secret derived from server-only material. This avoids another stored
+ *  credential while keeping App transfers and installation changes harmless. */
+export const githubWebhookSecret = (appId: string, encryptionKey: string): string =>
+  createHmac("sha256", encryptionKey).update(`derive-github-webhook:v1\0${appId}`).digest("hex")
+
+export const githubWebhookSignature = (body: string, secret: string): string =>
+  `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`
 
 export class GitHubError extends Error {
   constructor(
@@ -329,6 +337,66 @@ export interface ManifestConversion {
   client_secret: string
   /** PEM private key (PKCS#1). */
   pem: string
+}
+
+export interface AppWebhookConfig {
+  url: string
+  contentType: string
+  insecureSsl: string
+}
+
+/** Read the App webhook target. GitHub never returns the secret, only a masked placeholder. */
+export async function getAppWebhookConfig(
+  appId: string,
+  privateKeyPem: string,
+): Promise<AppWebhookConfig> {
+  const res = await fetch(`${API}/app/hook/config`, {
+    headers: ghHeaders(`Bearer ${appJwt(appId, privateKeyPem)}`),
+  })
+  if (!res.ok) return raise(res, "reading the GitHub App webhook")
+  const data = (await res.json()) as {
+    url?: unknown
+    content_type?: unknown
+    insecure_ssl?: unknown
+  }
+  return {
+    url: typeof data.url === "string" ? data.url : "",
+    contentType: typeof data.content_type === "string" ? data.content_type : "",
+    insecureSsl: String(data.insecure_ssl ?? ""),
+  }
+}
+
+/** Set the shared App webhook without exposing its secret to a browser or installation. */
+export async function configureAppWebhook(input: {
+  appId: string
+  privateKeyPem: string
+  url: string
+  secret: string
+}): Promise<AppWebhookConfig> {
+  const res = await fetch(`${API}/app/hook/config`, {
+    method: "PATCH",
+    headers: {
+      ...ghHeaders(`Bearer ${appJwt(input.appId, input.privateKeyPem)}`),
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      url: input.url,
+      content_type: "json",
+      insecure_ssl: "0",
+      secret: input.secret,
+    }),
+  })
+  if (!res.ok) return raise(res, "updating the GitHub App webhook")
+  const data = (await res.json()) as {
+    url?: unknown
+    content_type?: unknown
+    insecure_ssl?: unknown
+  }
+  return {
+    url: typeof data.url === "string" ? data.url : "",
+    contentType: typeof data.content_type === "string" ? data.content_type : "",
+    insecureSsl: String(data.insecure_ssl ?? ""),
+  }
 }
 
 /**

--- a/apps/api/src/routes/github.ts
+++ b/apps/api/src/routes/github.ts
@@ -7,15 +7,20 @@ import type { AppContext } from "../context"
 import {
   installationPickerHTML,
   MANIFEST_PERMISSIONS,
+  REQUIRED_EVENTS,
   REQUIRED_PERMISSIONS,
 } from "../github-app-setup"
-import { decryptSecret, signState, verifyState } from "../lib/crypto"
+import { decryptSecret, safeEqual, signState, verifyState } from "../lib/crypto"
 import {
+  configureAppWebhook,
   exchangeGithubUserCode,
   GitHubError,
   getAppInfo,
   getAppInstallation,
+  getAppWebhookConfig,
   getUserInstallation,
+  githubWebhookSecret,
+  githubWebhookSignature,
   listAppInstallations,
   listUserInstallations,
 } from "../lib/github-app"
@@ -75,6 +80,15 @@ export const githubRoutes = (ctx: AppContext) => {
     if (!found) return null
     return { app: found, pem: decryptSecret(found.private_key, deps.encryptionKey) }
   }
+
+  const webhookUrl = new URL("/v1/github/webhook", deps.baseUrl).toString()
+  const configureWebhook = async (loaded: { app: GitHubAppRecord; pem: string }) =>
+    configureAppWebhook({
+      appId: loaded.app.app_id,
+      privateKeyPem: loaded.pem,
+      url: webhookUrl,
+      secret: githubWebhookSecret(loaded.app.app_id, deps.encryptionKey ?? ""),
+    })
 
   const settingsRedirect = (
     result: "connected" | "canceled" | "expired" | "config" | "save",
@@ -154,8 +168,12 @@ export const githubRoutes = (ctx: AppContext) => {
         .enum(["ready", "update_required", "unknown"])
         .nullable()
         .describe(
-          "Whether the instance App has every current permission; null when no live App exists",
+          "Whether the instance App has every current permission and event; null when no live App exists",
         ),
+      app_webhook_state: z
+        .enum(["ready", "update_required", "unknown"])
+        .nullable()
+        .describe("Whether signed GitHub workflow completion events can reach this instance"),
       app_settings_url: z.string().nullable(),
       can_manage_app: z
         .boolean()
@@ -198,6 +216,9 @@ export const githubRoutes = (ctx: AppContext) => {
       let appPermissionsState: "ready" | "update_required" | "unknown" | null = loaded
         ? "unknown"
         : null
+      let appWebhookState: "ready" | "update_required" | "unknown" | null = loaded
+        ? "unknown"
+        : null
       const rank: Record<string, number> = { read: 1, write: 2, admin: 3 }
       if (loaded) {
         try {
@@ -211,18 +232,34 @@ export const githubRoutes = (ctx: AppContext) => {
               !live.permissions[permission] ||
               (rank[live.permissions[permission] ?? ""] ?? 0) < (rank[level] ?? 0),
           )
-          appPermissionsState = Object.entries(MANIFEST_PERMISSIONS).every(
+          const permissionsReady = Object.entries(MANIFEST_PERMISSIONS).every(
             ([permission, level]) =>
               !!live.permissions[permission] &&
               (rank[live.permissions[permission] ?? ""] ?? 0) >= (rank[level] ?? 0),
           )
-            ? "ready"
-            : "update_required"
+          const eventsReady = REQUIRED_EVENTS.every((event) => live.events.includes(event))
+          appPermissionsState = permissionsReady && eventsReady ? "ready" : "update_required"
+          if (eventsReady) {
+            try {
+              const hook = await getAppWebhookConfig(loaded.app.app_id, loaded.pem)
+              appWebhookState =
+                hook.url === webhookUrl &&
+                hook.contentType === "json" &&
+                (hook.insecureSsl === "0" || hook.insecureSsl === "false")
+                  ? "ready"
+                  : "update_required"
+            } catch {
+              appWebhookState = "unknown"
+            }
+          } else {
+            appWebhookState = "update_required"
+          }
         } catch (err) {
           // Deleted/revoked is definitive. A network/5xx failure must not hide a working App.
           if (err instanceof GitHubError && (err.status === 401 || err.status === 404)) {
             available = false
             appPermissionsState = null
+            appWebhookState = null
           }
         }
       }
@@ -299,6 +336,7 @@ export const githubRoutes = (ctx: AppContext) => {
         app_slug: slug,
         app_owner_login: appOwnerLogin,
         app_permissions_state: appPermissionsState,
+        app_webhook_state: appWebhookState,
         app_settings_url: slug
           ? appOwnerType === "Organization" && appOwnerLogin
             ? `https://github.com/organizations/${encodeURIComponent(appOwnerLogin)}/settings/apps/${encodeURIComponent(slug)}/permissions`
@@ -309,6 +347,77 @@ export const githubRoutes = (ctx: AppContext) => {
       })
     },
   )
+
+  app.post("/v1/github/webhook/configure", async (c) => {
+    const me = await requireUser(c)
+    if (me instanceof Response) return me
+    if (!(await isSuperAdmin(c))) return fail(c, 403, "instance operator required")
+    const loaded = await loadApp()
+    if (!loaded || !deps.encryptionKey) return fail(c, 404, "GitHub is not configured")
+    try {
+      await configureWebhook(loaded)
+      return c.json({ state: "ready" as const })
+    } catch (err) {
+      log.warn("github webhook configuration failed", {
+        error: err instanceof Error ? err.message : String(err),
+      })
+      return fail(c, 502, "GitHub could not update the App webhook")
+    }
+  })
+
+  // authz-exempt: GitHub signs the exact raw body with the server-derived App webhook secret.
+  const handleWebhook: Handler<BlankEnv> = async (c) => {
+    const loaded = await loadApp()
+    if (!loaded || !deps.encryptionKey) return fail(c, 404, "not found")
+    const declared = Number(c.req.header("content-length") ?? "0")
+    if (Number.isFinite(declared) && declared > 1_000_000) return fail(c, 413, "payload too large")
+    const raw = await c.req.text()
+    if (raw.length > 1_000_000) return fail(c, 413, "payload too large")
+    const expected = githubWebhookSignature(
+      raw,
+      githubWebhookSecret(loaded.app.app_id, deps.encryptionKey),
+    )
+    if (!safeEqual(expected, c.req.header("x-hub-signature-256")))
+      return fail(c, 401, "invalid signature")
+    const event = c.req.header("x-github-event") ?? ""
+    const delivery = c.req.header("x-github-delivery") ?? ""
+    if (!/^[a-z_]{1,64}$/.test(event) || !/^[A-Za-z0-9-]{1,100}$/.test(delivery))
+      return fail(c, 400, "invalid webhook headers")
+    let payload: unknown
+    try {
+      payload = JSON.parse(raw)
+    } catch {
+      return fail(c, 400, "body must be JSON")
+    }
+    if (event === "workflow_run") {
+      const body = payload as {
+        action?: unknown
+        installation?: { id?: unknown }
+        repository?: { full_name?: unknown }
+        workflow?: { path?: unknown }
+        workflow_run?: {
+          id?: unknown
+          status?: unknown
+          conclusion?: unknown
+          html_url?: unknown
+        }
+      }
+      if (body.action === "completed")
+        log.info("github workflow run completed", {
+          delivery_id: delivery,
+          installation_id: body.installation?.id,
+          repository: body.repository?.full_name,
+          workflow: body.workflow?.path,
+          run_id: body.workflow_run?.id,
+          status: body.workflow_run?.status,
+          conclusion: body.workflow_run?.conclusion,
+          url: body.workflow_run?.html_url,
+        })
+    }
+    return c.body(null, 202)
+  }
+  app.post("/v1/github/webhook", handleWebhook)
+  app.post("/v1/sync/github/webhook", handleWebhook)
 
   // Start with GitHub user authorization. This lets Derive discover an existing installation
   // even when an older App does not redirect installation updates to its setup URL.
@@ -404,6 +513,14 @@ export const githubRoutes = (ctx: AppContext) => {
     if (!loaded) return c.redirect(settingsRedirect("config"))
     try {
       await getAppInstallation(loaded.app.app_id, loaded.pem, installationId)
+      // An installation update is the natural repair point for an older App. Keep the install
+      // usable if GitHub's hook API has a transient failure; Settings shows the remaining step.
+      await configureWebhook(loaded).catch((err) =>
+        log.warn("github webhook repair after installation update failed", {
+          installation_id: installationId,
+          error: err instanceof Error ? err.message : String(err),
+        }),
+      )
     } catch (err) {
       // This lookup is also proof the id belongs to THIS App. Never persist an unverified id
       // from a hand-edited callback; it would create a source that can never mint a token.

--- a/apps/api/test/github-integration.test.ts
+++ b/apps/api/test/github-integration.test.ts
@@ -1,6 +1,7 @@
 import { generateKeyPairSync } from "node:crypto"
 import { describe, expect, it, vi } from "vitest"
 import { encryptSecret, signState } from "../src/lib/crypto"
+import { githubWebhookSecret, githubWebhookSignature } from "../src/lib/github-app"
 import { upsertGithubConnection } from "../src/lib/github-connection"
 import { as, jsonAs, makeAuthedApp, type quotaApp, type TestUser } from "./helpers"
 
@@ -37,6 +38,90 @@ describe("standard GitHub integration", () => {
     name: "Member",
   }
 
+  it("configures and verifies the signed App webhook without a browser-held secret", async () => {
+    const { app, meta } = makeAuthedApp("gh-webhook", [owner], "editor", {
+      deps: { encryptionKey: KEY },
+      operatorIds: [owner.id],
+    })
+    await seedApp(meta)
+    let configured: Record<string, unknown> | null = null
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL, init?: RequestInit) => {
+        if (new URL(String(url)).pathname !== "/app/hook/config")
+          return new Response("not found", { status: 404 })
+        configured = JSON.parse(String(init?.body)) as Record<string, unknown>
+        return new Response(
+          JSON.stringify({
+            url: configured.url,
+            content_type: configured.content_type,
+            insecure_ssl: configured.insecure_ssl,
+            secret: "********",
+          }),
+          { status: 200 },
+        )
+      }),
+    )
+
+    const repair = await app.request("/v1/github/webhook/configure", {
+      method: "POST",
+      headers: as(owner.email),
+    })
+    expect(repair.status).toBe(200)
+    expect(configured).toEqual({
+      url: "http://derive.test/v1/github/webhook",
+      content_type: "json",
+      insecure_ssl: "0",
+      secret: githubWebhookSecret("1", KEY),
+    })
+
+    const body = JSON.stringify({
+      action: "completed",
+      installation: { id: 44001 },
+      repository: { full_name: "Niftory/sift" },
+      workflow: { path: ".github/workflows/derive-docs-refresh.yml" },
+      workflow_run: {
+        id: 91,
+        status: "completed",
+        conclusion: "success",
+        html_url: "https://github.com/Niftory/sift/actions/runs/91",
+      },
+    })
+    const webhookHeaders = {
+      "content-type": "application/json",
+      "x-github-event": "workflow_run",
+      "x-github-delivery": "delivery-1",
+    }
+    expect(
+      (
+        await app.request("/v1/github/webhook", {
+          method: "POST",
+          headers: { ...webhookHeaders, "x-hub-signature-256": "sha256=wrong" },
+          body,
+        })
+      ).status,
+    ).toBe(401)
+    const signature = githubWebhookSignature(body, githubWebhookSecret("1", KEY))
+    expect(
+      (
+        await app.request("/v1/github/webhook", {
+          method: "POST",
+          headers: { ...webhookHeaders, "x-hub-signature-256": signature },
+          body,
+        })
+      ).status,
+    ).toBe(202)
+    expect(
+      (
+        await app.request("/v1/sync/github/webhook", {
+          method: "POST",
+          headers: { ...webhookHeaders, "x-hub-signature-256": signature },
+          body,
+        })
+      ).status,
+    ).toBe(202)
+  })
+
   it("turns an install callback into one stable source without collection work", async () => {
     const { app, meta } = makeAuthedApp("gh-standard", [owner, member], "editor", {
       deps: { encryptionKey: KEY },
@@ -63,6 +148,7 @@ describe("standard GitHub integration", () => {
     )
     let pullPermission = "write"
     let actionsPermission: string | undefined = "write"
+    let workflowRunEvent = true
     let installationActionsPermission: string | undefined = "write"
     let installationPullPermission: string | undefined = "write"
     let appStatus = 200
@@ -110,6 +196,16 @@ describe("standard GitHub integration", () => {
             }),
             { status: 200 },
           )
+        if (path === "/app/hook/config")
+          return new Response(
+            JSON.stringify({
+              url: "http://derive.test/v1/github/webhook",
+              content_type: "json",
+              insecure_ssl: "0",
+              secret: "********",
+            }),
+            { status: 200 },
+          )
         if (path === "/app")
           return new Response(
             JSON.stringify({
@@ -120,7 +216,7 @@ describe("standard GitHub integration", () => {
                 metadata: "read",
                 pull_requests: pullPermission,
               },
-              events: [],
+              events: workflowRunEvent ? ["workflow_run"] : [],
             }),
             { status: appStatus },
           )
@@ -223,6 +319,11 @@ describe("standard GitHub integration", () => {
       await (await app.request("/v1/github", { headers: as(owner.email) })).json(),
     ).toMatchObject({ app_permissions_state: "update_required", connected: true })
     actionsPermission = "write"
+    workflowRunEvent = false
+    expect(
+      await (await app.request("/v1/github", { headers: as(owner.email) })).json(),
+    ).toMatchObject({ app_permissions_state: "update_required", connected: true })
+    workflowRunEvent = true
     installationActionsPermission = undefined
     expect(
       await (await app.request("/v1/github", { headers: as(owner.email) })).json(),

--- a/apps/api/test/github-manifest.test.ts
+++ b/apps/api/test/github-manifest.test.ts
@@ -1,15 +1,18 @@
 import { describe, expect, it } from "vitest"
 import { buildManifest } from "../src/github-app-setup"
 
-// Locks the standard-source manifest. New installs query GitHub on demand: no contents,
-// issues, webhook events, or sync callback may creep back into this contract. Actions write is
-// server-narrowed to workflow discovery, dispatch, status, artifacts, and cancellation.
+// Locks the standard-source manifest. New installs query GitHub on demand. The only event is a
+// signed workflow completion signal. Actions write is server-narrowed to workflow discovery,
+// dispatch, status, artifacts, and cancellation.
 describe("GitHub App manifest", () => {
   const m = buildManifest("https://derive.example.com", "derive.example.com")
 
-  it("subscribes to no webhook events and configures no webhook", () => {
-    expect(m.default_events).toEqual([])
-    expect("hook_attributes" in m).toBe(false)
+  it("subscribes only to signed workflow completion events", () => {
+    expect(m.default_events).toEqual(["workflow_run"])
+    expect(m.hook_attributes).toEqual({
+      url: "https://derive.example.com/v1/github/webhook",
+      active: true,
+    })
   })
 
   it("is public so it can install on organizations, not just the owner", () => {

--- a/apps/docs/content/self-hosting/configuration.md
+++ b/apps/docs/content/self-hosting/configuration.md
@@ -315,11 +315,14 @@ one Derive workspace. Each workspace keeps an independent connection.
 
 Derive requests **Metadata: read**, **Pull requests: write**, and **Actions: write**. It uses
 these permissions for pull request reads, top-level pull request comments, workflow status, and
-workflow dispatch. Derive limits dispatch to workflow files named `derive-*.yml`.
+workflow dispatch. Derive limits dispatch to workflow files named `derive-*.yml`. The App also
+subscribes to `workflow_run`. Derive verifies each webhook signature before it accepts a workflow
+completion event.
 
-If a release adds an App permission, an App owner or manager must first update the shared App.
-Each connected GitHub account owner must then approve the permission update for that
-installation. Derive shows these as separate actions in **Settings → Integrations**.
+If a release adds an App permission or event, an App owner or manager must first update the shared
+App. Each connected GitHub account owner must then approve the update for that installation.
+Derive shows these as separate actions in **Settings → Integrations**. An instance operator can
+also repair the webhook URL and signing secret there. The secret stays on the server.
 
 ---
 

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -7472,10 +7472,15 @@ export interface components {
             app_slug: string | null;
             app_owner_login: string | null;
             /**
-             * @description Whether the instance App has every current permission; null when no live App exists
+             * @description Whether the instance App has every current permission and event; null when no live App exists
              * @enum {string|null}
              */
             app_permissions_state: "ready" | "update_required" | "unknown" | null;
+            /**
+             * @description Whether signed GitHub workflow completion events can reach this instance
+             * @enum {string|null}
+             */
+            app_webhook_state: "ready" | "update_required" | "unknown" | null;
             app_settings_url: string | null;
             /** @description Whether the caller is an instance operator who can configure the shared App */
             can_manage_app: boolean;

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1237,6 +1237,8 @@ export const api = {
       method: "DELETE",
       credentials: "include",
     }).then(() => undefined),
+  configureGithubWebhook: (): Promise<{ state: "ready" }> =>
+    f("/v1/github/webhook/configure", { ...opts({}), method: "POST" }).then(j),
 
   // OPERATOR-ONLY, and used as the operator SIGNAL itself: it 403s for everyone who is not a
   // super-admin, so a component can gate on whether this resolves rather than on a role the
@@ -1731,6 +1733,15 @@ export const api = {
     return f("/v1/connections?mine=1", opts())
       .then(j)
       .then((r) => r.connections as Connection[])
+  },
+  /** Connections the current workspace can bind to an automation. The server still enforces
+   *  personal ownership and workspace-manage access when the automation is saved. */
+  async automationConnections(): Promise<Connection[]> {
+    const [personal, workspace] = await Promise.all([
+      f("/v1/connections?mine=1", opts()).then(j),
+      f("/v1/connections?scope=workspace", opts()).then(j),
+    ])
+    return [...(personal.connections as Connection[]), ...(workspace.connections as Connection[])]
   },
   connect(toolkit: string): Promise<Connection & { connect_url: string }> {
     return f("/v1/connections", opts({ toolkit })).then(j)

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -171,6 +171,14 @@ export const connectionsQuery = () =>
     queryFn: () => api.connections(),
   })
 
+/** Every connection an owner may bind to an automation, including workspace GitHub Apps.
+ *  Keep this under the `connections` key so integration changes invalidate both views. */
+export const automationConnectionsQuery = () =>
+  queryOptions({
+    queryKey: ["connections", "automation"] as const,
+    queryFn: () => api.automationConnections(),
+  })
+
 // A small, flat slice of the Following feed — recent work from the people you follow —
 // for the "Recent activity" preview on the People tab. The full feed lives at /following
 // (the infinite libraryArtifactsQuery({ scope: "following" })); this is the peek.

--- a/apps/web/src/pages/settings/integrations-section.tsx
+++ b/apps/web/src/pages/settings/integrations-section.tsx
@@ -173,6 +173,11 @@ export function IntegrationsSection() {
     success: "GitHub disconnected",
     invalidate: [githubQuery().queryKey, connectionsQuery().queryKey],
   })
+  const configureGithubWebhook = useApiMutation({
+    mutationFn: () => api.configureGithubWebhook(),
+    success: "GitHub completion updates enabled",
+    invalidate: [githubQuery().queryKey],
+  })
   const confirmDisconnectGithub = () => {
     const connectionId = disconnectingGithub?.connection_id
     if (!connectionId) return
@@ -304,21 +309,56 @@ export function IntegrationsSection() {
               }
               meta={
                 github.app_permissions_state === "update_required"
-                  ? `${github.app_owner_login ? `@${github.app_owner_login} owns this App. ` : ""}An App owner or manager must grant Actions read and write before Derive can run workflows.`
+                  ? `${github.app_owner_login ? `@${github.app_owner_login} owns this App. ` : ""}An App owner or manager must grant Actions read and write and enable workflow run events.`
                   : github.app_permissions_state === "ready"
-                    ? `${github.app_owner_login ? `Owned by @${github.app_owner_login}. ` : ""}The App permissions are current.`
-                    : "Derive could not confirm the App permissions. Existing connections remain available."
+                    ? `${github.app_owner_login ? `Owned by @${github.app_owner_login}. ` : ""}The App permissions and events are current.`
+                    : "Derive could not confirm the App settings. Existing connections remain available."
               }
               actions={
                 github.app_permissions_state === "update_required" &&
                 github.can_manage_app &&
                 github.app_settings_url ? (
                   <Button data-testid="github-update-app" variant="ghost" size="sm" asChild>
-                    <a href={github.app_settings_url}>Open App settings</a>
+                    <a href={github.app_settings_url}>Review App settings</a>
                   </Button>
                 ) : undefined
               }
             />
+            {github.app_permissions_state === "ready" && (
+              <ListRow
+                title={
+                  <span className="flex flex-wrap items-center gap-2">
+                    Workflow completion updates
+                    {github.app_webhook_state === "ready" ? (
+                      <StatusBadge tone="ok">Active</StatusBadge>
+                    ) : github.app_webhook_state === "update_required" ? (
+                      <StatusBadge tone="attention">Setup required</StatusBadge>
+                    ) : (
+                      <StatusBadge tone="muted">Status unknown</StatusBadge>
+                    )}
+                  </span>
+                }
+                meta={
+                  github.app_webhook_state === "ready"
+                    ? "GitHub sends signed workflow completion events to Derive."
+                    : "Finish the signed webhook setup so Derive can receive workflow completion events."
+                }
+                actions={
+                  github.can_manage_app && github.app_webhook_state !== "ready" ? (
+                    <Button
+                      data-testid="github-configure-webhook"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => configureGithubWebhook.mutate()}
+                      loading={configureGithubWebhook.isPending}
+                      disabled={configureGithubWebhook.isPending}
+                    >
+                      Enable updates
+                    </Button>
+                  ) : undefined
+                }
+              />
+            )}
             {github.accounts.map((account) => (
               <ListRow
                 key={account.installation_id}

--- a/apps/web/src/pages/workflows/automated-workflows.tsx
+++ b/apps/web/src/pages/workflows/automated-workflows.tsx
@@ -10,6 +10,7 @@ import { LoadError } from "@/components/shared/load-error"
 import { RunReceipt } from "@/components/shared/run-receipt"
 import { Eyebrow } from "@/components/shared/section-eyebrow"
 import { SectionHeading } from "@/components/shared/section-title"
+import { SettingRow } from "@/components/shared/setting-row"
 import { SettingsEmpty } from "@/components/shared/settings-empty"
 import { SettingsGroup } from "@/components/shared/settings-group"
 import { StatusBadge } from "@/components/shared/status-badge"
@@ -51,6 +52,11 @@ export function AutomatedWorkflows() {
     qc.invalidateQueries({ queryKey: automationsQuery().queryKey })
     qc.invalidateQueries({ queryKey: runsQuery().queryKey })
   }
+  const enable = useApiMutation({
+    mutationFn: () => api.updateWorkspaceSettings({ automateBeta: true }),
+    success: "Workflows enabled",
+    onSuccess: (next) => qc.setQueryData(workspaceSettingsQuery().queryKey, next),
+  })
 
   return (
     <section className="flex flex-col gap-4">
@@ -75,10 +81,23 @@ export function AutomatedWorkflows() {
           <AutomationForm onDone={reload} />
         </div>
       ) : isAdmin ? (
-        <p className="text-sm text-muted-foreground">
-          Standing triggers are not enabled for this workspace. Existing definitions remain visible,
-          but they cannot start a new run.
-        </p>
+        <SettingsGroup>
+          <SettingRow
+            label="Enable single-agent workflows"
+            description="Create reusable jobs and run them here, on a schedule, or from an event."
+          >
+            <Button
+              data-testid="automations-enable"
+              variant="secondary"
+              size="sm"
+              onClick={() => enable.mutate()}
+              loading={enable.isPending}
+              disabled={enable.isPending}
+            >
+              Enable workflows
+            </Button>
+          </SettingRow>
+        </SettingsGroup>
       ) : (
         <AdminNote can="create workflows" />
       )}

--- a/apps/web/src/pages/workflows/automation-form.tsx
+++ b/apps/web/src/pages/workflows/automation-form.tsx
@@ -28,9 +28,9 @@ import { Textarea } from "@/components/ui/textarea"
 import {
   agentsQuery,
   artifactQuery,
+  automationConnectionsQuery,
   automationsQuery,
   collectionsQuery,
-  connectionsQuery,
   contextsQuery,
   modelCredentialsQuery,
   runsQuery,
@@ -103,27 +103,28 @@ export function AutomationForm({
     return (seed ?? []).map((r) => ({ ref: r, label: seedLabel(r) }))
   })
   const [pickerOpen, setPickerOpen] = useState(false)
-  const [sourcesOpen, setSourcesOpen] = useState(false)
-  // Ids, not objects: the row a source resolves to can change under us (a pending source signs
-  // in mid-edit), and holding the id means the label always reflects the CURRENT row.
-  const [sourceIds, setSourceIds] = useState<string[]>(automation?.connection_ids ?? [])
+  const [connectionsOpen, setConnectionsOpen] = useState(false)
+  // Ids, not objects: the row a connection resolves to can change under us (a pending source
+  // signs in mid-edit), and holding the id means the label always reflects the CURRENT row.
+  const [connectionIds, setConnectionIds] = useState<string[]>(automation?.connection_ids ?? [])
   const [q, setQ] = useState("")
   const tz = useMemo(() => Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC", [])
 
   const docs = useQuery(targetPickerQuery(q))
   const collections = useQuery(collectionsQuery())
-  // ACTIVE only. A pending source has an unpinned ref, which every run refuses — offering it
-  // here would let someone build an automation that silently reads nothing.
-  const connections = useQuery(connectionsQuery())
+  // ACTIVE only. A pending connection cannot provide tools, so offering it here would let
+  // someone build an automation that silently reads nothing.
+  const connections = useQuery(automationConnectionsQuery())
   const contexts = useQuery(contextsQuery())
   const modelCredentials = useQuery(modelCredentialsQuery())
   const personalPlan = modelCredentials.data?.find((c) => c.provider === provider)
-  const sources = useMemo(
-    () => (connections.data ?? []).filter((c) => c.kind === "mcp" && c.status === "active"),
+  const runConnections = useMemo(
+    () => (connections.data ?? []).filter((c) => c.status === "active"),
     [connections.data],
   )
-  const sourceLabel = (id: string): string =>
-    sources.find((s) => s.id === id)?.toolkit ?? "a disconnected source"
+  const connectionLabel = (id: string): string =>
+    runConnections.find((connection) => connection.id === id)?.toolkit ??
+    "a disconnected connection"
   const collectionMatches = useMemo(() => {
     const all = collections.data ?? []
     const needle = q.trim().toLowerCase()
@@ -183,7 +184,7 @@ export function AutomationForm({
         instruction: instruction.trim(),
         ...(!automation && runOnCreate ? { runNow: true } : {}),
         refs: buildRefs(),
-        connectionIds: sourceIds,
+        connectionIds,
       }
       return automation
         ? api.updateAutomation(automation.id, {
@@ -352,27 +353,27 @@ export function AutomationForm({
       </Field>
 
       <Field
-        label="Sources"
-        hint="Connected MCP servers this run may read from. Its tools were recorded when you connected it."
+        label="Connections"
+        hint="Connected tools this run can use. Add GitHub under Integrations, or add any runner adapter as an MCP source."
       >
         <div className="flex flex-wrap items-center gap-1.5">
-          {sourceIds.map((id) => (
+          {connectionIds.map((id) => (
             <Badge key={id} variant="outline" className="h-6 gap-1 pr-1 pl-1.5 font-normal">
               <Plug className="size-3.5 text-muted-foreground" aria-hidden />
-              <span className="max-w-40 truncate">{sourceLabel(id)}</span>
+              <span className="max-w-40 truncate">{connectionLabel(id)}</span>
               <button
                 type="button"
                 data-testid={`automation-source-remove-${id}`}
-                aria-label={`Remove ${sourceLabel(id)}`}
+                aria-label={`Remove ${connectionLabel(id)}`}
                 className="rounded-sm p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
-                onClick={() => setSourceIds((cur) => cur.filter((x) => x !== id))}
+                onClick={() => setConnectionIds((cur) => cur.filter((x) => x !== id))}
               >
                 <X className="size-3" aria-hidden />
               </button>
             </Badge>
           ))}
-          {sources.length > sourceIds.length ? (
-            <Popover open={sourcesOpen} onOpenChange={setSourcesOpen}>
+          {runConnections.length > connectionIds.length ? (
+            <Popover open={connectionsOpen} onOpenChange={setConnectionsOpen}>
               <PopoverTrigger asChild>
                 <Button
                   data-testid="automation-add-source"
@@ -385,26 +386,26 @@ export function AutomationForm({
               </PopoverTrigger>
               <PopoverContent className="w-80 p-0" align="start">
                 <Command>
-                  <CommandInput placeholder="Search sources…" />
+                  <CommandInput placeholder="Search connections…" />
                   <CommandList>
                     <CommandEmpty>No matches.</CommandEmpty>
                     <CommandGroup>
-                      {sources
-                        .filter((c) => !sourceIds.includes(c.id))
+                      {runConnections
+                        .filter((c) => !connectionIds.includes(c.id))
                         .map((c) => (
                           <CommandItem
                             key={c.id}
                             value={c.toolkit}
                             data-testid={`automation-source-${c.id}`}
                             onSelect={() => {
-                              setSourceIds((cur) => [...cur, c.id])
-                              setSourcesOpen(false)
+                              setConnectionIds((cur) => [...cur, c.id])
+                              setConnectionsOpen(false)
                             }}
                           >
                             <Plug className="size-3.5 text-muted-foreground" aria-hidden />
                             <span className="truncate">{c.toolkit}</span>
                             <span className="ml-auto max-w-36 truncate text-2xs text-muted-foreground">
-                              {c.base_url ?? ""}
+                              {c.scopes_label ?? c.base_url ?? c.kind ?? ""}
                             </span>
                           </CommandItem>
                         ))}
@@ -413,11 +414,12 @@ export function AutomationForm({
                 </Command>
               </PopoverContent>
             </Popover>
-          ) : sources.length === 0 ? (
-            // Said plainly rather than hidden: a run with no source can still only read what is
+          ) : runConnections.length === 0 ? (
+            // Said plainly rather than hidden: a run with no connection can only read what is
             // already in Derive, and that is the difference this field exists to explain.
             <span className="text-muted-foreground text-xs">
-              No sources connected yet. Add one under Settings → Sources.
+              No connections yet. Add GitHub under Settings → Integrations or an MCP source under
+              Settings → Sources.
             </span>
           ) : null}
         </div>


### PR DESCRIPTION
## Summary

- let owners enable single-agent workflows on the Workflows page
- expose workspace GitHub connections and personal MCP adapters to workflow definitions
- subscribe new Apps to signed workflow completion events
- add an operator repair action for existing App webhook settings
- preserve the legacy webhook URL as a verified compatibility alias

## Validation

- `pnpm verify`
- focused GitHub manifest, integration, and webhook signature tests
- web typecheck and tests

## Live target

After deploy, dogfood the manual workflow against `Niftory/sift` with `.github/workflows/derive-docs-refresh.yml`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/871"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790738096&installation_model_id=428097&pr_number=871&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F871&signature=83c24b8aa755d959b590f9f6a86fe93945f641663e92388ea69d5e9390256de6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->