### PR TITLE
Add shared Skills product surface

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -54,6 +54,7 @@ import { sessionRoutes } from "./routes/session"
 import { sharedStateRoutes } from "./routes/shared-state"
 import { sharingRoutes } from "./routes/sharing"
 import { siteRoutes } from "./routes/site"
+import { skillRoutes } from "./routes/skills"
 import { slackRoutes } from "./routes/slack"
 import { systemRoutes } from "./routes/system"
 import { templateLibraryRoutes } from "./routes/template-libraries"
@@ -459,6 +460,7 @@ export function createApp(deps: AppDeps): Hono {
     mcpOauthRoutes,
     modelCredentialRoutes,
     conciergeRoutes,
+    skillRoutes,
     workflowRoutes,
     reworkRoutes,
     commentRoutes,

--- a/apps/api/src/lib/after-publish.ts
+++ b/apps/api/src/lib/after-publish.ts
@@ -10,6 +10,7 @@
 import {
   type ArtifactRecord,
   type BlobStore,
+  type BundleManifest,
   DECK_CONTENT_TYPE,
   deriveFacts,
   FACT_GEN,
@@ -20,7 +21,10 @@ import {
   newId,
   parseFacts,
   type SearchIndex,
+  SKILL_CONTENT_TYPE,
+  SKILL_SIDECAR_PATH,
   type VersionRecord,
+  validateSkillDefinition,
 } from "@derive/core"
 import type { Backplane } from "../bus"
 import type { WebhookEvent } from "../events"
@@ -97,6 +101,17 @@ export const emitVersionBump = async (
   } catch (err) {
     log.error("data-slot extraction failed", { artifact: artifact.id, err: String(err) })
   }
+  // Skill relations are a query index over immutable bundle bytes, not another definition.
+  // Run on every canonical version bump (publish, restore, agent edit) so no surface can drift.
+  try {
+    await indexSkillVersion(meta, blobs, artifact, version)
+  } catch (err) {
+    log.error("skill relation indexing failed", {
+      artifact: artifact.id,
+      n: version.n,
+      err: String(err),
+    })
+  }
   // What this version SAYS, for the cards that describe it to someone who has not opened it.
   // Third sibling of the two above and the same contract in every respect: a failure logs and
   // the publish stands, because a link preview is never worth failing a write that already
@@ -120,6 +135,66 @@ export const emitVersionBump = async (
     await (deps.background ? deps.background(work) : work)
   }
   return storedRows
+}
+
+const indexSkillVersion = async (
+  meta: MetaStore,
+  blobs: BlobStore,
+  artifact: ArtifactRecord,
+  version: VersionRecord,
+): Promise<void> => {
+  if (version.content_type !== SKILL_CONTENT_TYPE) return
+  const manifestBytes = await blobs.get(version.blob_key)
+  if (!manifestBytes) throw new Error("skill manifest blob missing")
+  const manifest = JSON.parse(new TextDecoder().decode(manifestBytes)) as BundleManifest
+  const skillKey = manifest.files[manifest.entry]?.key
+  if (!skillKey) throw new Error("SKILL.md missing from skill manifest")
+  const skillBytes = await blobs.get(skillKey)
+  if (!skillBytes) throw new Error("SKILL.md blob missing")
+  const sidecarKey = manifest.files[SKILL_SIDECAR_PATH]?.key
+  const sidecarBytes = sidecarKey ? await blobs.get(sidecarKey) : null
+  const checked = validateSkillDefinition(
+    new TextDecoder().decode(skillBytes),
+    sidecarBytes ? new TextDecoder().decode(sidecarBytes) : null,
+  )
+  if (checked.errors.length > 0) throw new Error(checked.errors.join("; "))
+  const declared = Object.entries(checked.sidecar?.relations ?? {}).flatMap(([kind, refs]) =>
+    (refs ?? []).map((ref) => ({ kind: kind as "requires" | "extends" | "recommends", ref })),
+  )
+  const targets = await meta.getByShortIds([...new Set(declared.map(({ ref }) => ref.id))])
+  const byShortId = new Map(targets.map((target) => [target.short_id, target]))
+  const relations = []
+  for (const { kind, ref } of declared) {
+    const target = byShortId.get(ref.id)
+    if (!target || target.org_id !== artifact.org_id) {
+      log.warn("skill relation target unavailable", {
+        artifact: artifact.id,
+        n: version.n,
+        target: ref.id,
+      })
+      continue
+    }
+    const targetVersion = await meta.getVersion(target.id, ref.version)
+    if (targetVersion?.content_type !== SKILL_CONTENT_TYPE) {
+      log.warn("skill relation target version is not a Skill", {
+        artifact: artifact.id,
+        n: version.n,
+        target: ref.id,
+        target_version: ref.version,
+      })
+      continue
+    }
+    relations.push({
+      id: newId("skr"),
+      org_id: artifact.org_id,
+      source_artifact_id: artifact.id,
+      source_version: version.n,
+      target_artifact_id: target.id,
+      target_version: ref.version,
+      kind,
+    })
+  }
+  await meta.replaceSkillRelations(artifact.org_id, artifact.id, version.n, relations)
 }
 
 /** sha256 of the exact text handed to the model, hex. Web Crypto only — this runs on Workers

--- a/apps/api/src/lib/spa-paths.ts
+++ b/apps/api/src/lib/spa-paths.ts
@@ -27,6 +27,7 @@ const SPA_EXACT = new Set([
   "/settings",
   "/showcase",
   "/shared",
+  "/skills",
   "/template-libraries",
   "/templates",
   "/unlisted",

--- a/apps/api/src/routes/skills.ts
+++ b/apps/api/src/routes/skills.ts
@@ -121,6 +121,7 @@ export const skillRoutes = (ctx: AppContext) => {
             name: definition.metadata?.name ?? row.title ?? row.short_id,
             description: definition.metadata?.description ?? "",
             runtime: definition.sidecar?.runtime?.kind ?? "single",
+            workflow_launcher: definition.sidecar?.origin?.kind === "workflow-launcher",
           },
         })
         if (visible.length > limit) break
@@ -498,6 +499,10 @@ export const skillRoutes = (ctx: AppContext) => {
             // Keep the authored Workflow in Workflows and also expose its reusable
             // launcher in Skills. These are two views of the same runtime definition.
             catalog: true,
+            origin: {
+              kind: "workflow-launcher",
+              workflow: { short_id: row.short_id, version: row.n },
+            },
             runtime: { kind: runtimeKind, definition: parsed.definition },
           },
           null,

--- a/apps/api/src/routes/skills.ts
+++ b/apps/api/src/routes/skills.ts
@@ -221,6 +221,39 @@ export const skillRoutes = (ctx: AppContext) => {
     })
   })
 
+  app.get("/v1/artifacts/:shortId/skills", async (c) => {
+    const artifact = await requireArtifact(c, "read")
+    if (artifact instanceof Response) return artifact
+    const links = await meta.listArtifactSkillLinkHistory(artifact.id, artifact.org_id)
+    const skills = await meta.listArtifacts({
+      ids: [...new Set(links.map((link) => link.skill_artifact_id))],
+      orgId: artifact.org_id,
+      archived: "include",
+    })
+    const readable = new Map<string, (typeof skills)[number]>()
+    for (const skill of skills) {
+      if (skill.current_content_type !== SKILL_CONTENT_TYPE) continue
+      if (await authorize(c, "read", skill)) readable.set(skill.id, skill)
+    }
+    return c.json({
+      links: links
+        .filter((link) => readable.has(link.skill_artifact_id))
+        .map((link) => {
+          const skill = readable.get(link.skill_artifact_id)
+          return {
+            ...link,
+            skill: skill
+              ? {
+                  short_id: skill.short_id,
+                  title: skill.title,
+                  current_version: skill.current_version,
+                }
+              : null,
+          }
+        }),
+    })
+  })
+
   app.put("/v1/artifacts/:shortId/skill-installation", async (c) => {
     const skill = await requireArtifact(c, "read")
     if (skill instanceof Response) return skill

--- a/apps/api/src/routes/skills.ts
+++ b/apps/api/src/routes/skills.ts
@@ -292,7 +292,8 @@ export const skillRoutes = (ctx: AppContext) => {
     }> = []
 
     // Context definitions can change bundle entry type without changing artifact identity:
-    // append SKILL.md + the private catalog sidecar to the same bundle.
+    // append SKILL.md + a catalog-visible sidecar to the same bundle. The Context
+    // remains available in Contexts while its reusable definition also appears in Skills.
     const contexts = await meta.listContexts(orgId)
     const manifests = new Map<string, (typeof contexts)[number]>()
     for (const context of contexts) manifests.set(context.manifest_artifact_id, context)
@@ -335,7 +336,7 @@ export const skillRoutes = (ctx: AppContext) => {
       const bytes = await mergeBundleZip(blobs, manifest, {
         "SKILL.md": `---\nname: ${name}\ndescription: ${JSON.stringify(description)}\n---\n\n${parsed.body.trim()}\n`,
         "derive.skill.json": JSON.stringify(
-          { schema: "derive.skill/v1", catalog: false, runtime: { kind: "single" } },
+          { schema: "derive.skill/v1", catalog: true, runtime: { kind: "single" } },
           null,
           2,
         ),
@@ -461,7 +462,9 @@ export const skillRoutes = (ctx: AppContext) => {
         "derive.skill.json": JSON.stringify(
           {
             schema: "derive.skill/v1",
-            catalog: false,
+            // Keep the authored Workflow in Workflows and also expose its reusable
+            // launcher in Skills. These are two views of the same runtime definition.
+            catalog: true,
             runtime: { kind: runtimeKind, definition: parsed.definition },
           },
           null,
@@ -513,6 +516,16 @@ export const skillRoutes = (ctx: AppContext) => {
         launcherArtifact = published.artifact
         launcherVersion = published.version
       }
+      // This internal publish path does not pass through the HTTP/MCP adapters that
+      // normally stamp the human owner's artifact_member row. Stamp (or repair) it
+      // here so an unlisted launcher remains visible to its owner and can therefore
+      // appear in their Skills catalog without widening its access.
+      await meta.setArtifactMember({
+        id: newId("am"),
+        artifact_id: launcherArtifact.id,
+        user_id: human.id,
+        role: "owner",
+      })
       await afterPublish(
         {
           meta,

--- a/apps/api/src/routes/skills.ts
+++ b/apps/api/src/routes/skills.ts
@@ -1,0 +1,578 @@
+import {
+  type ArtifactSkillRole,
+  LINKED_BUNDLE_FACT,
+  newId,
+  parseFrontmatter,
+  publish,
+  SKILL_CONTENT_TYPE,
+  SKILL_SIDECAR_PATH,
+  type SkillClient,
+  type SkillInstallPolicy,
+  type SkillInstallScope,
+  toJson,
+  validateSkillDefinition,
+  WORKFLOW_DEFINITION_FACT,
+} from "@derive/core"
+import { OpenAPIHono } from "@hono/zod-openapi"
+import type { BlankEnv } from "hono/types"
+import { z } from "zod"
+import type { AppContext } from "../context"
+import { afterPublish } from "../lib/after-publish"
+import { manifestOf, mergeBundleZip, pageTextResolver, zipBundleFiles } from "../lib/bundle"
+import { ContextConflictError, createContextCore } from "../lib/create-context"
+import { fail, readJson } from "../lib/http"
+import { visibleArtifactIds } from "../lib/visibility"
+import { parseLinkedWorkflowFacts } from "../lib/workflow-facts"
+
+const installationBody = z.object({
+  skill_version: z.number().int().positive(),
+  scope_kind: z.enum(["project", "personal", "runner"]),
+  opaque_scope_id: z.string().min(16).max(128),
+  client: z.enum(["claude", "codex"]),
+  digest: z.string().regex(/^[a-f0-9]{64}$/i),
+  policy: z.enum(["pinned", "latest"]),
+  removed: z.boolean().optional(),
+})
+
+const artifactLinkBody = z.object({
+  artifact_version: z.number().int().positive(),
+  skill_short_id: z.string().min(1),
+  skill_version: z.number().int().positive(),
+  role: z.enum([
+    "created",
+    "revised",
+    "validated",
+    "example",
+    "anti-example",
+    "workflow-definition",
+  ]),
+})
+
+/** Skill catalog, graph, usage, installation receipts, and exact-version provenance. */
+export const skillRoutes = (ctx: AppContext) => {
+  const {
+    meta,
+    blobs,
+    currentUser,
+    agentFor,
+    isToken,
+    activeWorkspace,
+    membershipOf,
+    requireArtifact,
+    authorize,
+    actingHuman,
+    actingUser,
+    requireWorkspace,
+    bus,
+    notify,
+    notifyRender,
+    background,
+    search,
+    summarize,
+    deps,
+  } = ctx
+  const app = new OpenAPIHono<BlankEnv>()
+
+  const skillDefinition = async (artifactId: string, version: number) => {
+    const row = await meta.getVersion(artifactId, version)
+    if (!row || row.content_type !== SKILL_CONTENT_TYPE) return null
+    const manifest = await manifestOf(blobs, row)
+    if (!manifest) return null
+    const text = await pageTextResolver(blobs, row)
+    const checked = validateSkillDefinition(
+      (await text("/SKILL.md")) ?? "",
+      await text(SKILL_SIDECAR_PATH),
+    )
+    return checked.errors.length === 0 ? checked : null
+  }
+
+  app.get("/v1/skills", async (c) => {
+    const me = await currentUser(c)
+    const agent = me ? null : await agentFor(c)
+    if (!me && !agent && !isToken(c)) return fail(c, 401, "unauthenticated")
+    const orgId = await activeWorkspace(c)
+    const memberId = me?.id ?? agent?.created_by ?? agent?.id
+    const member = memberId ? await membershipOf(c, orgId, memberId) : null
+    const operator = isToken(c)
+    const limit = Math.min(100, Math.max(1, Number(c.req.query("limit")) || 30))
+    const visible = []
+    const pageSize = Math.min(100, Math.max(20, limit * 2))
+    let cursor: { key: string; id: string } | undefined
+    while (visible.length <= limit) {
+      // catalog:false is definition state inside the immutable bundle, not artifact
+      // metadata. Page the typed rows until we have enough visible definitions; a large
+      // set of embedded Context Skills must never crowd an older shared Skill out.
+      const rows = await meta.listArtifacts({
+        orgId,
+        limit: pageSize,
+        cursor,
+        q: c.req.query("query")?.trim().slice(0, 200) || undefined,
+        contentType: SKILL_CONTENT_TYPE,
+        publicOnly: !(operator || member),
+        viewerId: operator ? undefined : memberId,
+        excludeRemoved: true,
+      })
+      for (const row of rows) {
+        const definition = await skillDefinition(row.id, row.current_version)
+        if (!definition || definition.sidecar?.catalog === false) continue
+        visible.push({
+          ...toJson(deps.baseUrl, row, []),
+          skill: {
+            name: definition.metadata?.name ?? row.title ?? row.short_id,
+            description: definition.metadata?.description ?? "",
+            runtime: definition.sidecar?.runtime?.kind ?? "single",
+          },
+        })
+        if (visible.length > limit) break
+      }
+      const last = rows.at(-1)
+      if (visible.length > limit || rows.length < pageSize || !last) break
+      cursor = { key: last.created_at, id: last.id }
+    }
+    return c.json({
+      skills: visible.slice(0, limit),
+      has_more: visible.length > limit,
+    })
+  })
+
+  app.get("/v1/artifacts/:shortId/skill-graph", async (c) => {
+    const skill = await requireArtifact(c, "read")
+    if (skill instanceof Response) return skill
+    if (skill.current_content_type !== SKILL_CONTENT_TYPE) return fail(c, 404, "not a skill")
+    const relations = await meta.listSkillRelations(skill.id, skill.org_id)
+    const ids = [...new Set(relations.flatMap((r) => [r.source_artifact_id, r.target_artifact_id]))]
+    const candidates = await meta.listArtifacts({ ids, orgId: skill.org_id, archived: "include" })
+    const readable = new Map<string, (typeof candidates)[number]>()
+    for (const artifact of candidates) {
+      if (await authorize(c, "read", artifact)) readable.set(artifact.id, artifact)
+    }
+    const currentRelations = relations.filter((relation) => {
+      if (relation.source_artifact_id === skill.id)
+        return relation.source_version === skill.current_version
+      const source = readable.get(relation.source_artifact_id)
+      return (
+        relation.target_artifact_id === skill.id &&
+        relation.target_version === skill.current_version &&
+        source?.current_version === relation.source_version
+      )
+    })
+    return c.json({
+      root: skill.id,
+      nodes: [...readable.values()].map((a) => ({
+        id: a.id,
+        short_id: a.short_id,
+        title: a.title,
+        version: a.current_version,
+      })),
+      edges: currentRelations.filter(
+        (r) => readable.has(r.source_artifact_id) && readable.has(r.target_artifact_id),
+      ),
+    })
+  })
+
+  app.get("/v1/artifacts/:shortId/skill-usage", async (c) => {
+    const skill = await requireArtifact(c, "read")
+    if (skill instanceof Response) return skill
+    if (skill.current_content_type !== SKILL_CONTENT_TYPE) return fail(c, 404, "not a skill")
+    const [usage, installations, links] = await Promise.all([
+      meta.skillUsage(skill.id, skill.org_id),
+      meta.listSkillInstallations(skill.id, skill.org_id),
+      meta.listSkillArtifactLinks(skill.id, skill.org_id, 100),
+    ])
+    const linked = await meta.listArtifacts({
+      ids: [...new Set(links.map((l) => l.artifact_id))],
+      orgId: skill.org_id,
+      archived: "include",
+    })
+    const readable = new Set<string>()
+    for (const artifact of linked)
+      if (await authorize(c, "read", artifact)) readable.add(artifact.id)
+    const installSummary = new Map<
+      string,
+      { client: SkillClient; scope_kind: SkillInstallScope; count: number; last_synced_at: string }
+    >()
+    for (const installation of installations) {
+      if (installation.removed_at) continue
+      const key = `${installation.client}:${installation.scope_kind}`
+      const current = installSummary.get(key)
+      installSummary.set(key, {
+        client: installation.client,
+        scope_kind: installation.scope_kind,
+        count: (current?.count ?? 0) + 1,
+        last_synced_at:
+          !current || installation.updated_at > current.last_synced_at
+            ? installation.updated_at
+            : current.last_synced_at,
+      })
+    }
+    return c.json({
+      contexts: usage.contexts,
+      workflows: usage.workflows,
+      installations: [...installSummary.values()],
+      artifacts: links
+        .filter((link) => readable.has(link.artifact_id))
+        .map((link) => {
+          const artifact = linked.find((candidate) => candidate.id === link.artifact_id)
+          return {
+            ...link,
+            artifact: artifact ? { short_id: artifact.short_id, title: artifact.title } : null,
+          }
+        }),
+    })
+  })
+
+  app.put("/v1/artifacts/:shortId/skill-installation", async (c) => {
+    const skill = await requireArtifact(c, "read")
+    if (skill instanceof Response) return skill
+    const body = await readJson(c, installationBody)
+    if (body instanceof Response) return body
+    const definition = await skillDefinition(skill.id, body.skill_version)
+    if (!definition) return fail(c, 400, "skill version not found")
+    const actor = (await actingHuman(c)) ?? (await actingUser(c))
+    const now = new Date().toISOString()
+    const installation = await meta.upsertSkillInstallation({
+      id: newId("ski"),
+      org_id: skill.org_id,
+      skill_artifact_id: skill.id,
+      skill_version: body.skill_version,
+      scope_kind: body.scope_kind as SkillInstallScope,
+      opaque_scope_id: body.opaque_scope_id,
+      client: body.client as SkillClient,
+      digest: body.digest.toLowerCase(),
+      policy: body.policy as SkillInstallPolicy,
+      installed_by: actor?.id ?? null,
+      updated_at: now,
+      removed_at: body.removed ? now : null,
+    })
+    return c.json({ installation })
+  })
+
+  app.post("/v1/artifacts/:shortId/skills", async (c) => {
+    const artifact = await requireArtifact(c, "publish", { split: true })
+    if (artifact instanceof Response) return artifact
+    const body = await readJson(c, artifactLinkBody)
+    if (body instanceof Response) return body
+    const skill = await requireArtifact(c, "read", { shortId: body.skill_short_id })
+    if (skill instanceof Response) return skill
+    if (skill.org_id !== artifact.org_id) return fail(c, 400, "skill must be in the same workspace")
+    const [artifactVersion, definition] = await Promise.all([
+      meta.getVersion(artifact.id, body.artifact_version),
+      skillDefinition(skill.id, body.skill_version),
+    ])
+    if (!artifactVersion) return fail(c, 400, "artifact version not found")
+    if (!definition) return fail(c, 400, "skill version not found")
+    const actor = (await actingHuman(c)) ?? (await actingUser(c))
+    const link = await meta.linkArtifactSkill({
+      id: newId("asl"),
+      org_id: artifact.org_id,
+      artifact_id: artifact.id,
+      artifact_version: body.artifact_version,
+      skill_artifact_id: skill.id,
+      skill_version: body.skill_version,
+      role: body.role as ArtifactSkillRole,
+      linked_by: actor?.id ?? "system",
+    })
+    return c.json({ link }, 201)
+  })
+
+  app.post("/v1/skill-migrations", async (c) => {
+    const orgId = await requireWorkspace(c, "manage")
+    if (orgId instanceof Response) return orgId
+    const body = await readJson(c, z.object({ apply: z.boolean().default(false) }))
+    if (body instanceof Response) return body
+    const human = await actingHuman(c)
+    if (!human) return fail(c, 403, "a signed-in workspace manager must run migrations")
+    const actor = (await actingUser(c)) ?? human
+    const report: Array<{
+      kind: "context" | "workflow"
+      id: string
+      action: "migrate" | "skip"
+      reason?: string
+      skill_short_id?: string
+    }> = []
+
+    // Context definitions can change bundle entry type without changing artifact identity:
+    // append SKILL.md + the private catalog sidecar to the same bundle.
+    const contexts = await meta.listContexts(orgId)
+    const manifests = new Map<string, (typeof contexts)[number]>()
+    for (const context of contexts) manifests.set(context.manifest_artifact_id, context)
+    for (const [artifactId, context] of manifests) {
+      const artifact = (
+        await meta.listArtifacts({ ids: [artifactId], orgId, archived: "include" })
+      )[0]
+      if (!artifact || artifact.current_content_type === SKILL_CONTENT_TYPE) {
+        report.push({ kind: "context", id: context.id, action: "skip", reason: "already a Skill" })
+        continue
+      }
+      if (!(await authorize(c, "publish", artifact))) {
+        report.push({
+          kind: "context",
+          id: context.id,
+          action: "skip",
+          reason: "no publish access to definition",
+        })
+        continue
+      }
+      const version = await meta.getVersion(artifact.id, artifact.current_version)
+      const manifest = version ? await manifestOf(blobs, version) : null
+      const text = version ? await pageTextResolver(blobs, version) : null
+      const manifestMd = manifest && text ? await text("/MANIFEST.md") : null
+      if (!version || !manifest || !manifestMd) {
+        report.push({
+          kind: "context",
+          id: context.id,
+          action: "skip",
+          reason: "no bundle MANIFEST.md",
+        })
+        continue
+      }
+      report.push({ kind: "context", id: context.id, action: "migrate" })
+      if (!body.apply) continue
+      const parsed = parseFrontmatter(manifestMd)
+      const name = skillName(context.name, artifact.short_id)
+      const description =
+        parsed.attrs.description?.trim() || `Run the ${context.name} Derive Context.`
+      const bytes = await mergeBundleZip(blobs, manifest, {
+        "SKILL.md": `---\nname: ${name}\ndescription: ${JSON.stringify(description)}\n---\n\n${parsed.body.trim()}\n`,
+        "derive.skill.json": JSON.stringify(
+          { schema: "derive.skill/v1", catalog: false, runtime: { kind: "single" } },
+          null,
+          2,
+        ),
+      })
+      const published = await publish(
+        meta,
+        blobs,
+        {
+          bytes,
+          filename: "skill.zip",
+          isBundle: true,
+          title: artifact.title ?? context.name,
+          message: "Auto-migrate Context manifest to Skill definition",
+          author: human.name,
+          authorId: human.id,
+          agentId: actor.id === human.id ? null : actor.id,
+          agentName: actor.id === human.id ? null : actor.name,
+          source: "api",
+          existingArtifact: artifact,
+        },
+        artifact.short_id,
+      )
+      await afterPublish(
+        {
+          meta,
+          blobs,
+          bus,
+          notify,
+          notifyRender,
+          background,
+          search,
+          summarize,
+          baseUrl: deps.baseUrl,
+        },
+        published.artifact,
+        published.version,
+        { isNew: false, onBehalf: human.id, actorId: actor.id, actorName: actor.name },
+      )
+    }
+
+    // A Workflow is a visual artifact and cannot become a bundle in place. Create a private
+    // launcher Skill, pin its exact runtime graph, link the original version, then give it a
+    // root Context. A pre-existing link is the idempotency receipt for retries.
+    const workflowCandidates = await meta.listFactAcrossArtifacts(orgId, WORKFLOW_DEFINITION_FACT, {
+      limit: 100,
+    })
+    const allowedWorkflowIds = await visibleArtifactIds(
+      meta,
+      workflowCandidates.map((row) => row.id),
+      { orgId, viewerId: human.id },
+    )
+    const workflowRows = workflowCandidates.filter((row) => allowedWorkflowIds.has(row.id))
+    const workflowFacts = await meta.currentVersionDataForArtifacts(
+      workflowRows.map((row) => row.id),
+      [LINKED_BUNDLE_FACT],
+    )
+    const factsByArtifact = new Map<string, { slot: string; json: string }[]>(
+      workflowRows.map((row) => [row.id, [{ slot: WORKFLOW_DEFINITION_FACT, json: row.json }]]),
+    )
+    for (const fact of workflowFacts) factsByArtifact.get(fact.artifact_id)?.push(fact)
+    for (const row of workflowRows) {
+      const existing = (await meta.listArtifactSkillLinks(row.id, row.n, orgId)).find(
+        (link) => link.role === "workflow-definition",
+      )
+      if (existing) {
+        const linkedSkill = (
+          await meta.listArtifacts({
+            ids: [existing.skill_artifact_id],
+            orgId,
+            archived: "include",
+          })
+        )[0]
+        // The exact provenance link is the durable migration receipt, but the root
+        // Context is a separate write. Repair that second half on replay if a prior
+        // attempt stopped between the two writes.
+        if (
+          body.apply &&
+          linkedSkill &&
+          !contexts.some((context) => context.manifest_artifact_id === linkedSkill.id)
+        ) {
+          try {
+            const created = await createContextCore(meta, {
+              orgId,
+              userId: human.id,
+              name: `${row.title ?? "Workflow"} Launcher · ${row.short_id}`,
+              manifestArtifactId: linkedSkill.id,
+            })
+            contexts.push(created.context)
+          } catch (error) {
+            if (!(error instanceof ContextConflictError)) throw error
+          }
+        }
+        report.push({
+          kind: "workflow",
+          id: row.short_id,
+          action: "skip",
+          reason: "already linked",
+          ...(linkedSkill ? { skill_short_id: linkedSkill.short_id } : {}),
+        })
+        continue
+      }
+      const parsed = parseLinkedWorkflowFacts(factsByArtifact.get(row.id) ?? [])
+      if (!parsed.definition) {
+        report.push({
+          kind: "workflow",
+          id: row.short_id,
+          action: "skip",
+          reason: "invalid definition",
+        })
+        continue
+      }
+      report.push({ kind: "workflow", id: row.short_id, action: "migrate" })
+      if (!body.apply) continue
+      const runtimeKind = parsed.definition.diagrams.some(
+        (diagram) => (diagram.loops?.length ?? 0) > 0,
+      )
+        ? "loop"
+        : "graph"
+      const name = skillName(`${row.title ?? "workflow"}-${row.short_id}`, row.short_id)
+      const skillMd = `---\nname: ${name}\ndescription: ${JSON.stringify(`Run the ${row.title ?? "workflow"} workflow through Derive.`)}\n---\n\nUse the Derive integration to run workflow artifact \`${row.short_id}\`. The graph, human gates, retries, and loop bounds remain authoritative in Derive.\n`
+      const bytes = await zipBundleFiles({
+        "SKILL.md": skillMd,
+        "derive.skill.json": JSON.stringify(
+          {
+            schema: "derive.skill/v1",
+            catalog: false,
+            runtime: { kind: runtimeKind, definition: parsed.definition },
+          },
+          null,
+          2,
+        ),
+      })
+      const sourceArtifact = (
+        await meta.listArtifacts({ ids: [row.id], orgId, archived: "include" })
+      )[0]
+      if (!sourceArtifact) continue
+      // The deterministic id is the recovery receipt for the one unavoidable gap
+      // between creating the launcher artifact and writing its provenance link. A
+      // replay reuses that exact derived Skill instead of publishing a duplicate.
+      const launcherShortId = workflowSkillShortId(row.short_id)
+      const recoverable = await meta.getByShortId(launcherShortId)
+      if (
+        recoverable &&
+        (recoverable.org_id !== orgId ||
+          recoverable.derived_from !== sourceArtifact.id ||
+          recoverable.current_content_type !== SKILL_CONTENT_TYPE)
+      ) {
+        const reportRow = report.at(-1)
+        if (reportRow) Object.assign(reportRow, { action: "skip", reason: "launcher id collision" })
+        continue
+      }
+      let launcherArtifact = recoverable
+      let launcherVersion = recoverable
+        ? await meta.getVersion(recoverable.id, recoverable.current_version)
+        : null
+      if (!launcherArtifact || !launcherVersion) {
+        const published = await publish(meta, blobs, {
+          bytes,
+          filename: "skill.zip",
+          isBundle: true,
+          title: `${row.title ?? "Workflow"} Skill`,
+          message: `Auto-migrate workflow ${row.short_id} to a launcher Skill`,
+          author: human.name,
+          authorId: human.id,
+          agentId: actor.id === human.id ? null : actor.id,
+          agentName: actor.id === human.id ? null : actor.name,
+          source: "api",
+          orgId,
+          workspaceAccess: sourceArtifact.workspace_access,
+          linkRole: "none",
+          listed: "none",
+          derivedFrom: sourceArtifact.id,
+          mintShortId: launcherShortId,
+        })
+        launcherArtifact = published.artifact
+        launcherVersion = published.version
+      }
+      await afterPublish(
+        {
+          meta,
+          blobs,
+          bus,
+          notify,
+          notifyRender,
+          background,
+          search,
+          summarize,
+          baseUrl: deps.baseUrl,
+        },
+        launcherArtifact,
+        launcherVersion,
+        { isNew: !recoverable, onBehalf: human.id, actorId: actor.id, actorName: actor.name },
+      )
+      await meta.linkArtifactSkill({
+        id: newId("asl"),
+        org_id: orgId,
+        artifact_id: row.id,
+        artifact_version: row.n,
+        skill_artifact_id: launcherArtifact.id,
+        skill_version: launcherVersion.n,
+        role: "workflow-definition",
+        linked_by: human.id,
+      })
+      try {
+        await createContextCore(meta, {
+          orgId,
+          userId: human.id,
+          name: `${row.title ?? "Workflow"} Launcher · ${row.short_id}`,
+          manifestArtifactId: launcherArtifact.id,
+        })
+      } catch (error) {
+        if (!(error instanceof ContextConflictError)) throw error
+      }
+      const reportRow = report.at(-1)
+      if (reportRow) reportRow.skill_short_id = launcherArtifact.short_id
+    }
+
+    return c.json({ applied: body.apply, report })
+  })
+
+  return app
+}
+
+const skillName = (value: string, fallback: string): string => {
+  const normalized = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64)
+    .replace(/-+$/g, "")
+  return (
+    normalized ||
+    fallback
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .slice(0, 64)
+  )
+}
+
+const workflowSkillShortId = (sourceShortId: string): string => `skill-${sourceShortId}`

--- a/apps/api/test/artifacts.test.ts
+++ b/apps/api/test/artifacts.test.ts
@@ -964,7 +964,9 @@ describe("api surface", () => {
     // store-level filter is what makes a skills listing cheap. Both dialects run
     // this file (sqlite by default, pg via DERIVE_TEST_DB=pg).
     const zip = zipSync({
-      "SKILL.md": new TextEncoder().encode("---\nname: filter-probe\n---\n# P"),
+      "SKILL.md": new TextEncoder().encode(
+        "---\nname: filter-probe\ndescription: Filters skills.\n---\n# P",
+      ),
     })
     const { short_id: skillShort } = await (
       await upload("skill.zip", zip, { title: "Filter probe" })
@@ -1000,6 +1002,126 @@ describe("api surface", () => {
     expect((await app.request("/v1/artifacts/zzzzzzzz")).status).toBe(404)
     const bad = await upload("dist.zip", zipSync({}))
     expect(bad.status).toBe(400)
+  })
+})
+
+describe("Skills product surface", () => {
+  const publishSkill = async (
+    name: string,
+    sidecar: Record<string, unknown> = { schema: "derive.skill/v1" },
+  ) => {
+    const zip = zipSync({
+      "SKILL.md": new TextEncoder().encode(
+        `---\nname: ${name}\ndescription: Use ${name}.\n---\n\n# ${name}`,
+      ),
+      "derive.skill.json": new TextEncoder().encode(JSON.stringify(sidecar)),
+    })
+    return (await upload(`${name}.zip`, zip, { title: name })).json()
+  }
+
+  it("lists catalog skills, hides embedded ones, and returns permission-filtered graph edges", async () => {
+    const target = await publishSkill("graph-target")
+    const hidden = await publishSkill("embedded-only", {
+      schema: "derive.skill/v1",
+      catalog: false,
+    })
+    const source = await publishSkill("graph-source", {
+      schema: "derive.skill/v1",
+      relations: { requires: [{ id: target.short_id, version: 1 }] },
+    })
+    const catalog = await (await app.request("/v1/skills")).json()
+    expect(catalog.skills.map((skill: { short_id: string }) => skill.short_id)).toContain(
+      source.short_id,
+    )
+    expect(catalog.skills.map((skill: { short_id: string }) => skill.short_id)).not.toContain(
+      hidden.short_id,
+    )
+    const graph = await (await app.request(`/v1/artifacts/${source.short_id}/skill-graph`)).json()
+    const sourceArtifact = await meta.getByShortId(source.short_id)
+    const targetArtifact = await meta.getByShortId(target.short_id)
+    expect(graph.edges).toContainEqual(
+      expect.objectContaining({
+        source_artifact_id: sourceArtifact?.id,
+        target_artifact_id: targetArtifact?.id,
+        source_version: 1,
+        target_version: 1,
+        kind: "requires",
+      }),
+    )
+  })
+
+  it("pages past embedded Skills instead of letting them crowd catalog results out", async () => {
+    const visible = await publishSkill("crowding-visible")
+    for (let index = 0; index < 5; index += 1) {
+      await publishSkill(`crowding-hidden-${index}`, {
+        schema: "derive.skill/v1",
+        catalog: false,
+      })
+    }
+
+    const catalog = await (await app.request("/v1/skills?limit=1&query=crowding")).json()
+    expect(catalog.skills).toHaveLength(1)
+    expect(catalog.skills[0]?.short_id).toBe(visible.short_id)
+    expect(catalog.has_more).toBe(false)
+  })
+
+  it("records installation receipts and exact-version artifact provenance", async () => {
+    const skill = await publishSkill("receipt-skill")
+    const output = await (await upload("output.md", "# made with skill")).json()
+    const outputArtifact = await meta.getByShortId(output.short_id)
+    const receipt = await app.request(`/v1/artifacts/${skill.short_id}/skill-installation`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        skill_version: 1,
+        scope_kind: "project",
+        opaque_scope_id: "a".repeat(64),
+        client: "codex",
+        digest: "b".repeat(64),
+        policy: "pinned",
+      }),
+    })
+    expect(receipt.status).toBe(200)
+    const linked = await app.request(`/v1/artifacts/${output.short_id}/skills`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        artifact_version: 1,
+        skill_short_id: skill.short_id,
+        skill_version: 1,
+        role: "created",
+      }),
+    })
+    expect(linked.status).toBe(201)
+    const usage = await (await app.request(`/v1/artifacts/${skill.short_id}/skill-usage`)).json()
+    expect(usage.installations).toContainEqual(
+      expect.objectContaining({ client: "codex", scope_kind: "project", count: 1 }),
+    )
+    expect(usage.artifacts).toContainEqual(
+      expect.objectContaining({
+        artifact_id: outputArtifact?.id,
+        artifact_version: 1,
+        role: "created",
+      }),
+    )
+    expect(usage).toMatchObject({ contexts: [], workflows: [] })
+  })
+
+  it("rejects unresolved exact-version relations before a Skill version goes live", async () => {
+    const zip = zipSync({
+      "SKILL.md": new TextEncoder().encode(
+        "---\nname: broken-relation\ndescription: Broken on purpose.\n---\n# Broken",
+      ),
+      "derive.skill.json": new TextEncoder().encode(
+        JSON.stringify({
+          schema: "derive.skill/v1",
+          relations: { requires: [{ id: "missing99", version: 7 }] },
+        }),
+      ),
+    })
+    const response = await upload("broken.zip", zip)
+    expect(response.status).toBe(400)
+    expect(await response.text()).toContain("missing99@v7 was not found")
   })
 })
 

--- a/apps/api/test/contexts.test.ts
+++ b/apps/api/test/contexts.test.ts
@@ -117,6 +117,14 @@ describe("Context manifest to Skill migration", () => {
       name: "release-context",
       description: "Answers release questions.",
     })
+    const catalog = await (await app.request("/v1/skills", { headers: as(owner.email) })).json()
+    expect(catalog.skills).toContainEqual(expect.objectContaining({ short_id: artifact.short_id }))
+    const contextList = await (
+      await app.request("/v1/contexts", { headers: as(owner.email) })
+    ).json()
+    expect(contextList.contexts).toContainEqual(
+      expect.objectContaining({ manifest_short_id: artifact.short_id }),
+    )
 
     const replay = await app.request(
       "/v1/skill-migrations",

--- a/apps/api/test/contexts.test.ts
+++ b/apps/api/test/contexts.test.ts
@@ -58,6 +58,75 @@ describe("contexts: create + wire an agent to a manifest", () => {
   })
 })
 
+describe("Context manifest to Skill migration", () => {
+  const owner: TestUser = {
+    id: "u_skill_migrate",
+    email: "skill-migrate@derive.test",
+    name: "Owner",
+  }
+  const { app, meta } = makeAuthedApp("contexts-skill-migrate", [owner])
+
+  it("previews without writing, then appends a private Skill version on the same artifact", async () => {
+    const files = zipSync({
+      "MANIFEST.md": new TextEncoder().encode(
+        "---\ndescription: Answers release questions.\n---\n\n# Release guide\n\nUse the repository evidence.",
+      ),
+      "references/checklist.md": new TextEncoder().encode("# Checklist"),
+    })
+    const form = new FormData()
+    form.append("file", new Blob([files as BlobPart]), "manifest.zip")
+    form.append("title", "Release Context")
+    const artifact = await (
+      await app.request("/v1/artifacts", { method: "POST", body: form, headers: as(owner.email) })
+    ).json()
+    const created = await app.request(
+      "/v1/contexts",
+      jsonAs(as(owner.email), {
+        name: "Release Context",
+        manifest_short_id: artifact.short_id,
+      }),
+    )
+    expect(created.status).toBe(201)
+
+    const preview = await app.request(
+      "/v1/skill-migrations",
+      jsonAs(as(owner.email), { apply: false }),
+    )
+    expect(preview.status).toBe(200)
+    expect(await preview.json()).toMatchObject({
+      applied: false,
+      report: [expect.objectContaining({ kind: "context", action: "migrate" })],
+    })
+    expect((await meta.getByShortId(artifact.short_id))?.current_version).toBe(1)
+
+    const applied = await app.request(
+      "/v1/skill-migrations",
+      jsonAs(as(owner.email), { apply: true }),
+    )
+    expect(applied.status).toBe(200)
+    const migrated = await meta.getByShortId(artifact.short_id)
+    expect(migrated).toMatchObject({
+      current_version: 2,
+      current_content_type: "derive/skill",
+    })
+    const detail = await (
+      await app.request(`/v1/artifacts/${artifact.short_id}`, { headers: as(owner.email) })
+    ).json()
+    expect(detail.bundle).toMatchObject({
+      isSkill: true,
+      name: "release-context",
+      description: "Answers release questions.",
+    })
+
+    const replay = await app.request(
+      "/v1/skill-migrations",
+      jsonAs(as(owner.email), { apply: true }),
+    )
+    expect(replay.status).toBe(200)
+    expect((await meta.getByShortId(artifact.short_id))?.current_version).toBe(2)
+  })
+})
+
 describe("sessions: the ask → answer → follow-up loop", () => {
   const owner: TestUser = { id: "u_ss_own", email: "ssown@derive.test", name: "Owner" }
   const daniel: TestUser = { id: "u_ss_dan", email: "ssdan@derive.test", name: "Daniel" }

--- a/apps/api/test/embeds.test.ts
+++ b/apps/api/test/embeds.test.ts
@@ -258,7 +258,8 @@ describe("agent-readable share URLs (.md + Accept: text/markdown)", () => {
   it("passes a markdown-entry bundle (a skill) through verbatim", async () => {
     // pickBundleEntry prefers SKILL.md over non-root HTML, so a skill's entry is
     // markdown — running it through the HTML converter would strip its structure.
-    const source = "---\nname: my-skill\n---\n\n# My Skill\n\nUse when X.\n"
+    const source =
+      "---\nname: my-skill\ndescription: Use when X.\n---\n\n# My Skill\n\nUse when X.\n"
     const zip = zipSync({
       "SKILL.md": new TextEncoder().encode(source),
       "assets/demo.html": new TextEncoder().encode("<h1>demo</h1>"),

--- a/apps/api/test/mcp-surface-budget.test.ts
+++ b/apps/api/test/mcp-surface-budget.test.ts
@@ -265,7 +265,13 @@ describe("MCP surface budget (thin tools, thick skills)", () => {
     const form = new FormData()
     form.append(
       "file",
-      new Blob([zipSync({ "SKILL.md": new TextEncoder().encode("---\nname: probe\n---\n# P") })]),
+      new Blob([
+        zipSync({
+          "SKILL.md": new TextEncoder().encode(
+            "---\nname: probe\ndescription: Budget probe.\n---\n# P",
+          ),
+        }),
+      ]),
       "skill.zip",
     )
     form.append("title", "Budget probe")

--- a/apps/api/test/rework.test.ts
+++ b/apps/api/test/rework.test.ts
@@ -1,5 +1,5 @@
 import { generateKeyPairSync } from "node:crypto"
-import { publish } from "@derive/core"
+import { publish, validateSkillDefinition } from "@derive/core"
 import { zipSync } from "fflate"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { encryptSecret } from "../src/lib/crypto"
@@ -402,6 +402,23 @@ describe("workflow run: explicit local-agent handoff", () => {
     })
     const skill = await meta.getArtifactById(links[0]?.skill_artifact_id ?? "")
     expect(skill?.current_content_type).toBe("derive/skill")
+    const skillMd = await (
+      await app.request(`/v1/artifacts/${skill?.short_id}/content`, { headers: as(owner.email) })
+    ).text()
+    const sidecar = await (
+      await app.request(`/v1/artifacts/${skill?.short_id}/content?section=derive.skill.json`, {
+        headers: as(owner.email),
+      })
+    ).text()
+    expect(validateSkillDefinition(skillMd, sidecar).errors).toEqual([])
+    const catalog = await (await app.request("/v1/skills", { headers: as(owner.email) })).json()
+    expect(catalog.skills).toContainEqual(expect.objectContaining({ short_id: skill?.short_id }))
+    const workflows = await (
+      await app.request("/v1/workflows", { headers: as(owner.email) })
+    ).json()
+    expect(workflows.workflows).toContainEqual(
+      expect.objectContaining({ shortId: published.short_id }),
+    )
     const launcher = (await meta.listContexts("default")).find(
       (context) => context.manifest_artifact_id === skill?.id,
     )

--- a/apps/api/test/rework.test.ts
+++ b/apps/api/test/rework.test.ts
@@ -1,4 +1,6 @@
 import { generateKeyPairSync } from "node:crypto"
+import { publish } from "@derive/core"
+import { zipSync } from "fflate"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { encryptSecret } from "../src/lib/crypto"
 import { upsertGithubConnection } from "../src/lib/github-connection"
@@ -363,6 +365,118 @@ describe("workflow run: explicit local-agent handoff", () => {
       status: "ready",
     })
     expect(body.workflows.some((workflow) => workflow.shortId === hidden.short_id)).toBe(false)
+  })
+
+  it("migrates a Workflow to a linked launcher Skill without changing the original", async () => {
+    const { app, meta } = makeAuthedApp("workflow-skill-migrate", [owner])
+    const published = await (
+      await publishAs(app, workflowHtml(), { title: "Weekly brief" }, as(owner.email))
+    ).json()
+    const source = await meta.getByShortId(published.short_id)
+    expect(source?.current_content_type).toBe("text/x-derive-linked-bundle")
+
+    const migrated = await app.request(
+      "/v1/skill-migrations",
+      jsonAs(as(owner.email), { apply: true }),
+    )
+    expect(migrated.status).toBe(200)
+    const body = await migrated.json()
+    expect(body.report).toContainEqual(
+      expect.objectContaining({
+        kind: "workflow",
+        id: published.short_id,
+        action: "migrate",
+        skill_short_id: expect.any(String),
+      }),
+    )
+    expect(await meta.getByShortId(published.short_id)).toMatchObject({
+      current_version: 1,
+      current_content_type: "text/x-derive-linked-bundle",
+    })
+    const links = await meta.listArtifactSkillLinks(source?.id ?? "", 1, "default")
+    expect(links).toHaveLength(1)
+    expect(links[0]).toMatchObject({
+      role: "workflow-definition",
+      artifact_version: 1,
+      skill_version: 1,
+    })
+    const skill = await meta.getArtifactById(links[0]?.skill_artifact_id ?? "")
+    expect(skill?.current_content_type).toBe("derive/skill")
+    const launcher = (await meta.listContexts("default")).find(
+      (context) => context.manifest_artifact_id === skill?.id,
+    )
+    expect(launcher).toBeDefined()
+
+    // The link and root Context are separate durable writes. A replay repairs a
+    // missing Context instead of treating the provenance receipt as fully complete.
+    await meta.deleteContext(launcher?.id ?? "", "default")
+
+    const replay = await app.request(
+      "/v1/skill-migrations",
+      jsonAs(as(owner.email), { apply: true }),
+    )
+    expect(replay.status).toBe(200)
+    expect(await meta.listArtifactSkillLinks(source?.id ?? "", 1, "default")).toHaveLength(1)
+    expect(
+      (await meta.listContexts("default")).some(
+        (context) => context.manifest_artifact_id === skill?.id,
+      ),
+    ).toBe(true)
+  })
+
+  it("reuses the deterministic launcher after a publish-to-link interruption", async () => {
+    const { app, meta, ctx } = makeAuthedApp("workflow-skill-publish-link-repair", [owner])
+    const published = await (
+      await publishAs(app, workflowHtml(), { title: "Interrupted brief" }, as(owner.email))
+    ).json()
+    const source = await meta.getByShortId(published.short_id)
+    expect(source).toBeDefined()
+    // Seed the durable state left by an interruption immediately after publish but
+    // before linkArtifactSkill. This uses only the MetaStore contract, so the same
+    // recovery case runs against SQLite, D1, and the Postgres proxy facade.
+    await publish(meta, ctx.blobs, {
+      bytes: zipSync({
+        "SKILL.md": new TextEncoder().encode(
+          "---\nname: interrupted-brief\ndescription: Resume an interrupted workflow migration.\n---\n\n# Launcher",
+        ),
+        "derive.skill.json": new TextEncoder().encode(
+          JSON.stringify({ schema: "derive.skill/v1", catalog: false }),
+        ),
+      }),
+      filename: "skill.zip",
+      isBundle: true,
+      title: "Interrupted brief Skill",
+      author: owner.name ?? "Owner",
+      authorId: owner.id,
+      source: "api",
+      orgId: "default",
+      workspaceAccess: "member",
+      linkRole: "none",
+      listed: "none",
+      derivedFrom: source?.id,
+      mintShortId: `skill-${published.short_id}`,
+    })
+    const afterFailure = (
+      await meta.listArtifacts({ orgId: "default", contentType: "derive/skill" })
+    ).filter((artifact) => artifact.derived_from === source?.id)
+    expect(afterFailure).toHaveLength(1)
+    expect(afterFailure[0]?.short_id).toBe(`skill-${published.short_id}`)
+
+    const replay = await app.request(
+      "/v1/skill-migrations",
+      jsonAs(as(owner.email), { apply: true }),
+    )
+    expect(replay.status).toBe(200)
+    const afterReplay = (
+      await meta.listArtifacts({ orgId: "default", contentType: "derive/skill" })
+    ).filter((artifact) => artifact.derived_from === source?.id)
+    expect(afterReplay).toHaveLength(1)
+    expect(await meta.listArtifactSkillLinks(source?.id ?? "", 1, "default")).toHaveLength(1)
+    expect(
+      (await meta.listContexts("default")).some(
+        (context) => context.manifest_artifact_id === afterReplay[0]?.id,
+      ),
+    ).toBe(true)
   })
 
   it("GET previews without running; POST pins a fresh run and queues its instruction", async () => {

--- a/apps/api/test/rework.test.ts
+++ b/apps/api/test/rework.test.ts
@@ -412,7 +412,12 @@ describe("workflow run: explicit local-agent handoff", () => {
     ).text()
     expect(validateSkillDefinition(skillMd, sidecar).errors).toEqual([])
     const catalog = await (await app.request("/v1/skills", { headers: as(owner.email) })).json()
-    expect(catalog.skills).toContainEqual(expect.objectContaining({ short_id: skill?.short_id }))
+    expect(catalog.skills).toContainEqual(
+      expect.objectContaining({
+        short_id: skill?.short_id,
+        skill: expect.objectContaining({ workflow_launcher: true }),
+      }),
+    )
     const reverseLinks = await (
       await app.request(`/v1/artifacts/${published.short_id}/skills`, {
         headers: as(owner.email),

--- a/apps/api/test/rework.test.ts
+++ b/apps/api/test/rework.test.ts
@@ -413,6 +413,22 @@ describe("workflow run: explicit local-agent handoff", () => {
     expect(validateSkillDefinition(skillMd, sidecar).errors).toEqual([])
     const catalog = await (await app.request("/v1/skills", { headers: as(owner.email) })).json()
     expect(catalog.skills).toContainEqual(expect.objectContaining({ short_id: skill?.short_id }))
+    const reverseLinks = await (
+      await app.request(`/v1/artifacts/${published.short_id}/skills`, {
+        headers: as(owner.email),
+      })
+    ).json()
+    expect(reverseLinks.links).toContainEqual(
+      expect.objectContaining({
+        artifact_version: 1,
+        skill_version: 1,
+        role: "workflow-definition",
+        skill: expect.objectContaining({
+          short_id: skill?.short_id,
+          current_version: 1,
+        }),
+      }),
+    )
     const workflows = await (
       await app.request("/v1/workflows", { headers: as(owner.email) })
     ).json()
@@ -439,6 +455,28 @@ describe("workflow run: explicit local-agent handoff", () => {
         (context) => context.manifest_artifact_id === skill?.id,
       ),
     ).toBe(true)
+
+    // The durable relationship survives later Workflow revisions while preserving
+    // the exact versions that originally established provenance.
+    const revised = await publishAs(
+      app,
+      workflowHtml(),
+      { title: "Weekly brief" },
+      as(owner.email),
+      published.short_id,
+    )
+    expect(revised.status).toBe(201)
+    const historicalReverseLinks = await (
+      await app.request(`/v1/artifacts/${published.short_id}/skills`, {
+        headers: as(owner.email),
+      })
+    ).json()
+    expect(historicalReverseLinks.links).toContainEqual(
+      expect.objectContaining({
+        artifact_version: 1,
+        skill: expect.objectContaining({ short_id: skill?.short_id }),
+      }),
+    )
   })
 
   it("reuses the deterministic launcher after a publish-to-link interruption", async () => {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -614,7 +614,12 @@ export interface SkillCard {
   current_content_type: string | null
   updated_at: string | null
   created_at: string
-  skill: { name: string; description: string; runtime: "single" | "graph" | "loop" }
+  skill: {
+    name: string
+    description: string
+    runtime: "single" | "graph" | "loop"
+    workflow_launcher: boolean
+  }
 }
 export interface SkillRelation {
   id: string

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -648,6 +648,18 @@ export interface SkillUsage {
     artifact: { short_id: string; title: string | null } | null
   }>
 }
+export interface ArtifactSkills {
+  links: Array<{
+    id: string
+    artifact_id: string
+    artifact_version: number
+    skill_artifact_id: string
+    skill_version: number
+    role: "created" | "revised" | "validated" | "example" | "anti-example" | "workflow-definition"
+    created_at: string
+    skill: { short_id: string; title: string | null; current_version: number } | null
+  }>
+}
 
 // A per-user connected external account (WO3) — a Source. Always the caller's own.
 export interface Connection {
@@ -871,6 +883,8 @@ export const api = {
     f(`/v1/artifacts/${encodeURIComponent(shortId)}/skill-graph`, opts()).then(j),
   skillUsage: (shortId: string): Promise<SkillUsage> =>
     f(`/v1/artifacts/${encodeURIComponent(shortId)}/skill-usage`, opts()).then(j),
+  artifactSkills: (shortId: string): Promise<ArtifactSkills> =>
+    f(`/v1/artifacts/${encodeURIComponent(shortId)}/skills`, opts()).then(j),
   // The batched boot read: exactly the four bodies below (tags summary, collections,
   // workspace settings, notifications), one authenticated request. The client seeds
   // the four individual query caches from it — see lib/bootstrap.ts. Typed against the

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -607,6 +607,48 @@ export interface SearchHit {
   semantic: boolean
 }
 
+export interface SkillCard {
+  short_id: string
+  title: string | null
+  current_version: number
+  current_content_type: string | null
+  updated_at: string | null
+  created_at: string
+  skill: { name: string; description: string; runtime: "single" | "graph" | "loop" }
+}
+export interface SkillRelation {
+  id: string
+  source_artifact_id: string
+  source_version: number
+  target_artifact_id: string
+  target_version: number
+  kind: "requires" | "extends" | "recommends"
+}
+export interface SkillGraph {
+  root: string
+  nodes: Array<{ id: string; short_id: string; title: string | null; version: number }>
+  edges: SkillRelation[]
+}
+export interface SkillUsage {
+  contexts: Array<{ skill_version: number; count: number; last_used_at: string }>
+  workflows: Array<{ skill_version: number; count: number; last_used_at: string }>
+  installations: Array<{
+    scope_kind: "project" | "personal" | "runner"
+    client: "claude" | "codex"
+    count: number
+    last_synced_at: string
+  }>
+  artifacts: Array<{
+    id: string
+    artifact_id: string
+    artifact_version: number
+    skill_version: number
+    role: "created" | "revised" | "validated" | "example" | "anti-example" | "workflow-definition"
+    created_at: string
+    artifact: { short_id: string; title: string | null } | null
+  }>
+}
+
 // A per-user connected external account (WO3) — a Source. Always the caller's own.
 export interface Connection {
   id: string
@@ -820,6 +862,15 @@ export const api = {
   }> => {
     return f(artifactsListPath(params), opts(undefined, init)).then(j)
   },
+  listSkills: (query?: string): Promise<{ skills: SkillCard[]; has_more: boolean }> =>
+    f(
+      `/v1/skills${query?.trim() ? `?query=${encodeURIComponent(query.trim())}` : ""}`,
+      opts(),
+    ).then(j),
+  skillGraph: (shortId: string): Promise<SkillGraph> =>
+    f(`/v1/artifacts/${encodeURIComponent(shortId)}/skill-graph`, opts()).then(j),
+  skillUsage: (shortId: string): Promise<SkillUsage> =>
+    f(`/v1/artifacts/${encodeURIComponent(shortId)}/skill-usage`, opts()).then(j),
   // The batched boot read: exactly the four bodies below (tags summary, collections,
   // workspace settings, notifications), one authenticated request. The client seeds
   // the four individual query caches from it — see lib/bootstrap.ts. Typed against the

--- a/apps/web/src/components/chrome/command-palette.tsx
+++ b/apps/web/src/components/chrome/command-palette.tsx
@@ -268,6 +268,7 @@ export function CommandPalette() {
   const showFav = "favorites".includes(q)
   const showFollowing = "following".includes(q)
   const showTemplates = "templates".includes(q) || "start from a template".includes(q)
+  const showSkills = "skills".includes(q) || "shared skills".includes(q)
   // The way back to the connection instructions after onboarding.
   const showConnect =
     "connect an agent".includes(q) || "getting started".includes(q) || "mcp setup".includes(q)
@@ -292,6 +293,7 @@ export function CommandPalette() {
     !showFav &&
     !showFollowing &&
     !showTemplates &&
+    !showSkills &&
     !showConnect
 
   return (
@@ -376,7 +378,12 @@ export function CommandPalette() {
               </CommandGroup>
             )}
 
-            {(showAll || showFav || showFollowing || showTemplates || showConnect) && (
+            {(showAll ||
+              showFav ||
+              showFollowing ||
+              showTemplates ||
+              showSkills ||
+              showConnect) && (
               <CommandGroup heading="Jump to">
                 {showAll && (
                   <CommandItem
@@ -408,6 +415,14 @@ export function CommandPalette() {
                     onSelect={() => go(() => nav({ to: "/templates" }))}
                   >
                     <Icon name="templates" size={16} /> Templates
+                  </CommandItem>
+                )}
+                {showSkills && (
+                  <CommandItem
+                    value="jump-skills"
+                    onSelect={() => go(() => nav({ to: "/skills" }))}
+                  >
+                    <Icon name="skill" size={16} /> Skills
                   </CommandItem>
                 )}
                 {showConnect && (

--- a/apps/web/src/components/chrome/nav-rail.tsx
+++ b/apps/web/src/components/chrome/nav-rail.tsx
@@ -150,7 +150,7 @@ function NavItem({
   icon: IconName
   label: string
   count?: number
-  to: "/following" | "/contexts" | "/workflows" | "/templates" | "/chat"
+  to: "/following" | "/contexts" | "/skills" | "/workflows" | "/templates" | "/chat"
   active: boolean
   testId?: string
 }) {
@@ -380,6 +380,7 @@ export function NavRail() {
   const isAll = onLibrary && !search.collection
   const onContexts = loc.pathname.startsWith("/contexts") || loc.pathname.startsWith("/agents")
   const onWorkflows = loc.pathname.startsWith("/workflows")
+  const onSkills = loc.pathname.startsWith("/skills")
   const onTemplates = loc.pathname.startsWith("/templates")
   const onSettings = loc.pathname.startsWith("/settings")
   const onChat = loc.pathname.startsWith("/chat")
@@ -429,6 +430,13 @@ export function NavRail() {
                 to="/templates"
                 active={onTemplates}
                 testId="nav-templates"
+              />
+              <NavItem
+                icon="skill"
+                label="Skills"
+                to="/skills"
+                active={onSkills}
+                testId="nav-skills"
               />
               <NavItem
                 icon="context"

--- a/apps/web/src/components/icons.tsx
+++ b/apps/web/src/components/icons.tsx
@@ -61,6 +61,7 @@ import {
   Undo2,
   User,
   Users,
+  WandSparkles,
   X,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
@@ -80,6 +81,7 @@ const REG = {
   repo: FolderGit2,
   context: Bot,
   workflow: GitFork,
+  skill: WandSparkles,
   templates: LayoutTemplate,
   derive: GitFork,
   // Brandprint — the brand's fingerprint.

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -152,10 +152,32 @@ export const collectionSiblingsQuery = (collectionId: string) =>
 export const workspaceSkillsQuery = () =>
   queryOptions({
     queryKey: ["artifacts", "workspace-skills"] as const,
-    queryFn: () =>
-      api
-        .listArtifacts({ limit: 100 })
-        .then((r) => r.artifacts.filter((a) => a.current_content_type === "derive/skill")),
+    queryFn: () => api.listSkills().then((r) => r.skills),
+  })
+
+export const skillsQuery = (query = "") =>
+  queryOptions({
+    queryKey: ["skills", query] as const,
+    queryFn: () => api.listSkills(query),
+  })
+
+export const skillGraphQuery = (shortId: string) =>
+  queryOptions({
+    queryKey: ["skills", shortId, "graph"] as const,
+    queryFn: () => api.skillGraph(shortId),
+  })
+
+export const skillUsageQuery = (shortId: string) =>
+  queryOptions({
+    queryKey: ["skills", shortId, "usage"] as const,
+    queryFn: () => api.skillUsage(shortId),
+    // Installs arrive from the CLI and provenance can be written by an external
+    // agent, so no in-app mutation exists to invalidate this cache. Always refresh
+    // when the workbench mounts or regains focus; persisted 30s-old data made a hard
+    // reload visibly contradict the API during acceptance testing.
+    staleTime: 0,
+    refetchOnMount: "always",
+    refetchOnWindowFocus: "always",
   })
 
 // The caller's own connected sources. NO UI CONSUMES THIS YET, on purpose: the Sources

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -180,6 +180,12 @@ export const skillUsageQuery = (shortId: string) =>
     refetchOnWindowFocus: "always",
   })
 
+export const artifactSkillsQuery = (shortId: string) =>
+  queryOptions({
+    queryKey: ["artifacts", shortId, "skills"] as const,
+    queryFn: () => api.artifactSkills(shortId),
+  })
+
 // The caller's own connected sources. NO UI CONSUMES THIS YET, on purpose: the Sources
 // settings screen was removed because neither broker can produce a usable connection. The
 // local broker reports `active` immediately and then echoes a tool's own arguments back

--- a/apps/web/src/pages/artifact/bundle-bar.tsx
+++ b/apps/web/src/pages/artifact/bundle-bar.tsx
@@ -139,6 +139,9 @@ function SkillWorkbench({
               >
                 <Icon name="workflow" size={14} /> Workflow:{" "}
                 {workflowLinks[0].artifact.title ?? workflowLinks[0].artifact.short_id}
+                <span className="font-mono text-2xs text-muted-foreground">
+                  v{workflowLinks[0].artifact_version}
+                </span>
               </Link>
             </Button>
           ) : workflowLinks.length > 1 ? (

--- a/apps/web/src/pages/artifact/bundle-bar.tsx
+++ b/apps/web/src/pages/artifact/bundle-bar.tsx
@@ -1,5 +1,9 @@
+import { useQuery } from "@tanstack/react-query"
+import { Link } from "@tanstack/react-router"
 import { API_BASE, type Artifact } from "@/api"
 import { Badge } from "@/components/ui/badge"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { skillGraphQuery, skillUsageQuery } from "@/lib/queries"
 
 /**
  * Header chrome for a markdown bundle (a skill — entry SKILL.md — or a plain docs
@@ -23,6 +27,8 @@ export function BundleBar({
   // The entry doc IS the page below; list only the supporting files.
   const files = bundle.files.filter((f) => f.path !== bundle.entry)
   if (!bundle.isSkill && files.length === 0) return null
+  if (bundle.isSkill)
+    return <SkillWorkbench bundle={bundle} shortId={shortId} version={version} files={files} />
   return (
     // Toolbar canon: matches the view bar in index.tsx (px-4 py-2 border-border).
     <div className="flex flex-col gap-2 border-b border-border px-4 py-2" data-testid="bundle-bar">
@@ -62,5 +68,186 @@ export function BundleBar({
         </div>
       )}
     </div>
+  )
+}
+
+function SkillWorkbench({
+  bundle,
+  shortId,
+  version,
+  files,
+}: {
+  bundle: NonNullable<Artifact["bundle"]>
+  shortId: string
+  version: number
+  files: NonNullable<Artifact["bundle"]>["files"]
+}) {
+  const graph = useQuery(skillGraphQuery(shortId))
+  const usage = useQuery(skillUsageQuery(shortId))
+  const nodeById = new Map((graph.data?.nodes ?? []).map((node) => [node.id, node]))
+  const activeInstalls = (usage.data?.installations ?? []).reduce(
+    (sum, item) => sum + item.count,
+    0,
+  )
+  const contextRuns = (usage.data?.contexts ?? []).reduce((sum, item) => sum + item.count, 0)
+  const workflowRuns = (usage.data?.workflows ?? []).reduce((sum, item) => sum + item.count, 0)
+  const fileUrl = (path: string) => `${API_BASE}/raw/${shortId}/v/${version}/${path}`
+
+  return (
+    <div className="border-b border-border bg-card/60" data-testid="skill-workbench">
+      <div className="flex flex-wrap items-start justify-between gap-3 px-4 pt-3">
+        <div>
+          <div className="flex items-center gap-2">
+            <Badge variant="brand" shape="pill" className="uppercase tracking-wide">
+              Skill
+            </Badge>
+            <span className="font-serif text-base font-medium tracking-tight text-foreground">
+              {bundle.name ?? shortId}
+            </span>
+            <span className="font-mono text-2xs text-muted-foreground">v{version}</span>
+          </div>
+          {bundle.description && (
+            <p className="mt-1 max-w-3xl text-sm text-muted-foreground">{bundle.description}</p>
+          )}
+        </div>
+        <div className="flex gap-1.5">
+          <Badge variant="outline" shape="pill">
+            Claude
+          </Badge>
+          <Badge variant="outline" shape="pill">
+            Codex
+          </Badge>
+        </div>
+      </div>
+
+      <Tabs defaultValue="overview" className="mt-2">
+        <TabsList variant="line" className="px-4" aria-label="Skill views">
+          <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="graph">Graph</TabsTrigger>
+          <TabsTrigger value="usage">Usage</TabsTrigger>
+          <TabsTrigger value="artifacts">Artifacts</TabsTrigger>
+          <TabsTrigger value="files">Files</TabsTrigger>
+        </TabsList>
+        <TabsContent value="overview" className="px-4 py-3">
+          <div className="grid gap-2 sm:grid-cols-4">
+            <Metric value={graph.data?.edges.length ?? 0} label="connections" />
+            <Metric value={activeInstalls} label="active installs" />
+            <Metric value={contextRuns} label="Context runs" />
+            <Metric value={workflowRuns} label="Workflow runs" />
+          </div>
+        </TabsContent>
+        <TabsContent value="graph" className="px-4 py-3">
+          {graph.isPending ? (
+            <Muted>Loading connections…</Muted>
+          ) : graph.isError ? (
+            <Muted>Connections couldn’t be loaded.</Muted>
+          ) : graph.data.edges.length ? (
+            <div className="flex flex-col gap-2">
+              {graph.data.edges.map((edge) => {
+                const incoming = edge.target_artifact_id === graph.data.root
+                const connected = nodeById.get(
+                  incoming ? edge.source_artifact_id : edge.target_artifact_id,
+                )
+                return (
+                  <div
+                    key={edge.id}
+                    className="flex flex-wrap items-center gap-2 rounded-lg border bg-background px-3 py-2 text-sm"
+                  >
+                    <Badge variant="outline" shape="pill">
+                      {incoming ? `used by · ${edge.kind}` : edge.kind}
+                    </Badge>
+                    {connected ? (
+                      <Link
+                        to="/artifacts/$ref"
+                        params={{ ref: connected.short_id }}
+                        className="font-medium hover:underline"
+                      >
+                        {connected.title ?? connected.short_id}
+                      </Link>
+                    ) : (
+                      <span>Unavailable skill</span>
+                    )}
+                    <span className="ml-auto font-mono text-2xs text-muted-foreground">
+                      v{incoming ? edge.source_version : edge.target_version}
+                    </span>
+                  </div>
+                )
+              })}
+            </div>
+          ) : (
+            <Muted>
+              This skill stands alone. Add requires, extends, or recommends in derive.skill.json.
+            </Muted>
+          )}
+        </TabsContent>
+        <TabsContent value="usage" className="px-4 py-3">
+          <div className="grid gap-2 sm:grid-cols-3">
+            <Metric value={activeInstalls} label="active installs" />
+            <Metric value={contextRuns} label="Context runs" />
+            <Metric value={workflowRuns} label="Workflow runs" />
+          </div>
+          <p className="mt-2 text-xs text-muted-foreground">
+            These are separate observed signals. Derive does not guess local activations or combine
+            them into a synthetic total.
+          </p>
+        </TabsContent>
+        <TabsContent value="artifacts" className="px-4 py-3">
+          {usage.isPending ? (
+            <Muted>Loading linked artifacts…</Muted>
+          ) : usage.data?.artifacts.length ? (
+            <div className="flex flex-wrap gap-2">
+              {usage.data.artifacts.map((item) => (
+                <Badge key={item.id} asChild={!!item.artifact} variant="outline" shape="pill">
+                  {item.artifact ? (
+                    <Link to="/artifacts/$ref" params={{ ref: item.artifact.short_id }}>
+                      {item.artifact.title ?? item.artifact.short_id} · {item.role} · v
+                      {item.artifact_version}
+                    </Link>
+                  ) : (
+                    <span>
+                      {item.role} · artifact v{item.artifact_version}
+                    </span>
+                  )}
+                </Badge>
+              ))}
+            </div>
+          ) : (
+            <Muted>No artifacts have declared this skill yet.</Muted>
+          )}
+        </TabsContent>
+        <TabsContent value="files" className="px-4 py-3">
+          {files.length ? (
+            <div className="flex flex-wrap gap-1.5">
+              {files.map((file) => (
+                <Badge key={file.path} asChild variant="outline" shape="pill">
+                  <a href={fileUrl(file.path)} target="_blank" rel="noopener noreferrer">
+                    {file.path}
+                  </a>
+                </Badge>
+              ))}
+            </div>
+          ) : (
+            <Muted>This skill contains only SKILL.md.</Muted>
+          )}
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}
+
+function Metric({ value, label }: { value: number; label: string }) {
+  return (
+    <div className="rounded-lg border bg-background px-3 py-2">
+      <strong className="font-mono text-base font-medium tabular-nums">{value}</strong>
+      <span className="ml-2 text-xs text-muted-foreground">{label}</span>
+    </div>
+  )
+}
+
+function Muted({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="rounded-lg border border-dashed px-3 py-4 text-sm text-muted-foreground">
+      {children}
+    </p>
   )
 }

--- a/apps/web/src/pages/artifact/bundle-bar.tsx
+++ b/apps/web/src/pages/artifact/bundle-bar.tsx
@@ -199,7 +199,9 @@ function SkillWorkbench({
               {copied ? "Copied" : "Install locally"}
             </Button>
           </div>
-          <span className="text-2xs text-muted-foreground">Claude + Codex · current project</span>
+          <span className="text-2xs text-muted-foreground">
+            One command installs for Claude and Codex in this project.
+          </span>
         </div>
       </div>
 
@@ -213,10 +215,10 @@ function SkillWorkbench({
         </TabsList>
         <TabsContent value="overview" className="px-4 py-3">
           <div className="grid gap-2 sm:grid-cols-4">
-            <Metric value={graph.data?.edges.length ?? 0} label="connections" />
-            <Metric value={activeInstalls} label="active installs" />
-            <Metric value={contextRuns} label="Context runs" />
-            <Metric value={workflowRuns} label="Workflow runs" />
+            <Metric value={graph.data ? graph.data.edges.length : null} label="connections" />
+            <Metric value={usage.data ? activeInstalls : null} label="active installs" />
+            <Metric value={usage.data ? contextRuns : null} label="Context runs" />
+            <Metric value={usage.data ? workflowRuns : null} label="Workflow runs" />
           </div>
         </TabsContent>
         <TabsContent value="graph" className="px-4 py-3">
@@ -265,9 +267,9 @@ function SkillWorkbench({
         </TabsContent>
         <TabsContent value="usage" className="px-4 py-3">
           <div className="grid gap-2 sm:grid-cols-3">
-            <Metric value={activeInstalls} label="active installs" />
-            <Metric value={contextRuns} label="Context runs" />
-            <Metric value={workflowRuns} label="Workflow runs" />
+            <Metric value={usage.data ? activeInstalls : null} label="active installs" />
+            <Metric value={usage.data ? contextRuns : null} label="Context runs" />
+            <Metric value={usage.data ? workflowRuns : null} label="Workflow runs" />
           </div>
           <p className="mt-2 text-xs text-muted-foreground">
             These are separate observed signals. Derive does not guess local activations or combine
@@ -349,10 +351,10 @@ function SkillWorkbench({
   )
 }
 
-function Metric({ value, label }: { value: number; label: string }) {
+function Metric({ value, label }: { value: number | null; label: string }) {
   return (
     <div className="rounded-lg border bg-background px-3 py-2">
-      <strong className="font-mono text-base font-medium tabular-nums">{value}</strong>
+      <strong className="font-mono text-base font-medium tabular-nums">{value ?? "—"}</strong>
       <span className="ml-2 text-xs text-muted-foreground">{label}</span>
     </div>
   )

--- a/apps/web/src/pages/artifact/bundle-bar.tsx
+++ b/apps/web/src/pages/artifact/bundle-bar.tsx
@@ -1,9 +1,13 @@
 import { useQuery } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
 import { API_BASE, type Artifact } from "@/api"
+import { Icon } from "@/components/icons"
 import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { useCopy } from "@/lib/clipboard"
 import { skillGraphQuery, skillUsageQuery } from "@/lib/queries"
+import { ago } from "@/lib/time"
 
 /**
  * Header chrome for a markdown bundle (a skill — entry SKILL.md — or a plain docs
@@ -84,6 +88,7 @@ function SkillWorkbench({
 }) {
   const graph = useQuery(skillGraphQuery(shortId))
   const usage = useQuery(skillUsageQuery(shortId))
+  const { copied, copy } = useCopy(2000)
   const nodeById = new Map((graph.data?.nodes ?? []).map((node) => [node.id, node]))
   const activeInstalls = (usage.data?.installations ?? []).reduce(
     (sum, item) => sum + item.count,
@@ -92,6 +97,7 @@ function SkillWorkbench({
   const contextRuns = (usage.data?.contexts ?? []).reduce((sum, item) => sum + item.count, 0)
   const workflowRuns = (usage.data?.workflows ?? []).reduce((sum, item) => sum + item.count, 0)
   const fileUrl = (path: string) => `${API_BASE}/raw/${shortId}/v/${version}/${path}`
+  const installCommand = `derive skill add ${shortId}`
 
   return (
     <div className="border-b border-border bg-card/60" data-testid="skill-workbench">
@@ -110,13 +116,32 @@ function SkillWorkbench({
             <p className="mt-1 max-w-3xl text-sm text-muted-foreground">{bundle.description}</p>
           )}
         </div>
-        <div className="flex gap-1.5">
-          <Badge variant="outline" shape="pill">
-            Claude
-          </Badge>
-          <Badge variant="outline" shape="pill">
-            Codex
-          </Badge>
+        <div className="flex min-w-0 flex-col items-end gap-2">
+          <div className="flex gap-1.5">
+            <Badge variant="outline" shape="pill">
+              Claude
+            </Badge>
+            <Badge variant="outline" shape="pill">
+              Codex
+            </Badge>
+          </div>
+          <div className="flex max-w-full items-center gap-1 rounded-lg border bg-background p-1 pl-2">
+            <code className="truncate font-mono text-2xs text-muted-foreground">
+              {installCommand}
+            </code>
+            <Button
+              size="xs"
+              variant="secondary"
+              data-testid="skill-copy-install"
+              aria-label={copied ? "Install command copied" : "Copy install command"}
+              title="Installs this Skill for Claude and Codex in the current project"
+              onClick={() => void copy(installCommand, { success: "Install command copied" })}
+            >
+              <Icon name={copied ? "check" : "copy"} />
+              {copied ? "Copied" : "Install locally"}
+            </Button>
+          </div>
+          <span className="text-2xs text-muted-foreground">Claude + Codex · current project</span>
         </div>
       </div>
 
@@ -190,6 +215,37 @@ function SkillWorkbench({
             These are separate observed signals. Derive does not guess local activations or combine
             them into a synthetic total.
           </p>
+          {usage.isPending ? (
+            <Muted>Loading installation details…</Muted>
+          ) : usage.data?.installations.length ? (
+            <div className="mt-3 flex flex-col gap-2" data-testid="skill-installations">
+              <p className="text-xs font-medium text-foreground">Active installations</p>
+              {usage.data.installations.map((installation) => (
+                <div
+                  key={`${installation.client}:${installation.scope_kind}`}
+                  className="flex flex-wrap items-center gap-2 rounded-lg border bg-background px-3 py-2 text-sm"
+                >
+                  <Badge variant="outline" shape="pill" className="capitalize">
+                    {installation.client}
+                  </Badge>
+                  <Badge variant="outline" shape="pill" className="capitalize">
+                    {installation.scope_kind}
+                  </Badge>
+                  <span>
+                    {installation.count} {installation.count === 1 ? "install" : "installs"}
+                  </span>
+                  <span
+                    className="ml-auto text-xs text-muted-foreground"
+                    title={new Date(installation.last_synced_at).toLocaleString()}
+                  >
+                    synced {ago(installation.last_synced_at)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="mt-3 text-xs text-muted-foreground">No active installations yet.</p>
+          )}
         </TabsContent>
         <TabsContent value="artifacts" className="px-4 py-3">
           {usage.isPending ? (

--- a/apps/web/src/pages/artifact/bundle-bar.tsx
+++ b/apps/web/src/pages/artifact/bundle-bar.tsx
@@ -4,6 +4,13 @@ import { API_BASE, type Artifact } from "@/api"
 import { Icon } from "@/components/icons"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { useCopy } from "@/lib/clipboard"
 import { skillGraphQuery, skillUsageQuery } from "@/lib/queries"
@@ -98,9 +105,12 @@ function SkillWorkbench({
   const workflowRuns = (usage.data?.workflows ?? []).reduce((sum, item) => sum + item.count, 0)
   const fileUrl = (path: string) => `${API_BASE}/raw/${shortId}/v/${version}/${path}`
   const installCommand = `derive skill add ${shortId}`
-  const workflow = usage.data?.artifacts.find(
-    (item) => item.role === "workflow-definition" && item.artifact,
-  )?.artifact
+  const workflowLinks = (usage.data?.artifacts ?? []).filter(
+    (item, index, all) =>
+      item.role === "workflow-definition" &&
+      item.artifact &&
+      all.findIndex((candidate) => candidate.artifact_id === item.artifact_id) === index,
+  )
 
   return (
     <div className="border-b border-border bg-card/60" data-testid="skill-workbench">
@@ -120,12 +130,47 @@ function SkillWorkbench({
           )}
         </div>
         <div className="flex min-w-0 flex-col items-end gap-2">
-          {workflow ? (
+          {workflowLinks.length === 1 && workflowLinks[0]?.artifact ? (
             <Button asChild size="sm" variant="outline" data-testid="skill-open-workflow">
-              <Link to="/artifacts/$ref" params={{ ref: workflow.short_id }}>
-                <Icon name="workflow" size={14} /> Open workflow
+              <Link
+                to="/artifacts/$ref"
+                params={{ ref: workflowLinks[0].artifact.short_id }}
+                title={`Linked from Workflow v${workflowLinks[0].artifact_version}`}
+              >
+                <Icon name="workflow" size={14} /> Workflow:{" "}
+                {workflowLinks[0].artifact.title ?? workflowLinks[0].artifact.short_id}
               </Link>
             </Button>
+          ) : workflowLinks.length > 1 ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button size="sm" variant="outline" data-testid="skill-open-workflows">
+                  <Icon name="workflow" size={14} /> {workflowLinks.length} linked workflows
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="max-w-sm">
+                <DropdownMenuLabel>Workflows using this Skill</DropdownMenuLabel>
+                {workflowLinks.map((link) =>
+                  link.artifact ? (
+                    <DropdownMenuItem
+                      key={link.artifact_id}
+                      asChild
+                      data-testid={`skill-workflow-${link.artifact_id}`}
+                    >
+                      <Link to="/artifacts/$ref" params={{ ref: link.artifact.short_id }}>
+                        <Icon name="workflow" size={14} />
+                        <span className="min-w-0 flex-1 truncate">
+                          {link.artifact.title ?? link.artifact.short_id}
+                        </span>
+                        <span className="font-mono text-2xs text-muted-foreground">
+                          v{link.artifact_version}
+                        </span>
+                      </Link>
+                    </DropdownMenuItem>
+                  ) : null,
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
           ) : null}
           <div className="flex gap-1.5">
             <Badge variant="outline" shape="pill">

--- a/apps/web/src/pages/artifact/bundle-bar.tsx
+++ b/apps/web/src/pages/artifact/bundle-bar.tsx
@@ -98,6 +98,9 @@ function SkillWorkbench({
   const workflowRuns = (usage.data?.workflows ?? []).reduce((sum, item) => sum + item.count, 0)
   const fileUrl = (path: string) => `${API_BASE}/raw/${shortId}/v/${version}/${path}`
   const installCommand = `derive skill add ${shortId}`
+  const workflow = usage.data?.artifacts.find(
+    (item) => item.role === "workflow-definition" && item.artifact,
+  )?.artifact
 
   return (
     <div className="border-b border-border bg-card/60" data-testid="skill-workbench">
@@ -117,6 +120,13 @@ function SkillWorkbench({
           )}
         </div>
         <div className="flex min-w-0 flex-col items-end gap-2">
+          {workflow ? (
+            <Button asChild size="sm" variant="outline" data-testid="skill-open-workflow">
+              <Link to="/artifacts/$ref" params={{ ref: workflow.short_id }}>
+                <Icon name="workflow" size={14} /> Open workflow
+              </Link>
+            </Button>
+          ) : null}
           <div className="flex gap-1.5">
             <Badge variant="outline" shape="pill">
               Claude

--- a/apps/web/src/pages/artifact/linked-bundle-workspace.tsx
+++ b/apps/web/src/pages/artifact/linked-bundle-workspace.tsx
@@ -1,9 +1,12 @@
+import { useQuery } from "@tanstack/react-query"
+import { Link } from "@tanstack/react-router"
 import { useEffect, useMemo, useRef, useState } from "react"
 import type { Artifact, Comment, DirUser } from "@/api"
 import { Icon } from "@/components/icons"
 import { Count, Eyebrow } from "@/components/shared/section-eyebrow"
 import { SectionHeading, SectionTitle } from "@/components/shared/section-title"
 import { Button } from "@/components/ui/button"
+import { artifactSkillsQuery } from "@/lib/queries"
 import { ago } from "@/lib/time"
 import { cn } from "@/lib/utils"
 import { LinkedBundleFocusSearch, type LinkedBundleFocusTarget } from "./linked-bundle-focus"
@@ -937,6 +940,15 @@ export function LinkedBundleWorkspace({
   reviewState: LinkedBundleReviewState
   onReviewStateChange: (state: LinkedBundleReviewState) => void
 }) {
+  // surface-ignore: optional provenance chrome degrades to no launcher CTA; the
+  // Workflow workspace and all execution controls remain fully usable.
+  const linkedSkills = useQuery({
+    ...artifactSkillsQuery(shortId),
+    enabled: !!workflowPreview,
+  })
+  const launcher = linkedSkills.data?.links.find(
+    (link) => link.role === "workflow-definition" && link.skill,
+  )
   const diagrams = bundle.diagrams ?? []
   const counts = linkedBundleCommentCounts(comments)
   const members = useMemo(
@@ -1019,6 +1031,17 @@ export function LinkedBundleWorkspace({
             </div>
           </div>
           <div className="flex flex-wrap items-center gap-2">
+            {launcher?.skill ? (
+              <Button asChild variant="outline" size="sm" data-testid="workflow-open-skill">
+                <Link
+                  to="/artifacts/$ref"
+                  params={{ ref: launcher.skill.short_id }}
+                  title={`Launcher Skill v${launcher.skill_version}, linked from Workflow v${launcher.artifact_version}`}
+                >
+                  <Icon name="sparkles" size={14} /> Open Skill
+                </Link>
+              </Button>
+            ) : null}
             <fieldset className="flex rounded-lg border border-border p-0.5">
               <legend className="sr-only">Workspace view</legend>
               {workflowPreview ? (

--- a/apps/web/src/pages/artifact/linked-bundle-workspace.tsx
+++ b/apps/web/src/pages/artifact/linked-bundle-workspace.tsx
@@ -6,6 +6,13 @@ import { Icon } from "@/components/icons"
 import { Count, Eyebrow } from "@/components/shared/section-eyebrow"
 import { SectionHeading, SectionTitle } from "@/components/shared/section-title"
 import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 import { artifactSkillsQuery } from "@/lib/queries"
 import { ago } from "@/lib/time"
 import { cn } from "@/lib/utils"
@@ -946,8 +953,12 @@ export function LinkedBundleWorkspace({
     ...artifactSkillsQuery(shortId),
     enabled: !!workflowPreview,
   })
-  const launcher = linkedSkills.data?.links.find(
-    (link) => link.role === "workflow-definition" && link.skill,
+  const launchers = (linkedSkills.data?.links ?? []).filter(
+    (link, index, all) =>
+      link.role === "workflow-definition" &&
+      link.skill &&
+      all.findIndex((candidate) => candidate.skill_artifact_id === link.skill_artifact_id) ===
+        index,
   )
   const diagrams = bundle.diagrams ?? []
   const counts = linkedBundleCommentCounts(comments)
@@ -1031,16 +1042,47 @@ export function LinkedBundleWorkspace({
             </div>
           </div>
           <div className="flex flex-wrap items-center gap-2">
-            {launcher?.skill ? (
+            {launchers.length === 1 && launchers[0]?.skill ? (
               <Button asChild variant="outline" size="sm" data-testid="workflow-open-skill">
                 <Link
                   to="/artifacts/$ref"
-                  params={{ ref: launcher.skill.short_id }}
-                  title={`Launcher Skill v${launcher.skill_version}, linked from Workflow v${launcher.artifact_version}`}
+                  params={{ ref: launchers[0].skill.short_id }}
+                  title={`Launcher Skill v${launchers[0].skill_version}, linked from Workflow v${launchers[0].artifact_version}`}
                 >
-                  <Icon name="sparkles" size={14} /> Open Skill
+                  <Icon name="sparkles" size={14} /> Skill:{" "}
+                  {launchers[0].skill.title ?? launchers[0].skill.short_id}
                 </Link>
               </Button>
+            ) : launchers.length > 1 ? (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="outline" size="sm" data-testid="workflow-open-skills">
+                    <Icon name="sparkles" size={14} /> {launchers.length} linked Skills
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start" className="max-w-sm">
+                  <DropdownMenuLabel>Launcher Skills</DropdownMenuLabel>
+                  {launchers.map((launcher) =>
+                    launcher.skill ? (
+                      <DropdownMenuItem
+                        key={launcher.skill_artifact_id}
+                        asChild
+                        data-testid={`workflow-skill-${launcher.skill_artifact_id}`}
+                      >
+                        <Link to="/artifacts/$ref" params={{ ref: launcher.skill.short_id }}>
+                          <Icon name="sparkles" size={14} />
+                          <span className="min-w-0 flex-1 truncate">
+                            {launcher.skill.title ?? launcher.skill.short_id}
+                          </span>
+                          <span className="font-mono text-2xs text-muted-foreground">
+                            v{launcher.skill_version}
+                          </span>
+                        </Link>
+                      </DropdownMenuItem>
+                    ) : null,
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenu>
             ) : null}
             <fieldset className="flex rounded-lg border border-border p-0.5">
               <legend className="sr-only">Workspace view</legend>

--- a/apps/web/src/pages/artifact/linked-bundle-workspace.tsx
+++ b/apps/web/src/pages/artifact/linked-bundle-workspace.tsx
@@ -1051,6 +1051,9 @@ export function LinkedBundleWorkspace({
                 >
                   <Icon name="sparkles" size={14} /> Skill:{" "}
                   {launchers[0].skill.title ?? launchers[0].skill.short_id}
+                  <span className="font-mono text-2xs text-muted-foreground">
+                    v{launchers[0].skill_version}
+                  </span>
                 </Link>
               </Button>
             ) : launchers.length > 1 ? (

--- a/apps/web/src/pages/skills/index.tsx
+++ b/apps/web/src/pages/skills/index.tsx
@@ -102,9 +102,16 @@ export function Skills() {
                 <span className="grid size-9 place-items-center rounded-lg bg-primary/10 text-primary">
                   <Icon name="skill" />
                 </span>
-                <Badge variant="outline" shape="pill" className="capitalize">
-                  {skill.skill.runtime}
-                </Badge>
+                <div className="flex flex-wrap justify-end gap-1.5">
+                  {skill.skill.workflow_launcher ? (
+                    <Badge variant="brand" shape="pill">
+                      Workflow launcher
+                    </Badge>
+                  ) : null}
+                  <Badge variant="outline" shape="pill" className="capitalize">
+                    {skill.skill.runtime}
+                  </Badge>
+                </div>
               </div>
               <h2 className="mt-4 font-serif text-lg font-medium tracking-tight">
                 {skill.skill.name}

--- a/apps/web/src/pages/skills/index.tsx
+++ b/apps/web/src/pages/skills/index.tsx
@@ -1,0 +1,173 @@
+import { useQuery } from "@tanstack/react-query"
+import { Link } from "@tanstack/react-router"
+import { useState } from "react"
+import { useShell } from "@/components/chrome/shell-context"
+import { Icon } from "@/components/icons"
+import { EmptyState } from "@/components/shared/empty-state"
+import { LoadError } from "@/components/shared/load-error"
+import { PageHeader } from "@/components/shared/page-header"
+import { PageShell } from "@/components/shared/page-shell"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Skeleton } from "@/components/ui/skeleton"
+import { REVEAL } from "@/lib/interaction"
+import { skillsQuery } from "@/lib/queries"
+import { useDocumentTitle } from "@/lib/use-document-title"
+import { cn } from "@/lib/utils"
+import { refFor } from "../artifact/parse-ref"
+
+export function Skills() {
+  useDocumentTitle("Skills")
+  const { openAssistant } = useShell()
+  const [query, setQuery] = useState("")
+  const { data, isPending, isError, refetch } = useQuery(skillsQuery(query))
+  const skills = data?.skills ?? []
+  const connected = skills.filter((skill) => skill.skill.runtime !== "single").length
+
+  return (
+    <PageShell width="wide" className="flex flex-col gap-6">
+      <PageHeader
+        eyebrow="Workspace"
+        title="Skills"
+        subtitle="Shared instructions that Claude and Codex can install as local skills. Link them into graphs, see what they create, and keep every version reviewable."
+        actions={
+          <Button
+            size="sm"
+            data-testid="skills-new"
+            onClick={() =>
+              openAssistant(
+                "Help me create a reusable Skill. Start by clarifying when it should trigger, then publish a standards-compatible SKILL.md bundle.",
+              )
+            }
+          >
+            <Icon name="plus" /> New skill
+          </Button>
+        }
+      />
+
+      <div className="grid gap-2 sm:grid-cols-3">
+        <Summary value={skills.length} label="shared skills" />
+        <Summary value={connected} label="graphs or loops" />
+        <Summary value={Math.max(0, skills.length - connected)} label="single skills" />
+      </div>
+
+      <div className="relative max-w-md">
+        <Icon
+          name="search"
+          className="pointer-events-none absolute top-1/2 left-3 -translate-y-1/2 text-muted-foreground"
+        />
+        <Input
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search skills"
+          aria-label="Search skills"
+          data-testid="skills-search"
+          className="pl-9"
+        />
+      </div>
+
+      {isPending ? (
+        <SkillGridSkeleton />
+      ) : isError ? (
+        <LoadError
+          title="Couldn’t load skills"
+          testId="skills-retry"
+          layout="inline"
+          onRetry={() => refetch()}
+        />
+      ) : skills.length ? (
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3" data-testid="skills-grid">
+          {skills.map((skill) => (
+            <Link
+              key={skill.short_id}
+              to="/artifacts/$ref"
+              params={{ ref: refFor(skill) }}
+              className="group flex min-h-44 flex-col rounded-xl border bg-card p-4 transition-colors hover:border-foreground/20 hover:bg-secondary/20"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <span className="grid size-9 place-items-center rounded-lg bg-primary/10 text-primary">
+                  <Icon name="skill" />
+                </span>
+                <Badge variant="outline" shape="pill" className="capitalize">
+                  {skill.skill.runtime}
+                </Badge>
+              </div>
+              <h2 className="mt-4 font-serif text-lg font-medium tracking-tight">
+                {skill.skill.name}
+              </h2>
+              <p className="mt-1 line-clamp-3 text-sm text-muted-foreground">
+                {skill.skill.description}
+              </p>
+              <div className="mt-auto flex items-center justify-between pt-4 font-mono text-2xs text-muted-foreground">
+                <span>v{skill.current_version}</span>
+                <span className={cn("flex items-center gap-1 text-foreground", REVEAL)}>
+                  Open <Icon name="arrow" size={12} />
+                </span>
+              </div>
+            </Link>
+          ))}
+        </div>
+      ) : (
+        <EmptyState
+          icon={<Icon name="skill" />}
+          title={query ? "No matching skills" : "No shared skills yet"}
+          description={
+            query
+              ? "Try another name or description."
+              : "Publish a SKILL.md bundle once, then install it in Claude or Codex wherever you work."
+          }
+          action={
+            query ? (
+              <Button
+                size="sm"
+                variant="outline"
+                data-testid="skills-clear-search"
+                onClick={() => setQuery("")}
+              >
+                Clear search
+              </Button>
+            ) : undefined
+          }
+        />
+      )}
+    </PageShell>
+  )
+}
+
+function Summary({ value, label }: { value: number; label: string }) {
+  return (
+    <div className="flex items-baseline gap-2 rounded-xl border bg-card px-4 py-3">
+      <strong className="font-mono text-lg font-medium tabular-nums">{value}</strong>
+      <span className="text-xs text-muted-foreground">{label}</span>
+    </div>
+  )
+}
+
+function SkillGridSkeleton() {
+  return (
+    <div
+      className="grid gap-3 md:grid-cols-2 xl:grid-cols-3"
+      role="status"
+      aria-label="Loading skills"
+    >
+      {[0, 1, 2].map((item) => (
+        <Skeleton key={item} className="h-44 rounded-xl" />
+      ))}
+    </div>
+  )
+}
+
+export function SkillsPending() {
+  return (
+    <PageShell width="wide" className="flex flex-col gap-6">
+      <Skeleton className="h-20 w-full max-w-3xl" />
+      <div className="grid gap-2 sm:grid-cols-3">
+        <Skeleton className="h-14 rounded-xl" />
+        <Skeleton className="h-14 rounded-xl" />
+        <Skeleton className="h-14 rounded-xl" />
+      </div>
+      <SkillGridSkeleton />
+    </PageShell>
+  )
+}

--- a/apps/web/src/pages/skills/index.tsx
+++ b/apps/web/src/pages/skills/index.tsx
@@ -11,6 +11,7 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
+import { useCopy } from "@/lib/clipboard"
 import { REVEAL } from "@/lib/interaction"
 import { skillsQuery } from "@/lib/queries"
 import { useDocumentTitle } from "@/lib/use-document-title"
@@ -20,6 +21,7 @@ import { refFor } from "../artifact/parse-ref"
 export function Skills() {
   useDocumentTitle("Skills")
   const { openAssistant } = useShell()
+  const { copied, copy } = useCopy(2000)
   const [query, setQuery] = useState("")
   const { data, isPending, isError, refetch } = useQuery(skillsQuery(query))
   const skills = data?.skills ?? []
@@ -32,17 +34,31 @@ export function Skills() {
         title="Skills"
         subtitle="Shared instructions that Claude and Codex can install as local skills. Link them into graphs, see what they create, and keep every version reviewable."
         actions={
-          <Button
-            size="sm"
-            data-testid="skills-new"
-            onClick={() =>
-              openAssistant(
-                "Help me create a reusable Skill. Start by clarifying when it should trigger, then publish a standards-compatible SKILL.md bundle.",
-              )
-            }
-          >
-            <Icon name="plus" /> New skill
-          </Button>
+          <div className="flex flex-wrap gap-2">
+            <Button
+              size="sm"
+              variant="outline"
+              data-testid="skills-sync-all"
+              title="Copies a command that updates every Skill pinned in this project"
+              onClick={() =>
+                void copy("derive skill sync --all", { success: "Sync command copied" })
+              }
+            >
+              <Icon name={copied ? "check" : "copy"} />
+              {copied ? "Copied" : "Sync installed"}
+            </Button>
+            <Button
+              size="sm"
+              data-testid="skills-new"
+              onClick={() =>
+                openAssistant(
+                  "Help me create a reusable Skill. Start by clarifying when it should trigger, then publish a standards-compatible SKILL.md bundle.",
+                )
+              }
+            >
+              <Icon name="plus" /> New skill
+            </Button>
+          </div>
         }
       />
 

--- a/apps/web/src/pages/skills/index.tsx
+++ b/apps/web/src/pages/skills/index.tsx
@@ -17,6 +17,7 @@ import { skillsQuery } from "@/lib/queries"
 import { useDocumentTitle } from "@/lib/use-document-title"
 import { cn } from "@/lib/utils"
 import { refFor } from "../artifact/parse-ref"
+import { NEW_SKILL_PROMPT } from "./new-skill-prompt"
 
 export function Skills() {
   useDocumentTitle("Skills")
@@ -50,11 +51,7 @@ export function Skills() {
             <Button
               size="sm"
               data-testid="skills-new"
-              onClick={() =>
-                openAssistant(
-                  "Help me create a reusable Skill. Start by clarifying when it should trigger, then publish a standards-compatible SKILL.md bundle.",
-                )
-              }
+              onClick={() => openAssistant(NEW_SKILL_PROMPT)}
             >
               <Icon name="plus" /> New skill
             </Button>

--- a/apps/web/src/pages/skills/new-skill-prompt.test.ts
+++ b/apps/web/src/pages/skills/new-skill-prompt.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest"
+import { NEW_SKILL_PROMPT } from "./new-skill-prompt"
+
+describe("NEW_SKILL_PROMPT", () => {
+  it("requires a catalog-visible multi-file Skill instead of a plain artifact", () => {
+    expect(NEW_SKILL_PROMPT).toContain("exactly one concise question")
+    expect(NEW_SKILL_PROMPT).toContain("Do not browse, search, or research")
+    expect(NEW_SKILL_PROMPT).toContain("files payload")
+    expect(NEW_SKILL_PROMPT).toContain("Never use the single-file content payload")
+    expect(NEW_SKILL_PROMPT).toContain("SKILL.md")
+    expect(NEW_SKILL_PROMPT).toContain("derive.skill.json")
+    expect(NEW_SKILL_PROMPT).toContain('"schema":"derive.skill/v1"')
+    expect(NEW_SKILL_PROMPT).toContain('"catalog":true')
+    expect(NEW_SKILL_PROMPT).toContain("appears in the Skills catalog")
+  })
+})

--- a/apps/web/src/pages/skills/new-skill-prompt.ts
+++ b/apps/web/src/pages/skills/new-skill-prompt.ts
@@ -1,0 +1,14 @@
+export const NEW_SKILL_PROMPT = `Create a reusable Derive Skill with me.
+
+First, ask exactly one concise question: "What should the Skill do, and when should it trigger?" Then wait for my answer.
+
+After I answer:
+- Do not browse, search, or research conventions.
+- Immediately publish a NEW multi-file artifact using the Derive publish tool's files payload. Never use the single-file content payload and never try to convert an existing single-file artifact.
+- Include exactly two root files: SKILL.md and derive.skill.json.
+- SKILL.md must contain YAML frontmatter with name and description, followed by focused, executable instructions.
+- derive.skill.json must be valid JSON with {"schema":"derive.skill/v1","catalog":true,"runtime":{"kind":"single"},"relations":{}}.
+- Choose a clear short ID from my answer; if it is already taken, create a unique alternative instead of revising the existing artifact.
+- Return the published Skill link and nothing else beyond a one-line confirmation.
+
+The result is incomplete unless the published artifact is a multi-file bundle that appears in the Skills catalog.`

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as WorkflowsRouteImport } from './routes/workflows'
 import { Route as WelcomeRouteImport } from './routes/welcome'
 import { Route as UnlistedRouteImport } from './routes/unlisted'
+import { Route as SkillsRouteImport } from './routes/skills'
 import { Route as ShowcaseRouteImport } from './routes/showcase'
 import { Route as SharedRouteImport } from './routes/shared'
 import { Route as SettingsRouteImport } from './routes/settings'
@@ -62,6 +63,11 @@ const WelcomeRoute = WelcomeRouteImport.update({
 const UnlistedRoute = UnlistedRouteImport.update({
   id: '/unlisted',
   path: '/unlisted',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SkillsRoute = SkillsRouteImport.update({
+  id: '/skills',
+  path: '/skills',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ShowcaseRoute = ShowcaseRouteImport.update({
@@ -263,6 +269,7 @@ export interface FileRoutesByFullPath {
   '/settings': typeof SettingsRouteWithChildren
   '/shared': typeof SharedRoute
   '/showcase': typeof ShowcaseRoute
+  '/skills': typeof SkillsRoute
   '/unlisted': typeof UnlistedRoute
   '/welcome': typeof WelcomeRoute
   '/workflows': typeof WorkflowsRoute
@@ -303,6 +310,7 @@ export interface FileRoutesByTo {
   '/search': typeof SearchRoute
   '/shared': typeof SharedRoute
   '/showcase': typeof ShowcaseRoute
+  '/skills': typeof SkillsRoute
   '/unlisted': typeof UnlistedRoute
   '/welcome': typeof WelcomeRoute
   '/workflows': typeof WorkflowsRoute
@@ -345,6 +353,7 @@ export interface FileRoutesById {
   '/settings': typeof SettingsRouteWithChildren
   '/shared': typeof SharedRoute
   '/showcase': typeof ShowcaseRoute
+  '/skills': typeof SkillsRoute
   '/unlisted': typeof UnlistedRoute
   '/welcome': typeof WelcomeRoute
   '/workflows': typeof WorkflowsRoute
@@ -388,6 +397,7 @@ export interface FileRouteTypes {
     | '/settings'
     | '/shared'
     | '/showcase'
+    | '/skills'
     | '/unlisted'
     | '/welcome'
     | '/workflows'
@@ -428,6 +438,7 @@ export interface FileRouteTypes {
     | '/search'
     | '/shared'
     | '/showcase'
+    | '/skills'
     | '/unlisted'
     | '/welcome'
     | '/workflows'
@@ -469,6 +480,7 @@ export interface FileRouteTypes {
     | '/settings'
     | '/shared'
     | '/showcase'
+    | '/skills'
     | '/unlisted'
     | '/welcome'
     | '/workflows'
@@ -511,6 +523,7 @@ export interface RootRouteChildren {
   SettingsRoute: typeof SettingsRouteWithChildren
   SharedRoute: typeof SharedRoute
   ShowcaseRoute: typeof ShowcaseRoute
+  SkillsRoute: typeof SkillsRoute
   UnlistedRoute: typeof UnlistedRoute
   WelcomeRoute: typeof WelcomeRoute
   WorkflowsRoute: typeof WorkflowsRoute
@@ -554,6 +567,13 @@ declare module '@tanstack/react-router' {
       path: '/unlisted'
       fullPath: '/unlisted'
       preLoaderRoute: typeof UnlistedRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/skills': {
+      id: '/skills'
+      path: '/skills'
+      fullPath: '/skills'
+      preLoaderRoute: typeof SkillsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/showcase': {
@@ -843,6 +863,7 @@ const rootRouteChildren: RootRouteChildren = {
   SettingsRoute: SettingsRouteWithChildren,
   SharedRoute: SharedRoute,
   ShowcaseRoute: ShowcaseRoute,
+  SkillsRoute: SkillsRoute,
   UnlistedRoute: UnlistedRoute,
   WelcomeRoute: WelcomeRoute,
   WorkflowsRoute: WorkflowsRoute,

--- a/apps/web/src/routes/skills.tsx
+++ b/apps/web/src/routes/skills.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { bootstrapQuery } from "../lib/bootstrap"
+import { skillsQuery } from "../lib/queries"
+import { requireOnboarded } from "../lib/route-guards"
+import { Skills, SkillsPending } from "../pages/skills"
+
+export const Route = createFileRoute("/skills")({
+  beforeLoad: requireOnboarded,
+  loader: ({ context }) =>
+    Promise.all([
+      context.queryClient.ensureQueryData(bootstrapQuery(context.queryClient)).catch(() => {}),
+      context.queryClient.ensureQueryData(skillsQuery()).catch(() => {}),
+    ]),
+  pendingComponent: SkillsPending,
+  component: Skills,
+})

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -342,6 +342,48 @@ CREATE TABLE IF NOT EXISTS workflow_step_attempt (
   FOREIGN KEY (workflow_run_id) REFERENCES workflow_run(id)
 );
 
+CREATE TABLE IF NOT EXISTS skill_relation (
+  id TEXT PRIMARY KEY,
+  org_id TEXT NOT NULL,
+  source_artifact_id TEXT NOT NULL,
+  source_version INTEGER NOT NULL,
+  target_artifact_id TEXT NOT NULL,
+  target_version INTEGER NOT NULL,
+  kind TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  UNIQUE (source_artifact_id, source_version, target_artifact_id, target_version, kind)
+);
+
+CREATE TABLE IF NOT EXISTS skill_installation (
+  id TEXT PRIMARY KEY,
+  org_id TEXT NOT NULL,
+  skill_artifact_id TEXT NOT NULL,
+  skill_version INTEGER NOT NULL,
+  scope_kind TEXT NOT NULL,
+  opaque_scope_id TEXT NOT NULL,
+  client TEXT NOT NULL,
+  digest TEXT NOT NULL,
+  policy TEXT NOT NULL DEFAULT 'pinned',
+  installed_by TEXT,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  updated_at TEXT NOT NULL,
+  removed_at TEXT,
+  UNIQUE (org_id, skill_artifact_id, scope_kind, opaque_scope_id, client)
+);
+
+CREATE TABLE IF NOT EXISTS artifact_skill_link (
+  id TEXT PRIMARY KEY,
+  org_id TEXT NOT NULL,
+  artifact_id TEXT NOT NULL,
+  artifact_version INTEGER NOT NULL,
+  skill_artifact_id TEXT NOT NULL,
+  skill_version INTEGER NOT NULL,
+  role TEXT NOT NULL,
+  linked_by TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  UNIQUE (artifact_id, artifact_version, skill_artifact_id, skill_version, role)
+);
+
 CREATE TABLE IF NOT EXISTS plan (
   id TEXT PRIMARY KEY,
   org_id TEXT NOT NULL,
@@ -806,6 +848,12 @@ CREATE INDEX IF NOT EXISTS workflow_run_definition ON workflow_run (workflow_art
 CREATE INDEX IF NOT EXISTS workflow_run_external ON workflow_run (external_run_id);
 
 CREATE INDEX IF NOT EXISTS workflow_step_attempt_run ON workflow_step_attempt (workflow_run_id, created_at);
+
+CREATE INDEX IF NOT EXISTS skill_relation_incoming ON skill_relation (org_id, target_artifact_id, target_version);
+
+CREATE INDEX IF NOT EXISTS skill_installation_skill ON skill_installation (org_id, skill_artifact_id, updated_at);
+
+CREATE INDEX IF NOT EXISTS artifact_skill_link_skill ON artifact_skill_link (org_id, skill_artifact_id, created_at);
 
 CREATE INDEX IF NOT EXISTS invitation_org_email ON invitation (org_id, email);
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "overrides": {
       "adm-zip": ">=0.6.0",
       "esbuild": ">=0.25.0",
-      "fast-uri": ">=4.1.2",
+      "fast-uri": ">=4.1.3",
       "drizzle-orm": "0.45.2",
       "js-yaml": "^4.3.1",
       "sharp": ">=0.35.0",
@@ -30,6 +30,7 @@
       "ip-address": ">=10.3.1",
       "ws": "^8.21.0",
       "postcss": ">=8.5.23",
+      "qs": ">=6.16.0",
       "body-parser": "2.3.0",
       "nanoid@<4": ">=3.3.17",
       "brace-expansion@<2.0.0": "1.1.18",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -177,5 +177,16 @@ and serves Context sessions. `derive --help` is the current command index;
 the [Derive documentation](https://docs.derive.to/)
 explains the surrounding workflows.
 
+Published Skills install natively into both Claude and Codex by default:
+
+```sh
+derive skill add <short_id>
+derive skill sync <short_id> --client codex
+derive skill remove <short_id> --scope project
+```
+
+Project installs use `.claude/skills` and `.agents/skills`; personal installs use
+`~/.claude/skills` and `~/.codex/skills`. Installs are atomic and pinned in `derive.json`.
+
 Derive is licensed under FSL-1.1-ALv2 and converts to Apache-2.0 on the schedule in
 the [license](https://github.com/derive-to/derive/blob/main/LICENSE).

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -182,11 +182,13 @@ Published Skills install natively into both Claude and Codex by default:
 ```sh
 derive skill add <short_id>
 derive skill sync <short_id> --client codex
+derive skill sync --all
 derive skill remove <short_id> --scope project
 ```
 
 Project installs use `.claude/skills` and `.agents/skills`; personal installs use
 `~/.claude/skills` and `~/.codex/skills`. Installs are atomic and pinned in `derive.json`.
+`sync --all` updates every pinned Skill while preserving any Claude-only or Codex-only installs.
 
 Derive is licensed under FSL-1.1-ALv2 and converts to Apache-2.0 on the schedule in
 the [license](https://github.com/derive-to/derive/blob/main/LICENSE).

--- a/packages/cli/bin/derive.js
+++ b/packages/cli/bin/derive.js
@@ -35,9 +35,9 @@
 //   derive workflow run [run_id]          one authorized GitHub Actions graph harness
 import { spawn } from "node:child_process"
 import { createHash, randomBytes } from "node:crypto"
-import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs"
-import { tmpdir } from "node:os"
-import { join } from "node:path"
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { homedir, tmpdir } from "node:os"
+import { join, resolve } from "node:path"
 import { createInterface } from "node:readline"
 import { fileURLToPath } from "node:url"
 import {
@@ -54,6 +54,7 @@ import {
   loadConfig,
   mergeChosenWorkspaces,
   removeAccount,
+  removeSkillClients,
   resolveAccountRef,
   resolvePublish,
   resolveServer,
@@ -72,7 +73,7 @@ import {
 import { createAgent, createContext, saveAgentToken } from "../src/context.js"
 import { readTarget, uploadArtifact } from "../src/publish.js"
 import { DeriveClient, parseManifest } from "../src/runner.js"
-import { materializeNotes, materializeSkills, pinManifestSkills } from "../src/skills.js"
+import { materializeNotes, materializeSkills, pinManifestSkills, skillSlug } from "../src/skills.js"
 import {
   formatWorkflowPreview,
   previewWorkflowSource,
@@ -1323,8 +1324,10 @@ if (LOOP.includes(cmd)) {
 if (cmd === "skill") {
   const sub = positional.shift()
   const shortId = positional[0]
-  if (sub !== "add" || !shortId) {
-    console.error("usage: derive skill add <short_id>   materialize a skill into ./.claude/skills/")
+  if (!["add", "sync", "remove"].includes(sub) || !shortId) {
+    console.error(
+      "usage: derive skill add|sync|remove <short_id> [--client claude|codex|all] [--scope project|personal]",
+    )
     process.exit(cmd ? 1 : 0)
   }
   let cfg = null
@@ -1333,12 +1336,73 @@ if (cmd === "skill") {
   } catch {
     /* no derive.json yet — the pin creates one */
   }
+  const clients =
+    flags.client === "claude" || flags.client === "codex" ? [flags.client] : ["claude", "codex"]
+  if (flags.client && !["claude", "codex", "all"].includes(flags.client)) {
+    console.error("error: --client must be claude, codex, or all")
+    process.exit(1)
+  }
+  const scope = flags.scope ?? "project"
+  if (!["project", "personal"].includes(scope)) {
+    console.error("error: --scope must be project or personal")
+    process.exit(1)
+  }
+  const targetRoot = (client) =>
+    scope === "personal"
+      ? join(homedir(), client === "codex" ? ".codex" : ".claude", "skills")
+      : join(".", client === "codex" ? ".agents" : ".claude", "skills")
+
   const r = resolvePublish(flags, cfg)
   r.token = flags.token ?? process.env.DERIVE_TOKEN ?? (await freshToken(r.server, r.accountId))
   if (!r.token) {
     console.error("error: not signed in — run `derive login` first")
     process.exit(1)
   }
+  const deriveClient = new DeriveClient(r.server, r.token)
+
+  if (sub === "remove") {
+    const pin = cfg?.skills?.find((skill) => skill.id === shortId)
+    if (!pin?.name) {
+      console.error(`error: ${shortId} is not pinned in ${CONFIG_FILE}`)
+      process.exit(1)
+    }
+    const installedClients = pin.installs
+      ? clients.filter((target) => pin.installs[target])
+      : clients
+    if (installedClients.length === 0) {
+      console.error(`error: ${shortId} is not installed for ${clients.join(" + ")}`)
+      process.exit(1)
+    }
+    for (const target of installedClients) {
+      const installed = pin.installs?.[target] ?? pin
+      const dir = skillSlug(installed.name ?? pin.name)
+      if (!dir) {
+        console.error(`error: ${shortId} has no recorded directory for ${target}`)
+        process.exit(1)
+      }
+      rmSync(join(targetRoot(target), dir), { recursive: true, force: true })
+      const scopeId = createHash("sha256")
+        .update(`${scope}\0${resolve(targetRoot(target))}`)
+        .digest("hex")
+      await deriveClient.call(`/v1/artifacts/${shortId}/skill-installation`, {
+        method: "PUT",
+        headers: r.workspaceId ? { "x-derive-workspace": r.workspaceId } : {},
+        body: JSON.stringify({
+          skill_version: installed.version,
+          scope_kind: scope,
+          opaque_scope_id: scopeId,
+          client: target,
+          digest: "0".repeat(64),
+          policy: "pinned",
+          removed: true,
+        }),
+      })
+    }
+    removeSkillClients(".", shortId, installedClients)
+    console.log(`✓ removed ${pin.name} from ${installedClients.join(" + ")}`)
+    process.exit(0)
+  }
+
   const auth = {
     authorization: `Bearer ${r.token}`,
     ...(r.workspaceId ? { "x-derive-workspace": r.workspaceId } : {}),
@@ -1355,19 +1419,39 @@ if (cmd === "skill") {
     process.exit(1)
   }
   const version = detail.current_version
-  const api = new DeriveClient(r.server, r.token).skillApi()
-  const cat = await materializeSkills(
-    api,
-    [{ id: shortId, version }],
-    join(".", ".claude", "skills"),
-  )
-  const done = cat.find((s) => s.ok)
-  if (!done) {
-    console.error("error: could not materialize the skill")
-    process.exit(1)
+  const api = deriveClient.skillApi()
+  let done = null
+  for (const target of clients) {
+    const cat = await materializeSkills(api, [{ id: shortId, version }], targetRoot(target))
+    const installed = cat.find((s) => s.ok)
+    if (!installed) {
+      console.error(`error: could not materialize the skill for ${target}`)
+      process.exit(1)
+    }
+    done ??= installed
+    // Record each filesystem success immediately. If the other client or the receipt
+    // request fails, derive.json still describes what is actually on disk, so retry or
+    // targeted remove can recover without an orphaned installation.
+    writeSkillPin(".", { id: shortId, version, name: installed.name, clients: [target] })
+    const scopeId = createHash("sha256")
+      .update(`${scope}\0${resolve(targetRoot(target))}`)
+      .digest("hex")
+    await deriveClient.call(`/v1/artifacts/${shortId}/skill-installation`, {
+      method: "PUT",
+      headers: r.workspaceId ? { "x-derive-workspace": r.workspaceId } : {},
+      body: JSON.stringify({
+        skill_version: version,
+        scope_kind: scope,
+        opaque_scope_id: scopeId,
+        client: target,
+        digest: installed.digest,
+        policy: "pinned",
+      }),
+    })
   }
-  writeSkillPin(".", { id: shortId, version, name: done.name })
-  console.log(`✓ .claude/skills/${done.dir} — ${done.name} @v${version} (pinned in ${CONFIG_FILE})`)
+  console.log(
+    `✓ ${done.name} @v${version} installed for ${clients.join(" + ")} (${scope}; pinned in ${CONFIG_FILE})`,
+  )
   process.exit(0)
 }
 
@@ -1559,9 +1643,9 @@ if (cmd !== "publish") {
   derive workflow sync [file] [--json]     project definition topology into the visible graph, then Preview
   derive workflow preview [file] [--json]  explain + validate a graph/loop before it runs
   derive workflow run [run_id]             execute one assigned graph from GitHub Actions OIDC
-  derive skill add <short_id>              materialize a published skill into ./.claude/skills/ (pinned)
+  derive skill add|sync|remove <short_id>  install a pinned Skill for Claude + Codex (--client/--scope)
   derive brandprint pull                   materialize the workspace + your Brandprint into this repo`)
-  process.exit(cmd ? 1 : 0)
+  process.exit(cmd && cmd !== "--help" && cmd !== "help" ? 1 : 0)
 }
 
 // Merge derive.json (if present in cwd) with flags; flags win.

--- a/packages/cli/bin/derive.js
+++ b/packages/cli/bin/derive.js
@@ -65,6 +65,7 @@ import {
   setDefaultAccount,
   setDefaultWorkspace,
   setWorkspaces,
+  skillSyncPlan,
   TEMPLATES,
   writeContextConfig,
   writeId,
@@ -1316,7 +1317,7 @@ if (LOOP.includes(cmd)) {
   process.exit(0)
 }
 
-// ---- derive skill (add) -----------------------------------------------------
+// ---- derive skill (add/sync/remove) -----------------------------------------
 // The consumption half of the skill loop: author with `init --template skill` +
 // `publish`, then INSTALL a published skill into ./.claude/skills/<name>/ where
 // this project's agent auto-discovers it. Pinned in derive.json so an update is a
@@ -1324,9 +1325,10 @@ if (LOOP.includes(cmd)) {
 if (cmd === "skill") {
   const sub = positional.shift()
   const shortId = positional[0]
-  if (!["add", "sync", "remove"].includes(sub) || !shortId) {
+  const syncAll = sub === "sync" && flags.all === "true"
+  if (!["add", "sync", "remove"].includes(sub) || (!shortId && !syncAll) || (syncAll && shortId)) {
     console.error(
-      "usage: derive skill add|sync|remove <short_id> [--client claude|codex|all] [--scope project|personal]",
+      "usage: derive skill add|sync|remove <short_id> [--client claude|codex|all] [--scope project|personal]\n       derive skill sync --all [--client claude|codex|all] [--scope project|personal]",
     )
     process.exit(cmd ? 1 : 0)
   }
@@ -1359,6 +1361,12 @@ if (cmd === "skill") {
     process.exit(1)
   }
   const deriveClient = new DeriveClient(r.server, r.token)
+
+  const syncPlan = syncAll ? skillSyncPlan(cfg, clients) : [{ id: shortId, clients }]
+  if (syncAll && syncPlan.length === 0) {
+    console.error(`error: no installed skills match in ${CONFIG_FILE}`)
+    process.exit(1)
+  }
 
   if (sub === "remove") {
     const pin = cfg?.skills?.find((skill) => skill.id === shortId)
@@ -1407,51 +1415,56 @@ if (cmd === "skill") {
     authorization: `Bearer ${r.token}`,
     ...(r.workspaceId ? { "x-derive-workspace": r.workspaceId } : {}),
   }
-  const detail = await (await fetch(`${r.server}/v1/artifacts/${shortId}`, { headers: auth }))
-    .json()
-    .catch(() => null)
-  if (!detail?.current_version) {
-    console.error(`error: no such artifact ${shortId}`)
-    process.exit(1)
-  }
-  if (!detail.bundle?.isSkill) {
-    console.error(`error: ${shortId} is not a skill (a bundle with a SKILL.md)`)
-    process.exit(1)
-  }
-  const version = detail.current_version
   const api = deriveClient.skillApi()
-  let done = null
-  for (const target of clients) {
-    const cat = await materializeSkills(api, [{ id: shortId, version }], targetRoot(target))
-    const installed = cat.find((s) => s.ok)
-    if (!installed) {
-      console.error(`error: could not materialize the skill for ${target}`)
+  let synced = 0
+  for (const item of syncPlan) {
+    const detail = await (await fetch(`${r.server}/v1/artifacts/${item.id}`, { headers: auth }))
+      .json()
+      .catch(() => null)
+    if (!detail?.current_version) {
+      console.error(`error: no such artifact ${item.id}`)
       process.exit(1)
     }
-    done ??= installed
-    // Record each filesystem success immediately. If the other client or the receipt
-    // request fails, derive.json still describes what is actually on disk, so retry or
-    // targeted remove can recover without an orphaned installation.
-    writeSkillPin(".", { id: shortId, version, name: installed.name, clients: [target] })
-    const scopeId = createHash("sha256")
-      .update(`${scope}\0${resolve(targetRoot(target))}`)
-      .digest("hex")
-    await deriveClient.call(`/v1/artifacts/${shortId}/skill-installation`, {
-      method: "PUT",
-      headers: r.workspaceId ? { "x-derive-workspace": r.workspaceId } : {},
-      body: JSON.stringify({
-        skill_version: version,
-        scope_kind: scope,
-        opaque_scope_id: scopeId,
-        client: target,
-        digest: installed.digest,
-        policy: "pinned",
-      }),
-    })
+    if (!detail.bundle?.isSkill) {
+      console.error(`error: ${item.id} is not a skill (a bundle with a SKILL.md)`)
+      process.exit(1)
+    }
+    const version = detail.current_version
+    let done = null
+    for (const target of item.clients) {
+      const cat = await materializeSkills(api, [{ id: item.id, version }], targetRoot(target))
+      const installed = cat.find((skill) => skill.ok)
+      if (!installed) {
+        console.error(`error: could not materialize ${item.id} for ${target}`)
+        process.exit(1)
+      }
+      done ??= installed
+      // Record each filesystem success immediately. If the other client or the receipt
+      // request fails, derive.json still describes what is actually on disk, so retry or
+      // targeted remove can recover without an orphaned installation.
+      writeSkillPin(".", { id: item.id, version, name: installed.name, clients: [target] })
+      const scopeId = createHash("sha256")
+        .update(`${scope}\0${resolve(targetRoot(target))}`)
+        .digest("hex")
+      await deriveClient.call(`/v1/artifacts/${item.id}/skill-installation`, {
+        method: "PUT",
+        headers: r.workspaceId ? { "x-derive-workspace": r.workspaceId } : {},
+        body: JSON.stringify({
+          skill_version: version,
+          scope_kind: scope,
+          opaque_scope_id: scopeId,
+          client: target,
+          digest: installed.digest,
+          policy: "pinned",
+        }),
+      })
+    }
+    synced++
+    console.log(
+      `✓ ${done.name} @v${version} installed for ${item.clients.join(" + ")} (${scope}; pinned in ${CONFIG_FILE})`,
+    )
   }
-  console.log(
-    `✓ ${done.name} @v${version} installed for ${clients.join(" + ")} (${scope}; pinned in ${CONFIG_FILE})`,
-  )
+  if (syncAll) console.log(`✓ synced ${synced} installed ${synced === 1 ? "skill" : "skills"}`)
   process.exit(0)
 }
 
@@ -1644,6 +1657,7 @@ if (cmd !== "publish") {
   derive workflow preview [file] [--json]  explain + validate a graph/loop before it runs
   derive workflow run [run_id]             execute one assigned graph from GitHub Actions OIDC
   derive skill add|sync|remove <short_id>  install a pinned Skill for Claude + Codex (--client/--scope)
+  derive skill sync --all                  update every locally pinned Skill
   derive brandprint pull                   materialize the workspace + your Brandprint into this repo`)
   process.exit(cmd && cmd !== "--help" && cmd !== "help" ? 1 : 0)
 }

--- a/packages/cli/bin/derive.js
+++ b/packages/cli/bin/derive.js
@@ -1354,6 +1354,12 @@ if (cmd === "skill") {
       ? join(homedir(), client === "codex" ? ".codex" : ".claude", "skills")
       : join(".", client === "codex" ? ".agents" : ".claude", "skills")
 
+  const syncPlan = syncAll ? skillSyncPlan(cfg, clients) : [{ id: shortId, clients }]
+  if (syncAll && syncPlan.length === 0) {
+    console.error(`error: no installed skills match in ${CONFIG_FILE}`)
+    process.exit(1)
+  }
+
   const r = resolvePublish(flags, cfg)
   r.token = flags.token ?? process.env.DERIVE_TOKEN ?? (await freshToken(r.server, r.accountId))
   if (!r.token) {
@@ -1361,12 +1367,6 @@ if (cmd === "skill") {
     process.exit(1)
   }
   const deriveClient = new DeriveClient(r.server, r.token)
-
-  const syncPlan = syncAll ? skillSyncPlan(cfg, clients) : [{ id: shortId, clients }]
-  if (syncAll && syncPlan.length === 0) {
-    console.error(`error: no installed skills match in ${CONFIG_FILE}`)
-    process.exit(1)
-  }
 
   if (sub === "remove") {
     const pin = cfg?.skills?.find((skill) => skill.id === shortId)

--- a/packages/cli/src/config.js
+++ b/packages/cli/src/config.js
@@ -597,11 +597,65 @@ export function writeContextConfig(dir, patch) {
 /** Record (or replace) a skill pin in derive.json's top-level `skills` array — the
  *  lockfile `derive skill add` maintains, so a later `update` is an explicit, diffable
  *  act rather than silent drift. Same id ⇒ overwrite (a re-add repins). */
-export function writeSkillPin(dir, { id, version, name }) {
+export function writeSkillPin(dir, { id, version, name, clients = ["claude", "codex"] }) {
   const path = join(dir, CONFIG_FILE)
   const config = loadConfig(dir) ?? defaultConfig()
+  const existing = Array.isArray(config.skills) ? config.skills.find((s) => s.id === id) : null
   const kept = Array.isArray(config.skills) ? config.skills.filter((s) => s.id !== id) : []
-  config.skills = [...kept, { id, version, ...(name ? { name } : {}) }]
+  // Pre-client pins were written only by the old all-clients command. Expand them on
+  // first touch so a targeted sync/remove cannot lose the other local installation.
+  const installs = existing?.installs
+    ? { ...existing.installs }
+    : existing
+      ? {
+          claude: { version: existing.version, ...(existing.name ? { name: existing.name } : {}) },
+          codex: { version: existing.version, ...(existing.name ? { name: existing.name } : {}) },
+        }
+      : {}
+  for (const client of clients) installs[client] = { version, ...(name ? { name } : {}) }
+  config.skills = [...kept, { id, version, ...(name ? { name } : {}), installs }]
+  writeFileSync(path, `${JSON.stringify(config, null, 2)}\n`)
+  return config
+}
+
+/** Forget only the native destinations actually removed. The top-level pin stays as
+ * a portable dependency while either Claude or Codex still has a local installation. */
+export function removeSkillClients(dir, id, clients) {
+  const path = join(dir, CONFIG_FILE)
+  const config = loadConfig(dir) ?? defaultConfig()
+  const skills = Array.isArray(config.skills) ? config.skills : []
+  const existing = skills.find((skill) => skill.id === id)
+  if (!existing) return config
+  const installs = existing.installs
+    ? { ...existing.installs }
+    : {
+        claude: { version: existing.version, ...(existing.name ? { name: existing.name } : {}) },
+        codex: { version: existing.version, ...(existing.name ? { name: existing.name } : {}) },
+      }
+  for (const client of clients) delete installs[client]
+  const remaining = Object.values(installs)
+  config.skills =
+    remaining.length === 0
+      ? skills.filter((skill) => skill.id !== id)
+      : skills.map((skill) =>
+          skill.id === id
+            ? {
+                ...skill,
+                version: remaining[0].version,
+                ...(remaining[0].name ? { name: remaining[0].name } : {}),
+                installs,
+              }
+            : skill,
+        )
+  writeFileSync(path, `${JSON.stringify(config, null, 2)}\n`)
+  return config
+}
+
+/** Remove one project's skill pin, preserving every unrelated config key. */
+export function removeSkillPin(dir, id) {
+  const path = join(dir, CONFIG_FILE)
+  const config = loadConfig(dir) ?? defaultConfig()
+  config.skills = Array.isArray(config.skills) ? config.skills.filter((s) => s.id !== id) : []
   writeFileSync(path, `${JSON.stringify(config, null, 2)}\n`)
   return config
 }

--- a/packages/cli/src/config.js
+++ b/packages/cli/src/config.js
@@ -618,6 +618,22 @@ export function writeSkillPin(dir, { id, version, name, clients = ["claude", "co
   return config
 }
 
+/** Build the `sync --all` worklist from the local lockfile. Modern pins retain
+ * client-specific install state, so syncing everything updates only destinations
+ * that already exist instead of silently broadening a Claude-only install into
+ * Codex (or vice versa). Legacy pins predate that state and therefore mean both. */
+export function skillSyncPlan(config, requestedClients = ["claude", "codex"]) {
+  const skills = Array.isArray(config?.skills) ? config.skills : []
+  return skills
+    .map((skill) => ({
+      id: skill.id,
+      clients: skill.installs
+        ? requestedClients.filter((client) => skill.installs[client])
+        : [...requestedClients],
+    }))
+    .filter((item) => item.id && item.clients.length > 0)
+}
+
 /** Forget only the native destinations actually removed. The top-level pin stays as
  * a portable dependency while either Claude or Codex still has a local installation. */
 export function removeSkillClients(dir, id, clients) {

--- a/packages/cli/src/skills.js
+++ b/packages/cli/src/skills.js
@@ -9,8 +9,31 @@
 //   outline(id, version)  → { entry, pages: [{ path, type }] }   (bundle file tree)
 //   file(id, path, version) → bytes | string                     (one bundle file, raw)
 //   content(id, version)  → string                               (a single-file doc's source)
-import { mkdirSync, rmSync, writeFileSync } from "node:fs"
-import { dirname, join } from "node:path"
+import { createHash, randomBytes } from "node:crypto"
+import { existsSync, mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs"
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path"
+
+const MAX_SKILL_FILES = 2_000
+const MAX_SKILL_BYTES = 50 * 1024 * 1024
+
+const safeSkillPath = (path) => {
+  const clean = String(path).replaceAll("\\", "/").replace(/^\.\//, "")
+  if (!clean || isAbsolute(clean) || clean.split("/").some((part) => !part || part === ".."))
+    throw new Error(`unsafe skill path: ${path}`)
+  return clean
+}
+
+/** Stable digest of exact paths + bytes, independent of map insertion order. */
+export function skillDigest(files) {
+  const hash = createHash("sha256")
+  for (const [rawPath, value] of [...files].sort(([a], [b]) => a.localeCompare(b))) {
+    const path = safeSkillPath(rawPath)
+    const bytes = Buffer.isBuffer(value) ? value : Buffer.from(value)
+    hash.update(`${path}\0${bytes.byteLength}\0`)
+    hash.update(bytes)
+  }
+  return hash.digest("hex")
+}
 
 /** Read the frontmatter `name:` from a SKILL.md. Dependency-free (the CLI can't import
  *  @derive/core's parseFrontmatter) and deliberately minimal: the leading `--- … ---`
@@ -47,12 +70,14 @@ export async function fetchSkill(api, { id, version }) {
     const outline = await api.outline(id, v)
     const pages = outline?.pages ?? []
     if (pages.length === 0) throw new Error("no files in this version")
-    const entry = String(outline.entry ?? "SKILL.md").replace(/^\//, "")
+    const entry = safeSkillPath(String(outline.entry ?? "SKILL.md").replace(/^\//, ""))
+    if (entry !== "SKILL.md") throw new Error("skill entry must be the root SKILL.md")
     const files = new Map()
     for (const p of pages) {
-      const path = String(p.path).replace(/^\//, "")
+      const path = safeSkillPath(String(p.path).replace(/^\//, ""))
       files.set(path, await api.file(id, path, v))
     }
+    if (!files.has("SKILL.md")) throw new Error("skill bundle is missing its root SKILL.md")
     return { name: skillNameFrom(files.get(entry)), entry, files }
   }
   return fetchAt(version ?? null)
@@ -62,13 +87,48 @@ export async function fetchSkill(api, { id, version }) {
  *  runner's repos/), so it's replaced wholesale, never merged — a removed file at the
  *  source must not linger on disk. */
 export function writeSkill(destRoot, dir, files) {
-  const root = join(destRoot, dir)
-  rmSync(root, { recursive: true, force: true })
-  for (const [path, bytes] of files) {
-    const dest = join(root, path)
-    mkdirSync(dirname(dest), { recursive: true })
-    writeFileSync(dest, bytes)
+  const safeDir = skillSlug(dir)
+  if (!safeDir || safeDir !== dir) throw new Error(`unsafe skill directory: ${dir}`)
+  if (files.size > MAX_SKILL_FILES) throw new Error(`skill exceeds ${MAX_SKILL_FILES} files`)
+  let total = 0
+  const prepared = []
+  for (const [rawPath, value] of files) {
+    const path = safeSkillPath(rawPath)
+    const bytes = Buffer.isBuffer(value) ? value : Buffer.from(value)
+    total += bytes.byteLength
+    if (total > MAX_SKILL_BYTES) throw new Error("skill exceeds 50 MB")
+    prepared.push([path, bytes])
   }
+
+  const parent = resolve(destRoot)
+  const root = resolve(parent, safeDir)
+  if (relative(parent, root).startsWith(`..${sep}`)) throw new Error("unsafe skill destination")
+  mkdirSync(parent, { recursive: true })
+  const nonce = `${process.pid}-${randomBytes(6).toString("hex")}`
+  const staging = resolve(parent, `.${safeDir}.staging-${nonce}`)
+  const backup = resolve(parent, `.${safeDir}.backup-${nonce}`)
+  mkdirSync(staging)
+  try {
+    for (const [path, bytes] of prepared) {
+      const dest = resolve(staging, path)
+      if (dest !== staging && !dest.startsWith(`${staging}${sep}`))
+        throw new Error(`unsafe skill path: ${path}`)
+      mkdirSync(dirname(dest), { recursive: true })
+      writeFileSync(dest, bytes)
+    }
+    const hadExisting = existsSync(root)
+    if (hadExisting) renameSync(root, backup)
+    try {
+      renameSync(staging, root)
+    } catch (error) {
+      if (hadExisting && existsSync(backup)) renameSync(backup, root)
+      throw error
+    }
+    if (hadExisting) rmSync(backup, { recursive: true, force: true })
+  } finally {
+    rmSync(staging, { recursive: true, force: true })
+  }
+  return skillDigest(files)
 }
 
 /** Merge the ambient Brandprint skill layer with the manifest's own `skills:` into one
@@ -94,8 +154,8 @@ export async function materializeSkills(api, skills, destRoot) {
       const base = skillSlug(name) ?? s.id
       const dir = used.has(base) ? `${base}-${s.id}` : base
       used.add(dir)
-      writeSkill(destRoot, dir, files)
-      out.push({ id: s.id, version: s.version, dir, name: name ?? dir, ok: true })
+      const digest = writeSkill(destRoot, dir, files)
+      out.push({ id: s.id, version: s.version, dir, name: name ?? dir, digest, ok: true })
       console.log(`[skills] ${dir} @v${s.version}`)
     } catch (e) {
       console.error(`[skills] ${s.id}: ${e?.message ?? e}`)

--- a/packages/cli/test/config.test.js
+++ b/packages/cli/test/config.test.js
@@ -16,6 +16,7 @@ import {
   loadConfig,
   mergeChosenWorkspaces,
   removeAccount,
+  removeSkillClients,
   resolveAccountRef,
   resolvePublish,
   resolveWorkspaceRef,
@@ -270,14 +271,60 @@ describe("writeSkillPin", () => {
     writeSkillPin(d, { id: "sk1", version: 3, name: "chart-style" })
     let cfg = writeSkillPin(d, { id: "sk2", version: 1 })
     expect(cfg.skills).toEqual([
-      { id: "sk1", version: 3, name: "chart-style" },
-      { id: "sk2", version: 1 },
+      {
+        id: "sk1",
+        version: 3,
+        name: "chart-style",
+        installs: {
+          claude: { version: 3, name: "chart-style" },
+          codex: { version: 3, name: "chart-style" },
+        },
+      },
+      {
+        id: "sk2",
+        version: 1,
+        installs: { claude: { version: 1 }, codex: { version: 1 } },
+      },
     ])
     // Re-adding sk1 at a new version replaces it in place (still 2 entries).
     cfg = writeSkillPin(d, { id: "sk1", version: 4, name: "chart-style" })
     expect(cfg.skills).toHaveLength(2)
     expect(cfg.skills.find((s) => s.id === "sk1").version).toBe(4)
     expect(cfg.title).toBe("T") // untouched
+  })
+
+  it("tracks Claude and Codex independently across targeted syncs and removals", () => {
+    const d = tmp()
+    writeFileSync(join(d, CONFIG_FILE), JSON.stringify({ title: "T", entry: "context" }))
+    writeSkillPin(d, { id: "sk1", version: 7, name: "brief", clients: ["claude", "codex"] })
+    let cfg = writeSkillPin(d, {
+      id: "sk1",
+      version: 8,
+      name: "brief",
+      clients: ["codex"],
+    })
+    expect(cfg.skills[0].installs).toEqual({
+      claude: { version: 7, name: "brief" },
+      codex: { version: 8, name: "brief" },
+    })
+
+    cfg = removeSkillClients(d, "sk1", ["codex"])
+    expect(cfg.skills[0]).toMatchObject({
+      id: "sk1",
+      version: 7,
+      installs: { claude: { version: 7, name: "brief" } },
+    })
+    cfg = removeSkillClients(d, "sk1", ["claude"])
+    expect(cfg.skills).toEqual([])
+  })
+})
+
+describe("CLI help", () => {
+  it("prints the command index and exits successfully", () => {
+    const bin = join(import.meta.dirname, "..", "bin", "derive.js")
+    const result = spawnSync(process.execPath, [bin, "--help"], { encoding: "utf8" })
+    expect(result.status).toBe(0)
+    expect(result.stderr).toContain("derive skill add|sync|remove")
   })
 })
 

--- a/packages/cli/test/config.test.js
+++ b/packages/cli/test/config.test.js
@@ -27,6 +27,7 @@ import {
   setDefaultAccount,
   setDefaultWorkspace,
   setWorkspaces,
+  skillSyncPlan,
   writeContextConfig,
   writeId,
   writeSkillPin,
@@ -317,6 +318,30 @@ describe("writeSkillPin", () => {
     cfg = removeSkillClients(d, "sk1", ["claude"])
     expect(cfg.skills).toEqual([])
   })
+
+  it("plans an all-skill sync without broadening client-specific installs", () => {
+    expect(
+      skillSyncPlan(
+        {
+          skills: [
+            { id: "legacy", version: 1 },
+            { id: "claude-only", installs: { claude: { version: 2 } } },
+            { id: "codex-only", installs: { codex: { version: 3 } } },
+          ],
+        },
+        ["claude", "codex"],
+      ),
+    ).toEqual([
+      { id: "legacy", clients: ["claude", "codex"] },
+      { id: "claude-only", clients: ["claude"] },
+      { id: "codex-only", clients: ["codex"] },
+    ])
+    expect(
+      skillSyncPlan({ skills: [{ id: "claude-only", installs: { claude: { version: 2 } } }] }, [
+        "codex",
+      ]),
+    ).toEqual([])
+  })
 })
 
 describe("CLI help", () => {
@@ -325,6 +350,7 @@ describe("CLI help", () => {
     const result = spawnSync(process.execPath, [bin, "--help"], { encoding: "utf8" })
     expect(result.status).toBe(0)
     expect(result.stderr).toContain("derive skill add|sync|remove")
+    expect(result.stderr).toContain("derive skill sync --all")
   })
 })
 

--- a/packages/cli/test/runner.test.js
+++ b/packages/cli/test/runner.test.js
@@ -1,6 +1,7 @@
 import { execSync } from "node:child_process"
 import {
   chmodSync,
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -26,7 +27,7 @@ import {
   serveSession,
   syncRepos,
 } from "../src/runner.js"
-import { materializeSkills, skillSlug } from "../src/skills.js"
+import { materializeSkills, skillDigest, skillSlug, writeSkill } from "../src/skills.js"
 
 describe("parseAnswer", () => {
   it("rejects a missing block, bad JSON, and an empty body", () => {
@@ -773,6 +774,39 @@ describe("skills", () => {
       )
       expect(cat[0]).toMatchObject({ id: "missing", ok: false })
       expect(cat[1]).toMatchObject({ id: "ok1", dir: "good", ok: true })
+    })
+
+    it("rejects a claimed Skill bundle that omits its root SKILL.md", async () => {
+      const api = mockApi({
+        bad: { 1: { entry: "SKILL.md", files: { "references/only.md": "not a skill" } } },
+      })
+      const root = mkdtempSync(join(tmpdir(), "skills-"))
+      const [result] = await materializeSkills(api, [{ id: "bad", version: 1 }], root)
+      expect(result).toMatchObject({ id: "bad", ok: false })
+      expect(existsSync(join(root, "bad"))).toBe(false)
+    })
+
+    it("atomically replaces a skill and rejects paths outside its directory", () => {
+      const root = mkdtempSync(join(tmpdir(), "skills-"))
+      writeSkill(root, "safe", new Map([["SKILL.md", "old"]]))
+      expect(() =>
+        writeSkill(
+          root,
+          "safe",
+          new Map([
+            ["SKILL.md", "new"],
+            ["../escape", "bad"],
+          ]),
+        ),
+      ).toThrow(/unsafe skill path/)
+      expect(readFileSync(join(root, "safe", "SKILL.md"), "utf8")).toBe("old")
+
+      const next = new Map([
+        ["references/readme.md", "ref"],
+        ["SKILL.md", "new"],
+      ])
+      expect(writeSkill(root, "safe", next)).toBe(skillDigest(next))
+      expect(readFileSync(join(root, "safe", "SKILL.md"), "utf8")).toBe("new")
     })
   })
 })

--- a/packages/cli/test/skill-sync-all.test.js
+++ b/packages/cli/test/skill-sync-all.test.js
@@ -28,6 +28,28 @@ const run = (cwd, server, args) =>
   })
 
 describe("derive skill sync --all", () => {
+  it("reports an empty project before requiring authentication", async () => {
+    const project = mkdtempSync(join(tmpdir(), "derive-sync-all-empty-"))
+    dirs.push(project)
+    const child = spawn(
+      process.execPath,
+      [join(import.meta.dirname, "..", "bin", "derive.js"), "skill", "sync", "--all"],
+      {
+        cwd: project,
+        env: {
+          PATH: process.env.PATH,
+        },
+      },
+    )
+    let stderr = ""
+    child.stderr.on("data", (chunk) => (stderr += chunk))
+    const status = await new Promise((resolve) => child.on("close", resolve))
+
+    expect(status).toBe(1)
+    expect(stderr).toContain("no installed skills match")
+    expect(stderr).not.toContain("not signed in")
+  })
+
   it("updates every pin while preserving its installed clients", async () => {
     const receipts = []
     const names = { alpha: "Alpha Skill", beta: "Beta Skill" }

--- a/packages/cli/test/skill-sync-all.test.js
+++ b/packages/cli/test/skill-sync-all.test.js
@@ -1,0 +1,117 @@
+import { spawn } from "node:child_process"
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import http from "node:http"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
+
+const dirs = []
+const servers = []
+
+afterEach(async () => {
+  for (const server of servers.splice(0)) await new Promise((resolve) => server.close(resolve))
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true })
+})
+
+const run = (cwd, server, args) =>
+  new Promise((resolve) => {
+    const child = spawn(
+      process.execPath,
+      [join(import.meta.dirname, "..", "bin", "derive.js"), ...args, "--server", server],
+      { cwd, env: { ...process.env, DERIVE_TOKEN: "test-token" } },
+    )
+    let stdout = ""
+    let stderr = ""
+    child.stdout.on("data", (chunk) => (stdout += chunk))
+    child.stderr.on("data", (chunk) => (stderr += chunk))
+    child.on("close", (status) => resolve({ status, stdout, stderr }))
+  })
+
+describe("derive skill sync --all", () => {
+  it("updates every pin while preserving its installed clients", async () => {
+    const receipts = []
+    const names = { alpha: "Alpha Skill", beta: "Beta Skill" }
+    const server = http.createServer((request, response) => {
+      const url = new URL(request.url, "http://127.0.0.1")
+      const send = (status, value, type = "application/json") => {
+        response.writeHead(status, { "content-type": type })
+        response.end(type === "application/json" ? JSON.stringify(value) : value)
+      }
+      const detail = url.pathname.match(/^\/v1\/artifacts\/([^/]+)$/)
+      if (detail) return send(200, { current_version: 2, bundle: { isSkill: true } })
+      const content = url.pathname.match(/^\/v1\/artifacts\/([^/]+)\/content$/)
+      if (content) {
+        const name = names[content[1]]
+        if (url.searchParams.has("outline"))
+          return send(200, {
+            entry: "SKILL.md",
+            pages: [{ path: "SKILL.md", type: "text/markdown" }],
+          })
+        return send(
+          200,
+          `---\nname: ${name}\ndescription: fixture\n---\n\nVersion two.\n`,
+          "application/octet-stream",
+        )
+      }
+      const receipt = url.pathname.match(/^\/v1\/artifacts\/([^/]+)\/skill-installation$/)
+      if (receipt && request.method === "PUT") {
+        let body = ""
+        request.on("data", (chunk) => (body += chunk))
+        request.on("end", () => {
+          receipts.push({ id: receipt[1], ...JSON.parse(body) })
+          send(200, { ok: true })
+        })
+        return
+      }
+      send(404, { error: "not found" })
+    })
+    servers.push(server)
+    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve))
+    const base = `http://127.0.0.1:${server.address().port}`
+    const project = mkdtempSync(join(tmpdir(), "derive-sync-all-"))
+    dirs.push(project)
+    writeFileSync(
+      join(project, "derive.json"),
+      JSON.stringify({
+        title: "Fixture",
+        entry: "index.md",
+        skills: [
+          {
+            id: "alpha",
+            version: 1,
+            name: names.alpha,
+            installs: { claude: { version: 1 }, codex: { version: 1 } },
+          },
+          {
+            id: "beta",
+            version: 1,
+            name: names.beta,
+            installs: { claude: { version: 1 } },
+          },
+        ],
+      }),
+    )
+
+    const result = await run(project, base, ["skill", "sync", "--all"])
+
+    expect(result).toMatchObject({ status: 0 })
+    expect(result.stdout).toContain("synced 2 installed skills")
+    expect(existsSync(join(project, ".claude/skills/Alpha-Skill/SKILL.md"))).toBe(true)
+    expect(existsSync(join(project, ".agents/skills/Alpha-Skill/SKILL.md"))).toBe(true)
+    expect(existsSync(join(project, ".claude/skills/Beta-Skill/SKILL.md"))).toBe(true)
+    expect(existsSync(join(project, ".agents/skills/Beta-Skill"))).toBe(false)
+    expect(receipts.map(({ id, client }) => `${id}:${client}`).sort()).toEqual([
+      "alpha:claude",
+      "alpha:codex",
+      "beta:claude",
+    ])
+    const config = JSON.parse(readFileSync(join(project, "derive.json"), "utf8"))
+    expect(config.skills.find((skill) => skill.id === "alpha").installs).toEqual({
+      claude: { version: 2, name: names.alpha },
+      codex: { version: 2, name: names.alpha },
+    })
+    expect(config.skills.find((skill) => skill.id === "beta").installs).toEqual({
+      claude: { version: 2, name: names.beta },
+    })
+  })
+})

--- a/packages/core/src/md.test.ts
+++ b/packages/core/src/md.test.ts
@@ -4,7 +4,7 @@ import { renderMarkdown } from "./md"
 // The body content (between <main>…</main>) is the user-controlled markdown after
 // sanitization — assert against this so the page's own (trusted) script tag and
 // chrome don't muddy the checks.
-const bodyOf = (html: string) => html.split("<main>")[1]?.split("</main>")[0] ?? ""
+const bodyOf = (html: string) => html.match(/<main(?:\s[^>]*)?>([\s\S]*?)<\/main>/)?.[1] ?? ""
 
 describe("renderMarkdown — renders ordinary markdown", () => {
   it("turns common markdown into the expected HTML", async () => {
@@ -55,7 +55,7 @@ describe("renderMarkdown — document shell", () => {
   it("wraps the body in a full HTML document with the anchor client", async () => {
     const html = await renderMarkdown("hello", "My Doc")
     expect(html.startsWith("<!doctype html>")).toBe(true)
-    expect(html).toContain("<main>")
+    expect(html).toContain("<main data-derive-ready>")
     expect(html).toContain("<title>My Doc</title>")
     expect(html).toContain("/raw/derive-client.js") // SELECTION_SCRIPT
   })

--- a/packages/core/src/md.ts
+++ b/packages/core/src/md.ts
@@ -132,7 +132,7 @@ export const renderDocShell = (bodyHtml: string, title: string | null): string =
 <title>${escapeHtml(title ?? "Document")}</title>
 <style>${PAGE_CSS}</style>
 </head>
-<body><main>${bodyHtml}</main>${SELECTION_SCRIPT}</body>
+<body><main data-derive-ready>${bodyHtml}</main>${SELECTION_SCRIPT}</body>
 </html>`
 
 export async function renderMarkdown(source: string, title: string | null): Promise<string> {

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -2396,6 +2396,130 @@ export interface WorkflowRunStore {
   ): Promise<WorkflowStepAttemptRecord | null>
 }
 
+export type SkillRelationKind = "requires" | "extends" | "recommends"
+export type SkillClient = "claude" | "codex"
+export type SkillInstallScope = "project" | "personal" | "runner"
+export type SkillInstallPolicy = "pinned" | "latest"
+export type ArtifactSkillRole =
+  | "created"
+  | "revised"
+  | "validated"
+  | "example"
+  | "anti-example"
+  | "workflow-definition"
+
+export interface SkillRelationRecord {
+  id: string
+  org_id: string
+  source_artifact_id: string
+  source_version: number
+  target_artifact_id: string
+  target_version: number
+  kind: SkillRelationKind
+  created_at: string
+}
+
+export interface NewSkillRelation {
+  id: string
+  org_id: string
+  source_artifact_id: string
+  source_version: number
+  target_artifact_id: string
+  target_version: number
+  kind: SkillRelationKind
+}
+
+export interface SkillInstallationRecord {
+  id: string
+  org_id: string
+  skill_artifact_id: string
+  skill_version: number
+  scope_kind: SkillInstallScope
+  opaque_scope_id: string
+  client: SkillClient
+  digest: string
+  policy: SkillInstallPolicy
+  installed_by: string | null
+  created_at: string
+  updated_at: string
+  removed_at: string | null
+}
+
+export interface NewSkillInstallation {
+  id: string
+  org_id: string
+  skill_artifact_id: string
+  skill_version: number
+  scope_kind: SkillInstallScope
+  /** Stable one-way identifier supplied by the CLI; never a raw filesystem path. */
+  opaque_scope_id: string
+  client: SkillClient
+  digest: string
+  policy: SkillInstallPolicy
+  installed_by?: string | null
+  updated_at: string
+  removed_at?: string | null
+}
+
+export interface ArtifactSkillLinkRecord {
+  id: string
+  org_id: string
+  artifact_id: string
+  artifact_version: number
+  skill_artifact_id: string
+  skill_version: number
+  role: ArtifactSkillRole
+  linked_by: string
+  created_at: string
+}
+
+export interface NewArtifactSkillLink {
+  id: string
+  org_id: string
+  artifact_id: string
+  artifact_version: number
+  skill_artifact_id: string
+  skill_version: number
+  role: ArtifactSkillRole
+  linked_by: string
+}
+
+export interface SkillUsageBucket {
+  skill_version: number
+  count: number
+  last_used_at: string
+}
+
+/** Additive Skill indexes. Skill bundle bytes and the existing run ledgers stay authoritative. */
+export interface SkillStore {
+  replaceSkillRelations(
+    orgId: string,
+    skillArtifactId: string,
+    skillVersion: number,
+    relations: NewSkillRelation[],
+  ): Promise<void>
+  /** Direct incoming and outgoing semantic edges. Authorization stays at the route. */
+  listSkillRelations(skillArtifactId: string, orgId: string): Promise<SkillRelationRecord[]>
+  upsertSkillInstallation(installation: NewSkillInstallation): Promise<SkillInstallationRecord>
+  listSkillInstallations(skillArtifactId: string, orgId: string): Promise<SkillInstallationRecord[]>
+  linkArtifactSkill(link: NewArtifactSkillLink): Promise<ArtifactSkillLinkRecord>
+  listArtifactSkillLinks(
+    artifactId: string,
+    artifactVersion: number,
+    orgId: string,
+  ): Promise<ArtifactSkillLinkRecord[]>
+  listSkillArtifactLinks(
+    skillArtifactId: string,
+    orgId: string,
+    limit?: number,
+  ): Promise<ArtifactSkillLinkRecord[]>
+  /** Separate exact-version buckets; callers must not collapse them into a synthetic total. */
+  skillUsage(
+    skillArtifactId: string,
+    orgId: string,
+  ): Promise<{ contexts: SkillUsageBucket[]; workflows: SkillUsageBucket[] }>
+}
+
 export interface ModerationStore {
   // ---- Moderation: abuse reports, takedown, audit log --------------------
   createReport(r: NewReport): Promise<ReportRecord>
@@ -2583,6 +2707,7 @@ export interface MetaStore
     DirectoryStore,
     AgentStore,
     WorkflowRunStore,
+    SkillStore,
     ModerationStore,
     AssetStore,
     SharedStateStore {}

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -2508,6 +2508,12 @@ export interface SkillStore {
     artifactVersion: number,
     orgId: string,
   ): Promise<ArtifactSkillLinkRecord[]>
+  /** Exact-version provenance across an artifact's history, newest first. */
+  listArtifactSkillLinkHistory(
+    artifactId: string,
+    orgId: string,
+    limit?: number,
+  ): Promise<ArtifactSkillLinkRecord[]>
   listSkillArtifactLinks(
     skillArtifactId: string,
     orgId: string,

--- a/packages/core/src/publish.ts
+++ b/packages/core/src/publish.ts
@@ -15,7 +15,13 @@ import {
   type VersionRecord,
   type VersionSource,
 } from "./ports"
-import { isSkillBundle, parseFrontmatter } from "./skill"
+import {
+  isSkillBundle,
+  parseFrontmatter,
+  SKILL_SIDECAR_PATH,
+  type SkillSidecar,
+  validateSkillDefinition,
+} from "./skill"
 import { isVideoDocument, VIDEO_CONTENT_TYPE } from "./videos"
 
 /**
@@ -171,6 +177,8 @@ interface StoredContent {
   /** A skill bundle's frontmatter `name`, so a new artifact is titled from the skill
    *  rather than the zip's filename when the publisher gives no explicit title. */
   suggestedTitle?: string
+  /** Parsed only after the bundle passes the portable Skill contract. */
+  skillSidecar?: SkillSidecar | null
 }
 
 /**
@@ -232,10 +240,21 @@ async function storeContent(
     // frontmatter `name`, not the zip's filename, when no title is given.
     const isSkill = isSkillBundle(manifest)
     let suggestedTitle: string | undefined
+    let skillSidecar: SkillSidecar | null | undefined
     if (isSkill) {
       const entryKey = files[entry]?.key
       const entryBytes = entryKey ? await blobs.get(entryKey) : null
-      const name = entryBytes && parseFrontmatter(new TextDecoder().decode(entryBytes)).attrs.name
+      const skillMd = entryBytes ? new TextDecoder().decode(entryBytes) : ""
+      const sidecarKey = files[SKILL_SIDECAR_PATH]?.key
+      const sidecarBytes = sidecarKey ? await blobs.get(sidecarKey) : null
+      const checked = validateSkillDefinition(
+        skillMd,
+        sidecarBytes ? new TextDecoder().decode(sidecarBytes) : null,
+      )
+      if (checked.errors.length > 0)
+        throw new PublishError(400, `invalid skill: ${checked.errors.join("; ")}`)
+      skillSidecar = checked.sidecar
+      const name = parseFrontmatter(skillMd).attrs.name
       if (name) suggestedTitle = name
     }
     return {
@@ -244,6 +263,7 @@ async function storeContent(
       kind: "bundle",
       blobWriteMs,
       suggestedTitle,
+      skillSidecar,
     }
   }
   const text = new TextDecoder().decode(bytes)
@@ -291,6 +311,63 @@ async function storeContent(
   return { blobKey: await put(bytes), contentType, kind: "file", blobWriteMs }
 }
 
+/** Resolve every exact Skill reference before committing a version. Relations are part of the
+ * definition contract, so a missing/private-by-typo target is a publish error, not a graph edge
+ * that quietly disappears. Exact-version pinning makes cycles impossible during ordinary append
+ * publishes; the DFS also closes the replace-current case used by burst edits. */
+const validateSkillRelationsBeforePublish = async (
+  meta: MetaStore,
+  sidecar: SkillSidecar | null | undefined,
+  orgId: string,
+  sourceArtifactId?: string,
+  sourceVersion?: number,
+): Promise<void> => {
+  const declared = Object.entries(sidecar?.relations ?? {}).flatMap(([kind, refs]) =>
+    (refs ?? []).map((ref) => ({ kind, ref })),
+  )
+  if (declared.length === 0) return
+  const targets = await meta.getByShortIds([...new Set(declared.map(({ ref }) => ref.id))])
+  const byShortId = new Map(targets.map((target) => [target.short_id, target]))
+  for (const { ref } of declared) {
+    const target = byShortId.get(ref.id)
+    if (!target || target.org_id !== orgId)
+      throw new PublishError(400, `skill relation target ${ref.id}@v${ref.version} was not found`)
+    const version = await meta.getVersion(target.id, ref.version)
+    if (version?.content_type !== SKILL_CONTENT_TYPE)
+      throw new PublishError(400, `skill relation target ${ref.id}@v${ref.version} is not a Skill`)
+  }
+  if (!sourceArtifactId || !sourceVersion) return
+
+  const structural = declared.filter(({ kind }) => kind === "requires" || kind === "extends")
+  const seen = new Set<string>()
+  const reachesSource = async (artifactId: string, version: number): Promise<boolean> => {
+    if (artifactId === sourceArtifactId && version === sourceVersion) return true
+    const key = `${artifactId}@${version}`
+    if (seen.has(key)) return false
+    seen.add(key)
+    if (seen.size > 500) throw new PublishError(400, "skill relation graph exceeds 500 nodes")
+    const artifact = await meta.getArtifactById(artifactId)
+    if (!artifact) return false
+    const outgoing = (await meta.listSkillRelations(artifactId, orgId)).filter(
+      (edge) =>
+        edge.source_artifact_id === artifactId &&
+        edge.source_version === version &&
+        (edge.kind === "requires" || edge.kind === "extends"),
+    )
+    for (const edge of outgoing)
+      if (await reachesSource(edge.target_artifact_id, edge.target_version)) return true
+    return false
+  }
+  for (const { ref } of structural) {
+    const target = byShortId.get(ref.id)
+    if (target && (await reachesSource(target.id, ref.version)))
+      throw new PublishError(
+        400,
+        `skill relation creates a cycle through ${ref.id}@v${ref.version}`,
+      )
+  }
+}
+
 /**
  * Stores content and creates a new artifact (shortId undefined)
  * or the next version of an existing one.
@@ -302,13 +379,8 @@ export async function publish(
   shortId?: string,
 ): Promise<PublishResult> {
   const storeStartedAt = performance.now()
-  const { blobKey, contentType, kind, suggestedTitle, blobWriteMs } = await storeContent(
-    blobs,
-    input.bytes,
-    input.filename,
-    input.isBundle,
-    !!input.spa,
-  )
+  const { blobKey, contentType, kind, suggestedTitle, skillSidecar, blobWriteMs } =
+    await storeContent(blobs, input.bytes, input.filename, input.isBundle, !!input.spa)
   const timings = { blobWriteMs, storeContentMs: performance.now() - storeStartedAt }
 
   const author = input.author ?? "anonymous"
@@ -321,6 +393,13 @@ export async function publish(
     if (!artifact) throw new PublishError(404, `no artifact with short_id ${shortId}`)
     if (artifact.kind !== kind)
       throw new PublishError(409, `artifact is a ${artifact.kind}; republish the same kind`)
+    await validateSkillRelationsBeforePublish(
+      meta,
+      skillSidecar,
+      artifact.org_id,
+      artifact.id,
+      input.replaceCurrent?.n ?? artifact.current_version + 1,
+    )
     const nextVersion = {
       id: newId("v"),
       blob_key: blobKey,
@@ -367,6 +446,7 @@ export async function publish(
     input.title ?? suggestedTitle ?? input.filename.replace(/\.(html?|md|markdown|zip)$/i, "")
   if (input.mintShortId && (await meta.getByShortId(input.mintShortId)))
     throw new PublishError(409, `short_id ${input.mintShortId} is already taken`)
+  await validateSkillRelationsBeforePublish(meta, skillSidecar, input.orgId ?? "local")
   const artifact = await meta.createArtifact({
     id: newId("a"),
     short_id: input.mintShortId ?? newShortId(),

--- a/packages/core/src/skill.ts
+++ b/packages/core/src/skill.ts
@@ -24,6 +24,11 @@ export interface SkillSidecar {
   schema: typeof SKILL_DEFINITION_SCHEMA
   /** Whether this definition appears in the workspace Skills catalog. */
   catalog?: boolean
+  /** Why Derive created this Skill rather than a person publishing it directly. */
+  origin?: {
+    kind: "workflow-launcher"
+    workflow: { short_id: string; version: number }
+  }
   relations?: Partial<Record<SkillRelationKind, SkillRelationRef[]>>
   runtime?: { kind: "single" } | { kind: "graph" | "loop"; definition: WorkflowDefinition }
 }
@@ -83,6 +88,28 @@ export const validateSkillDefinition = (
     errors.push(`derive.skill.json schema must be "${SKILL_DEFINITION_SCHEMA}"`)
   if (raw.catalog !== undefined && typeof raw.catalog !== "boolean")
     errors.push("derive.skill.json catalog must be boolean")
+
+  let origin: SkillSidecar["origin"]
+  if (raw.origin !== undefined) {
+    const workflow = object(raw.origin) ? raw.origin.workflow : null
+    if (
+      !object(raw.origin) ||
+      raw.origin.kind !== "workflow-launcher" ||
+      !object(workflow) ||
+      typeof workflow.short_id !== "string" ||
+      !workflow.short_id.trim() ||
+      !Number.isInteger(workflow.version) ||
+      Number(workflow.version) < 1
+    )
+      errors.push(
+        "derive.skill.json origin must be a workflow-launcher with workflow short_id and version",
+      )
+    else
+      origin = {
+        kind: "workflow-launcher",
+        workflow: { short_id: workflow.short_id.trim(), version: Number(workflow.version) },
+      }
+  }
 
   const relations: Partial<Record<SkillRelationKind, SkillRelationRef[]>> = {}
   if (raw.relations !== undefined) {
@@ -150,6 +177,7 @@ export const validateSkillDefinition = (
         ? {
             schema: SKILL_DEFINITION_SCHEMA,
             ...(typeof raw.catalog === "boolean" ? { catalog: raw.catalog } : {}),
+            ...(origin ? { origin } : {}),
             ...(Object.keys(relations).length > 0 ? { relations } : {}),
             ...(runtime ? { runtime } : {}),
           }

--- a/packages/core/src/skill.ts
+++ b/packages/core/src/skill.ts
@@ -22,7 +22,7 @@ export interface SkillRelationRef {
 
 export interface SkillSidecar {
   schema: typeof SKILL_DEFINITION_SCHEMA
-  /** Embedded Context definitions stay private to their deployment until promoted. */
+  /** Whether this definition appears in the workspace Skills catalog. */
   catalog?: boolean
   relations?: Partial<Record<SkillRelationKind, SkillRelationRef[]>>
   runtime?: { kind: "single" } | { kind: "graph" | "loop"; definition: WorkflowDefinition }

--- a/packages/core/src/skill.ts
+++ b/packages/core/src/skill.ts
@@ -7,7 +7,160 @@
  * and read frontmatter, with NO new artifact kind and no heavy YAML dependency
  * (this module must run on Cloudflare Workers).
  */
-import type { BundleManifest } from "./ports"
+import type { BundleManifest, SkillRelationKind } from "./ports"
+import { validateWorkflowDefinition, type WorkflowDefinition } from "./workflow"
+
+export const SKILL_SIDECAR_PATH = "/derive.skill.json"
+export const SKILL_DEFINITION_SCHEMA = "derive.skill/v1" as const
+
+export type SkillRuntimeKind = "single" | "graph" | "loop"
+
+export interface SkillRelationRef {
+  id: string
+  version: number
+}
+
+export interface SkillSidecar {
+  schema: typeof SKILL_DEFINITION_SCHEMA
+  /** Embedded Context definitions stay private to their deployment until promoted. */
+  catalog?: boolean
+  relations?: Partial<Record<SkillRelationKind, SkillRelationRef[]>>
+  runtime?: { kind: "single" } | { kind: "graph" | "loop"; definition: WorkflowDefinition }
+}
+
+export interface SkillDefinitionValidation {
+  metadata: { name: string | null; description: string | null; compatibility: string | null }
+  sidecar: SkillSidecar | null
+  errors: string[]
+  warnings: string[]
+}
+
+const object = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value)
+
+const relationKinds: readonly SkillRelationKind[] = ["requires", "extends", "recommends"]
+
+/** Validate the portable Agent Skills contract plus Derive's optional typed sidecar. */
+export const validateSkillDefinition = (
+  skillMd: string,
+  sidecarSource?: string | null,
+): SkillDefinitionValidation => {
+  const attrs = parseFrontmatter(skillMd).attrs
+  const name = attrs.name?.trim() || null
+  const description = attrs.description?.trim() || null
+  const compatibility = attrs.compatibility?.trim() || null
+  const errors: string[] = []
+  const warnings: string[] = []
+
+  if (!name) errors.push("SKILL.md frontmatter requires name")
+  else {
+    if (name.length > 64) errors.push("SKILL.md name must be at most 64 characters")
+    if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(name))
+      errors.push("SKILL.md name must use lowercase letters, numbers, and single hyphens")
+  }
+  if (!description) errors.push("SKILL.md frontmatter requires description")
+  else if (description.length > 1024)
+    errors.push("SKILL.md description must be at most 1024 characters")
+  if (compatibility && compatibility.length > 500)
+    errors.push("SKILL.md compatibility must be at most 500 characters")
+
+  if (!sidecarSource) {
+    return { metadata: { name, description, compatibility }, sidecar: null, errors, warnings }
+  }
+
+  let raw: unknown
+  try {
+    raw = JSON.parse(sidecarSource)
+  } catch {
+    errors.push("derive.skill.json must be valid JSON")
+    return { metadata: { name, description, compatibility }, sidecar: null, errors, warnings }
+  }
+  if (!object(raw)) {
+    errors.push("derive.skill.json must be an object")
+    return { metadata: { name, description, compatibility }, sidecar: null, errors, warnings }
+  }
+  if (raw.schema !== SKILL_DEFINITION_SCHEMA)
+    errors.push(`derive.skill.json schema must be "${SKILL_DEFINITION_SCHEMA}"`)
+  if (raw.catalog !== undefined && typeof raw.catalog !== "boolean")
+    errors.push("derive.skill.json catalog must be boolean")
+
+  const relations: Partial<Record<SkillRelationKind, SkillRelationRef[]>> = {}
+  if (raw.relations !== undefined) {
+    if (!object(raw.relations)) errors.push("derive.skill.json relations must be an object")
+    else {
+      for (const kind of relationKinds) {
+        const list = raw.relations[kind]
+        if (list === undefined) continue
+        if (!Array.isArray(list)) {
+          errors.push(`derive.skill.json relations.${kind} must be an array`)
+          continue
+        }
+        const parsed: SkillRelationRef[] = []
+        const seen = new Set<string>()
+        for (const [index, item] of list.entries()) {
+          if (
+            !object(item) ||
+            typeof item.id !== "string" ||
+            !item.id.trim() ||
+            !Number.isInteger(item.version) ||
+            Number(item.version) < 1
+          ) {
+            errors.push(`derive.skill.json relations.${kind}[${index}] needs id and version`)
+            continue
+          }
+          const ref = { id: item.id.trim(), version: Number(item.version) }
+          const key = `${ref.id}@${ref.version}`
+          if (seen.has(key)) {
+            warnings.push(`duplicate ${kind} relation ${key} was ignored`)
+            continue
+          }
+          seen.add(key)
+          parsed.push(ref)
+        }
+        relations[kind] = parsed
+      }
+    }
+  }
+
+  let runtime: SkillSidecar["runtime"]
+  if (raw.runtime !== undefined) {
+    if (!object(raw.runtime)) errors.push("derive.skill.json runtime must be an object")
+    else if (raw.runtime.kind === "single") runtime = { kind: "single" }
+    else if (raw.runtime.kind === "graph" || raw.runtime.kind === "loop") {
+      const checked = validateWorkflowDefinition(raw.runtime.definition, null, {
+        allowUnlinked: true,
+      })
+      errors.push(...checked.errors.map((error) => `derive.skill.json runtime: ${error}`))
+      warnings.push(...checked.warnings.map((warning) => `derive.skill.json runtime: ${warning}`))
+      if (checked.definition) {
+        const loops = checked.definition.diagrams.flatMap((diagram) => diagram.loops ?? [])
+        if (raw.runtime.kind === "graph" && loops.length > 0)
+          errors.push("derive.skill.json graph runtime cannot declare loops")
+        if (raw.runtime.kind === "loop" && loops.length === 0)
+          errors.push("derive.skill.json loop runtime must declare at least one bounded loop")
+        runtime = { kind: raw.runtime.kind, definition: checked.definition }
+      }
+    } else errors.push('derive.skill.json runtime.kind must be "single", "graph", or "loop"')
+  }
+
+  return {
+    metadata: { name, description, compatibility },
+    sidecar:
+      errors.length === 0
+        ? {
+            schema: SKILL_DEFINITION_SCHEMA,
+            ...(typeof raw.catalog === "boolean" ? { catalog: raw.catalog } : {}),
+            ...(Object.keys(relations).length > 0 ? { relations } : {}),
+            ...(runtime ? { runtime } : {}),
+          }
+        : null,
+    errors,
+    warnings,
+  }
+}
+
+export const skillCatalogEnabled = (sidecar: SkillSidecar | null): boolean =>
+  sidecar?.catalog !== false
 
 /** A bundle whose entry document is a root `SKILL.md` is a skill. `pickBundleEntry`
  *  selects `/SKILL.md` as the entry for an HTML-less folder that contains one. */

--- a/packages/core/src/workflow.ts
+++ b/packages/core/src/workflow.ts
@@ -182,6 +182,7 @@ const nodeLabel = (node: LinkedBundleNode | undefined, fallback: string): string
 export const validateWorkflowDefinition = (
   value: unknown,
   linked?: LinkedBundleManifest | null,
+  options?: { allowUnlinked?: boolean },
 ): WorkflowValidation => {
   const errors: string[] = []
   const warnings: string[] = []
@@ -642,7 +643,7 @@ export const validateWorkflowDefinition = (
     for (const diagram of linked.diagrams ?? [])
       if (!diagramIds.has(diagram.id))
         errors.push(`WF-02 visible diagram "${diagram.id}" has no workflow definition`)
-  } else if (diagrams.length) {
+  } else if (diagrams.length && !options?.allowUnlinked) {
     errors.push("WF-02 workflow-definition requires a valid bundle-manifest in the same artifact")
   }
 

--- a/packages/core/test/skill.test.ts
+++ b/packages/core/test/skill.test.ts
@@ -38,6 +38,10 @@ describe("validateSkillDefinition", () => {
       JSON.stringify({
         schema: SKILL_DEFINITION_SCHEMA,
         catalog: false,
+        origin: {
+          kind: "workflow-launcher",
+          workflow: { short_id: "brief123", version: 4 },
+        },
         relations: {
           requires: [{ id: "research-core", version: 3 }],
           recommends: [
@@ -52,6 +56,10 @@ describe("validateSkillDefinition", () => {
     expect(checked.warnings).toEqual(["duplicate recommends relation tone-guide@2 was ignored"])
     expect(checked.sidecar).toMatchObject({
       catalog: false,
+      origin: {
+        kind: "workflow-launcher",
+        workflow: { short_id: "brief123", version: 4 },
+      },
       relations: {
         requires: [{ id: "research-core", version: 3 }],
         recommends: [{ id: "tone-guide", version: 2 }],

--- a/packages/core/test/skill.test.ts
+++ b/packages/core/test/skill.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest"
+import { SKILL_DEFINITION_SCHEMA, skillCatalogEnabled, validateSkillDefinition } from "../src/skill"
+
+const skill = (name = "weekly-brief") => `---
+name: ${name}
+description: Build a cited weekly brief.
+compatibility: Requires the Derive MCP for graph execution.
+---
+
+# Weekly brief
+`
+
+describe("validateSkillDefinition", () => {
+  it("accepts a portable skill without a Derive sidecar", () => {
+    const checked = validateSkillDefinition(skill())
+    expect(checked.errors).toEqual([])
+    expect(checked.metadata).toEqual({
+      name: "weekly-brief",
+      description: "Build a cited weekly brief.",
+      compatibility: "Requires the Derive MCP for graph execution.",
+    })
+    expect(skillCatalogEnabled(checked.sidecar)).toBe(true)
+  })
+
+  it("rejects names outside the Agent Skills portable subset", () => {
+    expect(validateSkillDefinition(skill("Weekly Brief")).errors).toContain(
+      "SKILL.md name must use lowercase letters, numbers, and single hyphens",
+    )
+    expect(validateSkillDefinition("# no frontmatter").errors).toEqual([
+      "SKILL.md frontmatter requires name",
+      "SKILL.md frontmatter requires description",
+    ])
+  })
+
+  it("parses exact semantic relations and embedded catalog state", () => {
+    const checked = validateSkillDefinition(
+      skill(),
+      JSON.stringify({
+        schema: SKILL_DEFINITION_SCHEMA,
+        catalog: false,
+        relations: {
+          requires: [{ id: "research-core", version: 3 }],
+          recommends: [
+            { id: "tone-guide", version: 2 },
+            { id: "tone-guide", version: 2 },
+          ],
+        },
+        runtime: { kind: "single" },
+      }),
+    )
+    expect(checked.errors).toEqual([])
+    expect(checked.warnings).toEqual(["duplicate recommends relation tone-guide@2 was ignored"])
+    expect(checked.sidecar).toMatchObject({
+      catalog: false,
+      relations: {
+        requires: [{ id: "research-core", version: 3 }],
+        recommends: [{ id: "tone-guide", version: 2 }],
+      },
+      runtime: { kind: "single" },
+    })
+    expect(skillCatalogEnabled(checked.sidecar)).toBe(false)
+  })
+
+  it("requires loop runtimes to carry a bounded workflow loop", () => {
+    const checked = validateSkillDefinition(
+      skill(),
+      JSON.stringify({
+        schema: SKILL_DEFINITION_SCHEMA,
+        runtime: {
+          kind: "loop",
+          definition: {
+            schema: "derive.workflow/v1",
+            purpose: "Publish once",
+            diagrams: [
+              {
+                id: "once",
+                entry: "done",
+                nodes: [{ id: "done", kind: "terminal", result: "Done" }],
+                routes: [],
+                scenarios: [{ id: "expected", kind: "expected", path: ["done"], outcome: "Done" }],
+              },
+            ],
+          },
+        },
+      }),
+    )
+    expect(checked.errors).toContain(
+      "derive.skill.json loop runtime must declare at least one bounded loop",
+    )
+  })
+})

--- a/packages/db/src/parity.ts
+++ b/packages/db/src/parity.ts
@@ -18,6 +18,7 @@ import type {
   ArtifactInviteRecord,
   ArtifactMemberRecord,
   ArtifactRecord,
+  ArtifactSkillLinkRecord,
   AssetRecord,
   AuditLogRecord,
   AutomationRecord,
@@ -46,6 +47,8 @@ import type {
   SharedStateActivityRecord,
   SharedStateRecord,
   SignupAttributionRecord,
+  SkillInstallationRecord,
+  SkillRelationRecord,
   SubscriptionRecord,
   TemplateLibraryEntryRecord,
   TemplateLibraryRecord,
@@ -84,6 +87,9 @@ export interface TypedTables {
   run: RunRecord
   workflowRun: WorkflowRunRecord
   workflowStepAttempt: WorkflowStepAttemptRecord
+  skillRelation: SkillRelationRecord
+  skillInstallation: SkillInstallationRecord
+  artifactSkillLink: ArtifactSkillLinkRecord
   plan: PlanRecord
   connection: ConnectionRecord
   artifactInvite: ArtifactInviteRecord

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -2,6 +2,7 @@ import type {
   AgentMentionKind,
   AgentMentionState,
   ArtifactKind,
+  ArtifactSkillRole,
   AuditAction,
   CommentState,
   ConnectionKind,
@@ -27,6 +28,10 @@ import type {
   SessionMessageAuthor,
   SessionState,
   SharedStateAction,
+  SkillClient,
+  SkillInstallPolicy,
+  SkillInstallScope,
+  SkillRelationKind,
   SlackAuthorFilter,
   SlackScopeKind,
   SlackThreadSurface,
@@ -383,6 +388,86 @@ export const workflowStepAttempt = pgTable(
     uniqueIndex("workflow_step_attempt_number").on(t.workflow_run_id, t.node_id, t.attempt),
     uniqueIndex("workflow_step_attempt_session").on(t.session_id),
     index("workflow_step_attempt_run").on(t.workflow_run_id, t.created_at),
+  ],
+)
+
+export const skillRelation = pgTable(
+  "skill_relation",
+  {
+    id: text("id").primaryKey(),
+    org_id: text("org_id").notNull(),
+    source_artifact_id: text("source_artifact_id").notNull(),
+    source_version: integer("source_version").notNull(),
+    target_artifact_id: text("target_artifact_id").notNull(),
+    target_version: integer("target_version").notNull(),
+    kind: text("kind").$type<SkillRelationKind>().notNull(),
+    created_at: text("created_at").notNull().$defaultFn(isoNow),
+  },
+  (t) => [
+    uniqueIndex("skill_relation_edge").on(
+      t.source_artifact_id,
+      t.source_version,
+      t.target_artifact_id,
+      t.target_version,
+      t.kind,
+    ),
+    index("skill_relation_incoming").on(t.org_id, t.target_artifact_id, t.target_version),
+  ],
+)
+
+// One receipt per physical opaque scope + client. installed_by is the latest synchronizer,
+// not part of identity, so a shared checkout counts as one native installation.
+export const skillInstallation = pgTable(
+  "skill_installation",
+  {
+    id: text("id").primaryKey(),
+    org_id: text("org_id").notNull(),
+    skill_artifact_id: text("skill_artifact_id").notNull(),
+    skill_version: integer("skill_version").notNull(),
+    scope_kind: text("scope_kind").$type<SkillInstallScope>().notNull(),
+    opaque_scope_id: text("opaque_scope_id").notNull(),
+    client: text("client").$type<SkillClient>().notNull(),
+    digest: text("digest").notNull(),
+    policy: text("policy").$type<SkillInstallPolicy>().notNull().default("pinned"),
+    installed_by: text("installed_by"),
+    created_at: text("created_at").notNull().$defaultFn(isoNow),
+    updated_at: text("updated_at").notNull(),
+    removed_at: text("removed_at"),
+  },
+  (t) => [
+    uniqueIndex("skill_installation_scope").on(
+      t.org_id,
+      t.skill_artifact_id,
+      t.scope_kind,
+      t.opaque_scope_id,
+      t.client,
+    ),
+    index("skill_installation_skill").on(t.org_id, t.skill_artifact_id, t.updated_at),
+  ],
+)
+
+export const artifactSkillLink = pgTable(
+  "artifact_skill_link",
+  {
+    id: text("id").primaryKey(),
+    org_id: text("org_id").notNull(),
+    artifact_id: text("artifact_id").notNull(),
+    artifact_version: integer("artifact_version").notNull(),
+    skill_artifact_id: text("skill_artifact_id").notNull(),
+    skill_version: integer("skill_version").notNull(),
+    role: text("role").$type<ArtifactSkillRole>().notNull(),
+    linked_by: text("linked_by").notNull(),
+    created_at: text("created_at").notNull().$defaultFn(isoNow),
+  },
+  (t) => [
+    uniqueIndex("artifact_skill_link_exact").on(
+      t.artifact_id,
+      t.artifact_version,
+      t.skill_artifact_id,
+      t.skill_version,
+      t.role,
+    ),
+    index("artifact_skill_link_skill").on(t.org_id, t.skill_artifact_id, t.created_at),
   ],
 )
 
@@ -1151,6 +1236,9 @@ const TABLES = [
   run,
   workflowRun,
   workflowStepAttempt,
+  skillRelation,
+  skillInstallation,
+  artifactSkillLink,
   plan,
   connection,
   invitation,

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -6,6 +6,7 @@ import type {
   ArtifactInviteRecord,
   ArtifactMemberRecord,
   ArtifactRecord,
+  ArtifactSkillLinkRecord,
   AssetRecord,
   AuditLogRecord,
   AutomationRecord,
@@ -51,6 +52,7 @@ import type {
   NewArtifact,
   NewArtifactInvite,
   NewArtifactMember,
+  NewArtifactSkillLink,
   NewAsset,
   NewAuditLog,
   NewAutomation,
@@ -78,6 +80,8 @@ import type {
   NewSessionMessage,
   NewSharedStateActivity,
   NewSignupAttribution,
+  NewSkillInstallation,
+  NewSkillRelation,
   NewSlackSubscription,
   NewTemplateLibrary,
   NewTemplateLibraryEntry,
@@ -111,6 +115,9 @@ import type {
   SharedStateRecord,
   SharedStateWrite,
   SignupAttributionRecord,
+  SkillInstallationRecord,
+  SkillRelationRecord,
+  SkillUsageBucket,
   SlackAuthorFilter,
   SlackInstallRecord,
   SlackSubscriptionRecord,
@@ -169,6 +176,7 @@ import {
   like,
   lt,
   lte,
+  max,
   ne,
   notExists,
   notInArray,
@@ -187,6 +195,7 @@ import {
   artifactFavorite,
   artifactInvite,
   artifactMember,
+  artifactSkillLink,
   artifactTag,
   asset,
   auditLog,
@@ -223,6 +232,8 @@ import {
   sharedState,
   sharedStateActivity,
   signupAttribution,
+  skillInstallation,
+  skillRelation,
   slackInstall,
   slackSubscription,
   slackThreadLink,
@@ -280,6 +291,9 @@ export const schema = {
   run,
   workflowRun,
   workflowStepAttempt,
+  skillRelation,
+  skillInstallation,
+  artifactSkillLink,
   plan,
   connection,
   artifactInvite,
@@ -333,6 +347,9 @@ const _schemaShapes: Shapes<typeof schema> = {
   run: true,
   workflowRun: true,
   workflowStepAttempt: true,
+  skillRelation: true,
+  skillInstallation: true,
+  artifactSkillLink: true,
   plan: true,
   connection: true,
   invitation: true,
@@ -5845,6 +5862,189 @@ export class PgMetaStore implements MetaStore {
       .returning()
     return rows[0] ?? null
   }
+  async replaceSkillRelations(
+    orgId: string,
+    skillArtifactId: string,
+    skillVersion: number,
+    relations: NewSkillRelation[],
+  ): Promise<void> {
+    await this.db.transaction(async (tx) => {
+      await tx
+        .delete(skillRelation)
+        .where(
+          and(
+            eq(skillRelation.org_id, orgId),
+            eq(skillRelation.source_artifact_id, skillArtifactId),
+            eq(skillRelation.source_version, skillVersion),
+          ),
+        )
+      if (relations.length > 0) await tx.insert(skillRelation).values(relations)
+    })
+  }
+  listSkillRelations(skillArtifactId: string, orgId: string): Promise<SkillRelationRecord[]> {
+    return this.db
+      .select()
+      .from(skillRelation)
+      .where(
+        and(
+          eq(skillRelation.org_id, orgId),
+          or(
+            eq(skillRelation.source_artifact_id, skillArtifactId),
+            eq(skillRelation.target_artifact_id, skillArtifactId),
+          ),
+        ),
+      )
+      .orderBy(desc(skillRelation.source_version), asc(skillRelation.kind))
+  }
+  async upsertSkillInstallation(i: NewSkillInstallation): Promise<SkillInstallationRecord> {
+    const rows = await this.db
+      .insert(skillInstallation)
+      .values(i)
+      .onConflictDoUpdate({
+        target: [
+          skillInstallation.org_id,
+          skillInstallation.skill_artifact_id,
+          skillInstallation.scope_kind,
+          skillInstallation.opaque_scope_id,
+          skillInstallation.client,
+        ],
+        set: {
+          skill_version: i.skill_version,
+          digest: i.digest,
+          policy: i.policy,
+          installed_by: i.installed_by ?? null,
+          updated_at: i.updated_at,
+          removed_at: i.removed_at ?? null,
+        },
+      })
+      .returning()
+    return one(rows)
+  }
+  listSkillInstallations(
+    skillArtifactId: string,
+    orgId: string,
+  ): Promise<SkillInstallationRecord[]> {
+    return this.db
+      .select()
+      .from(skillInstallation)
+      .where(
+        and(
+          eq(skillInstallation.org_id, orgId),
+          eq(skillInstallation.skill_artifact_id, skillArtifactId),
+        ),
+      )
+      .orderBy(desc(skillInstallation.updated_at), asc(skillInstallation.client))
+  }
+  async linkArtifactSkill(link: NewArtifactSkillLink): Promise<ArtifactSkillLinkRecord> {
+    const rows = await this.db
+      .insert(artifactSkillLink)
+      .values(link)
+      .onConflictDoUpdate({
+        target: [
+          artifactSkillLink.artifact_id,
+          artifactSkillLink.artifact_version,
+          artifactSkillLink.skill_artifact_id,
+          artifactSkillLink.skill_version,
+          artifactSkillLink.role,
+        ],
+        set: { linked_by: link.linked_by },
+      })
+      .returning()
+    return one(rows)
+  }
+  listArtifactSkillLinks(
+    artifactId: string,
+    artifactVersion: number,
+    orgId: string,
+  ): Promise<ArtifactSkillLinkRecord[]> {
+    return this.db
+      .select()
+      .from(artifactSkillLink)
+      .where(
+        and(
+          eq(artifactSkillLink.org_id, orgId),
+          eq(artifactSkillLink.artifact_id, artifactId),
+          eq(artifactSkillLink.artifact_version, artifactVersion),
+        ),
+      )
+      .orderBy(asc(artifactSkillLink.role), asc(artifactSkillLink.skill_artifact_id))
+  }
+  listSkillArtifactLinks(
+    skillArtifactId: string,
+    orgId: string,
+    limit = 100,
+  ): Promise<ArtifactSkillLinkRecord[]> {
+    return this.db
+      .select()
+      .from(artifactSkillLink)
+      .where(
+        and(
+          eq(artifactSkillLink.org_id, orgId),
+          eq(artifactSkillLink.skill_artifact_id, skillArtifactId),
+        ),
+      )
+      .orderBy(desc(artifactSkillLink.created_at), desc(artifactSkillLink.id))
+      .limit(Math.max(1, Math.min(limit, 100)))
+  }
+  async skillUsage(
+    skillArtifactId: string,
+    orgId: string,
+  ): Promise<{ contexts: SkillUsageBucket[]; workflows: SkillUsageBucket[] }> {
+    const contextRows = await this.db
+      .select({
+        skill_version: contextSession.context_version,
+        count: count(),
+        last_used_at: max(contextSession.created_at),
+      })
+      .from(contextSession)
+      .innerJoin(context, eq(context.id, contextSession.context_id))
+      .where(and(eq(context.org_id, orgId), eq(context.manifest_artifact_id, skillArtifactId)))
+      .groupBy(contextSession.context_version)
+      .orderBy(desc(contextSession.context_version))
+    const workflowRows = await this.db
+      .select({
+        skill_version: artifactSkillLink.skill_version,
+        count: count(),
+        last_used_at: max(workflowRun.created_at),
+      })
+      .from(workflowRun)
+      .innerJoin(
+        artifactSkillLink,
+        and(
+          eq(artifactSkillLink.artifact_id, workflowRun.workflow_artifact_id),
+          eq(artifactSkillLink.artifact_version, workflowRun.workflow_version),
+        ),
+      )
+      .where(
+        and(
+          eq(workflowRun.org_id, orgId),
+          eq(artifactSkillLink.org_id, orgId),
+          eq(artifactSkillLink.skill_artifact_id, skillArtifactId),
+          eq(artifactSkillLink.role, "workflow-definition"),
+        ),
+      )
+      .groupBy(artifactSkillLink.skill_version)
+      .orderBy(desc(artifactSkillLink.skill_version))
+    const buckets = (
+      rows: Array<{
+        skill_version: number | null
+        count: number | bigint
+        last_used_at: string | null
+      }>,
+    ): SkillUsageBucket[] =>
+      rows.flatMap((row) =>
+        row.last_used_at && row.skill_version !== null
+          ? [
+              {
+                skill_version: row.skill_version,
+                count: Number(row.count),
+                last_used_at: row.last_used_at,
+              },
+            ]
+          : [],
+      )
+    return { contexts: buckets(contextRows), workflows: buckets(workflowRows) }
+  }
   async createPlan(p: NewPlan): Promise<PlanRecord> {
     const rows = await this.db.insert(plan).values(p).returning()
     return one(rows)
@@ -6618,6 +6818,17 @@ export class PgMetaStore implements MetaStore {
       await tx.delete(webhook).where(eq(webhook.artifact_id, id))
       await tx.delete(sharedStateActivity).where(eq(sharedStateActivity.artifact_id, id))
       await tx.delete(sharedState).where(eq(sharedState.artifact_id, id))
+      await tx
+        .delete(skillRelation)
+        .where(
+          or(eq(skillRelation.source_artifact_id, id), eq(skillRelation.target_artifact_id, id)),
+        )
+      await tx.delete(skillInstallation).where(eq(skillInstallation.skill_artifact_id, id))
+      await tx
+        .delete(artifactSkillLink)
+        .where(
+          or(eq(artifactSkillLink.artifact_id, id), eq(artifactSkillLink.skill_artifact_id, id)),
+        )
       await tx.delete(versionData).where(eq(versionData.artifact_id, id))
       await tx.delete(version).where(eq(version.artifact_id, id))
       await tx.delete(comment).where(eq(comment.artifact_id, id))

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -5969,6 +5969,20 @@ export class PgMetaStore implements MetaStore {
       )
       .orderBy(asc(artifactSkillLink.role), asc(artifactSkillLink.skill_artifact_id))
   }
+  listArtifactSkillLinkHistory(
+    artifactId: string,
+    orgId: string,
+    limit = 100,
+  ): Promise<ArtifactSkillLinkRecord[]> {
+    return this.db
+      .select()
+      .from(artifactSkillLink)
+      .where(
+        and(eq(artifactSkillLink.org_id, orgId), eq(artifactSkillLink.artifact_id, artifactId)),
+      )
+      .orderBy(desc(artifactSkillLink.artifact_version), desc(artifactSkillLink.created_at))
+      .limit(Math.max(1, Math.min(limit, 100)))
+  }
   listSkillArtifactLinks(
     skillArtifactId: string,
     orgId: string,

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -4,6 +4,7 @@ import type {
   ArtifactInviteRecord,
   ArtifactMemberRecord,
   ArtifactRecord,
+  ArtifactSkillLinkRecord,
   AssetRecord,
   AuditLogRecord,
   AutomationRecord,
@@ -42,6 +43,7 @@ import type {
   NewArtifact,
   NewArtifactInvite,
   NewArtifactMember,
+  NewArtifactSkillLink,
   NewAsset,
   NewAuditLog,
   NewAutomation,
@@ -69,6 +71,8 @@ import type {
   NewSessionMessage,
   NewSharedStateActivity,
   NewSignupAttribution,
+  NewSkillInstallation,
+  NewSkillRelation,
   NewSlackSubscription,
   NewTemplateLibrary,
   NewTemplateLibraryEntry,
@@ -99,6 +103,9 @@ import type {
   SharedStateRecord,
   SharedStateWrite,
   SignupAttributionRecord,
+  SkillInstallationRecord,
+  SkillRelationRecord,
+  SkillUsageBucket,
   SlackAuthorFilter,
   SlackInstallRecord,
   SlackSubscriptionRecord,
@@ -157,6 +164,7 @@ import {
   like,
   lt,
   lte,
+  max,
   ne,
   notExists,
   notInArray,
@@ -174,6 +182,7 @@ import {
   artifactFavorite,
   artifactInvite,
   artifactMember,
+  artifactSkillLink,
   artifactTag,
   asset,
   auditLog,
@@ -209,6 +218,8 @@ import {
   sharedState,
   sharedStateActivity,
   signupAttribution,
+  skillInstallation,
+  skillRelation,
   slackInstall,
   slackSubscription,
   slackThreadLink,
@@ -402,6 +413,9 @@ export const schema = {
   run,
   workflowRun,
   workflowStepAttempt,
+  skillRelation,
+  skillInstallation,
+  artifactSkillLink,
   plan,
   connection,
   artifactInvite,
@@ -455,6 +469,9 @@ const _schemaShapes: Shapes<typeof schema> = {
   run: true,
   workflowRun: true,
   workflowStepAttempt: true,
+  skillRelation: true,
+  skillInstallation: true,
+  artifactSkillLink: true,
   plan: true,
   connection: true,
   invitation: true,
@@ -4716,6 +4733,187 @@ export function makeRepos(db: SqliteDb) {
         .get()) as WorkflowStepAttemptRecord | undefined) ?? null
     )
   }
+  const replaceSkillRelations = async (
+    orgId: string,
+    skillArtifactId: string,
+    skillVersion: number,
+    relations: NewSkillRelation[],
+  ): Promise<void> => {
+    await db
+      .delete(skillRelation)
+      .where(
+        and(
+          eq(skillRelation.org_id, orgId),
+          eq(skillRelation.source_artifact_id, skillArtifactId),
+          eq(skillRelation.source_version, skillVersion),
+        ),
+      )
+      .run()
+    if (relations.length > 0) await db.insert(skillRelation).values(relations).run()
+  }
+  const listSkillRelations = async (
+    skillArtifactId: string,
+    orgId: string,
+  ): Promise<SkillRelationRecord[]> =>
+    (await db
+      .select()
+      .from(skillRelation)
+      .where(
+        and(
+          eq(skillRelation.org_id, orgId),
+          or(
+            eq(skillRelation.source_artifact_id, skillArtifactId),
+            eq(skillRelation.target_artifact_id, skillArtifactId),
+          ),
+        ),
+      )
+      .orderBy(desc(skillRelation.source_version), asc(skillRelation.kind))
+      .all()) as SkillRelationRecord[]
+  const upsertSkillInstallation = async (
+    i: NewSkillInstallation,
+  ): Promise<SkillInstallationRecord> =>
+    (await db
+      .insert(skillInstallation)
+      .values(i)
+      .onConflictDoUpdate({
+        target: [
+          skillInstallation.org_id,
+          skillInstallation.skill_artifact_id,
+          skillInstallation.scope_kind,
+          skillInstallation.opaque_scope_id,
+          skillInstallation.client,
+        ],
+        set: {
+          skill_version: i.skill_version,
+          digest: i.digest,
+          policy: i.policy,
+          installed_by: i.installed_by ?? null,
+          updated_at: i.updated_at,
+          removed_at: i.removed_at ?? null,
+        },
+      })
+      .returning()
+      .get()) as SkillInstallationRecord
+  const listSkillInstallations = async (
+    skillArtifactId: string,
+    orgId: string,
+  ): Promise<SkillInstallationRecord[]> =>
+    (await db
+      .select()
+      .from(skillInstallation)
+      .where(
+        and(
+          eq(skillInstallation.org_id, orgId),
+          eq(skillInstallation.skill_artifact_id, skillArtifactId),
+        ),
+      )
+      .orderBy(desc(skillInstallation.updated_at), asc(skillInstallation.client))
+      .all()) as SkillInstallationRecord[]
+  const linkArtifactSkill = async (link: NewArtifactSkillLink): Promise<ArtifactSkillLinkRecord> =>
+    (await db
+      .insert(artifactSkillLink)
+      .values(link)
+      .onConflictDoUpdate({
+        target: [
+          artifactSkillLink.artifact_id,
+          artifactSkillLink.artifact_version,
+          artifactSkillLink.skill_artifact_id,
+          artifactSkillLink.skill_version,
+          artifactSkillLink.role,
+        ],
+        set: { linked_by: link.linked_by },
+      })
+      .returning()
+      .get()) as ArtifactSkillLinkRecord
+  const listArtifactSkillLinks = async (
+    artifactId: string,
+    artifactVersion: number,
+    orgId: string,
+  ): Promise<ArtifactSkillLinkRecord[]> =>
+    (await db
+      .select()
+      .from(artifactSkillLink)
+      .where(
+        and(
+          eq(artifactSkillLink.org_id, orgId),
+          eq(artifactSkillLink.artifact_id, artifactId),
+          eq(artifactSkillLink.artifact_version, artifactVersion),
+        ),
+      )
+      .orderBy(asc(artifactSkillLink.role), asc(artifactSkillLink.skill_artifact_id))
+      .all()) as ArtifactSkillLinkRecord[]
+  const listSkillArtifactLinks = async (
+    skillArtifactId: string,
+    orgId: string,
+    limit = 100,
+  ): Promise<ArtifactSkillLinkRecord[]> =>
+    (await db
+      .select()
+      .from(artifactSkillLink)
+      .where(
+        and(
+          eq(artifactSkillLink.org_id, orgId),
+          eq(artifactSkillLink.skill_artifact_id, skillArtifactId),
+        ),
+      )
+      .orderBy(desc(artifactSkillLink.created_at), desc(artifactSkillLink.id))
+      .limit(Math.max(1, Math.min(limit, 100)))
+      .all()) as ArtifactSkillLinkRecord[]
+  const skillUsage = async (
+    skillArtifactId: string,
+    orgId: string,
+  ): Promise<{ contexts: SkillUsageBucket[]; workflows: SkillUsageBucket[] }> => {
+    const contextRows = await db
+      .select({
+        skill_version: contextSession.context_version,
+        count: count(),
+        last_used_at: max(contextSession.created_at),
+      })
+      .from(contextSession)
+      .innerJoin(context, eq(context.id, contextSession.context_id))
+      .where(and(eq(context.org_id, orgId), eq(context.manifest_artifact_id, skillArtifactId)))
+      .groupBy(contextSession.context_version)
+      .orderBy(desc(contextSession.context_version))
+      .all()
+    const workflowRows = await db
+      .select({
+        skill_version: artifactSkillLink.skill_version,
+        count: count(),
+        last_used_at: max(workflowRun.created_at),
+      })
+      .from(workflowRun)
+      .innerJoin(
+        artifactSkillLink,
+        and(
+          eq(artifactSkillLink.artifact_id, workflowRun.workflow_artifact_id),
+          eq(artifactSkillLink.artifact_version, workflowRun.workflow_version),
+        ),
+      )
+      .where(
+        and(
+          eq(workflowRun.org_id, orgId),
+          eq(artifactSkillLink.org_id, orgId),
+          eq(artifactSkillLink.skill_artifact_id, skillArtifactId),
+          eq(artifactSkillLink.role, "workflow-definition"),
+        ),
+      )
+      .groupBy(artifactSkillLink.skill_version)
+      .orderBy(desc(artifactSkillLink.skill_version))
+      .all()
+    const buckets = (rows: typeof contextRows): SkillUsageBucket[] =>
+      rows.flatMap((row) =>
+        row.last_used_at && row.skill_version !== null
+          ? [
+              {
+                skill_version: row.skill_version,
+                count: Number(row.count),
+                last_used_at: row.last_used_at,
+              },
+            ]
+          : [],
+      )
+    return { contexts: buckets(contextRows), workflows: buckets(workflowRows) }
+  }
   const createPlan = async (p: NewPlan): Promise<PlanRecord> =>
     (await db.insert(plan).values(p).returning().get()) as PlanRecord
   const getPlan = async (id: string): Promise<PlanRecord | null> =>
@@ -5407,6 +5605,15 @@ export function makeRepos(db: SqliteDb) {
     await db.delete(webhook).where(eq(webhook.artifact_id, id)).run()
     await db.delete(sharedStateActivity).where(eq(sharedStateActivity.artifact_id, id)).run()
     await db.delete(sharedState).where(eq(sharedState.artifact_id, id)).run()
+    await db
+      .delete(skillRelation)
+      .where(or(eq(skillRelation.source_artifact_id, id), eq(skillRelation.target_artifact_id, id)))
+      .run()
+    await db.delete(skillInstallation).where(eq(skillInstallation.skill_artifact_id, id)).run()
+    await db
+      .delete(artifactSkillLink)
+      .where(or(eq(artifactSkillLink.artifact_id, id), eq(artifactSkillLink.skill_artifact_id, id)))
+      .run()
     await db.delete(versionData).where(eq(versionData.artifact_id, id)).run()
     await db.delete(version).where(eq(version.artifact_id, id)).run()
     await db.delete(comment).where(eq(comment.artifact_id, id)).run()
@@ -5799,6 +6006,14 @@ export function makeRepos(db: SqliteDb) {
     getWorkflowStepAttemptBySession,
     listWorkflowStepAttempts,
     transitionWorkflowStepAttempt,
+    replaceSkillRelations,
+    listSkillRelations,
+    upsertSkillInstallation,
+    listSkillInstallations,
+    linkArtifactSkill,
+    listArtifactSkillLinks,
+    listSkillArtifactLinks,
+    skillUsage,
     createPlan,
     getPlan,
     listPlans,

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -4842,6 +4842,20 @@ export function makeRepos(db: SqliteDb) {
       )
       .orderBy(asc(artifactSkillLink.role), asc(artifactSkillLink.skill_artifact_id))
       .all()) as ArtifactSkillLinkRecord[]
+  const listArtifactSkillLinkHistory = async (
+    artifactId: string,
+    orgId: string,
+    limit = 100,
+  ): Promise<ArtifactSkillLinkRecord[]> =>
+    (await db
+      .select()
+      .from(artifactSkillLink)
+      .where(
+        and(eq(artifactSkillLink.org_id, orgId), eq(artifactSkillLink.artifact_id, artifactId)),
+      )
+      .orderBy(desc(artifactSkillLink.artifact_version), desc(artifactSkillLink.created_at))
+      .limit(Math.max(1, Math.min(limit, 100)))
+      .all()) as ArtifactSkillLinkRecord[]
   const listSkillArtifactLinks = async (
     skillArtifactId: string,
     orgId: string,
@@ -6012,6 +6026,7 @@ export function makeRepos(db: SqliteDb) {
     listSkillInstallations,
     linkArtifactSkill,
     listArtifactSkillLinks,
+    listArtifactSkillLinkHistory,
     listSkillArtifactLinks,
     skillUsage,
     createPlan,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2,6 +2,7 @@ import type {
   AgentMentionKind,
   AgentMentionState,
   ArtifactKind,
+  ArtifactSkillRole,
   AuditAction,
   CommentState,
   ConnectionKind,
@@ -27,6 +28,10 @@ import type {
   SessionMessageAuthor,
   SessionState,
   SharedStateAction,
+  SkillClient,
+  SkillInstallPolicy,
+  SkillInstallScope,
+  SkillRelationKind,
   SlackAuthorFilter,
   SlackScopeKind,
   SlackThreadSurface,
@@ -444,6 +449,89 @@ export const workflowStepAttempt = sqliteTable(
     uniqueIndex("workflow_step_attempt_number").on(t.workflow_run_id, t.node_id, t.attempt),
     uniqueIndex("workflow_step_attempt_session").on(t.session_id),
     index("workflow_step_attempt_run").on(t.workflow_run_id, t.created_at),
+  ],
+)
+
+// Version-scoped semantic Skill edges. Bundle bytes remain authoritative; this is a query index.
+export const skillRelation = sqliteTable(
+  "skill_relation",
+  {
+    id: text("id").primaryKey(),
+    org_id: text("org_id").notNull(),
+    source_artifact_id: text("source_artifact_id").notNull(),
+    source_version: integer("source_version").notNull(),
+    target_artifact_id: text("target_artifact_id").notNull(),
+    target_version: integer("target_version").notNull(),
+    kind: text("kind").$type<SkillRelationKind>().notNull(),
+    created_at: text("created_at").notNull().default(now),
+  },
+  (t) => [
+    uniqueIndex("skill_relation_edge").on(
+      t.source_artifact_id,
+      t.source_version,
+      t.target_artifact_id,
+      t.target_version,
+      t.kind,
+    ),
+    index("skill_relation_incoming").on(t.org_id, t.target_artifact_id, t.target_version),
+  ],
+)
+
+// Current native availability. opaque_scope_id is a one-way identifier, never a local path.
+// Identity is physical scope + client, deliberately not actor: a shared checkout is one
+// installation, and installed_by records only its latest synchronizer.
+export const skillInstallation = sqliteTable(
+  "skill_installation",
+  {
+    id: text("id").primaryKey(),
+    org_id: text("org_id").notNull(),
+    skill_artifact_id: text("skill_artifact_id").notNull(),
+    skill_version: integer("skill_version").notNull(),
+    scope_kind: text("scope_kind").$type<SkillInstallScope>().notNull(),
+    opaque_scope_id: text("opaque_scope_id").notNull(),
+    client: text("client").$type<SkillClient>().notNull(),
+    digest: text("digest").notNull(),
+    policy: text("policy").$type<SkillInstallPolicy>().notNull().default("pinned"),
+    installed_by: text("installed_by"),
+    created_at: text("created_at").notNull().default(now),
+    updated_at: text("updated_at").notNull(),
+    removed_at: text("removed_at"),
+  },
+  (t) => [
+    uniqueIndex("skill_installation_scope").on(
+      t.org_id,
+      t.skill_artifact_id,
+      t.scope_kind,
+      t.opaque_scope_id,
+      t.client,
+    ),
+    index("skill_installation_skill").on(t.org_id, t.skill_artifact_id, t.updated_at),
+  ],
+)
+
+// Durable, explicit provenance between exact Artifact and Skill versions.
+export const artifactSkillLink = sqliteTable(
+  "artifact_skill_link",
+  {
+    id: text("id").primaryKey(),
+    org_id: text("org_id").notNull(),
+    artifact_id: text("artifact_id").notNull(),
+    artifact_version: integer("artifact_version").notNull(),
+    skill_artifact_id: text("skill_artifact_id").notNull(),
+    skill_version: integer("skill_version").notNull(),
+    role: text("role").$type<ArtifactSkillRole>().notNull(),
+    linked_by: text("linked_by").notNull(),
+    created_at: text("created_at").notNull().default(now),
+  },
+  (t) => [
+    uniqueIndex("artifact_skill_link_exact").on(
+      t.artifact_id,
+      t.artifact_version,
+      t.skill_artifact_id,
+      t.skill_version,
+      t.role,
+    ),
+    index("artifact_skill_link_skill").on(t.org_id, t.skill_artifact_id, t.created_at),
   ],
 )
 
@@ -1368,6 +1456,9 @@ const TABLES = [
   run,
   workflowRun,
   workflowStepAttempt,
+  skillRelation,
+  skillInstallation,
+  artifactSkillLink,
   plan,
   connection,
   invitation,

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -3421,6 +3421,135 @@ export function runStoreContract(
     })
   })
 
+  describe(`${label}: Skill indexes and usage truth`, () => {
+    it("replaces version-scoped relations and keeps incoming/outgoing reads workspace-scoped", async () => {
+      const source = await store.createArtifact(newArtifact({ kind: "bundle" }))
+      const target = await store.createArtifact(newArtifact({ kind: "bundle" }))
+      await store.replaceSkillRelations(ORG, source.id, 2, [
+        {
+          id: uuid(),
+          org_id: ORG,
+          source_artifact_id: source.id,
+          source_version: 2,
+          target_artifact_id: target.id,
+          target_version: 4,
+          kind: "requires",
+        },
+      ])
+      expect(await store.listSkillRelations(source.id, ORG)).toMatchObject([
+        { source_version: 2, target_version: 4, kind: "requires" },
+      ])
+      expect(await store.listSkillRelations(target.id, ORG)).toHaveLength(1)
+      expect(await store.listSkillRelations(source.id, `org_${uuid()}`)).toEqual([])
+
+      await store.replaceSkillRelations(ORG, source.id, 2, [
+        {
+          id: uuid(),
+          org_id: ORG,
+          source_artifact_id: source.id,
+          source_version: 2,
+          target_artifact_id: target.id,
+          target_version: 5,
+          kind: "recommends",
+        },
+      ])
+      expect(await store.listSkillRelations(source.id, ORG)).toMatchObject([
+        { source_version: 2, target_version: 5, kind: "recommends" },
+      ])
+    })
+
+    it("upserts native installation state without recording a local path", async () => {
+      const skill = await store.createArtifact(newArtifact({ kind: "bundle" }))
+      const base = {
+        id: uuid(),
+        org_id: ORG,
+        skill_artifact_id: skill.id,
+        skill_version: 3,
+        scope_kind: "project" as const,
+        opaque_scope_id: "sha256:project-a",
+        client: "codex" as const,
+        digest: "sha256:bundle-v3",
+        policy: "pinned" as const,
+        installed_by: "u1",
+        updated_at: "2026-09-01T20:00:00.000Z",
+      }
+      await store.upsertSkillInstallation(base)
+      await store.upsertSkillInstallation({
+        ...base,
+        id: uuid(),
+        skill_version: 4,
+        digest: "sha256:bundle-v4",
+        updated_at: "2026-09-01T21:00:00.000Z",
+      })
+      expect(await store.listSkillInstallations(skill.id, ORG)).toMatchObject([
+        {
+          skill_version: 4,
+          opaque_scope_id: "sha256:project-a",
+          client: "codex",
+          removed_at: null,
+        },
+      ])
+    })
+
+    it("derives exact Context and Workflow usage and keeps Artifact provenance deterministic", async () => {
+      const skill = await store.createArtifact(newArtifact({ kind: "bundle" }))
+      await store.addVersion(skill.id, newVersion({ content_type: "derive/skill" }))
+      const context = await store.createContext({
+        id: uuid(),
+        org_id: ORG,
+        name: `skill-context-${uuid()}`,
+        agent_id: uuid(),
+        manifest_artifact_id: skill.id,
+        created_by: "u1",
+      })
+      for (const id of [uuid(), uuid()])
+        await store.createSession({
+          id,
+          context_id: context.id,
+          context_version: 1,
+          org_id: ORG,
+          asker_id: "u1",
+        })
+
+      const workflow = await store.createArtifact(newArtifact())
+      const workflowVersion = await store.addVersion(workflow.id, newVersion())
+      const binding = {
+        id: uuid(),
+        org_id: ORG,
+        artifact_id: workflow.id,
+        artifact_version: workflowVersion.n,
+        skill_artifact_id: skill.id,
+        skill_version: 1,
+        role: "workflow-definition" as const,
+        linked_by: "migration",
+      }
+      await store.linkArtifactSkill(binding)
+      await store.linkArtifactSkill({ ...binding, id: uuid() })
+      expect(await store.listArtifactSkillLinks(workflow.id, workflowVersion.n, ORG)).toHaveLength(
+        1,
+      )
+      expect(await store.listSkillArtifactLinks(skill.id, ORG)).toHaveLength(1)
+      await store.createWorkflowRun({
+        id: uuid(),
+        org_id: ORG,
+        workflow_artifact_id: workflow.id,
+        workflow_version: workflowVersion.n,
+        workflow_blob_key: workflowVersion.blob_key,
+        workflow_content_type: workflowVersion.content_type,
+        diagram_id: "main",
+        reason: "manual:u1",
+      })
+
+      const usage = await store.skillUsage(skill.id, ORG)
+      expect(usage.contexts).toMatchObject([{ skill_version: 1, count: 2 }])
+      expect(usage.workflows).toMatchObject([{ skill_version: 1, count: 1 }])
+      expect(await store.skillUsage(skill.id, `org_${uuid()}`)).toEqual({
+        contexts: [],
+        workflows: [],
+      })
+    })
+  })
+
   describe(`${label}: deleteArtifact`, () => {
     it("hard-deletes the artifact row and all FK-dependent rows", async () => {
       const a = await store.createArtifact(newArtifact())

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -3528,6 +3528,7 @@ export function runStoreContract(
       expect(await store.listArtifactSkillLinks(workflow.id, workflowVersion.n, ORG)).toHaveLength(
         1,
       )
+      expect(await store.listArtifactSkillLinkHistory(workflow.id, ORG)).toHaveLength(1)
       expect(await store.listSkillArtifactLinks(skill.id, ORG)).toHaveLength(1)
       await store.createWorkflowRun({
         id: uuid(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   adm-zip: '>=0.6.0'
   esbuild: '>=0.25.0'
-  fast-uri: '>=4.1.2'
+  fast-uri: '>=4.1.3'
   drizzle-orm: 0.45.2
   js-yaml: ^4.3.1
   sharp: '>=0.35.0'
@@ -16,6 +16,7 @@ overrides:
   ip-address: '>=10.3.1'
   ws: ^8.21.0
   postcss: '>=8.5.23'
+  qs: '>=6.16.0'
   body-parser: 2.3.0
   nanoid@<4: '>=3.3.17'
   brace-expansion@<2.0.0: 1.1.18
@@ -5391,8 +5392,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@4.1.2:
-    resolution: {integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==}
+  fast-uri@4.1.3:
+    resolution: {integrity: sha512-7+72G6vLt7jjNas8SmSATx2qeyRIjxeqO3i4IkmDTxlqYZRKANhOe1bnovcp4WZmvsYrp60WyqPyHqgRiX0yXw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -6926,8 +6927,8 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  qs@6.15.2:
-    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
@@ -12060,7 +12061,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.2
+      fast-uri: 4.1.3
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -12367,7 +12368,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.2
+      qs: 6.16.0
       raw-body: 3.0.2
       type-is: 2.1.0
     transitivePeerDependencies:
@@ -13097,7 +13098,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.2
+      qs: 6.16.0
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -13132,7 +13133,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@4.1.2: {}
+  fast-uri@4.1.3: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -15012,8 +15013,9 @@ snapshots:
     dependencies:
       react: 19.2.7
 
-  qs@6.15.2:
+  qs@6.16.0:
     dependencies:
+      es-define-property: 1.0.1
       side-channel: 1.1.1
 
   queue-microtask@1.2.3: {}


### PR DESCRIPTION
## Review artifact

[Derive Skills PR1 — Local E2E Acceptance Report](https://derive.to/artifacts/derive-skills-pr1-local-e2e-acceptance-report-nynmfbm6)

## Summary

- introduce Skills as a first-class shared artifact surface with catalog, search, detail, files, graph relations, and artifact provenance
- install and synchronize exact Skill versions for Claude and Codex through the Derive CLI, with per-client state and usage receipts
- add Context and workflow-manifest migration foundations, including deterministic recovery from interrupted publish-to-link runs
- persist Skill definitions, relations, artifact links, install receipts, and aggregate usage across SQLite, Postgres, and D1
- keep existing Contexts in place; this PR does not migrate the current catalog wholesale

## Product boundary

Usage in PR1 measures active installations by physical scope and client. It does not infer or claim runtime invocation telemetry. Public aggregates omit opaque scope IDs and actor identity.

## Verification

- three independent GPT-5.6 Terra agents at medium reasoning: browser, real CLI, and migration/storage lanes
- full Node 24 verification: 3,139 tests passed
- focused Postgres verification: 73/73 passed
- production web build passed
- browser journeys passed for onboarding, catalog, search, graph, provenance, usage refresh, command palette, and responsive layout
- real CLI fixture passed 13/13 add, sync, selective remove, exact receipt, malformed bundle, traversal, and partial-failure recovery assertions

No preview deployment was required; acceptance was completed locally in the isolated feature worktree.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/879"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790907181&installation_model_id=428097&pr_number=879&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F879&signature=25ef3d1f9bd07b0211b471159d0eb2a36e58192072cf70d5c8cee0522e10c2c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->