### PR TITLE
Auto-route inference across US providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -333,6 +333,13 @@ DATA_DIR=./data
 # that routes one model id to several of them; unset = the gateway routes as it likes.
 # DERIVE_MODEL_PROVIDERS=provider-a,provider-b
 
+# Upstream backends ELIGIBLE for automatic routing, comma-separated. When set, this takes
+# precedence over DERIVE_MODEL_PROVIDERS: the gateway chooses among this allowlist using
+# current latency, while preferring endpoints sustaining at least 50 output tokens/sec.
+# Fallbacks remain enabled, so a rate-limited backend is tried elsewhere automatically.
+# Use this instead of a fixed order when availability and interactive speed matter most.
+# DERIVE_MODEL_AUTO_PROVIDERS=DeepInfra,DigitalOcean,BaseTen,CoreWeave,Together,Cloudflare
+
 # DEV ONLY — let a workspace with no broker plan use the ECHO stub instead of a broker that
 # refuses. The stub's `execute` returns the caller's own arguments: it reaches Stripe, Gmail
 # and nothing else, so a run using it reports success over data that never existed and writes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,9 +398,10 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          MODEL_AUTO_PROVIDERS: ${{ vars.DERIVE_MODEL_AUTO_PROVIDERS }}
         run: |
           for attempt in 1 2 3; do
-            if pnpm --filter @derive/api exec wrangler deploy --var BUILD_SHA:"$GITHUB_SHA"; then
+            if pnpm --filter @derive/api exec wrangler deploy --var BUILD_SHA:"$GITHUB_SHA" --var DERIVE_MODEL_AUTO_PROVIDERS:"$MODEL_AUTO_PROVIDERS"; then
               exit 0
             fi
             echo "::warning::wrangler deploy failed (attempt $attempt/3); retrying" >&2

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -148,6 +148,7 @@ jobs:
           MODEL_GATEWAYS: ${{ secrets.DERIVE_MODEL_GATEWAYS }}
           MODEL_DEFAULT: ${{ vars.DERIVE_MODEL_DEFAULT }}
           MODEL_PROVIDERS: ${{ vars.DERIVE_MODEL_PROVIDERS }}
+          MODEL_AUTO_PROVIDERS: ${{ vars.DERIVE_MODEL_AUTO_PROVIDERS }}
           MODEL_BASE_URL: ${{ vars.DERIVE_MODEL_BASE_URL }}
           MODEL_NAME: ${{ vars.DERIVE_MODEL_NAME }}
           # Optional: more model ids the SAME gateway serves. Set it and a preview can exercise
@@ -168,6 +169,7 @@ jobs:
           if [ -n "$MODEL_GATEWAYS" ]; then put DERIVE_MODEL_GATEWAYS "$MODEL_GATEWAYS"; fi
           if [ -n "$MODEL_DEFAULT" ]; then put DERIVE_MODEL_DEFAULT "$MODEL_DEFAULT"; fi
           if [ -n "$MODEL_PROVIDERS" ]; then put DERIVE_MODEL_PROVIDERS "$MODEL_PROVIDERS"; fi
+          if [ -n "$MODEL_AUTO_PROVIDERS" ]; then put DERIVE_MODEL_AUTO_PROVIDERS "$MODEL_AUTO_PROVIDERS"; fi
           if [ -n "$MODEL_BASE_URL" ]; then put DERIVE_MODEL_BASE_URL "$MODEL_BASE_URL"; fi
           if [ -n "$MODEL_NAME" ]; then put DERIVE_MODEL_NAME "$MODEL_NAME"; fi
           if [ -n "$MODEL_NAMES" ]; then put DERIVE_MODEL_NAMES "$MODEL_NAMES"; fi

--- a/apps/api/src/config-manifest.ts
+++ b/apps/api/src/config-manifest.ts
@@ -412,6 +412,12 @@ const CONFIG_VARS: ConfigVar[] = [
     example: "provider-a,provider-b",
   },
   {
+    name: "DERIVE_MODEL_AUTO_PROVIDERS",
+    group: "advanced",
+    doc: "Upstream backends eligible for automatic routing, comma-separated. When set, this takes\nprecedence over DERIVE_MODEL_PROVIDERS: the gateway chooses among the allowlist using current\nlatency, while preferring endpoints sustaining at least 50 output tokens/sec. Fallbacks remain\nenabled, so a rate-limited backend is tried elsewhere automatically.",
+    example: "DeepInfra,DigitalOcean,BaseTen,CoreWeave,Together,Cloudflare",
+  },
+  {
     name: "DERIVE_LOCAL_BROKER",
     group: "advanced",
     doc: "DEV ONLY — let a workspace with no broker plan use the ECHO stub instead of a broker that\nrefuses. The stub's `execute` returns the caller's own arguments: it reaches Stripe, Gmail\nand nothing else, so a run using it reports success over data that never existed and writes\nan artifact full of invented numbers, with no error anywhere. Unset = a workspace with no\nplan gets a refusing broker, which is what you want everywhere a human might see the output.\nMCP connections are unaffected either way — they carry their own server and route on their\nown ref.",

--- a/apps/api/src/lib/model-catalog.ts
+++ b/apps/api/src/lib/model-catalog.ts
@@ -77,6 +77,10 @@ export interface GatewayConfig {
   /** Preferred upstream backends, best first, comma-separated. Only meaningful on a gateway that
    *  routes; unset sends nothing. */
   providers?: string
+  /** Upstream backends eligible for automatic routing, comma-separated. When present this wins
+   *  over `providers`: the gateway chooses among this set from live performance rather than
+   *  walking a fixed order. */
+  autoProviders?: string
 }
 
 /**
@@ -93,18 +97,53 @@ export interface GatewayConfig {
  */
 const NO_THINKING = { reasoning: { enabled: false } } as const
 
+/** Keep interactive replies from winning on time-to-first-token only to then dribble output.
+ *  This is a PREFERENCE, not a gate: OpenRouter moves slower endpoints behind the preferred
+ *  group and can still use them if the fast group is unavailable. Fifty tokens/sec is enough
+ *  that generation no longer dominates an ordinary chat reply while leaving a broad fallback
+ *  pool for a large model. */
+const AUTO_MIN_THROUGHPUT = { p50: 50 } as const
+
+const providerList = (raw: string | undefined): string[] => {
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const provider of (raw ?? "")
+    .split(",")
+    .map((p) => p.trim())
+    .filter(Boolean)) {
+    if (seen.has(provider)) continue
+    seen.add(provider)
+    out.push(provider)
+  }
+  return out
+}
+
 /** The one construction path for a model on the configured gateway. Configured entries,
  * operator-added entries, and add-time probes must share every routing/body knob. */
 export const callModelFromGateway = (
   gw: GatewayConfig,
   id: string,
 ): AgentLoopInput["callModel"] => {
-  const order = (gw.providers ?? "")
-    .split(",")
-    .map((p) => p.trim())
-    .filter(Boolean)
+  const automatic = providerList(gw.autoProviders)
+  const order = providerList(gw.providers)
+  // A fixed `order` disables the gateway's live routing and keeps leaning on the first backend
+  // until it fails. The automatic mode instead limits WHO may receive a request while leaving
+  // WHICH eligible backend goes first to the gateway's rolling latency/throughput observations.
+  // Low latency is what an attended turn feels; the throughput floor prevents a quick first
+  // token from masking a slow completion. Fallbacks stay on so a provider 429 becomes another
+  // route attempt, not a failed Derive turn.
+  const provider = automatic.length
+    ? {
+        only: automatic,
+        sort: "latency",
+        preferred_min_throughput: AUTO_MIN_THROUGHPUT,
+        allow_fallbacks: true,
+      }
+    : order.length
+      ? { order, allow_fallbacks: true }
+      : undefined
   const extraBody = {
-    ...(order.length ? { provider: { order, allow_fallbacks: true } } : {}),
+    ...(provider ? { provider } : {}),
     ...NO_THINKING,
   }
   return openAiCompatModel({

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -335,6 +335,7 @@ const modelGateway = (): GatewayConfig | null => {
       model,
       alsoModels: process.env.DERIVE_MODEL_NAMES,
       providers: process.env.DERIVE_MODEL_PROVIDERS,
+      autoProviders: process.env.DERIVE_MODEL_AUTO_PROVIDERS,
     }
   if (baseUrl || apiKey || model)
     log.warn("model gateway ignored: set DERIVE_MODEL_BASE_URL, _API_KEY and _NAME together", {

--- a/apps/api/src/webhook-do.ts
+++ b/apps/api/src/webhook-do.ts
@@ -46,6 +46,7 @@ export interface WebhookOutboxEnv {
   DERIVE_MODEL_NAME?: string
   DERIVE_MODEL_NAMES?: string
   DERIVE_MODEL_PROVIDERS?: string
+  DERIVE_MODEL_AUTO_PROVIDERS?: string
   DERIVE_CHAT_ALLOWLIST?: string
 }
 
@@ -65,6 +66,7 @@ const mentionAnswerer = (env: WebhookOutboxEnv, store: MetaStore) => {
           model: env.DERIVE_MODEL_NAME,
           alsoModels: env.DERIVE_MODEL_NAMES,
           providers: env.DERIVE_MODEL_PROVIDERS,
+          autoProviders: env.DERIVE_MODEL_AUTO_PROVIDERS,
         }
       : undefined
   const models = catalogFromGateway(gw)

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -160,6 +160,9 @@ export interface Env {
   /** Preferred upstream backends, best first, on a gateway that ROUTES one model id to several
    *  of them. Unset ⇒ the gateway routes however it likes. */
   DERIVE_MODEL_PROVIDERS?: string
+  /** Eligible upstream backends for live performance routing. Takes precedence over the fixed
+   *  DERIVE_MODEL_PROVIDERS order when present. */
+  DERIVE_MODEL_AUTO_PROVIDERS?: string
   /** Additional providers as JSON — see parseGatewaysJson. Each carries its own key, models and
    *  backend routing, so a fourth provider is a list entry rather than four more variables. */
   DERIVE_MODEL_GATEWAYS?: string
@@ -571,8 +574,12 @@ function workerGateway(env: Env): GatewayConfig | undefined {
     DERIVE_MODEL_NAMES: alsoModels,
     // Preferred upstream backends on a gateway that routes; meaningless on one that does not.
     DERIVE_MODEL_PROVIDERS: providers,
+    // Eligible backends for live latency/throughput routing; wins over the fixed order above.
+    DERIVE_MODEL_AUTO_PROVIDERS: autoProviders,
   } = env
-  return baseUrl && apiKey && model ? { baseUrl, apiKey, model, alsoModels, providers } : undefined
+  return baseUrl && apiKey && model
+    ? { baseUrl, apiKey, model, alsoModels, providers, autoProviders }
+    : undefined
 }
 
 /** Run something with hosted-dispatch deps, inside a request-scoped DB context (a binding

--- a/apps/api/test/model-openai.test.ts
+++ b/apps/api/test/model-openai.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest"
+import { callModelFromGateway } from "../src/lib/model-catalog"
 import { openAiCompatModel } from "../src/lib/model-openai"
 
 // The OPENAI-COMPATIBLE adapter. Everything here is the mapping between the two wire formats,
@@ -90,6 +91,56 @@ describe("the request it builds", () => {
         function: { name: "svc.read", description: "read", parameters: { type: "object" } },
       },
     ])
+  })
+})
+
+describe("gateway provider routing", () => {
+  const routedBody = async (gateway: Parameters<typeof callModelFromGateway>[0]) => {
+    const { seen, impl } = capture()
+    vi.stubGlobal("fetch", impl)
+    try {
+      await callModelFromGateway(
+        gateway,
+        gateway.model,
+      )({
+        system: "s",
+        messages: [],
+        tools: [],
+      })
+      return seen[0]?.body
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  }
+
+  it("auto-routes inside an allowlist using latency plus a throughput floor", async () => {
+    const body = await routedBody({
+      baseUrl: "https://openrouter.ai/api/v1",
+      apiKey: "k",
+      model: "deepseek/deepseek-v4-flash-0731",
+      autoProviders: " DeepInfra,DigitalOcean,DeepInfra, BaseTen ",
+      // Automatic routing takes precedence over the old fixed order during migration.
+      providers: "Novita,GMICloud",
+    })
+    expect(body?.provider).toEqual({
+      only: ["DeepInfra", "DigitalOcean", "BaseTen"],
+      sort: "latency",
+      preferred_min_throughput: { p50: 50 },
+      allow_fallbacks: true,
+    })
+  })
+
+  it("keeps the existing fixed provider order when automatic routing is unset", async () => {
+    const body = await routedBody({
+      baseUrl: "https://gw.test/v1",
+      apiKey: "k",
+      model: "m",
+      providers: "provider-a,provider-b",
+    })
+    expect(body?.provider).toEqual({
+      order: ["provider-a", "provider-b"],
+      allow_fallbacks: true,
+    })
   })
 })
 


### PR DESCRIPTION
## Summary
- add an automatic provider mode that limits routing to an allow-list while ranking eligible backends by live latency
- prefer providers sustaining at least 50 output tokens/sec and keep fallbacks enabled so 429s move to another backend
- deploy the configured US allow-list to production and previews while preserving the existing fixed-order setting

## US provider pool
DeepInfra, DigitalOcean, Baseten, CoreWeave, Together, Cloudflare

## Verification
- pnpm run ci
- pnpm typecheck
- pnpm test
- workflow YAML parse

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/872"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790739964&installation_model_id=428097&pr_number=872&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F872&signature=ca26ca8794abb44b718450f6477e46b402949cbc17accf4c502c9933fb773506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->