### PR TITLE
Remove stale manifest wording from Contexts

### DIFF
--- a/apps/web/src/pages/context/index.tsx
+++ b/apps/web/src/pages/context/index.tsx
@@ -122,11 +122,11 @@ function ContextRow({ context: x }: { context: ContextInfo }) {
       <span className="flex flex-wrap items-center gap-1.5 pl-6 font-mono text-2xs">
         {x.manifest_version != null ? (
           <span className="rounded-md border border-share/20 bg-share/10 px-1.5 py-0.5 font-semibold text-share">
-            manifest v{x.manifest_version}
+            definition v{x.manifest_version}
           </span>
         ) : (
           <span className="rounded-md border border-border bg-muted/45 px-1.5 py-0.5 text-muted-foreground">
-            manifest unresolved
+            definition unresolved
           </span>
         )}
         {x.skills_count ? (

--- a/apps/web/src/pages/context/new-context-form.tsx
+++ b/apps/web/src/pages/context/new-context-form.tsx
@@ -27,7 +27,7 @@ export function NewContextForm({
   // "" = auto-mint (the default; nobody picks an agent). A non-empty id = run as
   // an existing service agent — an opt-in the roster's presence (admins) reveals.
   const [agentId, setAgentId] = useState("")
-  const [manifest, setManifest] = useState("")
+  const [definition, setDefinition] = useState("")
   // Creating a dedicated connection may return a bearer once. Defer navigation until
   // the user dismisses the reveal.
   const [minted, setMinted] = useState<{ contextId: string; name: string; token: string } | null>(
@@ -40,13 +40,13 @@ export function NewContextForm({
       api.createContext({
         name: name.trim(),
         ...(agentId ? { agent_id: agentId } : {}),
-        manifest_short_id: manifest.trim(),
+        manifest_short_id: definition.trim(),
       }),
     success: "Context created",
     onSuccess: (ctx) => {
       const created = name.trim()
       setName("")
-      setManifest("")
+      setDefinition("")
       onCreated()
       if (ctx.agent_token) {
         setMinted({ contextId: ctx.id, name: created, token: ctx.agent_token })
@@ -57,7 +57,7 @@ export function NewContextForm({
     },
   })
   const submit = () => {
-    if (name.trim() && manifest.trim()) create.mutate()
+    if (name.trim() && definition.trim()) create.mutate()
   }
 
   return (
@@ -73,10 +73,10 @@ export function NewContextForm({
         />
         <Input
           data-testid="context-create-manifest"
-          aria-label="Manifest short id"
-          placeholder="Manifest short id"
-          value={manifest}
-          onChange={(e) => setManifest(e.target.value)}
+          aria-label="Definition artifact short id"
+          placeholder="Definition artifact id"
+          value={definition}
+          onChange={(e) => setDefinition(e.target.value)}
           className="w-44 font-mono"
         />
         {/* Only admins can even load the roster; everyone else auto-mints. */}
@@ -103,7 +103,7 @@ export function NewContextForm({
           data-testid="context-create-submit"
           onClick={submit}
           loading={create.isPending}
-          disabled={create.isPending || !name.trim() || !manifest.trim()}
+          disabled={create.isPending || !name.trim() || !definition.trim()}
         >
           Create
         </Button>


### PR DESCRIPTION
Closes the last visible naming gap after Context definitions were migrated to Skills.

- Context cards say `definition vN`
- unresolved cards say `definition unresolved`
- advanced creation asks for a `Definition artifact id`

Verified with web typecheck and all web tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/883"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791076697&installation_model_id=428097&pr_number=883&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F883&signature=024c0363bfe9d23ba95f919c6336319838ba49a916889492f7fe1491969a5bd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->