### PR TITLE
Add artifact usefulness signals

### DIFF
--- a/apps/api/src/lib/search.ts
+++ b/apps/api/src/lib/search.ts
@@ -523,7 +523,13 @@ export interface WorkspaceSearchResult {
   semantic?: { snippet: string }
   /** Privacy-safe reason this artifact won a tie inside its relevance group. */
   usefulness?: {
-    label: "Essential" | "Useful" | "Improved through feedback" | "Mixed feedback"
+    label:
+      | "Essential"
+      | "Useful"
+      | "Improved through feedback"
+      | "Often referenced"
+      | "Actively maintained"
+      | "Mixed feedback"
     evidence: string
   }
 }
@@ -556,10 +562,15 @@ const viewBucket = (count: number): number => {
   if (count >= 10) return 2
   return count > 0 ? 1 : 0
 }
+const versionBucket = (currentVersion: number): number => {
+  if (currentVersion >= 10) return 3
+  if (currentVersion >= 5) return 2
+  return currentVersion >= 2 ? 1 : 0
+}
 
 /** Preserve relevance globally. Usefulness can reorder only inside each fixed
  *  group, so a popular artifact cannot jump over a much better query match. */
-export const rerankByUsefulness = <T extends { id: string }>(
+export const rerankByUsefulness = <T extends { id: string; current_version?: number }>(
   ranked: T[],
   signals: Record<string, UsefulnessSignals>,
   views: Record<string, number>,
@@ -576,6 +587,7 @@ export const rerankByUsefulness = <T extends { id: string }>(
         usefulnessBand(sb) - usefulnessBand(sa) ||
         revisionBucket(sb.resolved_revisions) - revisionBucket(sa.resolved_revisions) ||
         viewBucket(views[b.id] ?? 0) - viewBucket(views[a.id] ?? 0) ||
+        versionBucket(b.current_version ?? 1) - versionBucket(a.current_version ?? 1) ||
         (originalRank.get(a.id) ?? 0) - (originalRank.get(b.id) ?? 0)
       )
     })
@@ -586,12 +598,17 @@ export const rerankByUsefulness = <T extends { id: string }>(
 
 const usefulnessNote = (
   signal: UsefulnessSignals,
+  views: number,
+  currentVersion: number,
 ): WorkspaceSearchResult["usefulness"] | undefined => {
   const total = signal.not_useful + signal.useful + signal.essential
   const helpful = signal.useful + signal.essential
   const revisions = signal.resolved_revisions
   const revisionEvidence = revisions >= 2 ? "Improved across multiple revisions" : null
-  const evidence = (rating: string) => [rating, revisionEvidence].filter(Boolean).join("; ")
+  const viewEvidence = views >= 10 ? "Frequently opened" : null
+  const versionEvidence = currentVersion >= 5 ? "Maintained across multiple versions" : null
+  const evidence = (rating: string) =>
+    [rating, revisionEvidence, viewEvidence, versionEvidence].filter(Boolean).join("; ")
   const band = usefulnessBand(signal)
   if (band === 2)
     return {
@@ -609,8 +626,9 @@ const usefulnessNote = (
       evidence: evidence(`${signal.not_useful} of ${total} people marked this not useful`),
     }
   if (total >= 3) return { label: "Mixed feedback", evidence: evidence(`${total} ratings`) }
-  if (revisionEvidence)
-    return { label: "Improved through feedback", evidence: revisionEvidence ?? "Resolved feedback" }
+  if (revisionEvidence) return { label: "Improved through feedback", evidence: evidence("") }
+  if (viewEvidence) return { label: "Often referenced", evidence: evidence("") }
+  if (versionEvidence) return { label: "Actively maintained", evidence: versionEvidence }
   return undefined
 }
 
@@ -749,7 +767,11 @@ export const searchWorkspace = async (
       groups,
       total,
       semantic: total === 0 && chunk ? { snippet: snippetAround(chunk, opts.query) } : undefined,
-      usefulness: usefulnessNote(signals[a.id] ?? EMPTY_USEFULNESS),
+      usefulness: usefulnessNote(
+        signals[a.id] ?? EMPTY_USEFULNESS,
+        views[a.id] ?? 0,
+        a.current_version,
+      ),
     }
   }
   const results: WorkspaceSearchResult[] = []

--- a/apps/api/src/lib/search.ts
+++ b/apps/api/src/lib/search.ts
@@ -12,6 +12,7 @@ import {
   type SectionMarker,
   sectionMarkers,
   toMarkdown,
+  type UsefulnessSignals,
   type VersionRecord,
 } from "@derive/core"
 import { log } from "../log"
@@ -47,6 +48,8 @@ export interface WorkspaceSearchDeps extends SearchDeps {
       query: string,
       limit: number,
     ): Promise<{ id: string; rank: number }[]>
+    usefulnessSignals(artifactIds: string[]): Promise<Record<string, UsefulnessSignals>>
+    viewCounts(artifactIds: string[]): Promise<Record<string, number>>
   }
   /** The optional dense/semantic arm (pgvector + an embedder). Absent when no embedder is
    *  configured (or on SQLite) ⇒ nomination stays pure-lexical, byte-identical to before. */
@@ -518,6 +521,97 @@ export interface WorkspaceSearchResult {
   /** Set only for a dense-nominated hit the literal grep-confirm couldn't reproduce
    *  (total === 0): the best-matching passage, shown as the match evidence. */
   semantic?: { snippet: string }
+  /** Privacy-safe reason this artifact won a tie inside its relevance group. */
+  usefulness?: {
+    label: "Essential" | "Useful" | "Improved through feedback" | "Mixed feedback"
+    evidence: string
+  }
+}
+
+const EMPTY_USEFULNESS: UsefulnessSignals = {
+  not_useful: 0,
+  useful: 0,
+  essential: 0,
+  resolved_revisions: 0,
+}
+
+/** A coarse confidence band, not a universal score. Three ratings are required
+ *  before human votes can move search order. */
+export const usefulnessBand = (signal: UsefulnessSignals): -1 | 0 | 1 | 2 => {
+  const total = signal.not_useful + signal.useful + signal.essential
+  if (total < 3) return 0
+  if (signal.not_useful / total >= 0.5) return -1
+  const helpful = signal.useful + signal.essential
+  if (helpful / total >= 0.75 && signal.essential >= 1) return 2
+  if (helpful / total >= 0.67) return 1
+  return 0
+}
+
+// A single resolved thread can reveal one person's private review activity. Require
+// repeated feedback before it can influence ranking or appear in result evidence.
+const revisionBucket = (count: number): number => (count >= 2 ? 1 : 0)
+const viewBucket = (count: number): number => {
+  if (count >= 1000) return 4
+  if (count >= 100) return 3
+  if (count >= 10) return 2
+  return count > 0 ? 1 : 0
+}
+
+/** Preserve relevance globally. Usefulness can reorder only inside each fixed
+ *  group, so a popular artifact cannot jump over a much better query match. */
+export const rerankByUsefulness = <T extends { id: string }>(
+  ranked: T[],
+  signals: Record<string, UsefulnessSignals>,
+  views: Record<string, number>,
+  groupSize = 5,
+): T[] => {
+  const originalRank = new Map(ranked.map((item, index) => [item.id, index]))
+  const out: T[] = []
+  for (let start = 0; start < ranked.length; start += groupSize) {
+    const group = ranked.slice(start, start + groupSize)
+    group.sort((a, b) => {
+      const sa = signals[a.id] ?? EMPTY_USEFULNESS
+      const sb = signals[b.id] ?? EMPTY_USEFULNESS
+      return (
+        usefulnessBand(sb) - usefulnessBand(sa) ||
+        revisionBucket(sb.resolved_revisions) - revisionBucket(sa.resolved_revisions) ||
+        viewBucket(views[b.id] ?? 0) - viewBucket(views[a.id] ?? 0) ||
+        (originalRank.get(a.id) ?? 0) - (originalRank.get(b.id) ?? 0)
+      )
+    })
+    out.push(...group)
+  }
+  return out
+}
+
+const usefulnessNote = (
+  signal: UsefulnessSignals,
+): WorkspaceSearchResult["usefulness"] | undefined => {
+  const total = signal.not_useful + signal.useful + signal.essential
+  const helpful = signal.useful + signal.essential
+  const revisions = signal.resolved_revisions
+  const revisionEvidence = revisions >= 2 ? "Improved across multiple revisions" : null
+  const evidence = (rating: string) => [rating, revisionEvidence].filter(Boolean).join("; ")
+  const band = usefulnessBand(signal)
+  if (band === 2)
+    return {
+      label: "Essential",
+      evidence: evidence(`${helpful} of ${total} people found this useful`),
+    }
+  if (band === 1)
+    return {
+      label: "Useful",
+      evidence: evidence(`${helpful} of ${total} people found this useful`),
+    }
+  if (band === -1)
+    return {
+      label: "Mixed feedback",
+      evidence: evidence(`${signal.not_useful} of ${total} people marked this not useful`),
+    }
+  if (total >= 3) return { label: "Mixed feedback", evidence: evidence(`${total} ratings`) }
+  if (revisionEvidence)
+    return { label: "Improved through feedback", evidence: revisionEvidence ?? "Resolved feedback" }
+  return undefined
 }
 
 export const searchWorkspace = async (
@@ -594,12 +688,30 @@ export const searchWorkspace = async (
   // listArtifacts returns in its own (recency) order; restore relevance order.
   gated.sort((a, b) => (rankOf.get(a.id) ?? Infinity) - (rankOf.get(b.id) ?? Infinity))
 
+  // One shared usefulness pass for REST, MCP find, and Slack search. Read in D1-safe
+  // chunks, then reorder only inside fixed relevance groups of five. Only groups
+  // that can enter the grep window need signals; lower groups cannot cross it.
+  const grepCap = opts.limit ?? WORKSPACE_SEARCH_ARTIFACT_CAP
+  const signals: Record<string, UsefulnessSignals> = {}
+  const views: Record<string, number> = {}
+  const signalWindow = Math.ceil(grepCap / 5) * 5
+  const gatedIds = gated.slice(0, signalWindow).map((a) => a.id)
+  for (let i = 0; i < gatedIds.length; i += LIST_ID_CHUNK) {
+    const ids = gatedIds.slice(i, i + LIST_ID_CHUNK)
+    const [signalBatch, viewBatch] = await Promise.all([
+      deps.meta.usefulnessSignals(ids),
+      deps.meta.viewCounts(ids),
+    ])
+    Object.assign(signals, signalBatch)
+    Object.assign(views, viewBatch)
+  }
+  const usefulnessRanked = rerankByUsefulness(gated, signals, views)
+
   // Grep-confirm only the top-N most-relevant survivors — the blob-read+scan is the
   // real cost, so it stays bounded. A candidate the index nominated on token overlap
   // but whose exact literal/scope isn't actually present yields no hunks and drops out
   // here: the index is RECALL, the grep is PRECISION.
-  const grepCap = opts.limit ?? WORKSPACE_SEARCH_ARTIFACT_CAP
-  const toGrep = gated.slice(0, grepCap)
+  const toGrep = usefulnessRanked.slice(0, grepCap)
   // 4, not searchArtifactVersion's inner 8: the two fan-outs compose (a batch of
   // bundles each opens its own 8-wide page fan-out), so peak blob reads is the product
   // — 4×8=32 keeps that worst case reasonable without a cross-cutting semaphore.
@@ -637,6 +749,7 @@ export const searchWorkspace = async (
       groups,
       total,
       semantic: total === 0 && chunk ? { snippet: snippetAround(chunk, opts.query) } : undefined,
+      usefulness: usefulnessNote(signals[a.id] ?? EMPTY_USEFULNESS),
     }
   }
   const results: WorkspaceSearchResult[] = []
@@ -689,11 +802,12 @@ export const workspaceSearchReport = (
           note ? ` (${note})` : ""
         }`
   const body = results
-    .map((r) =>
-      r.total > 0
-        ? `## ${r.short_id} — ${r.title}\n${renderGroups(r.groups)}`
-        : `## ${r.short_id} — ${r.title}  (semantic match)\n  ~ ${r.semantic?.snippet ?? ""}`,
-    )
+    .map((r) => {
+      const useful = r.usefulness ? `\n> ${r.usefulness.label}: ${r.usefulness.evidence}\n` : ""
+      return r.total > 0
+        ? `## ${r.short_id} — ${r.title}${useful}\n${renderGroups(r.groups)}`
+        : `## ${r.short_id} — ${r.title}  (semantic match)${useful}\n  ~ ${r.semantic?.snippet ?? ""}`
+    })
     .join("\n\n")
   const fmt = where === "text" ? "text" : "html"
   const steer = `\n\nOpen one with search(short_id:"...", query:"${query}") for full context, or read(short_id:"...", lines:"from-to", format:"${fmt}").`
@@ -717,6 +831,7 @@ export interface SearchHit {
    *  the UI badge it as a meaning match. A hit found literally (with or without also matching
    *  semantically) is false. */
   semantic: boolean
+  usefulness?: WorkspaceSearchResult["usefulness"]
 }
 
 // A short lead of context BEFORE the match, then the rest trailing. The window is biased
@@ -768,5 +883,6 @@ export const toSearchHits = (results: WorkspaceSearchResult[], query: string): S
       snippet: hit ? snippetAround(stripMarkup(hit.text), query) : (r.semantic?.snippet ?? ""),
       // Semantic-only when there's no literal hit line but a dense passage carried it here.
       semantic: !hit && !!r.semantic?.snippet,
+      usefulness: r.usefulness,
     }
   })

--- a/apps/api/src/lib/search.ts
+++ b/apps/api/src/lib/search.ts
@@ -18,7 +18,7 @@ import {
 import { log } from "../log"
 import { cleanPath, manifestOf } from "./bundle"
 import { clip } from "./clip"
-import { visibleArtifacts } from "./visibility"
+import { LIST_ID_CHUNK, visibleArtifacts } from "./visibility"
 
 // The minimal store surface search needs — a BlobStore, a version→text resolver,
 // and (only for

--- a/apps/api/src/lib/search.ts
+++ b/apps/api/src/lib/search.ts
@@ -528,7 +528,7 @@ export interface WorkspaceSearchResult {
       | "Useful"
       | "Improved through feedback"
       | "Often referenced"
-      | "Actively maintained"
+      | "Frequently revised"
       | "Mixed feedback"
     evidence: string
   }
@@ -606,7 +606,7 @@ const usefulnessNote = (
   const revisions = signal.resolved_revisions
   const revisionEvidence = revisions >= 2 ? "Improved across multiple revisions" : null
   const viewEvidence = views >= 10 ? "Frequently opened" : null
-  const versionEvidence = currentVersion >= 5 ? "Maintained across multiple versions" : null
+  const versionEvidence = currentVersion >= 5 ? "Multiple published versions" : null
   const evidence = (rating: string) =>
     [rating, revisionEvidence, viewEvidence, versionEvidence].filter(Boolean).join("; ")
   const band = usefulnessBand(signal)
@@ -628,7 +628,7 @@ const usefulnessNote = (
   if (total >= 3) return { label: "Mixed feedback", evidence: evidence(`${total} ratings`) }
   if (revisionEvidence) return { label: "Improved through feedback", evidence: evidence("") }
   if (viewEvidence) return { label: "Often referenced", evidence: evidence("") }
-  if (versionEvidence) return { label: "Actively maintained", evidence: versionEvidence }
+  if (versionEvidence) return { label: "Frequently revised", evidence: versionEvidence }
   return undefined
 }
 

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -43,6 +43,7 @@ import {
   toJson,
   toMarkdown,
   type WorkflowPreview,
+  type VersionRecord,
   type WorkspaceAccess,
 } from "@derive/core"
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
@@ -142,6 +143,20 @@ const SAFE_BINARY_CONTENT_TYPES = new Set([
  */
 const INLINE_EDIT_COALESCE_MS = 5 * 60_000
 
+const ratingValue = z.enum(["not_useful", "useful", "essential"])
+const ratingReason = z.enum([
+  "clear",
+  "current",
+  "reusable",
+  "saved_time",
+  "outdated",
+  "wrong_scope",
+  "unclear",
+  "duplicate",
+])
+const positiveRatingReasons = new Set(["clear", "current", "reusable", "saved_time"])
+const negativeRatingReasons = new Set(["outdated", "wrong_scope", "unclear", "duplicate"])
+
 /** The artifact lifecycle: browse + summary, publish/republish, detail, restore,
  *  source read-back, and version diffs. */
 export const artifactRoutes = (ctx: AppContext) => {
@@ -173,6 +188,7 @@ export const artifactRoutes = (ctx: AppContext) => {
     resolveArtifact,
     requireArtifact,
     resolveArtifacts,
+    requireUser,
     workspaceCan,
     collectionRole,
     limited,
@@ -1522,6 +1538,116 @@ export const artifactRoutes = (ctx: AppContext) => {
     c.header("X-Content-Type-Options", "nosniff")
     c.header("Content-Type", "text/plain; charset=utf-8")
     return c.body(searchReport(c.req.param("shortId"), query, where, total, cap, groups, note))
+  })
+
+  // Human usefulness ratings. These routes stay deliberately small: one active
+  // rating per version and user, no public rater list, and no agent/static-token writes.
+  const ratingVersion = (c: Context, current: number): number | null => {
+    const raw = c.req.query("version")
+    const parsed = raw === undefined ? current : Number(raw)
+    return Number.isInteger(parsed) && parsed > 0 ? parsed : null
+  }
+  const isRatingAuthor = (
+    artifact: ArtifactRecord,
+    version: VersionRecord,
+    originalVersion: VersionRecord | null,
+    userId: string,
+  ) =>
+    artifact.author_id === userId ||
+    version.author_id === userId ||
+    originalVersion?.author_id === userId
+  const ratingPayload = async (artifact: ArtifactRecord, versionN: number, userId: string) => {
+    const [version, originalVersion, mine, signals] = await Promise.all([
+      meta.getVersion(artifact.id, versionN),
+      meta.getVersion(artifact.id, 1),
+      meta.getArtifactRating(artifact.id, versionN, userId),
+      meta.usefulnessSignals([artifact.id]),
+    ])
+    if (!version) return null
+    const signal = signals[artifact.id] ?? {
+      not_useful: 0,
+      useful: 0,
+      essential: 0,
+      resolved_revisions: 0,
+    }
+    const total = signal.not_useful + signal.useful + signal.essential
+    const helpful = signal.useful + signal.essential
+    return {
+      version: versionN,
+      eligible: !isRatingAuthor(artifact, version, originalVersion, userId),
+      rating: mine ? { value: mine.value, reason: mine.reason } : null,
+      aggregate:
+        total >= 3
+          ? {
+              total,
+              helpful_percent: Math.round((helpful / total) * 100),
+              essential: signal.essential,
+            }
+          : null,
+    }
+  }
+
+  app.get("/v1/artifacts/:shortId/rating", async (c) => {
+    const me = await requireUser(c)
+    if (me instanceof Response) return me
+    const artifact = await requireArtifact(c, "read")
+    if (artifact instanceof Response) return artifact
+    const versionN = ratingVersion(c, artifact.current_version)
+    if (versionN === null) return fail(c, 400, "bad version")
+    if (versionN !== artifact.current_version) return fail(c, 409, "rate the current version")
+    const payload = await ratingPayload(artifact, versionN, me.id)
+    return payload ? c.json(payload) : fail(c, 404, `no version ${versionN}`)
+  })
+
+  app.put("/v1/artifacts/:shortId/rating", async (c) => {
+    const me = await requireUser(c)
+    if (me instanceof Response) return me
+    const artifact = await requireArtifact(c, "read")
+    if (artifact instanceof Response) return artifact
+    const body = await readJson(
+      c,
+      z.object({
+        version: z.number().int().positive(),
+        value: ratingValue,
+        reason: ratingReason.nullable(),
+      }),
+    )
+    if (body instanceof Response) return body
+    if (body.version !== artifact.current_version) return fail(c, 409, "rate the current version")
+    const allowedReasons =
+      body.value === "not_useful" ? negativeRatingReasons : positiveRatingReasons
+    if (body.reason && !allowedReasons.has(body.reason))
+      return fail(c, 400, "reason does not match rating")
+    const version = await meta.getVersion(artifact.id, body.version)
+    if (!version) return fail(c, 404, `no version ${body.version}`)
+    const originalVersion = body.version === 1 ? version : await meta.getVersion(artifact.id, 1)
+    if (isRatingAuthor(artifact, version, originalVersion, me.id))
+      return fail(c, 403, "authors cannot rate their own version")
+    await meta.setArtifactRating({
+      id: newId("ar"),
+      artifact_id: artifact.id,
+      version_n: body.version,
+      user_id: me.id,
+      value: body.value,
+      reason: body.reason,
+    })
+    const payload = await ratingPayload(artifact, body.version, me.id)
+    return c.json(payload)
+  })
+
+  app.delete("/v1/artifacts/:shortId/rating", async (c) => {
+    const me = await requireUser(c)
+    if (me instanceof Response) return me
+    const artifact = await requireArtifact(c, "read")
+    if (artifact instanceof Response) return artifact
+    const versionN = ratingVersion(c, artifact.current_version)
+    if (versionN === null) return fail(c, 400, "bad version")
+    if (versionN !== artifact.current_version) return fail(c, 409, "rate the current version")
+    if (!(await meta.getVersion(artifact.id, versionN)))
+      return fail(c, 404, `no version ${versionN}`)
+    await meta.deleteArtifactRating(artifact.id, versionN, me.id)
+    const payload = await ratingPayload(artifact, versionN, me.id)
+    return c.json(payload)
   })
 
   app.openapi(

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -42,8 +42,8 @@ import {
   sortKeyOf,
   toJson,
   toMarkdown,
-  type WorkflowPreview,
   type VersionRecord,
+  type WorkflowPreview,
   type WorkspaceAccess,
 } from "@derive/core"
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
@@ -1547,19 +1547,12 @@ export const artifactRoutes = (ctx: AppContext) => {
     const parsed = raw === undefined ? current : Number(raw)
     return Number.isInteger(parsed) && parsed > 0 ? parsed : null
   }
-  const isRatingAuthor = (
-    artifact: ArtifactRecord,
-    version: VersionRecord,
-    originalVersion: VersionRecord | null,
-    userId: string,
-  ) =>
-    artifact.author_id === userId ||
-    version.author_id === userId ||
-    originalVersion?.author_id === userId
+  const isRatingAuthor = (artifact: ArtifactRecord, versions: VersionRecord[], userId: string) =>
+    artifact.author_id === userId || versions.some((version) => version.author_id === userId)
   const ratingPayload = async (artifact: ArtifactRecord, versionN: number, userId: string) => {
-    const [version, originalVersion, mine, signals] = await Promise.all([
+    const [version, versions, mine, signals] = await Promise.all([
       meta.getVersion(artifact.id, versionN),
-      meta.getVersion(artifact.id, 1),
+      meta.listVersions(artifact.id),
       meta.getArtifactRating(artifact.id, versionN, userId),
       meta.usefulnessSignals([artifact.id]),
     ])
@@ -1574,7 +1567,7 @@ export const artifactRoutes = (ctx: AppContext) => {
     const helpful = signal.useful + signal.essential
     return {
       version: versionN,
-      eligible: !isRatingAuthor(artifact, version, originalVersion, userId),
+      eligible: !isRatingAuthor(artifact, versions, userId),
       rating: mine ? { value: mine.value, reason: mine.reason } : null,
       aggregate:
         total >= 3
@@ -1620,8 +1613,8 @@ export const artifactRoutes = (ctx: AppContext) => {
       return fail(c, 400, "reason does not match rating")
     const version = await meta.getVersion(artifact.id, body.version)
     if (!version) return fail(c, 404, `no version ${body.version}`)
-    const originalVersion = body.version === 1 ? version : await meta.getVersion(artifact.id, 1)
-    if (isRatingAuthor(artifact, version, originalVersion, me.id))
+    const versions = await meta.listVersions(artifact.id)
+    if (isRatingAuthor(artifact, versions, me.id))
       return fail(c, 403, "authors cannot rate their own version")
     await meta.setArtifactRating({
       id: newId("ar"),

--- a/apps/api/test/search-hybrid.test.ts
+++ b/apps/api/test/search-hybrid.test.ts
@@ -8,7 +8,9 @@ import {
   rrfFuse,
   searchMatcher,
   searchWorkspace,
+  toSearchHits,
   type WorkspaceSearchDeps,
+  workspaceSearchReport,
 } from "../src/lib/search"
 
 // Hybrid (lexical FTS + dense/semantic) workspace search. These are pure-logic tests over the

--- a/apps/api/test/search-hybrid.test.ts
+++ b/apps/api/test/search-hybrid.test.ts
@@ -28,6 +28,7 @@ interface Doc {
   body: string
   org_id?: string
   workspace_access?: "member" | "none"
+  current_version?: number
 }
 
 // A partial ArtifactRecord is castable because ArtifactRecord is assignable to it (same trick the
@@ -37,7 +38,7 @@ const artifact = (d: Doc): ArtifactRecord =>
     id: d.id,
     short_id: d.short_id,
     title: d.title,
-    current_version: 1,
+    current_version: d.current_version ?? 1,
     org_id: d.org_id ?? ORG,
     workspace_access: d.workspace_access ?? "member",
     password_hash: null,
@@ -164,8 +165,11 @@ describe("rrfFuse", () => {
 })
 
 describe("usefulness reranking", () => {
-  it("uses ratings, resolved revision loops, then view buckets inside groups of five", () => {
-    const ranked = ["a", "b", "c", "d", "e", "f"].map((id) => ({ id }))
+  it("uses ratings, resolved revision loops, view buckets, then version buckets", () => {
+    const ranked = ["a", "b", "c", "d", "e", "f"].map((id) => ({
+      id,
+      current_version: id === "e" ? 5 : 1,
+    }))
     const result = rerankByUsefulness(
       ranked,
       {
@@ -175,7 +179,7 @@ describe("usefulness reranking", () => {
       },
       { d: 1000 },
     )
-    expect(result.map((item) => item.id)).toEqual(["b", "c", "d", "a", "e", "f"])
+    expect(result.map((item) => item.id)).toEqual(["b", "c", "d", "e", "a", "f"])
     // f is strong, but it cannot cross the fixed relevance-group boundary.
     expect(result[5]?.id).toBe("f")
   })
@@ -186,6 +190,7 @@ describe("usefulness reranking", () => {
       short_id: `${id}1`,
       title: `Guide ${id}`,
       body: "shared workflow",
+      current_version: id === "b" ? 5 : 1,
     }))
     const usefulness = {
       b: { not_useful: 0, useful: 0, essential: 0, resolved_revisions: 1 },
@@ -194,7 +199,7 @@ describe("usefulness reranking", () => {
     }
     const { results } = await run(makeDeps(docs, undefined, usefulness, { c: 1000 }), "workflow")
 
-    expect(results.map((result) => result.short_id)).toEqual(["e1", "d1", "c1", "a1", "b1"])
+    expect(results.map((result) => result.short_id)).toEqual(["e1", "d1", "c1", "b1", "a1"])
     expect(results[0]?.usefulness).toEqual({
       label: "Essential",
       evidence: "3 of 3 people found this useful",
@@ -202,6 +207,14 @@ describe("usefulness reranking", () => {
     expect(results[1]?.usefulness).toEqual({
       label: "Improved through feedback",
       evidence: "Improved across multiple revisions",
+    })
+    expect(results[2]?.usefulness).toEqual({
+      label: "Often referenced",
+      evidence: "Frequently opened",
+    })
+    expect(results[3]?.usefulness).toEqual({
+      label: "Actively maintained",
+      evidence: "Maintained across multiple versions",
     })
     expect(results[4]?.usefulness).toBeUndefined()
     expect(toSearchHits(results, "workflow")[0]?.usefulness?.label).toBe("Essential")

--- a/apps/api/test/search-hybrid.test.ts
+++ b/apps/api/test/search-hybrid.test.ts
@@ -1,8 +1,10 @@
-import type { ArtifactRecord, SearchIndex, VersionRecord } from "@derive/core"
+import type { ArtifactRecord, SearchIndex, UsefulnessSignals, VersionRecord } from "@derive/core"
 import { describe, expect, it } from "vitest"
 import {
   deleteArtifactAndUnindex,
   indexArtifactVersion,
+  reindexSearchBatch,
+  rerankByUsefulness,
   rrfFuse,
   searchMatcher,
   searchWorkspace,
@@ -67,7 +69,21 @@ const denseIndex = (
   search: async (_org, query, limit) => (byQuery[query] ?? []).slice(0, limit),
 })
 
-const makeDeps = (docs: Doc[], search?: SearchIndex): WorkspaceSearchDeps => {
+const selectRecord = <T>(ids: string[], values: Record<string, T>): Record<string, T> => {
+  const selected: Record<string, T> = {}
+  for (const id of ids) {
+    const value = values[id]
+    if (value !== undefined) selected[id] = value
+  }
+  return selected
+}
+
+const makeDeps = (
+  docs: Doc[],
+  search?: SearchIndex,
+  usefulness: Record<string, UsefulnessSignals> = {},
+  views: Record<string, number> = {},
+): WorkspaceSearchDeps => {
   const keyOf = (d: Doc) => `blob_${d.id}`
   const bodyForKey = (key: string) => docs.find((d) => keyOf(d) === key)?.body ?? null
   const version = (d: Doc) =>
@@ -109,6 +125,8 @@ const makeDeps = (docs: Doc[], search?: SearchIndex): WorkspaceSearchDeps => {
         return out
       },
       searchArtifactIds: async (orgId, query, limit) => lexical(docs, orgId, query, limit),
+      usefulnessSignals: async (ids) => selectRecord(ids, usefulness),
+      viewCounts: async (ids) => selectRecord(ids, views),
     },
     search,
   }
@@ -142,6 +160,78 @@ describe("rrfFuse", () => {
     expect(fused.map((f) => f.id)).toEqual(["a", "b", "c"]) // a in both ⇒ top; then b, c by rank
     expect(fused.find((f) => f.id === "a")?.chunk).toBe("A-chunk")
     expect(fused.find((f) => f.id === "b")?.chunk).toBeUndefined() // lexical-only ⇒ no chunk
+  })
+})
+
+describe("usefulness reranking", () => {
+  it("uses ratings, resolved revision loops, then view buckets inside groups of five", () => {
+    const ranked = ["a", "b", "c", "d", "e", "f"].map((id) => ({ id }))
+    const result = rerankByUsefulness(
+      ranked,
+      {
+        b: { not_useful: 0, useful: 2, essential: 1, resolved_revisions: 0 },
+        c: { not_useful: 0, useful: 0, essential: 0, resolved_revisions: 2 },
+        f: { not_useful: 0, useful: 2, essential: 1, resolved_revisions: 0 },
+      },
+      { d: 1000 },
+    )
+    expect(result.map((item) => item.id)).toEqual(["b", "c", "d", "a", "e", "f"])
+    // f is strong, but it cannot cross the fixed relevance-group boundary.
+    expect(result[5]?.id).toBe("f")
+  })
+
+  it("carries real signal batches through search results and agent reports", async () => {
+    const docs = ["a", "b", "c", "d", "e"].map((id) => ({
+      id,
+      short_id: `${id}1`,
+      title: `Guide ${id}`,
+      body: "shared workflow",
+    }))
+    const usefulness = {
+      b: { not_useful: 0, useful: 0, essential: 0, resolved_revisions: 1 },
+      d: { not_useful: 0, useful: 0, essential: 0, resolved_revisions: 2 },
+      e: { not_useful: 0, useful: 2, essential: 1, resolved_revisions: 0 },
+    }
+    const { results } = await run(makeDeps(docs, undefined, usefulness, { c: 1000 }), "workflow")
+
+    expect(results.map((result) => result.short_id)).toEqual(["e1", "d1", "c1", "a1", "b1"])
+    expect(results[0]?.usefulness).toEqual({
+      label: "Essential",
+      evidence: "3 of 3 people found this useful",
+    })
+    expect(results[1]?.usefulness).toEqual({
+      label: "Improved through feedback",
+      evidence: "Improved across multiple revisions",
+    })
+    expect(results[4]?.usefulness).toBeUndefined()
+    expect(toSearchHits(results, "workflow")[0]?.usefulness?.label).toBe("Essential")
+    expect(workspaceSearchReport("workflow", "text", results, null)).toContain(
+      "> Essential: 3 of 3 people found this useful",
+    )
+  })
+
+  it("requires three ratings and places a majority-negative artifact below neutral peers", () => {
+    const ranked = ["a", "b", "c"].map((id) => ({ id }))
+    const result = rerankByUsefulness(
+      ranked,
+      {
+        a: { not_useful: 2, useful: 1, essential: 0, resolved_revisions: 0 },
+        b: { not_useful: 0, useful: 1, essential: 1, resolved_revisions: 0 },
+      },
+      {},
+    )
+    // b has only two ratings, so it stays neutral. a has enough negative evidence to move down.
+    expect(result.map((item) => item.id)).toEqual(["b", "c", "a"])
+  })
+
+  it("does not let one resolved thread reveal or influence review activity", () => {
+    const ranked = ["a", "b"].map((id) => ({ id }))
+    const result = rerankByUsefulness(
+      ranked,
+      { b: { not_useful: 0, useful: 0, essential: 0, resolved_revisions: 1 } },
+      {},
+    )
+    expect(result.map((item) => item.id)).toEqual(["a", "b"])
   })
 })
 

--- a/apps/api/test/search-hybrid.test.ts
+++ b/apps/api/test/search-hybrid.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest"
 import {
   deleteArtifactAndUnindex,
   indexArtifactVersion,
-  reindexSearchBatch,
   rerankByUsefulness,
   rrfFuse,
   searchMatcher,
@@ -215,8 +214,8 @@ describe("usefulness reranking", () => {
       evidence: "Frequently opened",
     })
     expect(results[3]?.usefulness).toEqual({
-      label: "Actively maintained",
-      evidence: "Maintained across multiple versions",
+      label: "Frequently revised",
+      evidence: "Multiple published versions",
     })
     expect(results[4]?.usefulness).toBeUndefined()
     expect(toSearchHits(results, "workflow")[0]?.usefulness?.label).toBe("Essential")

--- a/apps/api/test/usefulness.test.ts
+++ b/apps/api/test/usefulness.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest"
+import { as, makeAuthedApp, publishAs } from "./helpers"
+
+describe("artifact usefulness ratings", () => {
+  const users = [
+    { id: "rate-author", email: "rate-author@x.test", name: "Author" },
+    { id: "rate-one", email: "rate-one@x.test", name: "One" },
+    { id: "rate-two", email: "rate-two@x.test", name: "Two" },
+    { id: "rate-three", email: "rate-three@x.test", name: "Three" },
+  ]
+
+  const put = (
+    app: ReturnType<typeof makeAuthedApp>["app"],
+    shortId: string,
+    email: string,
+    value: "not_useful" | "useful" | "essential",
+    reason: string | null = null,
+    version = 1,
+  ) =>
+    app.request(`/v1/artifacts/${shortId}/rating`, {
+      method: "PUT",
+      headers: { "content-type": "application/json", ...as(email) },
+      body: JSON.stringify({ version, value, reason }),
+    })
+
+  it("accepts human ratings, blocks self-ratings, and hides small aggregates", async () => {
+    const { app } = makeAuthedApp("usefulness-ratings", users, "editor")
+    const published = await publishAs(
+      app,
+      "# Useful guide",
+      { title: "Useful guide" },
+      as("rate-author@x.test"),
+    )
+    const { short_id: shortId } = (await published.json()) as { short_id: string }
+
+    const authorView = await app.request(`/v1/artifacts/${shortId}/rating?version=1`, {
+      headers: as("rate-author@x.test"),
+    })
+    expect(authorView.status).toBe(200)
+    expect(await authorView.json()).toMatchObject({
+      eligible: false,
+      rating: null,
+      aggregate: null,
+    })
+    expect((await put(app, shortId, "rate-author@x.test", "useful")).status).toBe(403)
+
+    const first = await put(app, shortId, "rate-one@x.test", "useful", "clear")
+    expect(first.status).toBe(200)
+    expect(await first.json()).toMatchObject({
+      eligible: true,
+      rating: { value: "useful", reason: "clear" },
+      aggregate: null,
+    })
+    expect((await put(app, shortId, "rate-two@x.test", "not_useful", "clear")).status).toBe(400)
+
+    await put(app, shortId, "rate-two@x.test", "essential", "saved_time")
+    const third = await put(app, shortId, "rate-three@x.test", "not_useful", "outdated")
+    expect(await third.json()).toMatchObject({
+      aggregate: { total: 3, helpful_percent: 67, essential: 1 },
+    })
+
+    const changed = await put(app, shortId, "rate-one@x.test", "essential", "reusable")
+    expect(await changed.json()).toMatchObject({
+      rating: { value: "essential", reason: "reusable" },
+      aggregate: { total: 3, helpful_percent: 67, essential: 2 },
+    })
+
+    const cleared = await app.request(`/v1/artifacts/${shortId}/rating?version=1`, {
+      method: "DELETE",
+      headers: as("rate-one@x.test"),
+    })
+    expect(await cleared.json()).toMatchObject({ rating: null, aggregate: null })
+  })
+
+  it("blocks the original author when an agent publishes the current version", async () => {
+    const { app } = makeAuthedApp("usefulness-original-author", users, "editor")
+    const published = await publishAs(
+      app,
+      "# First version",
+      { title: "Agent revised guide" },
+      as("rate-author@x.test"),
+    )
+    const { short_id: shortId } = (await published.json()) as { short_id: string }
+    const revised = await publishAs(
+      app,
+      "# Agent revision",
+      { message: "Agent revision" },
+      { authorization: "Bearer tok" },
+      shortId,
+    )
+    expect(revised.status).toBe(201)
+
+    const authorView = await app.request(`/v1/artifacts/${shortId}/rating?version=2`, {
+      headers: as("rate-author@x.test"),
+    })
+    expect(await authorView.json()).toMatchObject({ eligible: false })
+    expect((await put(app, shortId, "rate-author@x.test", "useful", null, 2)).status).toBe(403)
+  })
+
+  it("rejects anonymous rating reads and writes", async () => {
+    const { app } = makeAuthedApp("usefulness-ratings-auth", users, "editor")
+    const published = await publishAs(app, "# Guide", { title: "Guide" }, as("rate-author@x.test"))
+    const { short_id: shortId } = (await published.json()) as { short_id: string }
+    expect((await app.request(`/v1/artifacts/${shortId}/rating`)).status).toBe(401)
+    expect(
+      (
+        await app.request(`/v1/artifacts/${shortId}/rating`, {
+          method: "PUT",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ version: 1, value: "useful", reason: null }),
+        })
+      ).status,
+    ).toBe(403)
+  })
+})

--- a/apps/api/test/usefulness.test.ts
+++ b/apps/api/test/usefulness.test.ts
@@ -7,6 +7,7 @@ describe("artifact usefulness ratings", () => {
     { id: "rate-one", email: "rate-one@x.test", name: "One" },
     { id: "rate-two", email: "rate-two@x.test", name: "Two" },
     { id: "rate-three", email: "rate-three@x.test", name: "Three" },
+    { id: "rate-editor", email: "rate-editor@x.test", name: "Editor" },
   ]
 
   const put = (
@@ -95,6 +96,45 @@ describe("artifact usefulness ratings", () => {
     })
     expect(await authorView.json()).toMatchObject({ eligible: false })
     expect((await put(app, shortId, "rate-author@x.test", "useful", null, 2)).status).toBe(403)
+  })
+
+  it("blocks every human author after a later agent revision", async () => {
+    const { app } = makeAuthedApp("usefulness-intermediate-author", users, "editor")
+    const published = await publishAs(
+      app,
+      "# First version",
+      { title: "Multi-author guide" },
+      as("rate-author@x.test"),
+    )
+    const { short_id: shortId } = (await published.json()) as { short_id: string }
+    expect(
+      (
+        await publishAs(
+          app,
+          "# Human revision",
+          { message: "Human revision" },
+          as("rate-editor@x.test"),
+          shortId,
+        )
+      ).status,
+    ).toBe(201)
+    expect(
+      (
+        await publishAs(
+          app,
+          "# Agent revision",
+          { message: "Agent revision" },
+          { authorization: "Bearer tok" },
+          shortId,
+        )
+      ).status,
+    ).toBe(201)
+
+    const editorView = await app.request(`/v1/artifacts/${shortId}/rating?version=3`, {
+      headers: as("rate-editor@x.test"),
+    })
+    expect(await editorView.json()).toMatchObject({ eligible: false })
+    expect((await put(app, shortId, "rate-editor@x.test", "useful", null, 3)).status).toBe(403)
   })
 
   it("rejects anonymous rating reads and writes", async () => {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -327,6 +327,22 @@ export const workspaceDisplayName = (w: { name: string; personal: boolean }): st
   w.personal ? "Personal" : w.name
 /** Per-artifact view stats. Generated from the OpenAPI spec. */
 export type Analytics = components["schemas"]["Analytics"]
+export type ArtifactRatingValue = "not_useful" | "useful" | "essential"
+export type ArtifactRatingReason =
+  | "clear"
+  | "current"
+  | "reusable"
+  | "saved_time"
+  | "outdated"
+  | "wrong_scope"
+  | "unclear"
+  | "duplicate"
+export interface ArtifactRatingResponse {
+  version: number
+  eligible: boolean
+  rating: { value: ArtifactRatingValue; reason: ArtifactRatingReason | null } | null
+  aggregate: { total: number; helpful_percent: number; essential: number } | null
+}
 /** A resolved @mention: the picked user's id + the display name shown inline. */
 /** A person/agent @mentioned in a comment. Generated from the OpenAPI spec. */
 export type Mention = components["schemas"]["Mention"]
@@ -838,6 +854,23 @@ export const api = {
     workspace: string
   }> => f("/v1/tags", opts()).then(j),
   getArtifact: (id: string): Promise<Artifact> => f(`/v1/artifacts/${id}`, opts()).then(j),
+  getArtifactRating: (id: string, version: number): Promise<ArtifactRatingResponse> =>
+    f(`/v1/artifacts/${id}/rating?version=${version}`, opts()).then(j),
+  setArtifactRating: (
+    id: string,
+    version: number,
+    value: ArtifactRatingValue,
+    reason: ArtifactRatingReason | null,
+  ): Promise<ArtifactRatingResponse> =>
+    f(`/v1/artifacts/${id}/rating`, {
+      ...opts({ version, value, reason }),
+      method: "PUT",
+    }).then(j),
+  clearArtifactRating: (id: string, version: number): Promise<ArtifactRatingResponse> =>
+    f(`/v1/artifacts/${id}/rating?version=${version}`, {
+      method: "DELETE",
+      credentials: "include",
+    }).then(j),
   getContent: (id: string, v?: number): Promise<string> =>
     f(`/v1/artifacts/${id}/content${v ? `?v=${v}` : ""}`, { credentials: "include" }).then((r) => {
       if (!r.ok) throw new Error(`HTTP ${r.status}`)

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -356,6 +356,12 @@ export const notificationsQuery = () =>
     queryFn: ({ signal }: { signal: AbortSignal }) => api.notifications({ signal }),
   })
 
+export const artifactRatingQuery = (shortId: string, version: number) =>
+  queryOptions({
+    queryKey: ["artifact-rating", shortId, version] as const,
+    queryFn: () => api.getArtifactRating(shortId, version),
+  })
+
 export const commentsQuery = (shortId: string) =>
   queryOptions({
     queryKey: ["comments", shortId] as const,

--- a/apps/web/src/pages/artifact/artifact-comments.tsx
+++ b/apps/web/src/pages/artifact/artifact-comments.tsx
@@ -26,6 +26,7 @@ import {
   type Selection,
   selLabel,
 } from "./types"
+import { UsefulnessRating } from "./usefulness-rating"
 
 /**
  * All the comment surfaces for an artifact, in one place: the desktop activity rail,
@@ -67,6 +68,8 @@ export function ArtifactComments(p: {
    *  send-back write. */
   versions: Artifact["versions"]
   currentVersion: number
+  /** Current version shown by the reader. Historical versions cannot receive ratings. */
+  ratingVersion?: number
   rounds: ReviewRound[]
   pendingRound: ReviewRound | null
   meId: string
@@ -241,42 +244,47 @@ export function ArtifactComments(p: {
             ) : panel !== "hidden" && p.rail === "inspect" && p.inspectEnabled ? (
               p.inspectPanel
             ) : panel !== "hidden" ? (
-              <ActivityPanel
-                tabs={
-                  hasRailTabs && p.rail && p.onRail ? (
-                    <RailTabs
-                      tab={p.rail}
-                      commentCount={p.openCount}
-                      mapEnabled={p.mapEnabled}
-                      chatEnabled={p.chatBeta}
-                      inspectEnabled={p.inspectEnabled}
-                      onTab={p.onRail}
-                    />
-                  ) : undefined
-                }
-                items={items}
-                ready={p.ready}
-                openCount={p.openCount}
-                currentVersion={p.currentVersion}
-                pendingRound={p.pendingRound}
-                lens={lens}
-                onLens={setLens}
-                composer={p.composer}
-                onNewGeneral={newGeneralDesktop}
-                onSubmitNew={p.submitNew}
-                onCancelNew={cancelNew}
-                onHide={() => p.setPanel("hidden")}
-                visualPinAvailable={p.visualPinAvailable}
-                visualPinActive={p.visualPinActive}
-                onToggleVisualPin={p.onToggleVisualPin}
-                hints={p.hints}
-                editing={p.editing}
-                onGoToVersion={p.onGoToVersion}
-                onSendBack={p.onSendBack}
-                sendingBack={p.sendingBack}
-                anchorTops={p.anchorTops}
-                subscribeGeom={p.subscribeGeom}
-              />
+              <>
+                <ActivityPanel
+                  tabs={
+                    hasRailTabs && p.rail && p.onRail ? (
+                      <RailTabs
+                        tab={p.rail}
+                        commentCount={p.openCount}
+                        mapEnabled={p.mapEnabled}
+                        chatEnabled={p.chatBeta}
+                        inspectEnabled={p.inspectEnabled}
+                        onTab={p.onRail}
+                      />
+                    ) : undefined
+                  }
+                  items={items}
+                  ready={p.ready}
+                  openCount={p.openCount}
+                  currentVersion={p.currentVersion}
+                  pendingRound={p.pendingRound}
+                  lens={lens}
+                  onLens={setLens}
+                  composer={p.composer}
+                  onNewGeneral={newGeneralDesktop}
+                  onSubmitNew={p.submitNew}
+                  onCancelNew={cancelNew}
+                  onHide={() => p.setPanel("hidden")}
+                  visualPinAvailable={p.visualPinAvailable}
+                  visualPinActive={p.visualPinActive}
+                  onToggleVisualPin={p.onToggleVisualPin}
+                  hints={p.hints}
+                  editing={p.editing}
+                  onGoToVersion={p.onGoToVersion}
+                  onSendBack={p.onSendBack}
+                  sendingBack={p.sendingBack}
+                  anchorTops={p.anchorTops}
+                  subscribeGeom={p.subscribeGeom}
+                />
+                {p.ratingVersion !== undefined && (
+                  <UsefulnessRating shortId={p.shortId} version={p.ratingVersion} />
+                )}
+              </>
             ) : null}
           </aside>
         )}
@@ -310,6 +318,15 @@ export function ArtifactComments(p: {
             chatEnabled={p.chatBeta}
             inspectEnabled={p.inspectEnabled}
             openCount={p.openCount}
+            footer={
+              p.ratingVersion !== undefined ? (
+                <UsefulnessRating
+                  shortId={p.shortId}
+                  version={p.ratingVersion}
+                  className="pb-[max(10px,env(safe-area-inset-bottom))]"
+                />
+              ) : undefined
+            }
           />
         )}
         {/* Desktop: the anchored action menu above the selection (the mouse can

--- a/apps/web/src/pages/artifact/comment-panels.tsx
+++ b/apps/web/src/pages/artifact/comment-panels.tsx
@@ -54,6 +54,7 @@ export function MobileComments({
   chatEnabled,
   inspectEnabled,
   openCount,
+  footer,
   editing = false,
 }: {
   open: boolean
@@ -88,6 +89,8 @@ export function MobileComments({
   chatEnabled?: boolean
   inspectEnabled?: boolean
   openCount?: number
+  /** Current-version usefulness feedback, below the expanded activity stream. */
+  footer?: ReactNode
 }) {
   // The sheet is ALWAYS docked on a phone (peek is the floor — there is no hidden
   // state and no scrim; the doc above stays live). Two resting sizes: peek (the slim
@@ -383,7 +386,7 @@ export function MobileComments({
         <CommentTreeProvider value={sheetTree}>
           <div
             data-testid="activity-stream"
-            className="flex min-h-0 flex-1 flex-col overflow-auto px-3 pb-[max(14px,env(safe-area-inset-bottom))]"
+            className="flex min-h-0 flex-1 flex-col overflow-auto px-3 pb-3"
           >
             {!ready && <StreamSkeleton />}
             {ready && (
@@ -403,6 +406,7 @@ export function MobileComments({
               />
             )}
           </div>
+          {footer}
         </CommentTreeProvider>
       ) : latest ? (
         // Peek preview: a one-line teaser of the latest comment, so the resting

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -1672,6 +1672,7 @@ export function Artifact({ template = false }: { template?: boolean }) {
               onSheetHeight={setSheetInset}
               versions={art.versions}
               currentVersion={art.current_version}
+              ratingVersion={shown === art.current_version ? shown : undefined}
               rounds={review?.rounds ?? []}
               pendingRound={review?.pending ?? null}
               ready={streamReady}

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -78,7 +78,6 @@ import { useCommentsPanel } from "./use-comments-panel"
 import { unsavedEditsCopy, useInlineEdit } from "./use-inline-edit"
 import { useSeenCursor } from "./use-seen-cursor"
 import { useVersionDiff } from "./use-version-diff"
-import { UsefulnessRating } from "./usefulness-rating"
 import { WorkbenchSkeleton } from "./workbench-skeleton"
 
 // Heavy on-demand surfaces — split out of the artifact route's initial chunk and

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -78,6 +78,7 @@ import { useCommentsPanel } from "./use-comments-panel"
 import { unsavedEditsCopy, useInlineEdit } from "./use-inline-edit"
 import { useSeenCursor } from "./use-seen-cursor"
 import { useVersionDiff } from "./use-version-diff"
+import { UsefulnessRating } from "./usefulness-rating"
 import { WorkbenchSkeleton } from "./workbench-skeleton"
 
 // Heavy on-demand surfaces — split out of the artifact route's initial chunk and

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -237,8 +237,10 @@ export function Artifact({ template = false }: { template?: boolean }) {
   }, [search.use, loading, me, shortId, ref, selfRoute, nav])
   // The tab is named after the document, like the workbench header (title, else id).
   useDocumentTitle(art ? (art.title ?? shortId) : null)
-  const commentsAvailable =
-    !!me && !seeded && !!art && (!isGuest || canCommentWithRole(art.my_role))
+  // Comments are readable by every signed-in reader. The role only gates writes.
+  // Keep the activity rail available to link viewers so they can read feedback and
+  // rate the artifact without receiving a comment affordance they cannot use.
+  const commentsAvailable = !!me && !seeded && !!art
   const commentsQ = useQuery({
     ...commentsQuery(shortId),
     enabled: commentsAvailable,

--- a/apps/web/src/pages/artifact/usefulness-rating.tsx
+++ b/apps/web/src/pages/artifact/usefulness-rating.tsx
@@ -16,7 +16,6 @@ import {
   PopoverHeader,
   PopoverTitle,
 } from "@/components/ui/popover"
-import { toast } from "@/components/ui/sonner"
 import { artifactRatingQuery } from "@/lib/queries"
 import { cn } from "@/lib/utils"
 
@@ -36,7 +35,7 @@ const negativeReasons = [
 
 export function UsefulnessRating({ shortId, version }: { shortId: string; version: number }) {
   const query = artifactRatingQuery(shortId, version)
-  const { data, isError, refetch } = useQuery(query)
+  const { data, isError } = useQuery(query)
   const client = useQueryClient()
   const [open, setOpen] = useState(false)
   const [mode, setMode] = useState<"positive" | "negative">("positive")
@@ -49,24 +48,9 @@ export function UsefulnessRating({ shortId, version }: { shortId: string; versio
         ? api.setArtifactRating(shortId, version, next.value, next.reason)
         : api.clearArtifactRating(shortId, version),
     onSuccess: (next: ArtifactRatingResponse) => client.setQueryData(query.queryKey, next),
-    onError: () => toast.error("Could not save your rating. Try again."),
   })
 
-  if (isError)
-    return (
-      <div className="flex shrink-0 items-center justify-center gap-2 border-t border-border bg-background px-4 py-3 text-xs text-muted-foreground">
-        Rating unavailable.
-        <Button
-          type="button"
-          size="xs"
-          variant="ghost"
-          data-testid="artifact-rating-retry"
-          onClick={() => void refetch()}
-        >
-          Retry
-        </Button>
-      </div>
-    )
+  if (isError) return null
   if (!data?.eligible) return null
 
   const selected = data.rating?.value
@@ -92,35 +76,36 @@ export function UsefulnessRating({ shortId, version }: { shortId: string; versio
   const aggregate = data.aggregate
 
   return (
-    <div className="flex shrink-0 justify-center border-t border-border bg-background px-4 py-3">
+    <div className="flex shrink-0 items-center">
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverAnchor asChild>
-          <fieldset className="flex items-center gap-2">
+          <fieldset className="flex items-center gap-0.5">
             <legend className="sr-only">Rate this artifact version</legend>
-            <span className="mr-1 text-xs text-muted-foreground">Was this useful?</span>
             <Button
               type="button"
-              size="xs"
+              size="icon-sm"
               variant={selected === "not_useful" ? "secondary" : "ghost"}
+              aria-label="Not useful"
+              title="Not useful"
               aria-pressed={selected === "not_useful"}
               data-testid="artifact-rating-not-useful"
               loading={mutation.isPending && mode === "negative"}
               onClick={() => void choose("not_useful", "negative")}
             >
-              <ThumbsDown aria-hidden />
-              Not useful
+              <ThumbsDown className="size-4" aria-hidden />
             </Button>
             <Button
               type="button"
-              size="xs"
+              size="icon-sm"
               variant={selected === "useful" || selected === "essential" ? "secondary" : "ghost"}
+              aria-label={selected === "essential" ? "Essential" : "Useful"}
+              title={selected === "essential" ? "Essential" : "Useful"}
               aria-pressed={selected === "useful" || selected === "essential"}
               data-testid="artifact-rating-useful"
               loading={mutation.isPending && mode === "positive"}
               onClick={() => void choose("useful", "positive")}
             >
-              <ThumbsUp aria-hidden />
-              Useful
+              <ThumbsUp className="size-4" aria-hidden />
             </Button>
           </fieldset>
         </PopoverAnchor>

--- a/apps/web/src/pages/artifact/usefulness-rating.tsx
+++ b/apps/web/src/pages/artifact/usefulness-rating.tsx
@@ -1,0 +1,190 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { ThumbsDown, ThumbsUp } from "lucide-react"
+import { useState } from "react"
+import {
+  type ArtifactRatingReason,
+  type ArtifactRatingResponse,
+  type ArtifactRatingValue,
+  api,
+} from "@/api"
+import { Button } from "@/components/ui/button"
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+} from "@/components/ui/popover"
+import { toast } from "@/components/ui/sonner"
+import { artifactRatingQuery } from "@/lib/queries"
+import { cn } from "@/lib/utils"
+
+const positiveReasons = [
+  ["clear", "Clear"],
+  ["current", "Current"],
+  ["reusable", "Reusable"],
+  ["saved_time", "Saved time"],
+] as const satisfies readonly (readonly [ArtifactRatingReason, string])[]
+
+const negativeReasons = [
+  ["outdated", "Outdated"],
+  ["wrong_scope", "Wrong scope"],
+  ["unclear", "Unclear"],
+  ["duplicate", "Duplicate"],
+] as const satisfies readonly (readonly [ArtifactRatingReason, string])[]
+
+export function UsefulnessRating({ shortId, version }: { shortId: string; version: number }) {
+  const query = artifactRatingQuery(shortId, version)
+  const { data, isError, refetch } = useQuery(query)
+  const client = useQueryClient()
+  const [open, setOpen] = useState(false)
+  const [mode, setMode] = useState<"positive" | "negative">("positive")
+
+  const mutation = useMutation({
+    mutationFn: (
+      next: { value: ArtifactRatingValue; reason: ArtifactRatingReason | null } | null,
+    ) =>
+      next
+        ? api.setArtifactRating(shortId, version, next.value, next.reason)
+        : api.clearArtifactRating(shortId, version),
+    onSuccess: (next: ArtifactRatingResponse) => client.setQueryData(query.queryKey, next),
+    onError: () => toast.error("Could not save your rating. Try again."),
+  })
+
+  if (isError)
+    return (
+      <div className="flex shrink-0 items-center justify-center gap-2 border-t border-border bg-background px-4 py-3 text-xs text-muted-foreground">
+        Rating unavailable.
+        <Button
+          type="button"
+          size="xs"
+          variant="ghost"
+          data-testid="artifact-rating-retry"
+          onClick={() => void refetch()}
+        >
+          Retry
+        </Button>
+      </div>
+    )
+  if (!data?.eligible) return null
+
+  const selected = data.rating?.value
+  const choose = async (value: ArtifactRatingValue, nextMode: "positive" | "negative") => {
+    setMode(nextMode)
+    if (
+      (value === "not_useful" && selected === "not_useful") ||
+      (value === "useful" && (selected === "useful" || selected === "essential"))
+    ) {
+      setOpen(false)
+      await mutation.mutateAsync(null).catch(() => undefined)
+      return
+    }
+    const saved = await mutation.mutateAsync({ value, reason: null }).catch(() => null)
+    if (!saved) return
+    setOpen(true)
+  }
+
+  const refine = (value: ArtifactRatingValue, reason: ArtifactRatingReason | null) =>
+    mutation.mutate({ value, reason })
+
+  const reasons = mode === "positive" ? positiveReasons : negativeReasons
+  const aggregate = data.aggregate
+
+  return (
+    <div className="flex shrink-0 justify-center border-t border-border bg-background px-4 py-3">
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverAnchor asChild>
+          <fieldset className="flex items-center gap-2">
+            <legend className="sr-only">Rate this artifact version</legend>
+            <span className="mr-1 text-xs text-muted-foreground">Was this useful?</span>
+            <Button
+              type="button"
+              size="xs"
+              variant={selected === "not_useful" ? "secondary" : "ghost"}
+              aria-pressed={selected === "not_useful"}
+              data-testid="artifact-rating-not-useful"
+              loading={mutation.isPending && mode === "negative"}
+              onClick={() => void choose("not_useful", "negative")}
+            >
+              <ThumbsDown aria-hidden />
+              Not useful
+            </Button>
+            <Button
+              type="button"
+              size="xs"
+              variant={selected === "useful" || selected === "essential" ? "secondary" : "ghost"}
+              aria-pressed={selected === "useful" || selected === "essential"}
+              data-testid="artifact-rating-useful"
+              loading={mutation.isPending && mode === "positive"}
+              onClick={() => void choose("useful", "positive")}
+            >
+              <ThumbsUp aria-hidden />
+              Useful
+            </Button>
+          </fieldset>
+        </PopoverAnchor>
+        <PopoverContent side="top" align="center" className="w-80">
+          <PopoverHeader>
+            <PopoverTitle>
+              {mode === "positive" ? "What made it useful?" : "What should improve?"}
+            </PopoverTitle>
+            <PopoverDescription>Your note improves future search results.</PopoverDescription>
+          </PopoverHeader>
+
+          {mode === "positive" && (
+            <Button
+              type="button"
+              size="sm"
+              variant={selected === "essential" ? "secondary" : "outline"}
+              aria-pressed={selected === "essential"}
+              data-testid="artifact-rating-essential"
+              onClick={() => refine("essential", data.rating?.reason ?? null)}
+            >
+              <span className="flex -space-x-1" aria-hidden>
+                <ThumbsUp className="size-3.5" />
+                <ThumbsUp className="size-3.5" />
+              </span>
+              Essential
+            </Button>
+          )}
+
+          <div className="flex flex-wrap gap-1.5">
+            {reasons.map(([reason, label]) => {
+              const active = data.rating?.reason === reason
+              return (
+                <Button
+                  key={reason}
+                  type="button"
+                  size="xs"
+                  variant={active ? "secondary" : "outline"}
+                  aria-pressed={active}
+                  data-testid={`artifact-rating-reason-${reason}`}
+                  onClick={() =>
+                    refine(
+                      mode === "positive"
+                        ? selected === "essential"
+                          ? "essential"
+                          : "useful"
+                        : "not_useful",
+                      active ? null : reason,
+                    )
+                  }
+                >
+                  {label}
+                </Button>
+              )
+            })}
+          </div>
+
+          {aggregate && (
+            <p className={cn("text-xs text-muted-foreground", mutation.isPending && "opacity-60")}>
+              {aggregate.helpful_percent}% useful from {aggregate.total} ratings
+              {aggregate.essential > 0 ? ` · ${aggregate.essential} essential` : ""}
+            </p>
+          )}
+        </PopoverContent>
+      </Popover>
+    </div>
+  )
+}

--- a/apps/web/src/pages/artifact/usefulness-rating.tsx
+++ b/apps/web/src/pages/artifact/usefulness-rating.tsx
@@ -33,7 +33,15 @@ const negativeReasons = [
   ["duplicate", "Duplicate"],
 ] as const satisfies readonly (readonly [ArtifactRatingReason, string])[]
 
-export function UsefulnessRating({ shortId, version }: { shortId: string; version: number }) {
+export function UsefulnessRating({
+  shortId,
+  version,
+  className,
+}: {
+  shortId: string
+  version: number
+  className?: string
+}) {
   const query = artifactRatingQuery(shortId, version)
   const { data, isError } = useQuery(query)
   const client = useQueryClient()
@@ -76,7 +84,14 @@ export function UsefulnessRating({ shortId, version }: { shortId: string; versio
   const aggregate = data.aggregate
 
   return (
-    <div className="flex shrink-0 items-center">
+    <div
+      data-testid="artifact-usefulness"
+      className={cn(
+        "flex shrink-0 items-center justify-between gap-3 border-t border-border-soft px-3 py-2",
+        className,
+      )}
+    >
+      <span className="text-xs text-muted-foreground">Was this useful?</span>
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverAnchor asChild>
           <fieldset className="flex items-center gap-0.5">
@@ -109,7 +124,7 @@ export function UsefulnessRating({ shortId, version }: { shortId: string; versio
             </Button>
           </fieldset>
         </PopoverAnchor>
-        <PopoverContent side="top" align="center" className="w-80">
+        <PopoverContent side="top" align="end" className="w-80">
           <PopoverHeader>
             <PopoverTitle>
               {mode === "positive" ? "What made it useful?" : "What should improve?"}

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -123,6 +123,19 @@ CREATE TABLE IF NOT EXISTS comment (
   FOREIGN KEY (artifact_id) REFERENCES artifact(id)
 );
 
+CREATE TABLE IF NOT EXISTS artifact_rating (
+  id TEXT PRIMARY KEY,
+  artifact_id TEXT NOT NULL,
+  version_n INTEGER NOT NULL,
+  user_id TEXT NOT NULL,
+  value TEXT NOT NULL,
+  reason TEXT,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  UNIQUE (artifact_id, version_n, user_id),
+  FOREIGN KEY (artifact_id) REFERENCES artifact(id)
+);
+
 CREATE TABLE IF NOT EXISTS webhook (
   id TEXT PRIMARY KEY,
   org_id TEXT NOT NULL DEFAULT 'default',

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -906,6 +906,60 @@ export interface CommentStore {
   commentAuthorIds(artifactId: string): Promise<string[]>
 }
 
+export type ArtifactRatingValue = "not_useful" | "useful" | "essential"
+export type ArtifactRatingReason =
+  | "clear"
+  | "current"
+  | "reusable"
+  | "saved_time"
+  | "outdated"
+  | "wrong_scope"
+  | "unclear"
+  | "duplicate"
+
+/** One human's rating of one artifact version. Ratings stay version-scoped so a
+ *  new revision starts clean without erasing the old revision's history. */
+export interface ArtifactRatingRecord {
+  id: string
+  artifact_id: string
+  version_n: number
+  user_id: string
+  value: ArtifactRatingValue
+  reason: ArtifactRatingReason | null
+  created_at: string
+  updated_at: string
+}
+
+export interface NewArtifactRating {
+  id: string
+  artifact_id: string
+  version_n: number
+  user_id: string
+  value: ArtifactRatingValue
+  reason: ArtifactRatingReason | null
+}
+
+/** Batched, privacy-safe inputs for search ranking. No rater identity or reason
+ *  leaves the store. `resolved_revisions` counts threads resolved by a later version. */
+export interface UsefulnessSignals {
+  not_useful: number
+  useful: number
+  essential: number
+  resolved_revisions: number
+}
+
+export interface UsefulnessStore {
+  setArtifactRating(rating: NewArtifactRating): Promise<ArtifactRatingRecord>
+  getArtifactRating(
+    artifactId: string,
+    version: number,
+    userId: string,
+  ): Promise<ArtifactRatingRecord | null>
+  deleteArtifactRating(artifactId: string, version: number, userId: string): Promise<void>
+  /** Current-version rating totals plus resolved revision loops for many artifacts. */
+  usefulnessSignals(artifactIds: string[]): Promise<Record<string, UsefulnessSignals>>
+}
+
 export interface ArtifactQueryStore {
   /**
    * Newest-first artifact page. `cursor` is keyset pagination on created_at
@@ -2571,6 +2625,7 @@ export interface SharedStateStore {
 export interface MetaStore
   extends ArtifactStore,
     CommentStore,
+    UsefulnessStore,
     ArtifactQueryStore,
     WebhookStore,
     WorkspaceStore,

--- a/packages/db/src/parity.ts
+++ b/packages/db/src/parity.ts
@@ -17,6 +17,7 @@ import type {
   AgentRecord,
   ArtifactInviteRecord,
   ArtifactMemberRecord,
+  ArtifactRatingRecord,
   ArtifactRecord,
   AssetRecord,
   AuditLogRecord,
@@ -75,6 +76,7 @@ export interface TypedTables {
   membership: MembershipRecord
   workspace: WorkspaceRecord
   artifactMember: ArtifactMemberRecord
+  artifactRating: ArtifactRatingRecord
   notification: NotificationRecord
   follow: FollowRecord
   reviewRound: ReviewRoundRecord

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -2,6 +2,8 @@ import type {
   AgentMentionKind,
   AgentMentionState,
   ArtifactKind,
+  ArtifactRatingReason,
+  ArtifactRatingValue,
   AuditAction,
   CommentState,
   ConnectionKind,
@@ -202,6 +204,24 @@ export const comment = pgTable("comment", {
   created_at: text("created_at").notNull().$defaultFn(isoNow),
   meta: text("meta"),
 })
+
+// One active human rating per artifact version. Mirrors schema.ts.
+export const artifactRating = pgTable(
+  "artifact_rating",
+  {
+    id: text("id").primaryKey(),
+    artifact_id: text("artifact_id")
+      .notNull()
+      .references(() => artifact.id),
+    version_n: integer("version_n").notNull(),
+    user_id: text("user_id").notNull(),
+    value: text("value").$type<ArtifactRatingValue>().notNull(),
+    reason: text("reason").$type<ArtifactRatingReason>(),
+    created_at: text("created_at").notNull().$defaultFn(isoNow),
+    updated_at: text("updated_at").notNull().$defaultFn(isoNow),
+  },
+  (t) => [uniqueIndex("artifact_rating_user").on(t.artifact_id, t.version_n, t.user_id)],
+)
 
 export const webhook = pgTable("webhook", {
   id: text("id").primaryKey(),
@@ -1137,6 +1157,7 @@ const TABLES = [
   version,
   versionData,
   comment,
+  artifactRating,
   webhook,
   webhookDelivery,
   renderJob,

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -5,6 +5,7 @@ import type {
   ArtifactDetailOpts,
   ArtifactInviteRecord,
   ArtifactMemberRecord,
+  ArtifactRatingRecord,
   ArtifactRecord,
   AssetRecord,
   AuditLogRecord,
@@ -51,6 +52,7 @@ import type {
   NewArtifact,
   NewArtifactInvite,
   NewArtifactMember,
+  NewArtifactRating,
   NewAsset,
   NewAuditLog,
   NewAutomation,
@@ -121,6 +123,7 @@ import type {
   TemplateLibraryEntryRecord,
   TemplateLibraryRecord,
   TemplateLibraryScope,
+  UsefulnessSignals,
   UserDir,
   UserNotificationPrefRecord,
   UserProfile,
@@ -187,6 +190,7 @@ import {
   artifactFavorite,
   artifactInvite,
   artifactMember,
+  artifactRating,
   artifactTag,
   asset,
   auditLog,
@@ -262,6 +266,7 @@ export const schema = {
   version,
   versionData,
   comment,
+  artifactRating,
   webhook,
   webhookDelivery,
   exportJob,
@@ -317,6 +322,7 @@ const _schemaShapes: Shapes<typeof schema> = {
   version: true,
   versionData: true,
   comment: true,
+  artifactRating: true,
   webhook: true,
   webhookDelivery: true,
   renderJob: true,
@@ -1791,6 +1797,105 @@ export class PgMetaStore implements MetaStore {
       if (r.author_id === userId || this.commentMentionsUser(r.meta, userId)) ids.add(r.artifact_id)
     }
     return [...ids]
+  }
+
+  // ---- Human usefulness ratings ----------------------------------------
+  async setArtifactRating(rating: NewArtifactRating): Promise<ArtifactRatingRecord> {
+    const now = new Date().toISOString()
+    await this.db
+      .insert(artifactRating)
+      .values({ ...rating, created_at: now, updated_at: now })
+      .onConflictDoUpdate({
+        target: [artifactRating.artifact_id, artifactRating.version_n, artifactRating.user_id],
+        set: { value: rating.value, reason: rating.reason, updated_at: now },
+      })
+    const rows = await this.db
+      .select()
+      .from(artifactRating)
+      .where(
+        and(
+          eq(artifactRating.artifact_id, rating.artifact_id),
+          eq(artifactRating.version_n, rating.version_n),
+          eq(artifactRating.user_id, rating.user_id),
+        ),
+      )
+      .limit(1)
+    return one(rows)
+  }
+
+  async getArtifactRating(
+    artifactId: string,
+    versionN: number,
+    userId: string,
+  ): Promise<ArtifactRatingRecord | null> {
+    const rows = await this.db
+      .select()
+      .from(artifactRating)
+      .where(
+        and(
+          eq(artifactRating.artifact_id, artifactId),
+          eq(artifactRating.version_n, versionN),
+          eq(artifactRating.user_id, userId),
+        ),
+      )
+      .limit(1)
+    return rows[0] ?? null
+  }
+
+  async deleteArtifactRating(artifactId: string, versionN: number, userId: string): Promise<void> {
+    await this.db
+      .delete(artifactRating)
+      .where(
+        and(
+          eq(artifactRating.artifact_id, artifactId),
+          eq(artifactRating.version_n, versionN),
+          eq(artifactRating.user_id, userId),
+        ),
+      )
+  }
+
+  async usefulnessSignals(artifactIds: string[]): Promise<Record<string, UsefulnessSignals>> {
+    const out: Record<string, UsefulnessSignals> = {}
+    if (artifactIds.length === 0) return out
+    const signalFor = (id: string): UsefulnessSignals => {
+      const existing = out[id]
+      if (existing) return existing
+      const created = { not_useful: 0, useful: 0, essential: 0, resolved_revisions: 0 }
+      out[id] = created
+      return created
+    }
+    const [ratings, resolvedThreads] = await Promise.all([
+      this.db
+        .select({
+          artifact_id: artifactRating.artifact_id,
+          value: artifactRating.value,
+          total: count(),
+        })
+        .from(artifactRating)
+        .innerJoin(artifact, eq(artifact.id, artifactRating.artifact_id))
+        .where(
+          and(
+            inArray(artifactRating.artifact_id, artifactIds),
+            eq(artifactRating.version_n, artifact.current_version),
+          ),
+        )
+        .groupBy(artifactRating.artifact_id, artifactRating.value),
+      this.db
+        .select({
+          artifact_id: comment.artifact_id,
+          thread_id: comment.thread_id,
+          base_version: sql<number>`min(${comment.base_version})`,
+          current_version: artifact.current_version,
+        })
+        .from(comment)
+        .innerJoin(artifact, eq(artifact.id, comment.artifact_id))
+        .where(and(inArray(comment.artifact_id, artifactIds), eq(comment.state, "resolved")))
+        .groupBy(comment.artifact_id, comment.thread_id, artifact.current_version),
+    ])
+    for (const row of ratings) signalFor(row.artifact_id)[row.value] = row.total
+    for (const row of resolvedThreads)
+      if (row.base_version < row.current_version) signalFor(row.artifact_id).resolved_revisions += 1
+    return out
   }
 
   /** The list query as a BUILDER, so `listArtifacts` and `listPage` cannot diverge.
@@ -6483,6 +6588,7 @@ export class PgMetaStore implements MetaStore {
     await this.db.delete(collectionMember).where(eq(collectionMember.user_id, userId))
     await this.db.delete(follow).where(eq(follow.user_id, userId))
     await this.db.delete(artifactFavorite).where(eq(artifactFavorite.user_id, userId))
+    await this.db.delete(artifactRating).where(eq(artifactRating.user_id, userId))
     await this.db.delete(notification).where(eq(notification.user_id, userId))
     // Encrypted plan tokens must not linger after the account is gone; the workspace pool's
     // sentinel-user row is keyed differently, so it is never in scope.
@@ -6624,6 +6730,7 @@ export class PgMetaStore implements MetaStore {
       await tx.delete(artifactMember).where(eq(artifactMember.artifact_id, id))
       await tx.delete(artifactInvite).where(eq(artifactInvite.artifact_id, id))
       await tx.delete(artifactFavorite).where(eq(artifactFavorite.artifact_id, id))
+      await tx.delete(artifactRating).where(eq(artifactRating.artifact_id, id))
       await tx.delete(artifactTag).where(eq(artifactTag.artifact_id, id))
       await tx.delete(collectionItem).where(eq(collectionItem.artifact_id, id))
       await tx.delete(domain).where(eq(domain.artifact_id, id))

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -3,6 +3,7 @@ import type {
   AgentRecord,
   ArtifactInviteRecord,
   ArtifactMemberRecord,
+  ArtifactRatingRecord,
   ArtifactRecord,
   AssetRecord,
   AuditLogRecord,
@@ -42,6 +43,7 @@ import type {
   NewArtifact,
   NewArtifactInvite,
   NewArtifactMember,
+  NewArtifactRating,
   NewAsset,
   NewAuditLog,
   NewAutomation,
@@ -110,6 +112,7 @@ import type {
   TemplateLibraryEntryRecord,
   TemplateLibraryRecord,
   TemplateLibraryScope,
+  UsefulnessSignals,
   UserNotificationPrefRecord,
   UserProfile,
   VersionDataRecord,
@@ -174,6 +177,7 @@ import {
   artifactFavorite,
   artifactInvite,
   artifactMember,
+  artifactRating,
   artifactTag,
   asset,
   auditLog,
@@ -384,6 +388,7 @@ export const schema = {
   version,
   versionData,
   comment,
+  artifactRating,
   webhook,
   webhookDelivery,
   renderJob,
@@ -439,6 +444,7 @@ const _schemaShapes: Shapes<typeof schema> = {
   version: true,
   versionData: true,
   comment: true,
+  artifactRating: true,
   webhook: true,
   webhookDelivery: true,
   renderJob: true,
@@ -1551,6 +1557,114 @@ export function makeRepos(db: SqliteDb) {
       const sig = out[id]
       if (sig) sig.open_threads = set.size
     }
+    return out
+  }
+
+  // ---- Human usefulness ratings ----------------------------------------
+  const setArtifactRating = async (rating: NewArtifactRating): Promise<ArtifactRatingRecord> => {
+    const now = new Date().toISOString()
+    await db
+      .insert(artifactRating)
+      .values({ ...rating, created_at: now, updated_at: now })
+      .onConflictDoUpdate({
+        target: [artifactRating.artifact_id, artifactRating.version_n, artifactRating.user_id],
+        set: { value: rating.value, reason: rating.reason, updated_at: now },
+      })
+      .run()
+    const row = await db
+      .select()
+      .from(artifactRating)
+      .where(
+        and(
+          eq(artifactRating.artifact_id, rating.artifact_id),
+          eq(artifactRating.version_n, rating.version_n),
+          eq(artifactRating.user_id, rating.user_id),
+        ),
+      )
+      .get()
+    if (!row) throw new Error("rating upsert did not persist")
+    return row
+  }
+
+  const getArtifactRating = async (
+    artifactId: string,
+    versionN: number,
+    userId: string,
+  ): Promise<ArtifactRatingRecord | null> =>
+    (await db
+      .select()
+      .from(artifactRating)
+      .where(
+        and(
+          eq(artifactRating.artifact_id, artifactId),
+          eq(artifactRating.version_n, versionN),
+          eq(artifactRating.user_id, userId),
+        ),
+      )
+      .get()) ?? null
+
+  const deleteArtifactRating = async (
+    artifactId: string,
+    versionN: number,
+    userId: string,
+  ): Promise<void> => {
+    await db
+      .delete(artifactRating)
+      .where(
+        and(
+          eq(artifactRating.artifact_id, artifactId),
+          eq(artifactRating.version_n, versionN),
+          eq(artifactRating.user_id, userId),
+        ),
+      )
+      .run()
+  }
+
+  const usefulnessSignals = async (
+    artifactIds: string[],
+  ): Promise<Record<string, UsefulnessSignals>> => {
+    const out: Record<string, UsefulnessSignals> = {}
+    if (artifactIds.length === 0) return out
+    const signalFor = (id: string): UsefulnessSignals => {
+      const existing = out[id]
+      if (existing) return existing
+      const created = { not_useful: 0, useful: 0, essential: 0, resolved_revisions: 0 }
+      out[id] = created
+      return created
+    }
+    const [ratings, resolvedThreads] = await Promise.all([
+      db
+        .select({
+          artifact_id: artifactRating.artifact_id,
+          value: artifactRating.value,
+          total: count(),
+        })
+        .from(artifactRating)
+        .innerJoin(artifact, eq(artifact.id, artifactRating.artifact_id))
+        .where(
+          and(
+            inArray(artifactRating.artifact_id, artifactIds),
+            eq(artifactRating.version_n, artifact.current_version),
+          ),
+        )
+        .groupBy(artifactRating.artifact_id, artifactRating.value)
+        .all(),
+      db
+        .select({
+          artifact_id: comment.artifact_id,
+          thread_id: comment.thread_id,
+          base_version: sql<number>`min(${comment.base_version})`,
+          current_version: artifact.current_version,
+        })
+        .from(comment)
+        .innerJoin(artifact, eq(artifact.id, comment.artifact_id))
+        .where(and(inArray(comment.artifact_id, artifactIds), eq(comment.state, "resolved")))
+        .groupBy(comment.artifact_id, comment.thread_id, artifact.current_version)
+        .all(),
+    ])
+    for (const row of ratings) signalFor(row.artifact_id)[row.value] = row.total
+    for (const row of resolvedThreads)
+      if (row.base_version < row.current_version) signalFor(row.artifact_id).resolved_revisions += 1
     return out
   }
 
@@ -5286,6 +5400,7 @@ export function makeRepos(db: SqliteDb) {
     await db.delete(collectionMember).where(eq(collectionMember.user_id, userId)).run()
     await db.delete(follow).where(eq(follow.user_id, userId)).run()
     await db.delete(artifactFavorite).where(eq(artifactFavorite.user_id, userId)).run()
+    await db.delete(artifactRating).where(eq(artifactRating.user_id, userId)).run()
     await db.delete(notification).where(eq(notification.user_id, userId)).run()
     // Their connected model-plan credentials — encrypted plan tokens must not linger after
     // the account is gone. Keyed on a real user id, so the workspace pool's sentinel row is
@@ -5413,6 +5528,7 @@ export function makeRepos(db: SqliteDb) {
     await db.delete(artifactMember).where(eq(artifactMember.artifact_id, id)).run()
     await db.delete(artifactInvite).where(eq(artifactInvite.artifact_id, id)).run()
     await db.delete(artifactFavorite).where(eq(artifactFavorite.artifact_id, id)).run()
+    await db.delete(artifactRating).where(eq(artifactRating.artifact_id, id)).run()
     await db.delete(artifactTag).where(eq(artifactTag.artifact_id, id)).run()
     await db.delete(collectionItem).where(eq(collectionItem.artifact_id, id)).run()
     await db.delete(domain).where(eq(domain.artifact_id, id)).run()
@@ -5571,6 +5687,10 @@ export function makeRepos(db: SqliteDb) {
     setThreadState,
     deleteThread,
     commentSignals,
+    setArtifactRating,
+    getArtifactRating,
+    deleteArtifactRating,
+    usefulnessSignals,
     artifactIdsNeedingFeedback,
     createWebhook,
     listWebhooks,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2,6 +2,8 @@ import type {
   AgentMentionKind,
   AgentMentionState,
   ArtifactKind,
+  ArtifactRatingReason,
+  ArtifactRatingValue,
   AuditAction,
   CommentState,
   ConnectionKind,
@@ -245,6 +247,25 @@ export const comment = sqliteTable("comment", {
   created_at: text("created_at").notNull().default(now),
   meta: text("meta"),
 })
+
+// One active human rating per artifact version. A later artifact version gets a
+// fresh rating set while the old rows remain useful history.
+export const artifactRating = sqliteTable(
+  "artifact_rating",
+  {
+    id: text("id").primaryKey(),
+    artifact_id: text("artifact_id")
+      .notNull()
+      .references(() => artifact.id),
+    version_n: integer("version_n").notNull(),
+    user_id: text("user_id").notNull(),
+    value: text("value").$type<ArtifactRatingValue>().notNull(),
+    reason: text("reason").$type<ArtifactRatingReason>(),
+    created_at: text("created_at").notNull().default(now),
+    updated_at: text("updated_at").notNull().default(now),
+  },
+  (t) => [uniqueIndex("artifact_rating_user").on(t.artifact_id, t.version_n, t.user_id)],
+)
 
 export const webhook = sqliteTable("webhook", {
   id: text("id").primaryKey(),
@@ -1354,6 +1375,7 @@ const TABLES = [
   version,
   versionData,
   comment,
+  artifactRating,
   webhook,
   webhookDelivery,
   renderJob,

--- a/packages/db/src/sqlite.ts
+++ b/packages/db/src/sqlite.ts
@@ -29,6 +29,7 @@ import {
   artifact,
   artifactFavorite,
   artifactMember,
+  artifactRating,
   artifactTag,
   auditLog,
   CONTEXT_SESSION_RELAX_SQLITE,
@@ -315,6 +316,7 @@ export function createSqliteStore(path: string): MetaStore & { close(): void } {
         db.delete(comment).where(eq(comment.artifact_id, id)).run()
         db.delete(artifactMember).where(eq(artifactMember.artifact_id, id)).run()
         db.delete(artifactFavorite).where(eq(artifactFavorite.artifact_id, id)).run()
+        db.delete(artifactRating).where(eq(artifactRating.artifact_id, id)).run()
         db.delete(artifactTag).where(eq(artifactTag.artifact_id, id)).run()
         db.delete(collectionItem).where(eq(collectionItem.artifact_id, id)).run()
         db.delete(domain).where(eq(domain.artifact_id, id)).run()

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -1172,6 +1172,64 @@ export function runStoreContract(
     })
   })
 
+  describe(`${label}: usefulness ratings`, () => {
+    it("keeps one rating per user and version, and batches current signals", async () => {
+      const a = await store.createArtifact(newArtifact())
+      await store.addVersion(a.id, newVersion({ author_id: "author" }))
+      await store.addVersion(a.id, newVersion({ author_id: "author" }))
+      const rate = (user: string, value: "not_useful" | "useful" | "essential", version = 2) =>
+        store.setArtifactRating({
+          id: uuid(),
+          artifact_id: a.id,
+          version_n: version,
+          user_id: user,
+          value,
+          reason: null,
+        })
+
+      await rate("u1", "useful")
+      await rate("u2", "essential")
+      await rate("u3", "not_useful")
+      await rate("u1", "essential") // upsert, not a fourth row
+      await rate("old", "not_useful", 1) // history; not a current-version signal
+
+      const revised = uuid()
+      await store.createComment({
+        id: uuid(),
+        artifact_id: a.id,
+        thread_id: revised,
+        base_version: 1,
+        body_md: "fix this",
+        author: "reviewer",
+      })
+      await store.setThreadState(a.id, revised, "resolved")
+      const sameVersion = uuid()
+      await store.createComment({
+        id: uuid(),
+        artifact_id: a.id,
+        thread_id: sameVersion,
+        base_version: 2,
+        body_md: "no revision",
+        author: "reviewer",
+      })
+      await store.setThreadState(a.id, sameVersion, "resolved")
+
+      expect(await store.getArtifactRating(a.id, 2, "u1")).toMatchObject({
+        value: "essential",
+      })
+      expect((await store.usefulnessSignals([a.id]))[a.id]).toEqual({
+        not_useful: 1,
+        useful: 0,
+        essential: 2,
+        resolved_revisions: 1,
+      })
+      expect(await store.usefulnessSignals([])).toEqual({})
+
+      await store.deleteArtifactRating(a.id, 2, "u3")
+      expect(await store.getArtifactRating(a.id, 2, "u3")).toBeNull()
+    })
+  })
+
   describe(`${label}: shares, favorites, tags`, () => {
     it("sets and removes a per-artifact member (share)", async () => {
       const a = await store.createArtifact(newArtifact())


### PR DESCRIPTION
## Summary

- Add current-version ratings with Useful, Not useful, and Essential options.
- Place the compact controls below Activity on desktop and in the expanded mobile sheet.
- Keep rating aggregates private until three people rate the version.
- Block every human version author from rating a later revision.
- Reorder only fixed groups of five search results. Use ratings, repeated resolved feedback, view buckets, and a weak version bucket.
- Use the same ranked results in REST, MCP, and Slack.

## UX walkthrough

[Open the Derive walkthrough](https://derive.to/artifacts/the-usefulness-layer-ux-walkthrough-ljnpfxkt)

| Desktop activity rail | Expanded mobile sheet |
| --- | --- |
| ![Usefulness controls below the desktop activity rail](https://derive.to/blob/c47655506546b17ba4ec11c5be038d3c98c253ae2e08f686c7b8cf687d708047.jpg) | ![Usefulness controls below the expanded mobile activity sheet](https://derive.to/blob/f420d9a11c64315245120661dd88ca16cbe5afdbfc4f8de0500de1118eb667a1.jpg) |

## Terra review

Terra reviewed the rebased change with medium reasoning. The review found no remaining correctness blockers after this change:

- keeps Activity available to every signed-in reader while comment writes remain role-gated;
- checks every version author before a rating read or write;
- requires repeated resolved feedback before it affects or annotates search;
- describes version count as “Frequently revised,” not as a freshness claim;
- tests real signal batches through search ordering, annotations, REST output, and agent reports.

## Verification

- All 34 repository guardrails pass.
- All affected package type checks pass.
- All affected tests pass, including 1,721 API tests.
- The usefulness route passes against Postgres.
- Desktop, mobile, and signed-in read-only viewer states are browser-verified.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/880"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790907912&installation_model_id=428097&pr_number=880&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F880&signature=e24a7ca46c6abafdd9b5c7de405bff29d7dff6bcedb83b479c191a11dfa73fab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
