### PR TITLE
fix(web): correct Claude connector setup steps and link straight to t…

### DIFF
--- a/apps/web/src/components/shared/connect-agent.tsx
+++ b/apps/web/src/components/shared/connect-agent.tsx
@@ -118,14 +118,30 @@ export function ConnectAgent({ testidPrefix = "connect-agent" }: { testidPrefix?
       </TabsContent>
       <TabsContent value="claude" className={tabContent}>
         <p className="text-sm text-pretty text-muted-foreground">
-          In claude.ai or Claude Desktop:{" "}
-          <span className="font-medium text-foreground">
-            Settings → Connectors → Add custom connector
-          </span>
-          , then paste this URL.
+          Open{" "}
+          <a
+            href="https://claude.ai/customize/connectors"
+            target="_blank"
+            rel="noreferrer"
+            className="font-medium text-foreground underline underline-offset-4 transition-colors hover:text-muted-foreground"
+          >
+            claude.ai/customize/connectors
+          </a>{" "}
+          (<span className="font-medium text-foreground">Customize → Connectors</span> in the left
+          panel) and click <span className="font-medium text-foreground">Add</span>, then paste this
+          URL.
         </p>
         <PromptBlock text={mcp} testid={`${testidPrefix}-cmd-claude`} copyLabel="Copy URL" />
-        {consentHint}
+        {/* Not the shared consentHint: claude.ai approves in the connector dialog, not on
+            first tool call, and the connector stays off in chats until it is switched on. */}
+        <p className="text-sm text-pretty text-muted-foreground">
+          Approve access when Claude prompts, then switch Derive on in a chat from the{" "}
+          <span className="font-medium text-foreground">+</span> menu under Connectors.
+        </p>
+        <p className="text-xs text-pretty text-muted-foreground">
+          On Team or Enterprise, an owner adds it under Organization settings → Connectors first,
+          then everyone connects it here.
+        </p>
       </TabsContent>
       <TabsContent value="codex" className={tabContent}>
         <p className="text-sm text-pretty text-muted-foreground">One command connects Codex.</p>


### PR DESCRIPTION
## What

The Claude tab in the shared ConnectAgent surface (onboarding step 1, library empty state, Brandprint nudges, Rework menu) told users to go to Settings -> Connectors -> Add custom connector. That path no longer exists, so the first thing a new claude.ai user hits during signup is a dead end.

## Changes

- Correct path: **Customize -> Connectors -> Add**, matching the current claude.ai UI
- Link https://claude.ai/customize/connectors directly so users land on the right page in one click instead of hunting through menus
- Replace the shared "first call opens your browser" consent hint on this tab: it is accurate for Claude Code/Codex/Cursor but wrong for claude.ai, where approval happens in the connector dialog and the connector stays **off** until switched on per chat from the + menu. Without that step, onboarding sits on "Waiting for your agent to connect..." forever with no explanation
- Note the Team/Enterprise case: members cannot self-add, an owner has to add the connector under Organization settings first

## Verification

- `pnpm --filter @derive/web typecheck` passes
- `biome check` clean
- All 34 precommit guardrail checks pass
- Steps verified against Anthropic's current docs (support.claude.com 11175166, claude.com/docs/connectors/custom/remote-mcp) and a fresh-signup walkthrough on a test account
- Only e2e-referenced testid in this block (`welcome-cmd-claude-code`) is untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790795387&installation_model_id=428097&pr_number=875&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F875&signature=3cf4175facb971a10d057e4e4d8324a234fd1a59a9dab58e7bd6a9bd19ac3ec3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->