### PR TITLE
Make workflow Skill relationships automatic

### DIFF
--- a/apps/api/src/lib/after-publish.ts
+++ b/apps/api/src/lib/after-publish.ts
@@ -36,6 +36,7 @@ import { documentStructure } from "./doc-structure-cache"
 import { EMAIL_LAYOUT_FACT } from "./email-layout"
 import { indexArtifactVersion, isTextType } from "./search"
 import { recordThreadResolution } from "./thread-actions"
+import { indexWorkflowSkillLinks } from "./workflow-skill-links"
 
 /** The realtime + render + re-anchor core shared by every version bump (publish, restore):
  *  announce the new version so open tabs live-reload, enqueue its preview
@@ -107,6 +108,18 @@ export const emitVersionBump = async (
     await indexSkillVersion(meta, blobs, artifact, version)
   } catch (err) {
     log.error("skill relation indexing failed", {
+      artifact: artifact.id,
+      n: version.n,
+      err: String(err),
+    })
+  }
+  // A Workflow's Context refs resolve to exact Skill pins. Materialize those links on
+  // every version bump so the graph and every Skill can navigate to each other without
+  // relying on a one-off migration or parsing human prose in the browser.
+  try {
+    await indexWorkflowSkillLinks(meta, blobs, artifact, version, storedRows)
+  } catch (err) {
+    log.error("workflow skill link indexing failed", {
       artifact: artifact.id,
       n: version.n,
       err: String(err),

--- a/apps/api/src/lib/workflow-skill-links.ts
+++ b/apps/api/src/lib/workflow-skill-links.ts
@@ -1,0 +1,77 @@
+import {
+  type ArtifactRecord,
+  type BlobStore,
+  type MetaStore,
+  newId,
+  SKILL_CONTENT_TYPE,
+  type VersionRecord,
+} from "@derive/core"
+import { pageTextResolver } from "./bundle"
+import { parseManifestSkillPins } from "./manifest-pins"
+import { parseLinkedWorkflowFacts } from "./workflow-facts"
+
+type FactRow = { slot: string; json: string }
+
+/**
+ * Index the Skills a Workflow can actually materialize through its Context nodes.
+ *
+ * The workflow fact owns topology; each Context definition owns its exact Skill pins.
+ * This joins those two existing sources of truth into the bidirectional artifact ↔ Skill
+ * index used by the web UI. It deliberately does not infer Skill names from prose.
+ */
+export const indexWorkflowSkillLinks = async (
+  meta: MetaStore,
+  blobs: BlobStore,
+  artifact: ArtifactRecord,
+  version: VersionRecord,
+  facts: FactRow[],
+): Promise<void> => {
+  const definition = parseLinkedWorkflowFacts(facts).definition
+  if (!definition) return
+
+  const contextRefs = new Set(
+    definition.diagrams.flatMap((diagram) =>
+      diagram.nodes
+        .filter((node) => node.kind === "context" && node.context_ref)
+        .map((node) => node.context_ref as string),
+    ),
+  )
+  if (!contextRefs.size) return
+  const contexts = (await meta.listContexts(artifact.org_id)).filter(
+    (context) => contextRefs.has(context.id) || contextRefs.has(context.name),
+  )
+  const pins = new Map<string, number>()
+  for (const context of contexts) {
+    const manifestArtifact = await meta.getArtifactById(context.manifest_artifact_id)
+    if (!manifestArtifact || manifestArtifact.org_id !== artifact.org_id) continue
+    const manifestVersion = await meta.getVersion(
+      manifestArtifact.id,
+      manifestArtifact.current_version,
+    )
+    if (!manifestVersion) continue
+    const source = await pageTextResolver(blobs, manifestVersion)
+    const markdown = await source(null)
+    if (!markdown) continue
+    for (const pin of parseManifestSkillPins(markdown)) {
+      const skill = await meta.getByShortId(pin.id)
+      if (!skill || skill.org_id !== artifact.org_id) continue
+      const skillVersion = pin.version ?? skill.current_version
+      const exact = await meta.getVersion(skill.id, skillVersion)
+      if (exact?.content_type !== SKILL_CONTENT_TYPE) continue
+      pins.set(skill.id, skillVersion)
+    }
+  }
+
+  for (const [skillArtifactId, skillVersion] of pins) {
+    await meta.linkArtifactSkill({
+      id: newId("asl"),
+      org_id: artifact.org_id,
+      artifact_id: artifact.id,
+      artifact_version: version.n,
+      skill_artifact_id: skillArtifactId,
+      skill_version: skillVersion,
+      role: "workflow-definition",
+      linked_by: version.author_id ?? version.agent_id ?? "system",
+    })
+  }
+}

--- a/apps/api/src/routes/skills.ts
+++ b/apps/api/src/routes/skills.ts
@@ -23,6 +23,7 @@ import { ContextConflictError, createContextCore } from "../lib/create-context"
 import { fail, readJson } from "../lib/http"
 import { visibleArtifactIds } from "../lib/visibility"
 import { parseLinkedWorkflowFacts } from "../lib/workflow-facts"
+import { indexWorkflowSkillLinks } from "../lib/workflow-skill-links"
 
 const installationBody = z.object({
   skill_version: z.number().int().positive(),
@@ -410,13 +411,20 @@ export const skillRoutes = (ctx: AppContext) => {
       skill_short_id?: string
     }> = []
 
-    // Context definitions can change bundle entry type without changing artifact identity:
-    // append SKILL.md + a catalog-visible sidecar to the same bundle. The Context
-    // remains available in Contexts while its reusable definition also appears in Skills.
+    // A bundled Context definition can become a Skill without changing artifact identity.
+    // A legacy single-file definition cannot change artifact kind, so publish a replacement
+    // Skill and repoint every Context that shared it. In both cases the original definition is kept
+    // as MANIFEST.md and complete frontmatter survives in SKILL.md.
     const contexts = await meta.listContexts(orgId)
-    const manifests = new Map<string, (typeof contexts)[number]>()
-    for (const context of contexts) manifests.set(context.manifest_artifact_id, context)
-    for (const [artifactId, context] of manifests) {
+    const manifests = new Map<string, typeof contexts>()
+    for (const context of contexts) {
+      const attached = manifests.get(context.manifest_artifact_id) ?? []
+      attached.push(context)
+      manifests.set(context.manifest_artifact_id, attached)
+    }
+    for (const [artifactId, attachedContexts] of manifests) {
+      const context = attachedContexts[0]
+      if (!context) continue
       const artifact = (
         await meta.listArtifacts({ ids: [artifactId], orgId, archived: "include" })
       )[0]
@@ -436,13 +444,18 @@ export const skillRoutes = (ctx: AppContext) => {
       const version = await meta.getVersion(artifact.id, artifact.current_version)
       const manifest = version ? await manifestOf(blobs, version) : null
       const text = version ? await pageTextResolver(blobs, version) : null
-      const manifestMd = manifest && text ? await text("/MANIFEST.md") : null
-      if (!version || !manifest || !manifestMd) {
+      const manifestMd = text
+        ? await text(manifest?.files["/MANIFEST.md"] ? "/MANIFEST.md" : null)
+        : null
+      const markdown = version
+        ? version.content_type === "text/markdown" || !!manifest?.entry.match(/\.md$/i)
+        : false
+      if (!version || !manifestMd || !markdown) {
         report.push({
           kind: "context",
           id: context.id,
           action: "skip",
-          reason: "no bundle MANIFEST.md",
+          reason: "definition is not Markdown",
         })
         continue
       }
@@ -452,14 +465,23 @@ export const skillRoutes = (ctx: AppContext) => {
       const name = skillName(context.name, artifact.short_id)
       const description =
         parsed.attrs.description?.trim() || `Run the ${context.name} Derive Context.`
-      const bytes = await mergeBundleZip(blobs, manifest, {
-        "SKILL.md": `---\nname: ${name}\ndescription: ${JSON.stringify(description)}\n---\n\n${parsed.body.trim()}\n`,
-        "derive.skill.json": JSON.stringify(
-          { schema: "derive.skill/v1", catalog: true, runtime: { kind: "single" } },
-          null,
-          2,
-        ),
-      })
+      const skillMd = contextSkillSource(manifestMd, name, description)
+      const sidecar = JSON.stringify(
+        { schema: "derive.skill/v1", catalog: true, runtime: { kind: "single" } },
+        null,
+        2,
+      )
+      const bytes = manifest
+        ? await mergeBundleZip(blobs, manifest, {
+            "SKILL.md": skillMd,
+            "derive.skill.json": sidecar,
+          })
+        : await zipBundleFiles({
+            "MANIFEST.md": manifestMd,
+            "SKILL.md": skillMd,
+            "derive.skill.json": sidecar,
+          })
+      const existingArtifact = manifest ? artifact : undefined
       const published = await publish(
         meta,
         blobs,
@@ -474,10 +496,16 @@ export const skillRoutes = (ctx: AppContext) => {
           agentId: actor.id === human.id ? null : actor.id,
           agentName: actor.id === human.id ? null : actor.name,
           source: "api",
-          existingArtifact: artifact,
+          ...(existingArtifact ? { existingArtifact } : {}),
         },
-        artifact.short_id,
+        existingArtifact?.short_id,
       )
+      if (!existingArtifact)
+        await Promise.all(
+          attachedContexts.map((attached) =>
+            meta.setContextManifest(attached.id, published.artifact.id),
+          ),
+        )
       await afterPublish(
         {
           meta,
@@ -492,8 +520,15 @@ export const skillRoutes = (ctx: AppContext) => {
         },
         published.artifact,
         published.version,
-        { isNew: false, onBehalf: human.id, actorId: actor.id, actorName: actor.name },
+        {
+          isNew: !existingArtifact,
+          onBehalf: human.id,
+          actorId: actor.id,
+          actorName: actor.name,
+        },
       )
+      const reportEntry = report.at(-1)
+      if (reportEntry) reportEntry.skill_short_id = published.artifact.short_id
     }
 
     // A Workflow is a visual artifact and cannot become a bundle in place. Create a private
@@ -517,17 +552,41 @@ export const skillRoutes = (ctx: AppContext) => {
     )
     for (const fact of workflowFacts) factsByArtifact.get(fact.artifact_id)?.push(fact)
     for (const row of workflowRows) {
-      const existing = (await meta.listArtifactSkillLinks(row.id, row.n, orgId)).find(
-        (link) => link.role === "workflow-definition",
+      const parsed = parseLinkedWorkflowFacts(factsByArtifact.get(row.id) ?? [])
+      if (!parsed.definition) {
+        report.push({
+          kind: "workflow",
+          id: row.short_id,
+          action: "skip",
+          reason: "invalid definition",
+        })
+        continue
+      }
+      const sourceArtifact = (
+        await meta.listArtifacts({ ids: [row.id], orgId, archived: "include" })
+      )[0]
+      const sourceVersion = sourceArtifact ? await meta.getVersion(sourceArtifact.id, row.n) : null
+      if (!sourceArtifact || !sourceVersion) continue
+      if (body.apply)
+        await indexWorkflowSkillLinks(
+          meta,
+          blobs,
+          sourceArtifact,
+          sourceVersion,
+          factsByArtifact.get(row.id) ?? [],
+        )
+
+      // Supporting Skills and the launcher use the same provenance role. Identify the
+      // launcher by its deterministic id, never by whichever link happened to sort first.
+      const existingLinks = await meta.listArtifactSkillLinks(row.id, row.n, orgId)
+      const linkedIds = [...new Set(existingLinks.map((link) => link.skill_artifact_id))]
+      const linkedSkills = linkedIds.length
+        ? await meta.listArtifacts({ ids: linkedIds, orgId, archived: "include" })
+        : []
+      const linkedSkill = linkedSkills.find(
+        (skill) => skill.short_id === workflowSkillShortId(row.short_id),
       )
-      if (existing) {
-        const linkedSkill = (
-          await meta.listArtifacts({
-            ids: [existing.skill_artifact_id],
-            orgId,
-            archived: "include",
-          })
-        )[0]
+      if (linkedSkill) {
         // The exact provenance link is the durable migration receipt, but the root
         // Context is a separate write. Repair that second half on replay if a prior
         // attempt stopped between the two writes.
@@ -554,16 +613,6 @@ export const skillRoutes = (ctx: AppContext) => {
           action: "skip",
           reason: "already linked",
           ...(linkedSkill ? { skill_short_id: linkedSkill.short_id } : {}),
-        })
-        continue
-      }
-      const parsed = parseLinkedWorkflowFacts(factsByArtifact.get(row.id) ?? [])
-      if (!parsed.definition) {
-        report.push({
-          kind: "workflow",
-          id: row.short_id,
-          action: "skip",
-          reason: "invalid definition",
         })
         continue
       }
@@ -594,10 +643,6 @@ export const skillRoutes = (ctx: AppContext) => {
           2,
         ),
       })
-      const sourceArtifact = (
-        await meta.listArtifacts({ ids: [row.id], orgId, archived: "include" })
-      )[0]
-      if (!sourceArtifact) continue
       // The deterministic id is the recovery receipt for the one unavoidable gap
       // between creating the launcher artifact and writing its provenance link. A
       // replay reuses that exact derived Skill instead of publishing a duplicate.
@@ -712,3 +757,34 @@ const skillName = (value: string, fallback: string): string => {
 }
 
 const workflowSkillShortId = (sourceShortId: string): string => `skill-${sourceShortId}`
+
+const FRONTMATTER = /^﻿?---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n)*/
+
+/** Turn the existing Context definition into a portable SKILL.md without discarding
+ * nested frontmatter such as skills:, repos:, sources:, or future keys. */
+const contextSkillSource = (source: string, name: string, description: string): string => {
+  const match = FRONTMATTER.exec(source)
+  const existing = match?.[1]?.trimEnd() ?? ""
+  // Skill identity has a stricter schema than a legacy Context definition. Replace its
+  // top-level identity while leaving every composition/config key byte-for-byte intact.
+  const preserved: string[] = []
+  let skippedBlock = false
+  for (const line of existing.split(/\r?\n/)) {
+    if (/^(?:name|description)\s*:/.test(line)) {
+      skippedBlock = true
+      continue
+    }
+    if (skippedBlock && (/^[ \t]/.test(line) || !line.trim())) continue
+    skippedBlock = false
+    preserved.push(line)
+  }
+  const header = [
+    `name: ${name}`,
+    `description: ${JSON.stringify(description)}`,
+    preserved.join("\n").trim(),
+  ]
+    .filter(Boolean)
+    .join("\n")
+  const body = match ? source.slice(match[0].length) : source
+  return `---\n${header}\n---\n\n${body.trim()}\n`
+}

--- a/apps/api/test/contexts.test.ts
+++ b/apps/api/test/contexts.test.ts
@@ -69,7 +69,7 @@ describe("Context manifest to Skill migration", () => {
   it("previews without writing, then appends a private Skill version on the same artifact", async () => {
     const files = zipSync({
       "MANIFEST.md": new TextEncoder().encode(
-        "---\ndescription: Answers release questions.\n---\n\n# Release guide\n\nUse the repository evidence.",
+        "---\nname: Release Context\ndescription: Answers release questions.\nskills:\n  - id: release-proof\n    version: 3\n---\n\n# Release guide\n\nUse the repository evidence.",
       ),
       "references/checklist.md": new TextEncoder().encode("# Checklist"),
     })
@@ -87,6 +87,7 @@ describe("Context manifest to Skill migration", () => {
       }),
     )
     expect(created.status).toBe(201)
+    const context = await created.json()
 
     const preview = await app.request(
       "/v1/skill-migrations",
@@ -125,6 +126,13 @@ describe("Context manifest to Skill migration", () => {
     expect(contextList.contexts).toContainEqual(
       expect.objectContaining({ manifest_short_id: artifact.short_id }),
     )
+    const contextDetail = await (
+      await app.request(`/v1/contexts/${context.id}`, { headers: as(owner.email) })
+    ).json()
+    expect(contextDetail.manifest.md).toContain("  - id: release-proof\n    version: 3")
+    expect(contextDetail.skills).toContainEqual(
+      expect.objectContaining({ short_id: "release-proof", pinned: 3 }),
+    )
 
     const replay = await app.request(
       "/v1/skill-migrations",
@@ -132,6 +140,70 @@ describe("Context manifest to Skill migration", () => {
     )
     expect(replay.status).toBe(200)
     expect((await meta.getByShortId(artifact.short_id))?.current_version).toBe(2)
+  })
+
+  it("migrates a single-file Markdown definition without losing its Skill pins", async () => {
+    const definition = new FormData()
+    definition.append(
+      "file",
+      new Blob(
+        [
+          "---\nskills:\n  - id: evidence-check\n    version: 2\n---\n\n# Evidence Context\n\nCheck every claim.",
+        ],
+        { type: "text/markdown" },
+      ),
+      "evidence-context.md",
+    )
+    definition.append("title", "Evidence Context")
+    const manifest = await (
+      await app.request("/v1/artifacts", {
+        method: "POST",
+        body: definition,
+        headers: as(owner.email),
+      })
+    ).json()
+    const created = await (
+      await app.request(
+        "/v1/contexts",
+        jsonAs(as(owner.email), {
+          name: "Evidence Context",
+          manifest_short_id: manifest.short_id,
+        }),
+      )
+    ).json()
+    const sibling = await (
+      await app.request(
+        "/v1/contexts",
+        jsonAs(as(owner.email), {
+          name: "Evidence Context Copy",
+          manifest_short_id: manifest.short_id,
+        }),
+      )
+    ).json()
+
+    const applied = await app.request(
+      "/v1/skill-migrations",
+      jsonAs(as(owner.email), { apply: true }),
+    )
+    expect(applied.status).toBe(200)
+    expect(await meta.getByShortId(manifest.short_id)).toMatchObject({
+      current_version: 1,
+      current_content_type: "text/markdown",
+    })
+    const migratedContext = await meta.getContext(created.id)
+    const migratedSibling = await meta.getContext(sibling.id)
+    expect(migratedSibling?.manifest_artifact_id).toBe(migratedContext?.manifest_artifact_id)
+    expect(await meta.getArtifactById(migratedContext?.manifest_artifact_id ?? "")).toMatchObject({
+      current_version: 1,
+      current_content_type: "derive/skill",
+    })
+    const detail = await (
+      await app.request(`/v1/contexts/${created.id}`, { headers: as(owner.email) })
+    ).json()
+    expect(detail.manifest.md).toContain("  - id: evidence-check\n    version: 2")
+    expect(detail.skills).toContainEqual(
+      expect.objectContaining({ short_id: "evidence-check", pinned: 2 }),
+    )
   })
 })
 

--- a/apps/api/test/rework.test.ts
+++ b/apps/api/test/rework.test.ts
@@ -484,6 +484,115 @@ describe("workflow run: explicit local-agent handoff", () => {
     )
   })
 
+  it("automatically links a Workflow to the Skills pinned by its Context nodes", async () => {
+    const { app, meta } = makeAuthedApp("workflow-context-skill-links", [owner])
+    const skillFiles = zipSync({
+      "SKILL.md": new TextEncoder().encode(
+        "---\nname: brief-craft\ndescription: Draft a concise brief.\n---\n\n# Brief craft",
+      ),
+      "derive.skill.json": new TextEncoder().encode(
+        JSON.stringify({ schema: "derive.skill/v1", catalog: true }),
+      ),
+    })
+    const skillForm = new FormData()
+    skillForm.append("file", new Blob([skillFiles as BlobPart]), "brief-craft.zip")
+    skillForm.append("title", "Brief craft")
+    const skill = await (
+      await app.request("/v1/artifacts", {
+        method: "POST",
+        body: skillForm,
+        headers: as(owner.email),
+      })
+    ).json()
+    const manifest = await (
+      await publishAs(
+        app,
+        `---\nskills:\n  - id: ${skill.short_id}\n    version: 1\n---\n\n# Brief writer`,
+        { title: "Brief writer" },
+        as(owner.email),
+      )
+    ).json()
+    await app.request(
+      "/v1/contexts",
+      jsonAs(as(owner.email), {
+        name: "brief-writer",
+        manifest_short_id: manifest.short_id,
+      }),
+    )
+
+    const workflow = await (
+      await publishAs(app, workflowHtml(), { title: "Weekly brief" }, as(owner.email))
+    ).json()
+    const source = await meta.getByShortId(workflow.short_id)
+    const links = await meta.listArtifactSkillLinks(source?.id ?? "", 1, "default")
+    expect(links).toContainEqual(
+      expect.objectContaining({
+        artifact_version: 1,
+        skill_artifact_id: (await meta.getByShortId(skill.short_id))?.id,
+        skill_version: 1,
+        role: "workflow-definition",
+      }),
+    )
+    const reverse = await (
+      await app.request(`/v1/artifacts/${skill.short_id}/skill-usage`, {
+        headers: as(owner.email),
+      })
+    ).json()
+    expect(reverse.artifacts).toContainEqual(
+      expect.objectContaining({
+        role: "workflow-definition",
+        artifact: expect.objectContaining({ short_id: workflow.short_id }),
+      }),
+    )
+  })
+
+  it("does not mistake an operational Skill link for the generated launcher", async () => {
+    const { app, meta } = makeAuthedApp("workflow-operational-skill-link", [owner])
+    const published = await (
+      await publishAs(app, workflowHtml(), { title: "Weekly brief" }, as(owner.email))
+    ).json()
+    const workflow = await meta.getByShortId(published.short_id)
+    const skillFiles = zipSync({
+      "SKILL.md": new TextEncoder().encode(
+        "---\nname: workflow-helper\ndescription: Help one workflow step.\n---\n\n# Helper",
+      ),
+      "derive.skill.json": new TextEncoder().encode(
+        JSON.stringify({ schema: "derive.skill/v1", catalog: true }),
+      ),
+    })
+    const form = new FormData()
+    form.append("file", new Blob([skillFiles as BlobPart]), "helper.zip")
+    form.append("title", "Workflow helper")
+    const helper = await (
+      await app.request("/v1/artifacts", { method: "POST", body: form, headers: as(owner.email) })
+    ).json()
+    await app.request(
+      `/v1/artifacts/${published.short_id}/skills`,
+      jsonAs(as(owner.email), {
+        artifact_version: 1,
+        skill_short_id: helper.short_id,
+        skill_version: 1,
+        role: "workflow-definition",
+      }),
+    )
+
+    const migrated = await app.request(
+      "/v1/skill-migrations",
+      jsonAs(as(owner.email), { apply: true }),
+    )
+    expect(migrated.status).toBe(200)
+    const links = await meta.listArtifactSkillLinks(workflow?.id ?? "", 1, "default")
+    const linkedArtifacts = await meta.listArtifacts({
+      ids: links.map((link) => link.skill_artifact_id),
+      orgId: "default",
+      archived: "include",
+    })
+    expect(linkedArtifacts.map((artifact) => artifact.short_id)).toContain(helper.short_id)
+    expect(linkedArtifacts.map((artifact) => artifact.short_id)).toContain(
+      `skill-${published.short_id}`,
+    )
+  })
+
   it("reuses the deterministic launcher after a publish-to-link interruption", async () => {
     const { app, meta, ctx } = makeAuthedApp("workflow-skill-publish-link-repair", [owner])
     const published = await (

--- a/apps/web/src/pages/artifact/linked-bundle-workspace.tsx
+++ b/apps/web/src/pages/artifact/linked-bundle-workspace.tsx
@@ -953,7 +953,7 @@ export function LinkedBundleWorkspace({
     ...artifactSkillsQuery(shortId),
     enabled: !!workflowPreview,
   })
-  const launchers = (linkedSkills.data?.links ?? []).filter(
+  const workflowSkills = (linkedSkills.data?.links ?? []).filter(
     (link, index, all) =>
       link.role === "workflow-definition" &&
       link.skill &&
@@ -1042,43 +1042,41 @@ export function LinkedBundleWorkspace({
             </div>
           </div>
           <div className="flex flex-wrap items-center gap-2">
-            {launchers.length === 1 && launchers[0]?.skill ? (
+            {workflowSkills.length === 1 && workflowSkills[0]?.skill ? (
               <Button asChild variant="outline" size="sm" data-testid="workflow-open-skill">
                 <Link
                   to="/artifacts/$ref"
-                  params={{ ref: launchers[0].skill.short_id }}
-                  title={`Launcher Skill v${launchers[0].skill_version}, linked from Workflow v${launchers[0].artifact_version}`}
+                  params={{ ref: workflowSkills[0].skill.short_id }}
+                  title={`Skill v${workflowSkills[0].skill_version}, linked from Workflow v${workflowSkills[0].artifact_version}`}
                 >
-                  <Icon name="sparkles" size={14} /> Skill:{" "}
-                  {launchers[0].skill.title ?? launchers[0].skill.short_id}
+                  Skill: {workflowSkills[0].skill.title ?? workflowSkills[0].skill.short_id}
                   <span className="font-mono text-2xs text-muted-foreground">
-                    v{launchers[0].skill_version}
+                    v{workflowSkills[0].skill_version}
                   </span>
                 </Link>
               </Button>
-            ) : launchers.length > 1 ? (
+            ) : workflowSkills.length > 1 ? (
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button variant="outline" size="sm" data-testid="workflow-open-skills">
-                    <Icon name="sparkles" size={14} /> {launchers.length} linked Skills
+                    {workflowSkills.length} linked Skills
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="start" className="max-w-sm">
-                  <DropdownMenuLabel>Launcher Skills</DropdownMenuLabel>
-                  {launchers.map((launcher) =>
-                    launcher.skill ? (
+                  <DropdownMenuLabel>Skills used by this workflow</DropdownMenuLabel>
+                  {workflowSkills.map((link) =>
+                    link.skill ? (
                       <DropdownMenuItem
-                        key={launcher.skill_artifact_id}
+                        key={link.skill_artifact_id}
                         asChild
-                        data-testid={`workflow-skill-${launcher.skill_artifact_id}`}
+                        data-testid={`workflow-skill-${link.skill_artifact_id}`}
                       >
-                        <Link to="/artifacts/$ref" params={{ ref: launcher.skill.short_id }}>
-                          <Icon name="sparkles" size={14} />
+                        <Link to="/artifacts/$ref" params={{ ref: link.skill.short_id }}>
                           <span className="min-w-0 flex-1 truncate">
-                            {launcher.skill.title ?? launcher.skill.short_id}
+                            {link.skill.title ?? link.skill.short_id}
                           </span>
                           <span className="font-mono text-2xs text-muted-foreground">
-                            v{launcher.skill_version}
+                            v{link.skill_version}
                           </span>
                         </Link>
                       </DropdownMenuItem>
@@ -1153,7 +1151,7 @@ export function LinkedBundleWorkspace({
             ) : null}
             {canEdit ? (
               <Button variant="outline" size="sm" onClick={onEdit} data-testid="bundle-edit-source">
-                <Icon name="edit" size={14} /> Edit manifest
+                <Icon name="edit" size={14} /> Edit workflow
               </Button>
             ) : null}
             <Button

--- a/apps/web/src/pages/context/console.tsx
+++ b/apps/web/src/pages/context/console.tsx
@@ -211,7 +211,7 @@ function Console({ id }: { id: string }) {
         </div>
         <Eyebrow>
           Context
-          {context.manifest_version != null && <> · manifest v{context.manifest_version}</>}
+          {context.manifest_version != null && <> · definition v{context.manifest_version}</>}
           {" · "}
           {skillsCount} {skillsCount === 1 ? "skill" : "skills"}
           {sourcesCount > 0 && (
@@ -244,7 +244,7 @@ function Console({ id }: { id: string }) {
             Chat
           </TabsTrigger>
           <TabsTrigger value="manifest" data-testid="console-tab-manifest">
-            Manifest
+            Definition
           </TabsTrigger>
           <TabsTrigger value="output" data-testid="console-tab-output">
             Output
@@ -518,7 +518,7 @@ function ContextStatusWorkspace({
           ) : null}
           {context.manifest_version != null ? (
             <span className="rounded-md border border-share/20 bg-share/10 px-1.5 py-0.5 font-semibold text-share">
-              manifest v{context.manifest_version}
+              definition v{context.manifest_version}
             </span>
           ) : null}
         </div>
@@ -926,7 +926,14 @@ function SkillsCard({
       <ul className="flex flex-col gap-1.5">
         {skills.slice(0, 6).map((s) => (
           <li key={s.short_id} className="flex items-center gap-2 text-sm text-foreground">
-            <span className="truncate">{s.title ?? s.short_id}</span>
+            <Link
+              to="/artifacts/$ref"
+              params={{ ref: s.short_id }}
+              className="min-w-0 truncate underline-offset-4 hover:underline"
+              data-testid={`rail-skill-${s.short_id}`}
+            >
+              {s.title ?? s.short_id}
+            </Link>
             <span
               className={cn(
                 "ml-auto shrink-0 font-mono text-2xs tabular-nums",
@@ -948,7 +955,7 @@ function SkillsCard({
         onClick={onSeeManifest}
         className="self-start text-xs text-muted-foreground underline-offset-4 hover:underline"
       >
-        see manifest →
+        View Context definition →
       </button>
     </div>
   )
@@ -968,7 +975,7 @@ function SourcesCard({ count }: { count: number }) {
   )
 }
 
-// The manifest, framed as a package rather than a raw document: pin health (each
+// The Context definition, framed as a package rather than a raw document: pin health (each
 // skill's pinned version against its actual current one), the frontmatter's repo
 // pointers, and the body as a doc — the YAML never renders raw, because a human
 // reading "id: cd34y version: 3" learns nothing a title + a status column can't say
@@ -981,8 +988,8 @@ function ManifestTab({ context }: { context: ContextDetail }) {
     return (
       <EmptyState
         icon={<Icon name="context" strokeWidth={1.75} />}
-        title="No manifest"
-        description="This Context's manifest artifact can't be resolved."
+        title="No definition"
+        description="This Context's definition artifact can't be resolved."
       />
     )
   }
@@ -990,7 +997,7 @@ function ManifestTab({ context }: { context: ContextDetail }) {
     <div className="flex flex-col gap-6" data-testid="manifest-tab">
       <div className="flex flex-wrap items-center gap-3">
         <Eyebrow>
-          manifest · {manifest.title ?? context.name} · v{manifest.version} · pushed{" "}
+          definition · {manifest.title ?? context.name} · v{manifest.version} · pushed{" "}
           {ago(manifest.pushed_at)}
         </Eyebrow>
         <Link
@@ -1082,7 +1089,7 @@ function ManifestTab({ context }: { context: ContextDetail }) {
           <p className="text-xs text-muted-foreground">
             A pin is exact. The runner uses the pinned version, not the latest one.{" "}
             <code className="font-mono">derive context push</code> re-pins to current and publishes
-            a new manifest version; the runner picks it up on its next pull. No deploy.
+            a new definition version; the runner picks it up on its next pull. No deploy.
           </p>
         </div>
       )}

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -1642,6 +1642,9 @@ export interface ContextStore {
   touchContextSeen(id: string, at: string): Promise<void>
   /** Set who may ask (workspace | invited). Does not touch the roster. */
   setContextAskPolicy(id: string, policy: "workspace" | "invited"): Promise<void>
+  /** Repoint the Context to a replacement definition artifact. Used by migrations that
+   *  cannot preserve artifact identity because the immutable artifact kind changes. */
+  setContextManifest(id: string, manifestArtifactId: string): Promise<void>
   /** Replace the context's bound connections (a JSON array of ids, or null for none).
    *  Whole-list semantics: the caller has already checked every id is attachable. */
   setContextConnections(id: string, connectionIds: string | null): Promise<void>

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -4477,6 +4477,12 @@ export class PgMetaStore implements MetaStore {
   async setContextAskPolicy(id: string, policy: "workspace" | "invited"): Promise<void> {
     await this.db.update(context).set({ ask_policy: policy }).where(eq(context.id, id))
   }
+  async setContextManifest(id: string, manifestArtifactId: string): Promise<void> {
+    await this.db
+      .update(context)
+      .set({ manifest_artifact_id: manifestArtifactId })
+      .where(eq(context.id, id))
+  }
   async setContextConnections(id: string, connectionIds: string | null): Promise<void> {
     await this.db.update(context).set({ connection_ids: connectionIds }).where(eq(context.id, id))
   }

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -3608,6 +3608,13 @@ export function makeRepos(db: SqliteDb) {
   ): Promise<void> => {
     await db.update(context).set({ ask_policy: policy }).where(eq(context.id, id)).run()
   }
+  const setContextManifest = async (id: string, manifestArtifactId: string): Promise<void> => {
+    await db
+      .update(context)
+      .set({ manifest_artifact_id: manifestArtifactId })
+      .where(eq(context.id, id))
+      .run()
+  }
   const setContextConnections = async (id: string, connectionIds: string | null): Promise<void> => {
     await db.update(context).set({ connection_ids: connectionIds }).where(eq(context.id, id)).run()
   }
@@ -5952,6 +5959,7 @@ export function makeRepos(db: SqliteDb) {
     deleteContext,
     touchContextSeen,
     setContextAskPolicy,
+    setContextManifest,
     setContextConnections,
     listContextAskers,
     getContextAsker,


### PR DESCRIPTION
## What changed
- derive exact Workflow → Skill links from each graph node’s Context pins on every publish
- preserve reusable Context instructions and all existing frontmatter when migrating definitions to Skills
- migrate legacy single-file definitions safely by creating a Skill and repointing every shared Context
- keep workflow graphs as the runnable topology while adding bidirectional Skill navigation
- make Context Skill rows clickable and replace user-facing manifest language with definition language

## Sift Demo proof
- the live Sift Demo workflow now links all four pinned Skills
- each Skill shows a backlink to `Sift Demo: One-Shot Execution Graph · v11`
- graph nodes continue to show the exact Skill/version used at that step

## Verification
- `pnpm run ci` (34/34 checks)
- `pnpm typecheck`
- `pnpm test` (3,150 passed)
- focused migration + relationship suite (48/48)
- authenticated browser dogfood of the live Sift Demo workflow and reverse Skill link

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/882"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791075499&installation_model_id=428097&pr_number=882&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F882&signature=92732ad773ee48201fe5405f07a0c79f450eb74192dfef2caadef50fba01189a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->