### PR TITLE
fix(mcp): Preserve code-mode request context

### DIFF
--- a/apps/api/src/lib/code-sandbox-cloudflare.ts
+++ b/apps/api/src/lib/code-sandbox-cloudflare.ts
@@ -18,6 +18,7 @@ import {
 const MAX_CODE_CPU_MS = 5_000
 type CodemodeModule = typeof import("@cloudflare/codemode")
 type CodemodeLoader = ConstructorParameters<CodemodeModule["DynamicWorkerExecutor"]>[0]["loader"]
+type HostCallRunner = <T>(call: () => Promise<T>) => Promise<T>
 
 const messageOf = (error: unknown): string =>
   error instanceof Error ? error.message : String(error)
@@ -100,12 +101,18 @@ console.error = (...values) => __derive_emit_log(__derive_console_error, values)
  * Each call creates a Dynamic Worker with no parent bindings or outbound network. Tool calls
  * cross Workers RPC back into the static Derive Worker, which owns the caller-scoped handlers.
  */
-export const cloudflareSandbox = (loader: WorkerLoader): Sandbox => ({
+export const cloudflareSandbox = (
+  loader: WorkerLoader,
+  captureHostCallRunner: () => HostCallRunner = () => (call) => call(),
+): Sandbox => ({
   name: "cloudflare-dynamic-worker",
   async run({ code, host, timeoutMs }): Promise<SandboxResult> {
     // Keep the Cloudflare-only package out of the Node module graph. The Node test suite imports
     // worker.ts to verify fail-closed startup, but it never runs this adapter.
     const { DynamicWorkerExecutor } = await import("@cloudflare/codemode")
+    // Worker RPC callbacks run in a separate async context. Capture the host request context
+    // before entering the Dynamic Worker, then restore it around each caller-scoped tool handler.
+    const runHostCall = captureHostCallRunner()
     const toolCalls: string[] = []
     const fns = {
       toolNames: async () => host.toolNames,
@@ -121,12 +128,12 @@ export const cloudflareSandbox = (loader: WorkerLoader): Sandbox => ({
           return { error: `tool call limit exceeded (${MAX_CODE_TOOL_CALLS})` }
         toolCalls.push(name)
         try {
-          return await host.callTool(
-            name,
+          const args =
             record.args && typeof record.args === "object" && !Array.isArray(record.args)
               ? (record.args as Record<string, unknown>)
-              : {},
-          )
+              : {}
+          const call = () => host.callTool(name, args)
+          return await runHostCall(call)
         } catch (error) {
           return { error: messageOf(error) }
         }

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -327,7 +327,10 @@ const handle = (req: Request, env: Env, ctx: ExecutionContext): Response | Promi
         modelGateway: workerGateway(env),
         // Code Mode stays read-only in mcp-tools/code.ts. The dynamic Worker receives no parent
         // bindings or network access; its find/read calls return through Workers RPC to this host.
-        codeSandbox: cloudflareSandbox(env.LOADER),
+        codeSandbox: cloudflareSandbox(env.LOADER, () => {
+          const connection = requestPg.getStore()
+          return connection ? (call) => requestPg.run(connection, call) : (call) => call()
+        }),
         // Multi-tenant, so the allowlist matters here more than anywhere: without it any
         // workspace owner could enable chat and spend Derive's key.
         chatAllowlist: (env.DERIVE_CHAT_ALLOWLIST ?? "")

--- a/apps/api/test/worker/code-sandbox-workerd.test.ts
+++ b/apps/api/test/worker/code-sandbox-workerd.test.ts
@@ -60,6 +60,28 @@ describe("Cloudflare Dynamic Worker resource limits", () => {
     expect(calls).toEqual([])
     expect(result.toolCalls).toEqual([])
   })
+
+  it("restores the request Postgres connection inside RPC callbacks", async () => {
+    let insideCapturedContext = false
+    const sandbox = cloudflareSandbox(env.LOADER, () => async (call) => {
+      insideCapturedContext = true
+      try {
+        return await call()
+      } finally {
+        insideCapturedContext = false
+      }
+    })
+    const result = await sandbox.run({
+      code: `return await tools.read({ short_id: "abc" })`,
+      host: {
+        toolNames: ["read"],
+        callTool: async () => ({ insideCapturedContext }),
+      },
+      timeoutMs: 10_000,
+    })
+
+    expect(result.value).toEqual({ insideCapturedContext: true })
+  })
 })
 
 // This suite runs the actual Cloudflare SDK executor through Miniflare's Worker Loader. It proves


### PR DESCRIPTION
## What & why

The first production `derive_code` call exposed that Dynamic Worker RPC callbacks lose the host request's async context. The read handlers then cannot reach their Postgres binding.

## Changes

- Capture the host call runner before entering the Dynamic Worker.
- Restore the request Postgres context around each RPC callback.
- Add a Worker-runtime regression test for the context boundary.

## Testing

- [x] `pnpm verify` passes under Node 24.
- [x] 3,154 repository tests pass.
- [x] Worker-runtime suite passes 28 tests with 1 intentional skip.

## Notes for reviewers

This was found by exercising the merged tool against the production MCP. The new tool remains read-only and isolated.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/889"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791150517&installation_model_id=428097&pr_number=889&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F889&signature=30c1e6ce8dd9abe001769acee1d9e450de2bd3fe6c8495eedc17d98f9bfaba2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->