### PR TITLE
Infer Skill relationships from SKILL.md links

### DIFF
--- a/apps/api/src/lib/after-publish.ts
+++ b/apps/api/src/lib/after-publish.ts
@@ -14,6 +14,7 @@ import {
   DECK_CONTENT_TYPE,
   deriveFacts,
   FACT_GEN,
+  inferredSkillRelationRefs,
   isAuthoredFactType,
   isHtmlLike,
   type MetaStore,
@@ -150,7 +151,7 @@ export const emitVersionBump = async (
   return storedRows
 }
 
-const indexSkillVersion = async (
+export const indexSkillVersion = async (
   meta: MetaStore,
   blobs: BlobStore,
   artifact: ArtifactRecord,
@@ -174,7 +175,12 @@ const indexSkillVersion = async (
   const declared = Object.entries(checked.sidecar?.relations ?? {}).flatMap(([kind, refs]) =>
     (refs ?? []).map((ref) => ({ kind: kind as "requires" | "extends" | "recommends", ref })),
   )
-  const targets = await meta.getByShortIds([...new Set(declared.map(({ ref }) => ref.id))])
+  const skillMd = new TextDecoder().decode(skillBytes)
+  const inferred = inferredSkillRelationRefs(skillMd)
+  const targetIds = [
+    ...new Set([...declared.map(({ ref }) => ref.id), ...inferred.map((ref) => ref.id)]),
+  ]
+  const targets = await meta.getByShortIds(targetIds)
   const byShortId = new Map(targets.map((target) => [target.short_id, target]))
   const relations = []
   for (const { kind, ref } of declared) {
@@ -205,6 +211,27 @@ const indexSkillVersion = async (
       target_artifact_id: target.id,
       target_version: ref.version,
       kind,
+    })
+  }
+  // Explicit sidecar relationships carry authored semantics and always win. A plain link in
+  // SKILL.md becomes the intentionally weaker `references` edge, pinned to the linked version
+  // when present and otherwise to the target's current version at publication time.
+  const declaredTargets = new Set(declared.map(({ ref }) => ref.id))
+  for (const ref of inferred) {
+    const target = byShortId.get(ref.id)
+    if (!target || target.id === artifact.id || target.org_id !== artifact.org_id) continue
+    if (declaredTargets.has(ref.id)) continue
+    const targetVersionNumber = ref.version ?? target.current_version
+    const targetVersion = await meta.getVersion(target.id, targetVersionNumber)
+    if (targetVersion?.content_type !== SKILL_CONTENT_TYPE) continue
+    relations.push({
+      id: newId("skr"),
+      org_id: artifact.org_id,
+      source_artifact_id: artifact.id,
+      source_version: version.n,
+      target_artifact_id: target.id,
+      target_version: targetVersionNumber,
+      kind: "references" as const,
     })
   }
   await meta.replaceSkillRelations(artifact.org_id, artifact.id, version.n, relations)

--- a/apps/api/src/routes/skills.ts
+++ b/apps/api/src/routes/skills.ts
@@ -17,13 +17,14 @@ import { OpenAPIHono } from "@hono/zod-openapi"
 import type { BlankEnv } from "hono/types"
 import { z } from "zod"
 import type { AppContext } from "../context"
-import { afterPublish } from "../lib/after-publish"
+import { afterPublish, indexSkillVersion } from "../lib/after-publish"
 import { manifestOf, mergeBundleZip, pageTextResolver, zipBundleFiles } from "../lib/bundle"
 import { ContextConflictError, createContextCore } from "../lib/create-context"
 import { fail, readJson } from "../lib/http"
 import { visibleArtifactIds } from "../lib/visibility"
 import { parseLinkedWorkflowFacts } from "../lib/workflow-facts"
 import { indexWorkflowSkillLinks } from "../lib/workflow-skill-links"
+import { log } from "../log"
 
 const installationBody = z.object({
   skill_version: z.number().int().positive(),
@@ -732,6 +733,40 @@ export const skillRoutes = (ctx: AppContext) => {
       }
       const reportRow = report.at(-1)
       if (reportRow) reportRow.skill_short_id = launcherArtifact.short_id
+    }
+
+    // Rebuild current Skill relation indexes so this migration also backfills references
+    // inferred from Skills published before inference existed. This is idempotent and does not
+    // create a new artifact version: the index remains a cache over immutable version bytes.
+    if (body.apply) {
+      let cursor: { key: string; id: string } | undefined
+      for (;;) {
+        const skills = await meta.listArtifacts({
+          orgId,
+          contentType: SKILL_CONTENT_TYPE,
+          archived: "include",
+          limit: 100,
+          cursor,
+        })
+        for (const skill of skills) {
+          const version = await meta.getVersion(skill.id, skill.current_version)
+          if (!version) continue
+          try {
+            await indexSkillVersion(meta, blobs, skill, version)
+          } catch (error) {
+            // One damaged historical bundle must not prevent every healthy Skill from being
+            // backfilled. The same best-effort boundary is used by the live publish indexer.
+            log.warn("skill relation backfill failed", {
+              artifact: skill.id,
+              n: version.n,
+              error: String(error),
+            })
+          }
+        }
+        const last = skills.at(-1)
+        if (skills.length < 100 || !last) break
+        cursor = { key: last.created_at, id: last.id }
+      }
     }
 
     return c.json({ applied: body.apply, report })

--- a/apps/api/test/artifacts.test.ts
+++ b/apps/api/test/artifacts.test.ts
@@ -1094,6 +1094,32 @@ describe("Skills product surface", () => {
     )
   })
 
+  it("infers a version-pinned reference from a SKILL.md artifact link", async () => {
+    const target = await publishSkill("linked-target")
+    const source = await publishSkill("linked-source")
+    const opened = await (await app.request(`/v1/artifacts/${source.short_id}/skill-source`)).json()
+    const updated = await app.request(`/v1/artifacts/${source.short_id}/skill-source`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        source: `${opened.source}\n\nUse [the linked Skill](/artifacts/${target.short_id}@v1).`,
+        base_version: 1,
+      }),
+    })
+    expect(updated.status).toBe(200)
+
+    const graph = await (await app.request(`/v1/artifacts/${source.short_id}/skill-graph`)).json()
+    expect(graph.edges).toContainEqual(
+      expect.objectContaining({
+        source_version: 2,
+        target_version: 1,
+        kind: "references",
+      }),
+    )
+    const reverse = await (await app.request(`/v1/artifacts/${target.short_id}/skill-graph`)).json()
+    expect(reverse.edges).toContainEqual(expect.objectContaining({ kind: "references" }))
+  })
+
   it("pages past embedded Skills instead of letting them crowd catalog results out", async () => {
     const visible = await publishSkill("crowding-visible")
     for (let index = 0; index < 5; index += 1) {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -627,7 +627,7 @@ export interface SkillRelation {
   source_version: number
   target_artifact_id: string
   target_version: number
-  kind: "requires" | "extends" | "recommends"
+  kind: "requires" | "extends" | "recommends" | "references"
 }
 export interface SkillGraph {
   root: string

--- a/apps/web/src/pages/artifact/bundle-bar.tsx
+++ b/apps/web/src/pages/artifact/bundle-bar.tsx
@@ -225,7 +225,8 @@ function SkillWorkbench({
               </div>
             ) : (
               <Muted>
-                This skill stands alone. Add requires, extends, or recommends in derive.skill.json.
+                This skill stands alone. Link another Skill in SKILL.md, or declare requires,
+                extends, or recommends in derive.skill.json.
               </Muted>
             )}
           </TabsContent>

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -2399,7 +2399,7 @@ export interface WorkflowRunStore {
   ): Promise<WorkflowStepAttemptRecord | null>
 }
 
-export type SkillRelationKind = "requires" | "extends" | "recommends"
+export type SkillRelationKind = "requires" | "extends" | "recommends" | "references"
 export type SkillClient = "claude" | "codex"
 export type SkillInstallScope = "project" | "personal" | "runner"
 export type SkillInstallPolicy = "pinned" | "latest"

--- a/packages/core/src/skill.ts
+++ b/packages/core/src/skill.ts
@@ -7,6 +7,8 @@
  * and read frontmatter, with NO new artifact kind and no heavy YAML dependency
  * (this module must run on Cloudflare Workers).
  */
+
+import { parseRef } from "./ids"
 import type { BundleManifest, SkillRelationKind } from "./ports"
 import { validateWorkflowDefinition, type WorkflowDefinition } from "./workflow"
 
@@ -44,6 +46,66 @@ const object = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === "object" && !Array.isArray(value)
 
 const relationKinds: readonly SkillRelationKind[] = ["requires", "extends", "recommends"]
+
+export interface InferredSkillRelationRef {
+  id: string
+  version?: number
+}
+
+// A Skill reference is inferred only from an authored link target. Bare short ids in prose
+// are deliberately ignored: they are indistinguishable from examples, hashes, and unrelated
+// identifiers. Both Markdown links and inline HTML are valid inside SKILL.md.
+const SKILL_HTML_HREF = /\bhref\s*=\s*("([^"]*)"|'([^']*)'|([^\s>]+))/gi
+
+// Index walking keeps this linear on adversarial Markdown. A compact regex for the same
+// grammar is easy to make polynomial when a long malformed target never closes.
+const markdownLinkTargets = (source: string): string[] => {
+  const targets: string[] = []
+  let cursor = 0
+  while (cursor < source.length) {
+    const marker = source.indexOf("](", cursor)
+    if (marker < 0) break
+    const start = marker + 2
+    let end = start
+    while (end < source.length && source[end] !== ")" && !/\s/.test(source[end] ?? "")) end += 1
+    if (end > start && source[end] === ")") targets.push(source.slice(start, end))
+    cursor = Math.max(end + 1, start + 1)
+  }
+  return targets
+}
+
+/** Mechanically extract exact Derive artifact refs from SKILL.md. This records only that the
+ * Skill points at another artifact; the publisher later verifies that target is actually a
+ * readable Skill in the same workspace. */
+export const inferredSkillRelationRefs = (skillMd: string): InferredSkillRelationRef[] => {
+  const targets: string[] = []
+  targets.push(...markdownLinkTargets(skillMd))
+  for (const match of skillMd.matchAll(SKILL_HTML_HREF))
+    targets.push(match[2] ?? match[3] ?? match[4] ?? "")
+
+  const refs: InferredSkillRelationRef[] = []
+  const seen = new Set<string>()
+  for (const target of targets) {
+    let decoded = target
+    try {
+      decoded = decodeURIComponent(target)
+    } catch {
+      // A malformed escape cannot make the whole Skill invalid; parse the raw target.
+    }
+    const match = /\/artifacts\/([^/?#\s]+)/.exec(decoded)
+    if (!match?.[1]) continue
+    const parsed = parseRef(match[1])
+    if (!/^[0-9a-z]{6,12}$/.test(parsed.shortId) || seen.has(parsed.shortId)) continue
+    seen.add(parsed.shortId)
+    refs.push({
+      id: parsed.shortId,
+      ...(Number.isInteger(parsed.version) && Number(parsed.version) > 0
+        ? { version: parsed.version }
+        : {}),
+    })
+  }
+  return refs
+}
 
 /** Validate the portable Agent Skills contract plus Derive's optional typed sidecar. */
 export const validateSkillDefinition = (

--- a/packages/core/test/skill.test.ts
+++ b/packages/core/test/skill.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest"
-import { SKILL_DEFINITION_SCHEMA, skillCatalogEnabled, validateSkillDefinition } from "../src/skill"
+import {
+  inferredSkillRelationRefs,
+  SKILL_DEFINITION_SCHEMA,
+  skillCatalogEnabled,
+  validateSkillDefinition,
+} from "../src/skill"
 
 const skill = (name = "weekly-brief") => `---
 name: ${name}
@@ -11,6 +16,16 @@ compatibility: Requires the Derive MCP for graph execution.
 `
 
 describe("validateSkillDefinition", () => {
+  it("infers exact Derive artifact links without treating bare ids as relationships", () => {
+    expect(
+      inferredSkillRelationRefs(`See [research](/artifacts/research-core-abc12345@v3) and
+<a href="https://derive.to/artifacts/tone-guide-def67890">tone</a>.
+The bare id zzz99999 and [an artifact-shaped external link](https://example.com/artifacts/nope1234).`),
+    ).toEqual([{ id: "abc12345", version: 3 }, { id: "nope1234" }, { id: "def67890" }])
+    expect(inferredSkillRelationRefs("The bare id abc12345 is not a relationship.")).toEqual([])
+    expect(inferredSkillRelationRefs("](!".repeat(10_000))).toEqual([])
+  })
+
   it("accepts a portable skill without a Derive sidecar", () => {
     const checked = validateSkillDefinition(skill())
     expect(checked.errors).toEqual([])


### PR DESCRIPTION
## Summary
- infer exact Skill-to-Skill references from Derive artifact links in SKILL.md
- preserve explicit requires/extends/recommends semantics and surface inferred edges as references
- pin inferred edges to an authored version or the target version current at publish time
- backfill existing Skill versions through the idempotent workspace migration
- update the Skill empty state and API types

## Safety
- no fuzzy title or prose matching
- bare short IDs are ignored
- targets must resolve to a Skill in the same workspace
- explicit sidecar relationships override inferred references
- one damaged historical bundle cannot stop the workspace backfill

## Verification
- pnpm run ci (34/34)
- all package typechecks
- pnpm test (3,152 passing; existing skips only)
- targeted core and API suites

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/884"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791080358&installation_model_id=428097&pr_number=884&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F884&signature=21574df6c8d28f44e1af80e28eab187693954ae953e2b432c0386e1f002d1301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->