### PR TITLE
Add local Skill activity scans

### DIFF
--- a/apps/api/src/routes/skills.ts
+++ b/apps/api/src/routes/skills.ts
@@ -36,6 +36,13 @@ const installationBody = z.object({
   removed: z.boolean().optional(),
 })
 
+const localUseBody = z.object({
+  event_id: z.string().min(8).max(128),
+  skill_version: z.number().int().positive(),
+  client: z.enum(["claude", "codex", "other"]),
+  useful: z.boolean().optional(),
+})
+
 const artifactLinkBody = z.object({
   artifact_version: z.number().int().positive(),
   skill_short_id: z.string().min(1),
@@ -262,8 +269,9 @@ export const skillRoutes = (ctx: AppContext) => {
     const skill = await requireArtifact(c, "read")
     if (skill instanceof Response) return skill
     if (skill.current_content_type !== SKILL_CONTENT_TYPE) return fail(c, 404, "not a skill")
-    const [usage, installations, links] = await Promise.all([
+    const [usage, local, installations, links] = await Promise.all([
       meta.skillUsage(skill.id, skill.org_id),
+      meta.skillLocalUsage(skill.id, skill.org_id),
       meta.listSkillInstallations(skill.id, skill.org_id),
       meta.listSkillArtifactLinks(skill.id, skill.org_id, 100),
     ])
@@ -296,6 +304,7 @@ export const skillRoutes = (ctx: AppContext) => {
     return c.json({
       contexts: usage.contexts,
       workflows: usage.workflows,
+      local,
       installations: [...installSummary.values()],
       artifacts: links
         .filter((link) => readable.has(link.artifact_id))
@@ -307,6 +316,32 @@ export const skillRoutes = (ctx: AppContext) => {
           }
         }),
     })
+  })
+
+  app.post("/v1/artifacts/:shortId/skill-usage", async (c) => {
+    const skill = await requireArtifact(c, "read")
+    if (skill instanceof Response) return skill
+    if (skill.current_content_type !== SKILL_CONTENT_TYPE) return fail(c, 404, "not a skill")
+    const body = await readJson(c, localUseBody)
+    if (body instanceof Response) return body
+    if (!(await skillDefinition(skill.id, body.skill_version)))
+      return fail(c, 400, "skill version not found")
+    const actor = (await actingHuman(c)) ?? (await actingUser(c))
+    if (!actor) return fail(c, 401, "a signed-in user or user-authorized agent is required")
+    const now = new Date().toISOString()
+    const use = await meta.recordSkillUse({
+      id: newId("sku"),
+      event_id: body.event_id,
+      org_id: skill.org_id,
+      skill_artifact_id: skill.id,
+      skill_version: body.skill_version,
+      used_by: actor.id,
+      client: body.client,
+      ...(body.useful !== undefined ? { useful: body.useful ? 1 : 0 } : {}),
+      occurred_at: now,
+      updated_at: now,
+    })
+    return c.json({ use })
   })
 
   app.get("/v1/artifacts/:shortId/skills", async (c) => {

--- a/apps/api/src/routes/skills.ts
+++ b/apps/api/src/routes/skills.ts
@@ -9,6 +9,7 @@ import {
   type SkillClient,
   type SkillInstallPolicy,
   type SkillInstallScope,
+  type SkillUseClient,
   toJson,
   validateSkillDefinition,
   WORKFLOW_DEFINITION_FACT,
@@ -40,7 +41,32 @@ const localUseBody = z.object({
   event_id: z.string().min(8).max(128),
   skill_version: z.number().int().positive(),
   client: z.enum(["claude", "codex", "other"]),
+  stage: z.enum(["selected", "loaded", "acted", "completed"]).optional(),
+  evidence: z.enum(["native_hook", "structured_log", "skill_file_read", "claimed"]).optional(),
+  skill_digest: z
+    .string()
+    .regex(/^[a-f0-9]{64}$/i)
+    .optional(),
+  opaque_session_id: z
+    .string()
+    .regex(/^[a-f0-9]{64}$/i)
+    .optional(),
+  occurred_at: z.string().datetime().optional(),
   useful: z.boolean().optional(),
+})
+
+const scannedUseBody = localUseBody.extend({ skill_short_id: z.string().min(1).max(128) })
+const scanCoverageBody = z.object({
+  client: z.enum(["claude", "codex"]),
+  source_files: z.number().int().nonnegative(),
+  sessions_scanned: z.number().int().nonnegative(),
+  records_scanned: z.number().int().nonnegative(),
+  parser_version: z.number().int().positive(),
+  scanned_at: z.string().datetime(),
+})
+const scanBatchBody = z.object({
+  uses: z.array(scannedUseBody).max(500),
+  coverage: z.array(scanCoverageBody).max(10),
 })
 
 const artifactLinkBody = z.object({
@@ -269,11 +295,12 @@ export const skillRoutes = (ctx: AppContext) => {
     const skill = await requireArtifact(c, "read")
     if (skill instanceof Response) return skill
     if (skill.current_content_type !== SKILL_CONTENT_TYPE) return fail(c, 404, "not a skill")
-    const [usage, local, installations, links] = await Promise.all([
+    const [usage, local, installations, links, coverageRows] = await Promise.all([
       meta.skillUsage(skill.id, skill.org_id),
       meta.skillLocalUsage(skill.id, skill.org_id),
       meta.listSkillInstallations(skill.id, skill.org_id),
       meta.listSkillArtifactLinks(skill.id, skill.org_id, 100),
+      meta.listSkillScanCoverage(skill.org_id),
     ])
     const linked = await meta.listArtifacts({
       ids: [...new Set(links.map((l) => l.artifact_id))],
@@ -301,11 +328,39 @@ export const skillRoutes = (ctx: AppContext) => {
             : current.last_synced_at,
       })
     }
+    const coverage = new Map<
+      SkillUseClient,
+      {
+        client: SkillUseClient
+        contributors: number
+        source_files: number
+        sessions_scanned: number
+        records_scanned: number
+        parser_version: number
+        last_scanned_at: string
+      }
+    >()
+    for (const row of coverageRows) {
+      const current = coverage.get(row.client)
+      coverage.set(row.client, {
+        client: row.client,
+        contributors: (current?.contributors ?? 0) + 1,
+        source_files: (current?.source_files ?? 0) + row.source_files,
+        sessions_scanned: (current?.sessions_scanned ?? 0) + row.sessions_scanned,
+        records_scanned: (current?.records_scanned ?? 0) + row.records_scanned,
+        parser_version: Math.max(current?.parser_version ?? 0, row.parser_version),
+        last_scanned_at:
+          !current || row.scanned_at > current.last_scanned_at
+            ? row.scanned_at
+            : current.last_scanned_at,
+      })
+    }
     return c.json({
       contexts: usage.contexts,
       workflows: usage.workflows,
       local,
       installations: [...installSummary.values()],
+      coverage: [...coverage.values()],
       artifacts: links
         .filter((link) => readable.has(link.artifact_id))
         .map((link) => {
@@ -337,11 +392,65 @@ export const skillRoutes = (ctx: AppContext) => {
       skill_version: body.skill_version,
       used_by: actor.id,
       client: body.client,
+      stage: body.stage ?? "completed",
+      evidence: body.evidence ?? "claimed",
+      ...(body.skill_digest ? { skill_digest: body.skill_digest } : {}),
+      ...(body.opaque_session_id ? { opaque_session_id: body.opaque_session_id } : {}),
       ...(body.useful !== undefined ? { useful: body.useful ? 1 : 0 } : {}),
-      occurred_at: now,
+      occurred_at: body.occurred_at ?? now,
       updated_at: now,
     })
     return c.json({ use })
+  })
+
+  app.post("/v1/skill-usage/batch", async (c) => {
+    const body = await readJson(c, scanBatchBody)
+    if (body instanceof Response) return body
+    const actor = (await actingHuman(c)) ?? (await actingUser(c))
+    if (!actor) return fail(c, 401, "a signed-in user or user-authorized agent is required")
+    const orgId = await activeWorkspace(c)
+    const definitions = []
+    for (const item of body.uses) {
+      const skill = await requireArtifact(c, "read", { shortId: item.skill_short_id })
+      if (skill instanceof Response) return skill
+      if (skill.org_id !== orgId || skill.current_content_type !== SKILL_CONTENT_TYPE)
+        return fail(c, 404, `not a skill: ${item.skill_short_id}`)
+      if (!(await skillDefinition(skill.id, item.skill_version)))
+        return fail(c, 400, `skill version not found: ${item.skill_short_id}`)
+      definitions.push({ item, skill })
+    }
+    const now = new Date().toISOString()
+    for (const { item, skill } of definitions)
+      await meta.recordSkillUse({
+        id: newId("sku"),
+        event_id: item.event_id,
+        org_id: orgId,
+        skill_artifact_id: skill.id,
+        skill_version: item.skill_version,
+        used_by: actor.id,
+        client: item.client,
+        stage: item.stage ?? "loaded",
+        evidence: item.evidence ?? "structured_log",
+        ...(item.skill_digest ? { skill_digest: item.skill_digest } : {}),
+        ...(item.opaque_session_id ? { opaque_session_id: item.opaque_session_id } : {}),
+        ...(item.useful !== undefined ? { useful: item.useful ? 1 : 0 } : {}),
+        occurred_at: item.occurred_at ?? now,
+        updated_at: now,
+      })
+    for (const row of body.coverage)
+      await meta.upsertSkillScanCoverage({
+        id: newId("skc"),
+        org_id: orgId,
+        scanned_by: actor.id,
+        client: row.client,
+        source_files: row.source_files,
+        sessions_scanned: row.sessions_scanned,
+        records_scanned: row.records_scanned,
+        parser_version: row.parser_version,
+        scanned_at: row.scanned_at,
+        updated_at: now,
+      })
+    return c.json({ recorded: definitions.length, coverage: body.coverage.length })
   })
 
   app.get("/v1/artifacts/:shortId/skills", async (c) => {

--- a/apps/api/test/artifacts.test.ts
+++ b/apps/api/test/artifacts.test.ts
@@ -1177,6 +1177,61 @@ describe("Skills product surface", () => {
     expect(usage).toMatchObject({ contexts: [], workflows: [] })
   })
 
+  it("counts one local Skill use and updates its usefulness without double counting", async () => {
+    const user: TestUser = {
+      id: "local-skill-user",
+      email: "local-skill-user@test.dev",
+      name: "Local Skill User",
+    }
+    const { app: localUseApp } = makeAuthedApp("local-skill-use", [user])
+    const zip = zipSync({
+      "SKILL.md": new TextEncoder().encode(
+        "---\nname: locally-used-skill\ndescription: Use locally-used-skill.\n---\n\n# locally-used-skill",
+      ),
+      "derive.skill.json": new TextEncoder().encode(JSON.stringify({ schema: "derive.skill/v1" })),
+    })
+    const form = new FormData()
+    form.append("file", new Blob([zip]), "locally-used-skill.zip")
+    form.append("title", "locally-used-skill")
+    const skill = await (
+      await localUseApp.request("/v1/artifacts", {
+        method: "POST",
+        headers: as(user.email),
+        body: form,
+      })
+    ).json()
+    const event = {
+      event_id: "local-use-fixture-1",
+      skill_version: 1,
+      client: "codex",
+    }
+    for (const body of [event, { ...event, useful: true }]) {
+      const response = await localUseApp.request(`/v1/artifacts/${skill.short_id}/skill-usage`, {
+        method: "POST",
+        headers: { ...as(user.email), "content-type": "application/json" },
+        body: JSON.stringify(body),
+      })
+      expect(response.status).toBe(200)
+    }
+
+    const usage = await (
+      await localUseApp.request(`/v1/artifacts/${skill.short_id}/skill-usage`, {
+        headers: as(user.email),
+      })
+    ).json()
+    expect(usage.local).toEqual([
+      {
+        skill_version: 1,
+        client: "codex",
+        count: 1,
+        useful: 1,
+        not_useful: 0,
+        unrated: 0,
+        last_used_at: expect.any(String),
+      },
+    ])
+  })
+
   it("rejects unresolved exact-version relations before a Skill version goes live", async () => {
     const zip = zipSync({
       "SKILL.md": new TextEncoder().encode(

--- a/apps/api/test/artifacts.test.ts
+++ b/apps/api/test/artifacts.test.ts
@@ -1213,23 +1213,75 @@ describe("Skills product surface", () => {
       })
       expect(response.status).toBe(200)
     }
+    const scannedAt = new Date().toISOString()
+    const batch = await localUseApp.request("/v1/skill-usage/batch", {
+      method: "POST",
+      headers: { ...as(user.email), "content-type": "application/json" },
+      body: JSON.stringify({
+        uses: [
+          {
+            event_id: "scan-use-fixture-1",
+            skill_short_id: skill.short_id,
+            skill_version: 1,
+            client: "claude",
+            stage: "loaded",
+            evidence: "structured_log",
+            skill_digest: "d".repeat(64),
+            opaque_session_id: "e".repeat(64),
+            occurred_at: scannedAt,
+          },
+        ],
+        coverage: [
+          {
+            client: "claude",
+            source_files: 3,
+            sessions_scanned: 3,
+            records_scanned: 120,
+            parser_version: 1,
+            scanned_at: scannedAt,
+          },
+        ],
+      }),
+    })
+    expect(batch.status).toBe(200)
 
     const usage = await (
       await localUseApp.request(`/v1/artifacts/${skill.short_id}/skill-usage`, {
         headers: as(user.email),
       })
     ).json()
-    expect(usage.local).toEqual([
-      {
+    expect(usage.local).toContainEqual(
+      expect.objectContaining({
         skill_version: 1,
         client: "codex",
+        stage: "completed",
+        evidence: "claimed",
         count: 1,
         useful: 1,
         not_useful: 0,
         unrated: 0,
         last_used_at: expect.any(String),
-      },
-    ])
+      }),
+    )
+    expect(usage.local).toContainEqual(
+      expect.objectContaining({
+        skill_version: 1,
+        client: "claude",
+        stage: "loaded",
+        evidence: "structured_log",
+        count: 1,
+      }),
+    )
+    expect(usage.coverage).toContainEqual(
+      expect.objectContaining({
+        client: "claude",
+        contributors: 1,
+        source_files: 3,
+        sessions_scanned: 3,
+        records_scanned: 120,
+        parser_version: 1,
+      }),
+    )
   })
 
   it("rejects unresolved exact-version relations before a Skill version goes live", async () => {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -637,6 +637,15 @@ export interface SkillGraph {
 export interface SkillUsage {
   contexts: Array<{ skill_version: number; count: number; last_used_at: string }>
   workflows: Array<{ skill_version: number; count: number; last_used_at: string }>
+  local: Array<{
+    skill_version: number
+    client: "claude" | "codex" | "other"
+    count: number
+    useful: number
+    not_useful: number
+    unrated: number
+    last_used_at: string
+  }>
   installations: Array<{
     scope_kind: "project" | "personal" | "runner"
     client: "claude" | "codex"

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -640,11 +640,22 @@ export interface SkillUsage {
   local: Array<{
     skill_version: number
     client: "claude" | "codex" | "other"
+    stage: "selected" | "loaded" | "acted" | "completed"
+    evidence: "native_hook" | "structured_log" | "skill_file_read" | "claimed"
     count: number
     useful: number
     not_useful: number
     unrated: number
     last_used_at: string
+  }>
+  coverage: Array<{
+    client: "claude" | "codex" | "other"
+    contributors: number
+    source_files: number
+    sessions_scanned: number
+    records_scanned: number
+    parser_version: number
+    last_scanned_at: string
   }>
   installations: Array<{
     scope_kind: "project" | "personal" | "runner"

--- a/apps/web/src/pages/artifact/bundle-bar.tsx
+++ b/apps/web/src/pages/artifact/bundle-bar.tsx
@@ -108,6 +108,7 @@ function SkillWorkbench({
   )
   const contextRuns = (usage.data?.contexts ?? []).reduce((sum, item) => sum + item.count, 0)
   const workflowRuns = (usage.data?.workflows ?? []).reduce((sum, item) => sum + item.count, 0)
+  const localUses = (usage.data?.local ?? []).reduce((sum, item) => sum + item.count, 0)
   const fileUrl = (path: string) => `${API_BASE}/raw/${shortId}/v/${version}/${path}`
   const installCommand = `derive skill add ${shortId}`
   const workflowLinks = (usage.data?.artifacts ?? []).filter(
@@ -231,14 +232,14 @@ function SkillWorkbench({
             )}
           </TabsContent>
           <TabsContent value="usage" className="px-4 py-3">
-            <div className="grid gap-2 sm:grid-cols-3">
+            <div className="grid gap-2 sm:grid-cols-4">
               <Metric value={usage.data ? activeInstalls : null} label="active installs" />
+              <Metric value={usage.data ? localUses : null} label="local uses" />
               <Metric value={usage.data ? contextRuns : null} label="Context runs" />
               <Metric value={usage.data ? workflowRuns : null} label="Workflow runs" />
             </div>
             <p className="mt-2 text-xs text-muted-foreground">
-              These are separate observed signals. Derive does not guess local activations or
-              combine them into a synthetic total.
+              Local uses are explicit CLI receipts. Installs and hosted runs stay separate.
             </p>
             {usage.isPending ? (
               <Muted>Loading installation details…</Muted>
@@ -270,6 +271,38 @@ function SkillWorkbench({
               </div>
             ) : (
               <p className="mt-3 text-xs text-muted-foreground">No active installations yet.</p>
+            )}
+            {usage.data?.local.length ? (
+              <div className="mt-3 flex flex-col gap-2" data-testid="skill-local-usage">
+                <p className="text-xs font-medium text-foreground">Local use</p>
+                {usage.data.local.map((item) => (
+                  <div
+                    key={`${item.client}:${item.skill_version}`}
+                    className="flex flex-wrap items-center gap-2 rounded-lg border bg-background px-3 py-2 text-sm"
+                  >
+                    <Badge variant="outline" shape="pill" className="capitalize">
+                      {item.client}
+                    </Badge>
+                    <span>
+                      {item.count} {item.count === 1 ? "use" : "uses"}
+                    </span>
+                    <span className="text-xs text-muted-foreground">
+                      {item.useful} useful · {item.not_useful} not useful · {item.unrated} unrated
+                    </span>
+                    <span
+                      className="ml-auto text-xs text-muted-foreground"
+                      title={new Date(item.last_used_at).toLocaleString()}
+                    >
+                      used {ago(item.last_used_at)} · v{item.skill_version}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="mt-3 text-xs text-muted-foreground">
+                No local use reported yet. Run{" "}
+                <code>derive skill used {shortId} --client codex</code>.
+              </p>
             )}
           </TabsContent>
           <TabsContent value="artifacts" className="px-4 py-3">

--- a/apps/web/src/pages/artifact/bundle-bar.tsx
+++ b/apps/web/src/pages/artifact/bundle-bar.tsx
@@ -239,8 +239,37 @@ function SkillWorkbench({
               <Metric value={usage.data ? workflowRuns : null} label="Workflow runs" />
             </div>
             <p className="mt-2 text-xs text-muted-foreground">
-              Local uses are explicit CLI receipts. Installs and hosted runs stay separate.
+              Local activity comes from explicit receipts and private on-device log scans. Installs
+              and hosted runs stay separate.
             </p>
+            {usage.data?.coverage.length ? (
+              <div className="mt-3 flex flex-col gap-2" data-testid="skill-scan-coverage">
+                <p className="text-xs font-medium text-foreground">Scan coverage</p>
+                {usage.data.coverage.map((item) => (
+                  <div
+                    key={item.client}
+                    className="flex flex-wrap items-center gap-2 rounded-lg border bg-background px-3 py-2 text-sm"
+                  >
+                    <Badge variant="outline" shape="pill" className="capitalize">
+                      {item.client}
+                    </Badge>
+                    <span>
+                      {item.sessions_scanned} scanned{" "}
+                      {item.sessions_scanned === 1 ? "session" : "sessions"}
+                    </span>
+                    <span className="text-xs text-muted-foreground">
+                      {item.source_files} log files · parser v{item.parser_version}
+                    </span>
+                    <span
+                      className="ml-auto text-xs text-muted-foreground"
+                      title={new Date(item.last_scanned_at).toLocaleString()}
+                    >
+                      scanned {ago(item.last_scanned_at)}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            ) : null}
             {usage.isPending ? (
               <Muted>Loading installation details…</Muted>
             ) : usage.data?.installations.length ? (
@@ -283,11 +312,15 @@ function SkillWorkbench({
                     <Badge variant="outline" shape="pill" className="capitalize">
                       {item.client}
                     </Badge>
+                    <Badge variant="outline" shape="pill" className="capitalize">
+                      {item.stage}
+                    </Badge>
                     <span>
                       {item.count} {item.count === 1 ? "use" : "uses"}
                     </span>
                     <span className="text-xs text-muted-foreground">
-                      {item.useful} useful · {item.not_useful} not useful · {item.unrated} unrated
+                      {item.evidence.replaceAll("_", " ")} · {item.useful} useful ·{" "}
+                      {item.not_useful} not useful · {item.unrated} unrated
                     </span>
                     <span
                       className="ml-auto text-xs text-muted-foreground"
@@ -300,8 +333,8 @@ function SkillWorkbench({
               </div>
             ) : (
               <p className="mt-3 text-xs text-muted-foreground">
-                No local use reported yet. Run{" "}
-                <code>derive skill used {shortId} --client codex</code>.
+                No local use reported yet. Run <code>derive skill scan --since 30d</code> to
+                backfill private local logs.
               </p>
             )}
           </TabsContent>

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -371,6 +371,20 @@ CREATE TABLE IF NOT EXISTS skill_installation (
   UNIQUE (org_id, skill_artifact_id, scope_kind, opaque_scope_id, client)
 );
 
+CREATE TABLE IF NOT EXISTS skill_use (
+  id TEXT PRIMARY KEY,
+  event_id TEXT NOT NULL,
+  org_id TEXT NOT NULL,
+  skill_artifact_id TEXT NOT NULL,
+  skill_version INTEGER NOT NULL,
+  used_by TEXT NOT NULL,
+  client TEXT NOT NULL,
+  useful INTEGER,
+  occurred_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  UNIQUE (org_id, skill_artifact_id, used_by, event_id)
+);
+
 CREATE TABLE IF NOT EXISTS artifact_skill_link (
   id TEXT PRIMARY KEY,
   org_id TEXT NOT NULL,
@@ -852,6 +866,8 @@ CREATE INDEX IF NOT EXISTS workflow_step_attempt_run ON workflow_step_attempt (w
 CREATE INDEX IF NOT EXISTS skill_relation_incoming ON skill_relation (org_id, target_artifact_id, target_version);
 
 CREATE INDEX IF NOT EXISTS skill_installation_skill ON skill_installation (org_id, skill_artifact_id, updated_at);
+
+CREATE INDEX IF NOT EXISTS skill_use_skill ON skill_use (org_id, skill_artifact_id, occurred_at);
 
 CREATE INDEX IF NOT EXISTS artifact_skill_link_skill ON artifact_skill_link (org_id, skill_artifact_id, created_at);
 

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -371,6 +371,20 @@ CREATE TABLE IF NOT EXISTS skill_installation (
   UNIQUE (org_id, skill_artifact_id, scope_kind, opaque_scope_id, client)
 );
 
+CREATE TABLE IF NOT EXISTS skill_scan_coverage (
+  id TEXT PRIMARY KEY,
+  org_id TEXT NOT NULL,
+  scanned_by TEXT NOT NULL,
+  client TEXT NOT NULL,
+  source_files INTEGER NOT NULL,
+  sessions_scanned INTEGER NOT NULL,
+  records_scanned INTEGER NOT NULL,
+  parser_version INTEGER NOT NULL,
+  scanned_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  UNIQUE (org_id, scanned_by, client)
+);
+
 CREATE TABLE IF NOT EXISTS skill_use (
   id TEXT PRIMARY KEY,
   event_id TEXT NOT NULL,
@@ -379,6 +393,10 @@ CREATE TABLE IF NOT EXISTS skill_use (
   skill_version INTEGER NOT NULL,
   used_by TEXT NOT NULL,
   client TEXT NOT NULL,
+  stage TEXT NOT NULL DEFAULT 'completed',
+  evidence TEXT NOT NULL DEFAULT 'claimed',
+  skill_digest TEXT,
+  opaque_session_id TEXT,
   useful INTEGER,
   occurred_at TEXT NOT NULL,
   updated_at TEXT NOT NULL,
@@ -866,6 +884,8 @@ CREATE INDEX IF NOT EXISTS workflow_step_attempt_run ON workflow_step_attempt (w
 CREATE INDEX IF NOT EXISTS skill_relation_incoming ON skill_relation (org_id, target_artifact_id, target_version);
 
 CREATE INDEX IF NOT EXISTS skill_installation_skill ON skill_installation (org_id, skill_artifact_id, updated_at);
+
+CREATE INDEX IF NOT EXISTS skill_scan_coverage_workspace ON skill_scan_coverage (org_id, scanned_at);
 
 CREATE INDEX IF NOT EXISTS skill_use_skill ON skill_use (org_id, skill_artifact_id, occurred_at);
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -183,12 +183,19 @@ Published Skills install natively into both Claude and Codex by default:
 derive skill add <short_id>
 derive skill sync <short_id> --client codex
 derive skill sync --all
+derive skill used <short_id> --client codex
+derive skill used <short_id> --client codex --event <event_id> --useful yes
 derive skill remove <short_id> --scope project
 ```
 
 Project installs use `.claude/skills` and `.agents/skills`; personal installs use
 `~/.claude/skills` and `~/.codex/skills`. Installs are atomic and pinned in `derive.json`.
 `sync --all` updates every pinned Skill while preserving any Claude-only or Codex-only installs.
+
+Run `skill used` after a local agent invokes a pinned Skill. Derive generates an event ID unless
+the caller supplies one. Reuse an event ID to add or change its usefulness rating without adding
+another use. Derive stores the signed-in user, workspace, pinned version, client, and time on the
+server. The Skill page shows aggregate counts. It does not store prompts or generated content.
 
 Derive is licensed under FSL-1.1-ALv2 and converts to Apache-2.0 on the schedule in
 the [license](https://github.com/derive-to/derive/blob/main/LICENSE).

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -185,6 +185,11 @@ derive skill sync <short_id> --client codex
 derive skill sync --all
 derive skill used <short_id> --client codex
 derive skill used <short_id> --client codex --event <event_id> --useful yes
+derive skill scan --dry-run --since 30d
+derive skill scan --since 30d
+derive skill scan setup
+derive skill scan setup --schedule
+derive skill scan status
 derive skill remove <short_id> --scope project
 ```
 
@@ -196,6 +201,17 @@ Run `skill used` after a local agent invokes a pinned Skill. Derive generates an
 the caller supplies one. Reuse an event ID to add or change its usefulness rating without adding
 another use. Derive stores the signed-in user, workspace, pinned version, client, and time on the
 server. The Skill page shows aggregate counts. It does not store prompts or generated content.
+
+`skill scan` reads structured local Codex and Claude logs. It reads only records added after its
+saved cursor. Claude provides an explicit Skill attribution. For Codex, the scanner detects a
+structured tool call that reads a known installed `SKILL.md`. The scanner uploads the Skill ID,
+version, digest, client, evidence type, an opaque session hash, and the event time. It does not
+upload prompts, responses, tool arguments, file contents, repository paths, or user names.
+
+Run `skill scan --dry-run --since 30d` before the first backfill. `skill scan setup` installs an
+asynchronous session-end command hook for Codex and Claude. The hook does not call an LLM. Add
+`--schedule` to install a 30-minute launchd, systemd, or Windows Task Scheduler fallback. Failed
+uploads stay in a local spool and retry on the next scan.
 
 Derive is licensed under FSL-1.1-ALv2 and converts to Apache-2.0 on the schedule in
 the [license](https://github.com/derive-to/derive/blob/main/LICENSE).

--- a/packages/cli/bin/derive.js
+++ b/packages/cli/bin/derive.js
@@ -1317,7 +1317,7 @@ if (LOOP.includes(cmd)) {
   process.exit(0)
 }
 
-// ---- derive skill (add/sync/remove) -----------------------------------------
+// ---- derive skill (add/sync/remove/used) ------------------------------------
 // The consumption half of the skill loop: author with `init --template skill` +
 // `publish`, then INSTALL a published skill into ./.claude/skills/<name>/ where
 // this project's agent auto-discovers it. Pinned in derive.json so an update is a
@@ -1326,9 +1326,13 @@ if (cmd === "skill") {
   const sub = positional.shift()
   const shortId = positional[0]
   const syncAll = sub === "sync" && flags.all === "true"
-  if (!["add", "sync", "remove"].includes(sub) || (!shortId && !syncAll) || (syncAll && shortId)) {
+  if (
+    !["add", "sync", "remove", "used"].includes(sub) ||
+    (!shortId && !syncAll) ||
+    (syncAll && shortId)
+  ) {
     console.error(
-      "usage: derive skill add|sync|remove <short_id> [--client claude|codex|all] [--scope project|personal]\n       derive skill sync --all [--client claude|codex|all] [--scope project|personal]",
+      "usage: derive skill add|sync|remove <short_id> [--client claude|codex|all] [--scope project|personal]\n       derive skill used <short_id> --client claude|codex|other [--useful yes|no] [--event id]\n       derive skill sync --all [--client claude|codex|all] [--scope project|personal]",
     )
     process.exit(cmd ? 1 : 0)
   }
@@ -1337,6 +1341,48 @@ if (cmd === "skill") {
     cfg = loadConfig(".")
   } catch {
     /* no derive.json yet — the pin creates one */
+  }
+  if (sub === "used") {
+    const client = flags.client ?? "other"
+    if (!["claude", "codex", "other"].includes(client)) {
+      console.error("error: --client must be claude, codex, or other")
+      process.exit(1)
+    }
+    if (flags.useful && !["yes", "no"].includes(flags.useful)) {
+      console.error("error: --useful must be yes or no")
+      process.exit(1)
+    }
+    const pin = cfg?.skills?.find((skill) => skill.id === shortId)
+    const installed = pin?.installs?.[client]
+    const version = installed?.version ?? pin?.version
+    if (!version) {
+      console.error(`error: ${shortId} is not pinned in ${CONFIG_FILE}; run derive skill add first`)
+      process.exit(1)
+    }
+    const r = resolvePublish(flags, cfg)
+    r.token = flags.token ?? process.env.DERIVE_TOKEN ?? (await freshToken(r.server, r.accountId))
+    if (!r.token) {
+      console.error("error: not signed in — run `derive login` first")
+      process.exit(1)
+    }
+    const eventId = flags.event ?? randomBytes(16).toString("hex")
+    const deriveClient = new DeriveClient(r.server, r.token)
+    await deriveClient.call(`/v1/artifacts/${shortId}/skill-usage`, {
+      method: "POST",
+      headers: r.workspaceId ? { "x-derive-workspace": r.workspaceId } : {},
+      body: JSON.stringify({
+        event_id: eventId,
+        skill_version: version,
+        client,
+        ...(flags.useful ? { useful: flags.useful === "yes" } : {}),
+      }),
+    })
+    console.log(
+      `✓ recorded ${pin.name ?? shortId} @v${version} used by ${client} (${eventId})${
+        flags.useful ? ` · ${flags.useful === "yes" ? "useful" : "not useful"}` : " · unrated"
+      }`,
+    )
+    process.exit(0)
   }
   const clients =
     flags.client === "claude" || flags.client === "codex" ? [flags.client] : ["claude", "codex"]
@@ -1657,6 +1703,7 @@ if (cmd !== "publish") {
   derive workflow preview [file] [--json]  explain + validate a graph/loop before it runs
   derive workflow run [run_id]             execute one assigned graph from GitHub Actions OIDC
   derive skill add|sync|remove <short_id>  install a pinned Skill for Claude + Codex (--client/--scope)
+  derive skill used <short_id>             record one local use (--client; optional --useful yes|no)
   derive skill sync --all                  update every locally pinned Skill
   derive brandprint pull                   materialize the workspace + your Brandprint into this repo`)
   process.exit(cmd && cmd !== "--help" && cmd !== "help" ? 1 : 0)

--- a/packages/cli/bin/derive.js
+++ b/packages/cli/bin/derive.js
@@ -33,6 +33,7 @@
 //   derive context push|dev                ship a Context dir as its manifest / tune it live
 //   derive workflow sync|preview [file] [--json] sync the visible graph, then explain + validate
 //   derive workflow run [run_id]          one authorized GitHub Actions graph harness
+//   derive skill scan [setup|status]      scan local agent logs for installed Skill use
 import { spawn } from "node:child_process"
 import { createHash, randomBytes } from "node:crypto"
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
@@ -74,6 +75,17 @@ import {
 import { createAgent, createContext, saveAgentToken } from "../src/context.js"
 import { readTarget, uploadArtifact } from "../src/publish.js"
 import { DeriveClient, parseManifest } from "../src/runner.js"
+import {
+  addToSkillScanSpool,
+  groupSkillScanSpool,
+  listSkillInstalls,
+  recordSkillInstall,
+  removeFromSkillScanSpool,
+  removeSkillInstall,
+  scanSkillLogs,
+  skillScanStatus,
+} from "../src/skill-scan.js"
+import { setupSkillScan } from "../src/skill-scan-setup.js"
 import { materializeNotes, materializeSkills, pinManifestSkills, skillSlug } from "../src/skills.js"
 import {
   formatWorkflowPreview,
@@ -102,6 +114,9 @@ for (let i = 0; i < args.length; i++) {
   else if (a === "--manage") flags.manage = "true"
   else if (a === "--suggest") flags.suggest = "true"
   else if (a === "--update") flags.update = "true"
+  else if (a === "--dry-run") flags["dry-run"] = "true"
+  else if (a === "--schedule") flags.schedule = "true"
+  else if (a === "--quiet") flags.quiet = "true"
   // Boolean, so it must be listed here: the catch-all below would otherwise eat the next
   // argument as its value, and `derive delete abc --yes` would silently not be confirmed.
   else if (a === "--yes") flags.yes = "true"
@@ -1317,7 +1332,7 @@ if (LOOP.includes(cmd)) {
   process.exit(0)
 }
 
-// ---- derive skill (add/sync/remove/used) ------------------------------------
+// ---- derive skill (add/sync/remove/used/scan) -------------------------------
 // The consumption half of the skill loop: author with `init --template skill` +
 // `publish`, then INSTALL a published skill into ./.claude/skills/<name>/ where
 // this project's agent auto-discovers it. Pinned in derive.json so an update is a
@@ -1327,12 +1342,12 @@ if (cmd === "skill") {
   const shortId = positional[0]
   const syncAll = sub === "sync" && flags.all === "true"
   if (
-    !["add", "sync", "remove", "used"].includes(sub) ||
-    (!shortId && !syncAll) ||
+    !["add", "sync", "remove", "used", "scan"].includes(sub) ||
+    (!shortId && !syncAll && sub !== "scan") ||
     (syncAll && shortId)
   ) {
     console.error(
-      "usage: derive skill add|sync|remove <short_id> [--client claude|codex|all] [--scope project|personal]\n       derive skill used <short_id> --client claude|codex|other [--useful yes|no] [--event id]\n       derive skill sync --all [--client claude|codex|all] [--scope project|personal]",
+      "usage: derive skill add|sync|remove <short_id> [--client claude|codex|all] [--scope project|personal]\n       derive skill used <short_id> --client claude|codex|other [--useful yes|no] [--event id]\n       derive skill scan [setup|status] [--since 30d] [--dry-run] [--schedule]\n       derive skill sync --all [--client claude|codex|all] [--scope project|personal]",
     )
     process.exit(cmd ? 1 : 0)
   }
@@ -1341,6 +1356,167 @@ if (cmd === "skill") {
     cfg = loadConfig(".")
   } catch {
     /* no derive.json yet — the pin creates one */
+  }
+  if (sub === "scan") {
+    const action = positional[0] ?? "run"
+    if (!["run", "setup", "status"].includes(action)) {
+      console.error(
+        "usage: derive skill scan [setup|status] [--since 30d] [--dry-run] [--schedule]",
+      )
+      process.exit(1)
+    }
+    if (flags.client && !["claude", "codex"].includes(flags.client)) {
+      console.error("error: --client must be claude or codex")
+      process.exit(1)
+    }
+
+    const r = resolvePublish(flags, cfg)
+    // Backfill the local install registry for pins created before Skill scan existed.
+    for (const pin of cfg?.skills ?? []) {
+      for (const client of ["claude", "codex"]) {
+        const installed = pin.installs?.[client]
+        if (!installed) continue
+        const dir = skillSlug(installed.name ?? pin.name)
+        if (!dir) continue
+        const candidates = [
+          {
+            scope: "project",
+            path: join(".", client === "codex" ? ".agents" : ".claude", "skills", dir),
+          },
+          {
+            scope: "personal",
+            path: join(homedir(), client === "codex" ? ".codex" : ".claude", "skills", dir),
+          },
+        ]
+        for (const candidate of candidates) {
+          if (!existsSync(candidate.path)) continue
+          recordSkillInstall({
+            id: pin.id,
+            version: installed.version ?? pin.version,
+            name: installed.name ?? pin.name,
+            client,
+            path: candidate.path,
+            digest: installed.digest ?? null,
+            scope: candidate.scope,
+            server: r.server,
+            workspaceId: r.workspaceId,
+            accountId: r.accountId,
+          })
+        }
+      }
+    }
+
+    if (action === "status") {
+      const status = skillScanStatus()
+      if (flags.json) console.log(JSON.stringify(status))
+      else {
+        console.log(`Skill scan parser v${status.parser_version}`)
+        console.log(`last scan: ${status.last_scan_at ?? "never"}`)
+        console.log(`installed Skills tracked: ${status.installs}`)
+        console.log(`pending receipts: ${status.pending}`)
+        for (const source of status.sources)
+          console.log(
+            `  ${source.client}: ${source.files} log files · ${source.tracked} tracked · ${source.sessions_90d} sessions in coverage`,
+          )
+      }
+      process.exit(0)
+    }
+
+    if (action === "setup") {
+      await scanSkillLogs({ baseline: true, client: flags.client })
+      const setup = setupSkillScan({ schedule: flags.schedule === "true" })
+      if (flags.json) console.log(JSON.stringify(setup))
+      else {
+        for (const hook of setup.hooks)
+          console.log(
+            `✓ ${hook.client} session-end hook ${hook.changed ? "installed" : "already installed"}`,
+          )
+        if (setup.schedule)
+          console.log(`✓ 30-minute system schedule installed at ${setup.schedule}`)
+        console.log(
+          "Existing logs were left untouched. Run `derive skill scan --since 30d` to backfill.",
+        )
+      }
+      process.exit(0)
+    }
+
+    const result = await scanSkillLogs({
+      since: flags.since,
+      dryRun: flags["dry-run"] === "true",
+      client: flags.client,
+    })
+    if (flags["dry-run"] === "true") {
+      const output = {
+        dry_run: true,
+        events: result.events.map(({ target: _target, ...event }) => event),
+        coverage: result.coverage,
+      }
+      if (flags.json) console.log(JSON.stringify(output))
+      else {
+        console.log(
+          `Dry run found ${result.events.length} Skill ${result.events.length === 1 ? "use" : "uses"}.`,
+        )
+        for (const row of result.coverage)
+          console.log(
+            `  ${row.client}: ${row.source_files} files · ${row.records_scanned} records · ${row.matched_events} matches`,
+          )
+      }
+      process.exit(0)
+    }
+
+    let spool = addToSkillScanSpool(result.events, result.coverage)
+    const sentIds = []
+    const sentCoverage = new Set()
+    const failedCoverage = new Set()
+    let failed = null
+    for (const group of groupSkillScanSpool(spool, listSkillInstalls())) {
+      const token =
+        flags.token ??
+        process.env.DERIVE_TOKEN ??
+        (await freshToken(group.target.server, group.target.account_id))
+      if (!token) {
+        failed = `not signed in to ${group.target.server}`
+        for (const row of group.coverage) failedCoverage.add(row.client)
+        continue
+      }
+      const deriveClient = new DeriveClient(group.target.server, token)
+      try {
+        await deriveClient.call("/v1/skill-usage/batch", {
+          method: "POST",
+          headers: group.target.workspace_id
+            ? { "x-derive-workspace": group.target.workspace_id }
+            : {},
+          body: JSON.stringify({
+            uses: group.events.map(({ target: _target, ...event }) => event),
+            coverage: group.coverage,
+          }),
+        })
+        sentIds.push(...group.events.map((event) => event.event_id))
+        for (const row of group.coverage) sentCoverage.add(row.client)
+      } catch (error) {
+        failed = error.message
+        for (const row of group.coverage) failedCoverage.add(row.client)
+      }
+    }
+    spool = removeFromSkillScanSpool(
+      sentIds,
+      [...sentCoverage].filter((client) => !failedCoverage.has(client)),
+    )
+    const output = {
+      found: result.events.length,
+      uploaded: sentIds.length,
+      pending: spool.pending.length,
+      coverage: result.coverage,
+      ...(failed ? { error: failed } : {}),
+    }
+    if (flags.json) console.log(JSON.stringify(output))
+    else if (!flags.quiet) {
+      console.log(
+        `✓ found ${output.found} · uploaded ${output.uploaded} · ${output.pending} pending receipt${output.pending === 1 ? "" : "s"}`,
+      )
+      if (failed) console.error(`error: ${failed}; receipts remain in the local spool`)
+    }
+    process.exit(failed && !flags.quiet ? 1 : 0)
   }
   if (sub === "used") {
     const client = flags.client ?? "other"
@@ -1451,6 +1627,12 @@ if (cmd === "skill") {
           removed: true,
         }),
       })
+      removeSkillInstall({
+        client: target,
+        path: join(targetRoot(target), dir),
+        server: r.server,
+        workspaceId: r.workspaceId,
+      })
     }
     removeSkillClients(".", shortId, installedClients)
     console.log(`✓ removed ${pin.name} from ${installedClients.join(" + ")}`)
@@ -1503,6 +1685,18 @@ if (cmd === "skill") {
           digest: installed.digest,
           policy: "pinned",
         }),
+      })
+      recordSkillInstall({
+        id: item.id,
+        version,
+        name: installed.name,
+        client: target,
+        path: join(targetRoot(target), installed.name),
+        digest: installed.digest,
+        scope,
+        server: r.server,
+        workspaceId: r.workspaceId,
+        accountId: r.accountId,
       })
     }
     synced++
@@ -1704,6 +1898,10 @@ if (cmd !== "publish") {
   derive workflow run [run_id]             execute one assigned graph from GitHub Actions OIDC
   derive skill add|sync|remove <short_id>  install a pinned Skill for Claude + Codex (--client/--scope)
   derive skill used <short_id>             record one local use (--client; optional --useful yes|no)
+  derive skill scan [--since 30d]          scan appended Codex + Claude logs and sync receipts
+  derive skill scan --dry-run              preview matches without changing local or server state
+  derive skill scan setup [--schedule]     add session-end hooks; optionally scan every 30 minutes
+  derive skill scan status                 show sources, cursors, coverage, and pending receipts
   derive skill sync --all                  update every locally pinned Skill
   derive brandprint pull                   materialize the workspace + your Brandprint into this repo`)
   process.exit(cmd && cmd !== "--help" && cmd !== "help" ? 1 : 0)

--- a/packages/cli/bin/derive.js
+++ b/packages/cli/bin/derive.js
@@ -1516,7 +1516,10 @@ if (cmd === "skill") {
       )
       if (failed) console.error(`error: ${failed}; receipts remain in the local spool`)
     }
-    process.exit(failed && !flags.quiet ? 1 : 0)
+    // Quiet suppresses routine scheduler output. It must not hide a failed
+    // upload from the scheduler, which otherwise cannot report that the spool
+    // needs another run.
+    process.exit(failed ? 1 : 0)
   }
   if (sub === "used") {
     const client = flags.client ?? "other"

--- a/packages/cli/bin/derive.js
+++ b/packages/cli/bin/derive.js
@@ -1424,7 +1424,7 @@ if (cmd === "skill") {
 
     if (action === "setup") {
       await scanSkillLogs({ baseline: true, client: flags.client })
-      const setup = setupSkillScan({ schedule: flags.schedule === "true" })
+      const setup = setupSkillScan({ schedule: flags.schedule === "true", client: flags.client })
       if (flags.json) console.log(JSON.stringify(setup))
       else {
         for (const hook of setup.hooks)

--- a/packages/cli/src/skill-scan-setup.js
+++ b/packages/cli/src/skill-scan-setup.js
@@ -43,7 +43,7 @@ const addSessionEndHook = (path, command) => {
 const xml = (value) =>
   String(value).replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;")
 
-const installMacSchedule = ({ home, node, cli, activate }) => {
+const installMacSchedule = ({ home, node, cli, client, activate }) => {
   const path = join(home, "Library", "LaunchAgents", "to.derive.skill-scan.plist")
   mkdirSync(dirname(path), { recursive: true })
   const source = `<?xml version="1.0" encoding="UTF-8"?>
@@ -51,7 +51,7 @@ const installMacSchedule = ({ home, node, cli, activate }) => {
 <plist version="1.0"><dict>
   <key>Label</key><string>to.derive.skill-scan</string>
   <key>ProgramArguments</key><array>
-    <string>${xml(node)}</string><string>${xml(cli)}</string><string>skill</string><string>scan</string><string>--quiet</string>
+    <string>${xml(node)}</string><string>${xml(cli)}</string><string>skill</string><string>scan</string><string>--quiet</string>${client ? `<string>--client</string><string>${xml(client)}</string>` : ""}
   </array>
   <key>StartInterval</key><integer>1800</integer>
   <key>RunAtLoad</key><true/>
@@ -69,14 +69,14 @@ const installMacSchedule = ({ home, node, cli, activate }) => {
 
 const shellQuote = (value) => `'${String(value).replaceAll("'", `'\\''`)}'`
 
-const installLinuxSchedule = ({ home, node, cli, activate }) => {
+const installLinuxSchedule = ({ home, node, cli, client, activate }) => {
   const root = join(home, ".config", "systemd", "user")
   const service = join(root, "derive-skill-scan.service")
   const timer = join(root, "derive-skill-scan.timer")
   mkdirSync(root, { recursive: true })
   writeFileSync(
     service,
-    `[Unit]\nDescription=Scan local agent logs for Derive Skill use\n\n[Service]\nType=oneshot\nExecStart=${shellQuote(node)} ${shellQuote(cli)} skill scan --quiet\n`,
+    `[Unit]\nDescription=Scan local agent logs for Derive Skill use\n\n[Service]\nType=oneshot\nExecStart=${shellQuote(node)} ${shellQuote(cli)} skill scan --quiet${client ? ` --client ${shellQuote(client)}` : ""}\n`,
   )
   writeFileSync(
     timer,
@@ -96,8 +96,8 @@ const installLinuxSchedule = ({ home, node, cli, activate }) => {
   return timer
 }
 
-const installWindowsSchedule = ({ node, cli, activate }) => {
-  const command = `"${node}" "${cli}" skill scan --quiet`
+const installWindowsSchedule = ({ node, cli, client, activate }) => {
+  const command = `"${node}" "${cli}" skill scan --quiet${client ? ` --client ${client}` : ""}`
   if (activate) {
     const result = spawnSync(
       "schtasks",
@@ -115,7 +115,11 @@ export function setupSkillScan(options = {}) {
   const cli = options.cli ?? process.argv[1]
   const platform = options.platform ?? process.platform
   const activate = options.activate ?? true
-  const command = `"${node}" "${cli}" skill scan --quiet`
+  if (options.schedule && !["darwin", "linux", "win32"].includes(platform))
+    throw new Error(`automatic schedule is not supported on ${platform}`)
+  const command = `"${node}" "${cli}" skill scan --quiet${
+    options.client ? ` --client ${options.client}` : ""
+  }`
   const hooks = [
     {
       client: "codex",
@@ -125,14 +129,18 @@ export function setupSkillScan(options = {}) {
       client: "claude",
       path: join(home, ".claude", "settings.json"),
     },
-  ].map((target) => ({ ...target, changed: addSessionEndHook(target.path, command) }))
+  ]
+    .filter((target) => !options.client || target.client === options.client)
+    .map((target) => ({ ...target, changed: addSessionEndHook(target.path, command) }))
 
   let schedule = null
   if (options.schedule) {
-    if (platform === "darwin") schedule = installMacSchedule({ home, node, cli, activate })
-    else if (platform === "linux") schedule = installLinuxSchedule({ home, node, cli, activate })
-    else if (platform === "win32") schedule = installWindowsSchedule({ node, cli, activate })
-    else throw new Error(`automatic schedule is not supported on ${platform}`)
+    if (platform === "darwin")
+      schedule = installMacSchedule({ home, node, cli, client: options.client, activate })
+    else if (platform === "linux")
+      schedule = installLinuxSchedule({ home, node, cli, client: options.client, activate })
+    else if (platform === "win32")
+      schedule = installWindowsSchedule({ node, cli, client: options.client, activate })
   }
   return { hooks, schedule }
 }

--- a/packages/cli/src/skill-scan-setup.js
+++ b/packages/cli/src/skill-scan-setup.js
@@ -1,0 +1,138 @@
+import { spawnSync } from "node:child_process"
+import { randomBytes } from "node:crypto"
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs"
+import { homedir } from "node:os"
+import { dirname, join } from "node:path"
+
+const DERIVE_HOOK_MARKER = "skill scan --quiet"
+
+const readJson = (path) => {
+  if (!existsSync(path)) return {}
+  const parsed = JSON.parse(readFileSync(path, "utf8"))
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
+    throw new Error(`${path} must contain a JSON object`)
+  return parsed
+}
+
+const writeJson = (path, value) => {
+  mkdirSync(dirname(path), { recursive: true })
+  const temporary = `${path}.${process.pid}.${randomBytes(5).toString("hex")}.tmp`
+  writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 })
+  renameSync(temporary, path)
+}
+
+const hasDeriveHook = (groups) =>
+  groups.some((group) =>
+    (group?.hooks ?? []).some(
+      (hook) => typeof hook?.command === "string" && hook.command.includes(DERIVE_HOOK_MARKER),
+    ),
+  )
+
+const addSessionEndHook = (path, command) => {
+  const config = readJson(path)
+  config.hooks ??= {}
+  config.hooks.SessionEnd ??= []
+  if (hasDeriveHook(config.hooks.SessionEnd)) return false
+  config.hooks.SessionEnd.push({
+    hooks: [{ type: "command", command, async: true, timeout: 3 }],
+  })
+  writeJson(path, config)
+  return true
+}
+
+const xml = (value) =>
+  String(value).replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;")
+
+const installMacSchedule = ({ home, node, cli, activate }) => {
+  const path = join(home, "Library", "LaunchAgents", "to.derive.skill-scan.plist")
+  mkdirSync(dirname(path), { recursive: true })
+  const source = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>Label</key><string>to.derive.skill-scan</string>
+  <key>ProgramArguments</key><array>
+    <string>${xml(node)}</string><string>${xml(cli)}</string><string>skill</string><string>scan</string><string>--quiet</string>
+  </array>
+  <key>StartInterval</key><integer>1800</integer>
+  <key>RunAtLoad</key><true/>
+</dict></plist>
+`
+  writeFileSync(path, source)
+  if (activate) {
+    const domain = `gui/${process.getuid()}`
+    spawnSync("launchctl", ["bootout", domain, path], { stdio: "ignore" })
+    const result = spawnSync("launchctl", ["bootstrap", domain, path], { encoding: "utf8" })
+    if (result.status !== 0) throw new Error(result.stderr.trim() || "launchctl bootstrap failed")
+  }
+  return path
+}
+
+const shellQuote = (value) => `'${String(value).replaceAll("'", `'\\''`)}'`
+
+const installLinuxSchedule = ({ home, node, cli, activate }) => {
+  const root = join(home, ".config", "systemd", "user")
+  const service = join(root, "derive-skill-scan.service")
+  const timer = join(root, "derive-skill-scan.timer")
+  mkdirSync(root, { recursive: true })
+  writeFileSync(
+    service,
+    `[Unit]\nDescription=Scan local agent logs for Derive Skill use\n\n[Service]\nType=oneshot\nExecStart=${shellQuote(node)} ${shellQuote(cli)} skill scan --quiet\n`,
+  )
+  writeFileSync(
+    timer,
+    `[Unit]\nDescription=Scan local agent logs for Derive Skill use\n\n[Timer]\nOnBootSec=5m\nOnUnitActiveSec=30m\nPersistent=true\n\n[Install]\nWantedBy=timers.target\n`,
+  )
+  if (activate) {
+    const reload = spawnSync("systemctl", ["--user", "daemon-reload"], { encoding: "utf8" })
+    if (reload.status !== 0)
+      throw new Error(reload.stderr.trim() || "systemctl daemon-reload failed")
+    const enabled = spawnSync(
+      "systemctl",
+      ["--user", "enable", "--now", "derive-skill-scan.timer"],
+      { encoding: "utf8" },
+    )
+    if (enabled.status !== 0) throw new Error(enabled.stderr.trim() || "systemctl enable failed")
+  }
+  return timer
+}
+
+const installWindowsSchedule = ({ node, cli, activate }) => {
+  const command = `"${node}" "${cli}" skill scan --quiet`
+  if (activate) {
+    const result = spawnSync(
+      "schtasks",
+      ["/Create", "/SC", "MINUTE", "/MO", "30", "/TN", "Derive Skill Scan", "/TR", command, "/F"],
+      { encoding: "utf8" },
+    )
+    if (result.status !== 0) throw new Error(result.stderr.trim() || "schtasks create failed")
+  }
+  return "Task Scheduler: Derive Skill Scan"
+}
+
+export function setupSkillScan(options = {}) {
+  const home = options.home ?? homedir()
+  const node = options.node ?? process.execPath
+  const cli = options.cli ?? process.argv[1]
+  const platform = options.platform ?? process.platform
+  const activate = options.activate ?? true
+  const command = `"${node}" "${cli}" skill scan --quiet`
+  const hooks = [
+    {
+      client: "codex",
+      path: join(home, ".codex", "hooks.json"),
+    },
+    {
+      client: "claude",
+      path: join(home, ".claude", "settings.json"),
+    },
+  ].map((target) => ({ ...target, changed: addSessionEndHook(target.path, command) }))
+
+  let schedule = null
+  if (options.schedule) {
+    if (platform === "darwin") schedule = installMacSchedule({ home, node, cli, activate })
+    else if (platform === "linux") schedule = installLinuxSchedule({ home, node, cli, activate })
+    else if (platform === "win32") schedule = installWindowsSchedule({ node, cli, activate })
+    else throw new Error(`automatic schedule is not supported on ${platform}`)
+  }
+  return { hooks, schedule }
+}

--- a/packages/cli/src/skill-scan.js
+++ b/packages/cli/src/skill-scan.js
@@ -291,7 +291,16 @@ export async function scanSkillLogs(options = {}) {
       state.sources[source.path] = { identity, offset: stats.size, client: source.client }
       continue
     }
-    const context = { session: basename(source.path, ".jsonl"), turn: null }
+    // A session header is normally written once, before later turns. Keep the
+    // parser context beside the byte offset so an incremental scan can attribute
+    // a newly appended tool call to that same session and turn.
+    const context =
+      start > 0 && saved?.identity === identity
+        ? {
+            session: saved.session ?? basename(source.path, ".jsonl"),
+            turn: saved.turn ?? null,
+          }
+        : { session: basename(source.path, ".jsonl"), turn: null }
     const clientInstalls = installs.filter((install) => install.client === source.client)
     const end = await completeLines(source.path, start, async (lineBytes) => {
       coverage[source.client].records_scanned++
@@ -317,7 +326,13 @@ export async function scanSkillLogs(options = {}) {
     })
     const sessionHash = hash(["derive-skill-session-v1", source.client, context.session].join("\0"))
     state.sessions[source.client][sessionHash] = new Date(stats.mtimeMs).toISOString()
-    state.sources[source.path] = { identity, offset: end, client: source.client }
+    state.sources[source.path] = {
+      identity,
+      offset: end,
+      client: source.client,
+      session: context.session,
+      turn: context.turn,
+    }
   }
 
   const cutoff = now - 90 * 86_400_000

--- a/packages/cli/src/skill-scan.js
+++ b/packages/cli/src/skill-scan.js
@@ -1,0 +1,427 @@
+import { createHash, randomBytes } from "node:crypto"
+import {
+  createReadStream,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from "node:fs"
+import { homedir } from "node:os"
+import { basename, dirname, join, resolve } from "node:path"
+
+export const SKILL_SCAN_PARSER_VERSION = 1
+
+const configRoot = () => process.env.DERIVE_CONFIG_DIR ?? join(homedir(), ".config", "derive")
+const installsPath = () => join(configRoot(), "skill-installs.json")
+const scanStatePath = () => join(configRoot(), "skill-scan.json")
+const spoolPath = () => join(configRoot(), "skill-scan-spool.json")
+
+const readJson = (path, fallback) => {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"))
+  } catch {
+    return fallback
+  }
+}
+
+const writeJson = (path, value) => {
+  mkdirSync(dirname(path), { recursive: true })
+  const temporary = `${path}.${process.pid}.${randomBytes(5).toString("hex")}.tmp`
+  writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 })
+  renameSync(temporary, path)
+}
+
+const hash = (value) => createHash("sha256").update(value).digest("hex")
+
+const installKey = (install) =>
+  [install.server, install.workspace_id ?? "", install.client, resolve(install.path)].join("\0")
+
+export function listSkillInstalls() {
+  const data = readJson(installsPath(), { version: 1, installs: [] })
+  return Array.isArray(data.installs) ? data.installs.filter((item) => !item.removed_at) : []
+}
+
+export function recordSkillInstall(install) {
+  const data = readJson(installsPath(), { version: 1, installs: [] })
+  const installs = Array.isArray(data.installs) ? data.installs : []
+  const normalized = {
+    id: install.id,
+    version: install.version,
+    name: install.name,
+    client: install.client,
+    path: resolve(install.path),
+    digest: install.digest,
+    scope: install.scope,
+    server: install.server,
+    workspace_id: install.workspaceId ?? null,
+    account_id: install.accountId ?? null,
+    updated_at: new Date().toISOString(),
+  }
+  const key = installKey(normalized)
+  const next = installs.filter((item) => installKey(item) !== key)
+  next.push(normalized)
+  writeJson(installsPath(), { version: 1, installs: next })
+  return normalized
+}
+
+export function removeSkillInstall({ client, path, server, workspaceId }) {
+  const data = readJson(installsPath(), { version: 1, installs: [] })
+  const target = resolve(path)
+  const now = new Date().toISOString()
+  const installs = (Array.isArray(data.installs) ? data.installs : []).map((item) =>
+    item.client === client &&
+    resolve(item.path) === target &&
+    item.server === server &&
+    (item.workspace_id ?? null) === (workspaceId ?? null)
+      ? { ...item, removed_at: now, updated_at: now }
+      : item,
+  )
+  writeJson(installsPath(), { version: 1, installs })
+}
+
+export function parseSince(value, now = Date.now()) {
+  if (!value) return null
+  const relative = /^(\d+)([mhdw])$/.exec(String(value).trim())
+  if (relative) {
+    const unit = { m: 60_000, h: 3_600_000, d: 86_400_000, w: 604_800_000 }[relative[2]]
+    return now - Number(relative[1]) * unit
+  }
+  const absolute = Date.parse(value)
+  if (!Number.isFinite(absolute)) throw new Error("--since must be an ISO date or a value like 30d")
+  return absolute
+}
+
+const walk = (root, suffix) => {
+  if (!existsSync(root)) return []
+  const found = []
+  const pending = [root]
+  while (pending.length) {
+    const dir = pending.pop()
+    let entries = []
+    try {
+      entries = readdirSync(dir, { withFileTypes: true })
+    } catch {
+      continue
+    }
+    for (const entry of entries) {
+      const path = join(dir, entry.name)
+      if (entry.isDirectory()) pending.push(path)
+      else if (entry.isFile() && entry.name.endsWith(suffix)) found.push(path)
+    }
+  }
+  return found
+}
+
+export function discoverSkillLogSources(home = homedir()) {
+  return [
+    ...walk(join(home, ".codex", "sessions"), ".jsonl").map((path) => ({ client: "codex", path })),
+    ...walk(join(home, ".codex", "archived_sessions"), ".jsonl").map((path) => ({
+      client: "codex",
+      path,
+    })),
+    ...walk(join(home, ".claude", "projects"), ".jsonl").map((path) => ({
+      client: "claude",
+      path,
+    })),
+  ]
+}
+
+const installAliases = (install) => {
+  const dir = basename(install.path).toLowerCase()
+  const name = String(install.name ?? "")
+    .replace(/^\//, "")
+    .toLowerCase()
+  return new Set([dir, name].filter(Boolean))
+}
+
+const codexPatterns = (install) => {
+  const path = resolve(install.path).replaceAll("\\", "/").toLowerCase()
+  const dir = basename(path)
+  return [`${path}/skill.md`, `.agents/skills/${dir}/skill.md`, `.codex/skills/${dir}/skill.md`]
+}
+
+const timestampOf = (record) => {
+  const value = record?.timestamp ?? record?.created_at ?? record?.payload?.timestamp
+  const parsed = typeof value === "string" ? Date.parse(value) : Number.NaN
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : null
+}
+
+const sourceIdentity = (stats) => `${stats.dev}:${stats.ino}`
+
+const completeLines = async (path, start, onLine) => {
+  let carry = Buffer.alloc(0)
+  let consumed = start
+  for await (const chunk of createReadStream(path, { start })) {
+    const bytes = carry.length ? Buffer.concat([carry, chunk]) : chunk
+    let lineStart = 0
+    let index = bytes.indexOf(10, lineStart)
+    while (index !== -1) {
+      const line = bytes.subarray(lineStart, index)
+      consumed += index + 1 - lineStart
+      lineStart = index + 1
+      if (line.length) await onLine(line)
+      index = bytes.indexOf(10, lineStart)
+    }
+    carry = bytes.subarray(lineStart)
+  }
+  return consumed
+}
+
+const eventFor = ({ install, client, session, turn, occurredAt, evidence }) => ({
+  event_id: hash(["derive-skill-scan-v1", client, session, turn, install.id].join("\0")),
+  skill_short_id: install.id,
+  skill_version: install.version,
+  ...(install.digest ? { skill_digest: install.digest } : {}),
+  client,
+  stage: "loaded",
+  evidence,
+  opaque_session_id: hash(["derive-skill-session-v1", client, session].join("\0")),
+  occurred_at: occurredAt ?? new Date().toISOString(),
+  target: {
+    server: install.server,
+    workspace_id: install.workspace_id ?? null,
+    account_id: install.account_id ?? null,
+  },
+})
+
+const parseClaudeLine = (record, context, installs, sinceMs) => {
+  if (record?.type === "user") context.turn = record.promptId ?? record.uuid ?? context.turn
+  const attribution =
+    typeof record?.attributionSkill === "string"
+      ? record.attributionSkill.replace(/^\//, "").toLowerCase()
+      : null
+  if (!attribution) return []
+  const occurredAt = timestampOf(record)
+  if (sinceMs !== null && occurredAt && Date.parse(occurredAt) < sinceMs) return []
+  return installs
+    .filter((install) => installAliases(install).has(attribution))
+    .map((install) =>
+      eventFor({
+        install,
+        client: "claude",
+        session: record.sessionId ?? context.session,
+        turn: context.turn ?? record.parentUuid ?? record.uuid,
+        occurredAt,
+        evidence: "structured_log",
+      }),
+    )
+}
+
+const codexToolText = (payload) => {
+  if (!payload || !["function_call", "custom_tool_call"].includes(payload.type)) return ""
+  const value = payload.arguments ?? payload.input
+  return typeof value === "string" ? value.toLowerCase() : JSON.stringify(value ?? "").toLowerCase()
+}
+
+const parseCodexLine = (record, context, installs, sinceMs) => {
+  const payload = record?.payload
+  if (record?.type === "turn_context" && payload?.turn_id) context.turn = payload.turn_id
+  if (record?.type === "session_meta" && payload?.id) context.session = payload.id
+  if (record?.type === "event_msg" && payload?.turn_id) context.turn = payload.turn_id
+  const text = record?.type === "response_item" ? codexToolText(payload) : ""
+  if (!text) return []
+  const occurredAt = timestampOf(record)
+  if (sinceMs !== null && occurredAt && Date.parse(occurredAt) < sinceMs) return []
+  return installs
+    .filter((install) => codexPatterns(install).some((pattern) => text.includes(pattern)))
+    .map((install) =>
+      eventFor({
+        install,
+        client: "codex",
+        session: context.session,
+        turn: context.turn ?? payload.call_id ?? payload.id,
+        occurredAt,
+        evidence: "skill_file_read",
+      }),
+    )
+}
+
+const defaultState = () => ({
+  version: 1,
+  parser_version: SKILL_SCAN_PARSER_VERSION,
+  sources: {},
+  sessions: { claude: {}, codex: {} },
+  last_scan_at: null,
+})
+
+const targetKey = (target) =>
+  [target.server, target.workspace_id ?? "", target.account_id ?? ""].join("\0")
+
+export async function scanSkillLogs(options = {}) {
+  const home = options.home ?? homedir()
+  const now = options.now ?? Date.now()
+  const sinceMs = parseSince(options.since, now)
+  const installs = (options.installs ?? listSkillInstalls()).filter(
+    (item) => !options.client || item.client === options.client,
+  )
+  const state = readJson(scanStatePath(), defaultState())
+  state.sources ??= {}
+  state.sessions ??= { claude: {}, codex: {} }
+  state.sessions.claude ??= {}
+  state.sessions.codex ??= {}
+  const sources = (options.sources ?? discoverSkillLogSources(home)).filter(
+    (item) => !options.client || item.client === options.client,
+  )
+  const events = new Map()
+  const coverage = {
+    claude: { client: "claude", source_files: 0, records_scanned: 0, matched_events: 0 },
+    codex: { client: "codex", source_files: 0, records_scanned: 0, matched_events: 0 },
+  }
+
+  for (const source of sources) {
+    let stats
+    try {
+      stats = statSync(source.path)
+    } catch {
+      continue
+    }
+    if (sinceMs !== null && stats.mtimeMs < sinceMs) continue
+    const identity = sourceIdentity(stats)
+    const saved = state.sources[source.path]
+    let start = 0
+    if (sinceMs === null) {
+      if (saved?.identity === identity && saved.offset <= stats.size) start = saved.offset
+      else if (options.baseline) start = stats.size
+    }
+    coverage[source.client].source_files++
+    if (start === stats.size) {
+      state.sources[source.path] = { identity, offset: stats.size, client: source.client }
+      continue
+    }
+    const context = { session: basename(source.path, ".jsonl"), turn: null }
+    const clientInstalls = installs.filter((install) => install.client === source.client)
+    const end = await completeLines(source.path, start, async (lineBytes) => {
+      coverage[source.client].records_scanned++
+      const relevant =
+        source.client === "claude"
+          ? lineBytes.includes('"attributionSkill"') || lineBytes.includes('"type":"user"')
+          : lineBytes.includes('"type":"session_meta"') ||
+            lineBytes.includes('"type":"turn_context"') ||
+            lineBytes.includes("SKILL.md") ||
+            lineBytes.includes("skill.md")
+      if (!relevant) return
+      let record
+      try {
+        record = JSON.parse(lineBytes.toString("utf8").replace(/\r$/, ""))
+      } catch {
+        return
+      }
+      const found =
+        source.client === "claude"
+          ? parseClaudeLine(record, context, clientInstalls, sinceMs)
+          : parseCodexLine(record, context, clientInstalls, sinceMs)
+      for (const event of found) events.set(event.event_id, event)
+    })
+    const sessionHash = hash(["derive-skill-session-v1", source.client, context.session].join("\0"))
+    state.sessions[source.client][sessionHash] = new Date(stats.mtimeMs).toISOString()
+    state.sources[source.path] = { identity, offset: end, client: source.client }
+  }
+
+  const cutoff = now - 90 * 86_400_000
+  for (const client of ["claude", "codex"])
+    for (const [session, seenAt] of Object.entries(state.sessions[client]))
+      if (Date.parse(seenAt) < cutoff) delete state.sessions[client][session]
+
+  for (const event of events.values()) coverage[event.client].matched_events++
+  const scannedAt = new Date(now).toISOString()
+  const coverageRows = Object.values(coverage)
+    .filter((row) => row.source_files > 0)
+    .map((row) => ({
+      ...row,
+      sessions_scanned: Object.keys(state.sessions[row.client]).length,
+      parser_version: SKILL_SCAN_PARSER_VERSION,
+      scanned_at: scannedAt,
+    }))
+  state.parser_version = SKILL_SCAN_PARSER_VERSION
+  state.last_scan_at = scannedAt
+
+  if (!options.dryRun) writeJson(scanStatePath(), state)
+  return { events: [...events.values()], coverage: coverageRows, state, sources }
+}
+
+export function addToSkillScanSpool(events, coverage) {
+  const spool = readJson(spoolPath(), { version: 1, pending: [], coverage: [] })
+  const pending = new Map((spool.pending ?? []).map((event) => [event.event_id, event]))
+  for (const event of events) pending.set(event.event_id, event)
+  const coverageByClient = new Map((spool.coverage ?? []).map((row) => [row.client, row]))
+  for (const row of coverage) coverageByClient.set(row.client, row)
+  const next = {
+    version: 1,
+    pending: [...pending.values()],
+    coverage: [...coverageByClient.values()],
+  }
+  writeJson(spoolPath(), next)
+  return next
+}
+
+export function readSkillScanSpool() {
+  return readJson(spoolPath(), { version: 1, pending: [], coverage: [] })
+}
+
+export function removeFromSkillScanSpool(eventIds, clients = []) {
+  const spool = readSkillScanSpool()
+  const sent = new Set(eventIds)
+  const covered = new Set(clients)
+  const next = {
+    version: 1,
+    pending: (spool.pending ?? []).filter((event) => !sent.has(event.event_id)),
+    coverage: (spool.coverage ?? []).filter((row) => !covered.has(row.client)),
+  }
+  writeJson(spoolPath(), next)
+  return next
+}
+
+export function skillScanStatus(home = homedir()) {
+  const state = readJson(scanStatePath(), defaultState())
+  const spool = readSkillScanSpool()
+  const sources = discoverSkillLogSources(home)
+  return {
+    parser_version: SKILL_SCAN_PARSER_VERSION,
+    last_scan_at: state.last_scan_at ?? null,
+    installs: listSkillInstalls().length,
+    pending: spool.pending?.length ?? 0,
+    sources: ["claude", "codex"].map((client) => ({
+      client,
+      files: sources.filter((item) => item.client === client).length,
+      tracked: Object.values(state.sources ?? {}).filter((item) => item.client === client).length,
+      sessions_90d: Object.keys(state.sessions?.[client] ?? {}).length,
+    })),
+  }
+}
+
+export function groupSkillScanSpool(spool, installs = listSkillInstalls()) {
+  const groups = new Map()
+  for (const install of installs) {
+    const target = {
+      server: install.server,
+      workspace_id: install.workspace_id ?? null,
+      account_id: install.account_id ?? null,
+    }
+    const key = targetKey(target)
+    if (!groups.has(key)) groups.set(key, { target, events: [], coverage: [] })
+  }
+  for (const event of spool.pending ?? []) {
+    const key = targetKey(event.target)
+    const group = groups.get(key) ?? { target: event.target, events: [], coverage: [] }
+    group.events.push(event)
+    groups.set(key, group)
+  }
+  for (const row of spool.coverage ?? []) {
+    // Coverage belongs to every target with an install for this client.
+    for (const [key, group] of groups) {
+      const hasClient = installs.some((install) => {
+        const target = {
+          server: install.server,
+          workspace_id: install.workspace_id ?? null,
+          account_id: install.account_id ?? null,
+        }
+        return targetKey(target) === key && install.client === row.client
+      })
+      if (hasClient) group.coverage.push(row)
+    }
+  }
+  return [...groups.values()].filter((group) => group.events.length || group.coverage.length)
+}

--- a/packages/cli/src/skill-scan.js
+++ b/packages/cli/src/skill-scan.js
@@ -358,7 +358,7 @@ export async function scanSkillLogs(options = {}) {
 }
 
 export function addToSkillScanSpool(events, coverage) {
-  const spool = readJson(spoolPath(), { version: 1, pending: [], coverage: [] })
+  const spool = readSkillScanSpool()
   const pending = new Map((spool.pending ?? []).map((event) => [event.event_id, event]))
   for (const event of events) pending.set(event.event_id, event)
   const coverageByClient = new Map((spool.coverage ?? []).map((row) => [row.client, row]))
@@ -373,7 +373,21 @@ export function addToSkillScanSpool(events, coverage) {
 }
 
 export function readSkillScanSpool() {
-  return readJson(spoolPath(), { version: 1, pending: [], coverage: [] })
+  const path = spoolPath()
+  try {
+    const spool = JSON.parse(readFileSync(path, "utf8"))
+    if (
+      !spool ||
+      typeof spool !== "object" ||
+      !Array.isArray(spool.pending) ||
+      !Array.isArray(spool.coverage)
+    )
+      throw new Error("expected pending and coverage arrays")
+    return spool
+  } catch (error) {
+    if (error?.code === "ENOENT") return { version: 1, pending: [], coverage: [] }
+    throw new Error(`cannot read Skill scan spool at ${path}: ${error.message}`)
+  }
 }
 
 export function removeFromSkillScanSpool(eventIds, clients = []) {

--- a/packages/cli/test/skill-sync-all.test.js
+++ b/packages/cli/test/skill-sync-all.test.js
@@ -137,3 +137,76 @@ describe("derive skill sync --all", () => {
     })
   })
 })
+
+describe("derive skill used", () => {
+  it("reports the pinned version and can rate the same event", async () => {
+    const receipts = []
+    const server = http.createServer((request, response) => {
+      const send = (status, value) => {
+        response.writeHead(status, { "content-type": "application/json" })
+        response.end(JSON.stringify(value))
+      }
+      if (request.url === "/v1/artifacts/review-skill/skill-usage" && request.method === "POST") {
+        let body = ""
+        request.on("data", (chunk) => (body += chunk))
+        request.on("end", () => {
+          receipts.push(JSON.parse(body))
+          send(200, { ok: true })
+        })
+        return
+      }
+      send(404, { error: "not found" })
+    })
+    servers.push(server)
+    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve))
+    const base = `http://127.0.0.1:${server.address().port}`
+    const project = mkdtempSync(join(tmpdir(), "derive-skill-used-"))
+    dirs.push(project)
+    writeFileSync(
+      join(project, "derive.json"),
+      JSON.stringify({
+        skills: [
+          {
+            id: "review-skill",
+            version: 4,
+            name: "Review",
+            installs: { codex: { version: 4, name: "Review" } },
+          },
+        ],
+      }),
+    )
+
+    const first = await run(project, base, [
+      "skill",
+      "used",
+      "review-skill",
+      "--client",
+      "codex",
+      "--event",
+      "dogfood-event-1",
+    ])
+    const rated = await run(project, base, [
+      "skill",
+      "used",
+      "review-skill",
+      "--client",
+      "codex",
+      "--event",
+      "dogfood-event-1",
+      "--useful",
+      "yes",
+    ])
+
+    expect(first).toMatchObject({ status: 0 })
+    expect(first.stdout).toContain("Review @v4 used by codex")
+    expect(receipts).toHaveLength(2)
+    expect(receipts[0]).not.toHaveProperty("useful")
+    expect(receipts[1]).toMatchObject({
+      event_id: "dogfood-event-1",
+      skill_version: 4,
+      client: "codex",
+      useful: true,
+    })
+    expect(rated.status).toBe(0)
+  })
+})

--- a/packages/cli/test/skill-sync-all.test.js
+++ b/packages/cli/test/skill-sync-all.test.js
@@ -5,7 +5,7 @@ import http from "node:http"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, describe, expect, it } from "vitest"
-import { recordSkillInstall, scanSkillLogs } from "../src/skill-scan.js"
+import { addToSkillScanSpool, recordSkillInstall, scanSkillLogs } from "../src/skill-scan.js"
 import { setupSkillScan } from "../src/skill-scan-setup.js"
 
 const dirs = []
@@ -587,5 +587,20 @@ describe("derive skill scan", () => {
     expect(
       JSON.parse(readFileSync(join(config, "skill-scan-spool.json"), "utf8")).pending,
     ).toHaveLength(1)
+  })
+
+  it("does not overwrite a malformed receipt spool", () => {
+    const root = mkdtempSync(join(tmpdir(), "derive-skill-scan-spool-"))
+    dirs.push(root)
+    const priorConfig = process.env.DERIVE_CONFIG_DIR
+    process.env.DERIVE_CONFIG_DIR = root
+    try {
+      writeFileSync(join(root, "skill-scan-spool.json"), "{broken")
+      expect(() => addToSkillScanSpool([], [])).toThrow("cannot read Skill scan spool")
+      expect(readFileSync(join(root, "skill-scan-spool.json"), "utf8")).toBe("{broken")
+    } finally {
+      if (priorConfig === undefined) delete process.env.DERIVE_CONFIG_DIR
+      else process.env.DERIVE_CONFIG_DIR = priorConfig
+    }
   })
 })

--- a/packages/cli/test/skill-sync-all.test.js
+++ b/packages/cli/test/skill-sync-all.test.js
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process"
+import { createHash } from "node:crypto"
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import http from "node:http"
 import { tmpdir } from "node:os"
@@ -334,6 +335,68 @@ describe("derive skill scan", () => {
     }
   })
 
+  it("keeps Codex session context across an incremental append", async () => {
+    const root = mkdtempSync(join(tmpdir(), "derive-skill-scan-context-"))
+    dirs.push(root)
+    const home = join(root, "home")
+    const config = join(root, "config")
+    const priorConfig = process.env.DERIVE_CONFIG_DIR
+    process.env.DERIVE_CONFIG_DIR = config
+    try {
+      const skillPath = join(home, ".codex", "skills", "review-skill")
+      recordSkillInstall({
+        id: "review123",
+        version: 4,
+        name: "review-skill",
+        client: "codex",
+        path: skillPath,
+        digest: "a".repeat(64),
+        scope: "personal",
+        server: "https://derive.test",
+        workspaceId: "workspace-test",
+        accountId: "account-test",
+      })
+      const log = join(home, ".codex", "sessions", "rollout.jsonl")
+      mkdirSync(join(home, ".codex", "sessions"), { recursive: true })
+      writeFileSync(
+        log,
+        `${JSON.stringify({
+          type: "session_meta",
+          timestamp: "2026-09-05T12:00:00.000Z",
+          payload: { id: "session-a" },
+        })}\n${JSON.stringify({
+          type: "turn_context",
+          timestamp: "2026-09-05T12:01:00.000Z",
+          payload: { turn_id: "turn-a" },
+        })}\n`,
+      )
+      expect((await scanSkillLogs({ home })).events).toEqual([])
+      writeFileSync(
+        log,
+        `${JSON.stringify({
+          type: "response_item",
+          timestamp: "2026-09-05T12:01:01.000Z",
+          payload: {
+            type: "function_call",
+            call_id: "call-a",
+            arguments: JSON.stringify({ cmd: `cat ${skillPath}/SKILL.md` }),
+          },
+        })}\n`,
+        { flag: "a" },
+      )
+      const result = await scanSkillLogs({ home })
+      expect(result.events).toHaveLength(1)
+      expect(result.events[0].opaque_session_id).toBe(
+        createHash("sha256")
+          .update(["derive-skill-session-v1", "codex", "session-a"].join("\0"))
+          .digest("hex"),
+      )
+    } finally {
+      if (priorConfig === undefined) delete process.env.DERIVE_CONFIG_DIR
+      else process.env.DERIVE_CONFIG_DIR = priorConfig
+    }
+  })
+
   it("installs idempotent session-end hooks and a macOS schedule", () => {
     const root = mkdtempSync(join(tmpdir(), "derive-skill-scan-setup-"))
     dirs.push(root)
@@ -362,6 +425,39 @@ describe("derive skill scan", () => {
     expect(second.hooks.every((hook) => !hook.changed)).toBe(true)
     expect(JSON.parse(readFileSync(codexHooks, "utf8"))).toMatchObject({ description: "keep me" })
     expect(readFileSync(first.schedule, "utf8")).toContain("to.derive.skill-scan")
+  })
+
+  it("limits setup hooks and schedules to the selected client", () => {
+    const root = mkdtempSync(join(tmpdir(), "derive-skill-scan-client-"))
+    dirs.push(root)
+    const setup = setupSkillScan({
+      home: root,
+      node: "/usr/bin/node",
+      cli: "/usr/local/bin/derive",
+      platform: "darwin",
+      client: "codex",
+      schedule: true,
+      activate: false,
+    })
+
+    expect(setup.hooks).toHaveLength(1)
+    expect(setup.hooks[0].client).toBe("codex")
+    expect(existsSync(join(root, ".claude", "settings.json"))).toBe(false)
+    expect(readFileSync(join(root, ".codex", "hooks.json"), "utf8")).toContain("--client codex")
+    expect(readFileSync(setup.schedule, "utf8")).toContain(
+      "<string>--client</string><string>codex</string>",
+    )
+  })
+
+  it("does not install hooks when scheduling is unsupported", () => {
+    const root = mkdtempSync(join(tmpdir(), "derive-skill-scan-unsupported-"))
+    dirs.push(root)
+
+    expect(() =>
+      setupSkillScan({ home: root, platform: "freebsd", schedule: true, activate: false }),
+    ).toThrow("automatic schedule is not supported on freebsd")
+    expect(existsSync(join(root, ".codex", "hooks.json"))).toBe(false)
+    expect(existsSync(join(root, ".claude", "settings.json"))).toBe(false)
   })
 
   it("uploads scanned receipts and coverage as one batch", async () => {

--- a/packages/cli/test/skill-sync-all.test.js
+++ b/packages/cli/test/skill-sync-all.test.js
@@ -535,4 +535,57 @@ describe("derive skill scan", () => {
       coverage: [expect.objectContaining({ client: "claude", sessions_scanned: 1 })],
     })
   })
+
+  it("keeps a nonzero status for a quiet failed upload", async () => {
+    const project = mkdtempSync(join(tmpdir(), "derive-skill-scan-quiet-failure-"))
+    dirs.push(project)
+    const home = join(project, "home")
+    const config = join(project, ".derive-test-config")
+    const skillPath = join(home, ".claude", "skills", "review-skill")
+    mkdirSync(config, { recursive: true })
+    writeFileSync(
+      join(config, "skill-installs.json"),
+      JSON.stringify({
+        version: 1,
+        installs: [
+          {
+            id: "review123",
+            version: 4,
+            name: "review-skill",
+            client: "claude",
+            path: skillPath,
+            scope: "personal",
+            server: "https://derive.test",
+            workspace_id: null,
+            account_id: null,
+          },
+        ],
+      }),
+    )
+    const log = join(home, ".claude", "projects", "project-a", "session-a.jsonl")
+    mkdirSync(join(home, ".claude", "projects", "project-a"), { recursive: true })
+    writeFileSync(
+      log,
+      `${JSON.stringify({
+        type: "assistant",
+        timestamp: new Date().toISOString(),
+        sessionId: "session-a",
+        attributionSkill: "review-skill",
+      })}\n`,
+    )
+
+    const child = spawn(
+      process.execPath,
+      [join(import.meta.dirname, "..", "bin", "derive.js"), "skill", "scan", "--quiet"],
+      {
+        cwd: project,
+        env: { PATH: process.env.PATH, HOME: home, DERIVE_CONFIG_DIR: config },
+      },
+    )
+    const status = await new Promise((resolve) => child.on("close", resolve))
+    expect(status).toBe(1)
+    expect(
+      JSON.parse(readFileSync(join(config, "skill-scan-spool.json"), "utf8")).pending,
+    ).toHaveLength(1)
+  })
 })

--- a/packages/cli/test/skill-sync-all.test.js
+++ b/packages/cli/test/skill-sync-all.test.js
@@ -1,9 +1,11 @@
 import { spawn } from "node:child_process"
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import http from "node:http"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, describe, expect, it } from "vitest"
+import { recordSkillInstall, scanSkillLogs } from "../src/skill-scan.js"
+import { setupSkillScan } from "../src/skill-scan-setup.js"
 
 const dirs = []
 const servers = []
@@ -13,12 +15,20 @@ afterEach(async () => {
   for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true })
 })
 
-const run = (cwd, server, args) =>
+const run = (cwd, server, args, extraEnv = {}) =>
   new Promise((resolve) => {
     const child = spawn(
       process.execPath,
       [join(import.meta.dirname, "..", "bin", "derive.js"), ...args, "--server", server],
-      { cwd, env: { ...process.env, DERIVE_TOKEN: "test-token" } },
+      {
+        cwd,
+        env: {
+          ...process.env,
+          DERIVE_TOKEN: "test-token",
+          DERIVE_CONFIG_DIR: join(cwd, ".derive-test-config"),
+          ...extraEnv,
+        },
+      },
     )
     let stdout = ""
     let stderr = ""
@@ -208,5 +218,225 @@ describe("derive skill used", () => {
       useful: true,
     })
     expect(rated.status).toBe(0)
+  })
+})
+
+describe("derive skill scan", () => {
+  it("finds structured Claude attribution and Codex Skill file reads incrementally", async () => {
+    const root = mkdtempSync(join(tmpdir(), "derive-skill-scan-"))
+    dirs.push(root)
+    const home = join(root, "home")
+    const config = join(root, "config")
+    const priorConfig = process.env.DERIVE_CONFIG_DIR
+    process.env.DERIVE_CONFIG_DIR = config
+    try {
+      const codexSkill = join(home, ".codex", "skills", "review-skill")
+      const claudeSkill = join(home, ".claude", "skills", "review-skill")
+      recordSkillInstall({
+        id: "review123",
+        version: 4,
+        name: "review-skill",
+        client: "codex",
+        path: codexSkill,
+        digest: "a".repeat(64),
+        scope: "personal",
+        server: "https://derive.test",
+        workspaceId: "workspace-test",
+        accountId: "account-test",
+      })
+      recordSkillInstall({
+        id: "review123",
+        version: 4,
+        name: "review-skill",
+        client: "claude",
+        path: claudeSkill,
+        digest: "a".repeat(64),
+        scope: "personal",
+        server: "https://derive.test",
+        workspaceId: "workspace-test",
+        accountId: "account-test",
+      })
+
+      const codexLog = join(home, ".codex", "sessions", "rollout-session-a.jsonl")
+      mkdirSync(join(home, ".codex", "sessions"), { recursive: true })
+      writeFileSync(
+        codexLog,
+        `${[
+          {
+            type: "session_meta",
+            timestamp: "2026-09-05T12:00:00.000Z",
+            payload: { id: "session-a" },
+          },
+          {
+            type: "turn_context",
+            timestamp: "2026-09-05T12:01:00.000Z",
+            payload: { turn_id: "turn-a" },
+          },
+          {
+            type: "response_item",
+            timestamp: "2026-09-05T12:01:01.000Z",
+            payload: {
+              type: "function_call",
+              name: "exec_command",
+              call_id: "call-a",
+              arguments: JSON.stringify({ cmd: `cat ${codexSkill}/SKILL.md` }),
+            },
+          },
+        ]
+          .map((row) => JSON.stringify(row))
+          .join("\n")}\n`,
+      )
+      const claudeLog = join(home, ".claude", "projects", "project-a", "session-b.jsonl")
+      mkdirSync(join(home, ".claude", "projects", "project-a"), { recursive: true })
+      writeFileSync(
+        claudeLog,
+        `${[
+          {
+            type: "user",
+            timestamp: "2026-09-05T12:02:00.000Z",
+            sessionId: "session-b",
+            promptId: "prompt-b",
+          },
+          {
+            type: "assistant",
+            timestamp: "2026-09-05T12:02:01.000Z",
+            sessionId: "session-b",
+            attributionSkill: "review-skill",
+          },
+        ]
+          .map((row) => JSON.stringify(row))
+          .join("\n")}\n`,
+      )
+
+      const first = await scanSkillLogs({ home, since: "30d", now: Date.parse("2026-09-06") })
+      expect(first.events).toHaveLength(2)
+      expect(first.events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            client: "codex",
+            evidence: "skill_file_read",
+            stage: "loaded",
+          }),
+          expect.objectContaining({
+            client: "claude",
+            evidence: "structured_log",
+            stage: "loaded",
+          }),
+        ]),
+      )
+      expect(first.events.every((event) => !JSON.stringify(event).includes(home))).toBe(true)
+
+      const second = await scanSkillLogs({ home, now: Date.parse("2026-09-06") })
+      expect(second.events).toEqual([])
+    } finally {
+      if (priorConfig === undefined) delete process.env.DERIVE_CONFIG_DIR
+      else process.env.DERIVE_CONFIG_DIR = priorConfig
+    }
+  })
+
+  it("installs idempotent session-end hooks and a macOS schedule", () => {
+    const root = mkdtempSync(join(tmpdir(), "derive-skill-scan-setup-"))
+    dirs.push(root)
+    const codexHooks = join(root, ".codex", "hooks.json")
+    mkdirSync(join(root, ".codex"), { recursive: true })
+    writeFileSync(codexHooks, JSON.stringify({ description: "keep me" }))
+
+    const first = setupSkillScan({
+      home: root,
+      node: "/usr/bin/node",
+      cli: "/usr/local/bin/derive",
+      platform: "darwin",
+      schedule: true,
+      activate: false,
+    })
+    const second = setupSkillScan({
+      home: root,
+      node: "/usr/bin/node",
+      cli: "/usr/local/bin/derive",
+      platform: "darwin",
+      schedule: true,
+      activate: false,
+    })
+
+    expect(first.hooks.every((hook) => hook.changed)).toBe(true)
+    expect(second.hooks.every((hook) => !hook.changed)).toBe(true)
+    expect(JSON.parse(readFileSync(codexHooks, "utf8"))).toMatchObject({ description: "keep me" })
+    expect(readFileSync(first.schedule, "utf8")).toContain("to.derive.skill-scan")
+  })
+
+  it("uploads scanned receipts and coverage as one batch", async () => {
+    const received = []
+    const server = http.createServer((request, response) => {
+      if (request.url === "/v1/skill-usage/batch" && request.method === "POST") {
+        let body = ""
+        request.on("data", (chunk) => (body += chunk))
+        request.on("end", () => {
+          received.push(JSON.parse(body))
+          response.writeHead(200, { "content-type": "application/json" })
+          response.end(JSON.stringify({ recorded: 1, coverage: 1 }))
+        })
+        return
+      }
+      response.writeHead(404, { "content-type": "application/json" })
+      response.end(JSON.stringify({ error: "not found" }))
+    })
+    servers.push(server)
+    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve))
+    const base = `http://127.0.0.1:${server.address().port}`
+    const project = mkdtempSync(join(tmpdir(), "derive-skill-scan-cli-"))
+    dirs.push(project)
+    const home = join(project, "home")
+    const config = join(project, ".derive-test-config")
+    const skillPath = join(home, ".claude", "skills", "review-skill")
+    mkdirSync(config, { recursive: true })
+    writeFileSync(
+      join(config, "skill-installs.json"),
+      JSON.stringify({
+        version: 1,
+        installs: [
+          {
+            id: "review123",
+            version: 4,
+            name: "review-skill",
+            client: "claude",
+            path: skillPath,
+            digest: "a".repeat(64),
+            scope: "personal",
+            server: base,
+            workspace_id: null,
+            account_id: null,
+            updated_at: "2026-09-05T12:00:00.000Z",
+          },
+        ],
+      }),
+    )
+    const log = join(home, ".claude", "projects", "project-a", "session-a.jsonl")
+    mkdirSync(join(home, ".claude", "projects", "project-a"), { recursive: true })
+    writeFileSync(
+      log,
+      `${JSON.stringify({
+        type: "assistant",
+        timestamp: new Date().toISOString(),
+        sessionId: "session-a",
+        attributionSkill: "review-skill",
+      })}\n`,
+    )
+
+    const result = await run(project, base, ["skill", "scan", "--since", "30d", "--json"], {
+      HOME: home,
+    })
+    expect(result.status).toBe(0)
+    expect(JSON.parse(result.stdout)).toMatchObject({ found: 1, uploaded: 1, pending: 0 })
+    expect(received).toHaveLength(1)
+    expect(received[0]).toMatchObject({
+      uses: [
+        expect.objectContaining({
+          skill_short_id: "review123",
+          client: "claude",
+          evidence: "structured_log",
+        }),
+      ],
+      coverage: [expect.objectContaining({ client: "claude", sessions_scanned: 1 })],
+    })
   })
 })

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -2419,6 +2419,7 @@ export type SkillRelationKind = "requires" | "extends" | "recommends" | "referen
 export type SkillClient = "claude" | "codex"
 export type SkillInstallScope = "project" | "personal" | "runner"
 export type SkillInstallPolicy = "pinned" | "latest"
+export type SkillUseClient = "claude" | "codex" | "other"
 export type ArtifactSkillRole =
   | "created"
   | "revised"
@@ -2480,6 +2481,42 @@ export interface NewSkillInstallation {
   removed_at?: string | null
 }
 
+export interface SkillUseRecord {
+  id: string
+  event_id: string
+  org_id: string
+  skill_artifact_id: string
+  skill_version: number
+  used_by: string
+  client: SkillUseClient
+  useful: number | null
+  occurred_at: string
+  updated_at: string
+}
+
+export interface NewSkillUse {
+  id: string
+  event_id: string
+  org_id: string
+  skill_artifact_id: string
+  skill_version: number
+  used_by: string
+  client: SkillUseClient
+  useful?: number | null
+  occurred_at: string
+  updated_at: string
+}
+
+export interface SkillLocalUsageBucket {
+  skill_version: number
+  client: SkillUseClient
+  count: number
+  useful: number
+  not_useful: number
+  unrated: number
+  last_used_at: string
+}
+
 export interface ArtifactSkillLinkRecord {
   id: string
   org_id: string
@@ -2521,6 +2558,8 @@ export interface SkillStore {
   listSkillRelations(skillArtifactId: string, orgId: string): Promise<SkillRelationRecord[]>
   upsertSkillInstallation(installation: NewSkillInstallation): Promise<SkillInstallationRecord>
   listSkillInstallations(skillArtifactId: string, orgId: string): Promise<SkillInstallationRecord[]>
+  recordSkillUse(use: NewSkillUse): Promise<SkillUseRecord>
+  skillLocalUsage(skillArtifactId: string, orgId: string): Promise<SkillLocalUsageBucket[]>
   linkArtifactSkill(link: NewArtifactSkillLink): Promise<ArtifactSkillLinkRecord>
   listArtifactSkillLinks(
     artifactId: string,

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -2420,6 +2420,8 @@ export type SkillClient = "claude" | "codex"
 export type SkillInstallScope = "project" | "personal" | "runner"
 export type SkillInstallPolicy = "pinned" | "latest"
 export type SkillUseClient = "claude" | "codex" | "other"
+export type SkillUseStage = "selected" | "loaded" | "acted" | "completed"
+export type SkillUseEvidence = "native_hook" | "structured_log" | "skill_file_read" | "claimed"
 export type ArtifactSkillRole =
   | "created"
   | "revised"
@@ -2489,6 +2491,10 @@ export interface SkillUseRecord {
   skill_version: number
   used_by: string
   client: SkillUseClient
+  stage: SkillUseStage
+  evidence: SkillUseEvidence
+  skill_digest: string | null
+  opaque_session_id: string | null
   useful: number | null
   occurred_at: string
   updated_at: string
@@ -2502,6 +2508,10 @@ export interface NewSkillUse {
   skill_version: number
   used_by: string
   client: SkillUseClient
+  stage: SkillUseStage
+  evidence: SkillUseEvidence
+  skill_digest?: string | null
+  opaque_session_id?: string | null
   useful?: number | null
   occurred_at: string
   updated_at: string
@@ -2510,12 +2520,29 @@ export interface NewSkillUse {
 export interface SkillLocalUsageBucket {
   skill_version: number
   client: SkillUseClient
+  stage: SkillUseStage
+  evidence: SkillUseEvidence
   count: number
   useful: number
   not_useful: number
   unrated: number
   last_used_at: string
 }
+
+export interface SkillScanCoverageRecord {
+  id: string
+  org_id: string
+  scanned_by: string
+  client: SkillUseClient
+  source_files: number
+  sessions_scanned: number
+  records_scanned: number
+  parser_version: number
+  scanned_at: string
+  updated_at: string
+}
+
+export type NewSkillScanCoverage = SkillScanCoverageRecord
 
 export interface ArtifactSkillLinkRecord {
   id: string
@@ -2560,6 +2587,8 @@ export interface SkillStore {
   listSkillInstallations(skillArtifactId: string, orgId: string): Promise<SkillInstallationRecord[]>
   recordSkillUse(use: NewSkillUse): Promise<SkillUseRecord>
   skillLocalUsage(skillArtifactId: string, orgId: string): Promise<SkillLocalUsageBucket[]>
+  upsertSkillScanCoverage(coverage: NewSkillScanCoverage): Promise<SkillScanCoverageRecord>
+  listSkillScanCoverage(orgId: string): Promise<SkillScanCoverageRecord[]>
   linkArtifactSkill(link: NewArtifactSkillLink): Promise<ArtifactSkillLinkRecord>
   listArtifactSkillLinks(
     artifactId: string,

--- a/packages/db/src/parity.ts
+++ b/packages/db/src/parity.ts
@@ -49,6 +49,7 @@ import type {
   SignupAttributionRecord,
   SkillInstallationRecord,
   SkillRelationRecord,
+  SkillUseRecord,
   SubscriptionRecord,
   TemplateLibraryEntryRecord,
   TemplateLibraryRecord,
@@ -89,6 +90,7 @@ export interface TypedTables {
   workflowStepAttempt: WorkflowStepAttemptRecord
   skillRelation: SkillRelationRecord
   skillInstallation: SkillInstallationRecord
+  skillUse: SkillUseRecord
   artifactSkillLink: ArtifactSkillLinkRecord
   plan: PlanRecord
   connection: ConnectionRecord

--- a/packages/db/src/parity.ts
+++ b/packages/db/src/parity.ts
@@ -49,6 +49,7 @@ import type {
   SignupAttributionRecord,
   SkillInstallationRecord,
   SkillRelationRecord,
+  SkillScanCoverageRecord,
   SkillUseRecord,
   SubscriptionRecord,
   TemplateLibraryEntryRecord,
@@ -91,6 +92,7 @@ export interface TypedTables {
   skillRelation: SkillRelationRecord
   skillInstallation: SkillInstallationRecord
   skillUse: SkillUseRecord
+  skillScanCoverage: SkillScanCoverageRecord
   artifactSkillLink: ArtifactSkillLinkRecord
   plan: PlanRecord
   connection: ConnectionRecord

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -32,6 +32,7 @@ import type {
   SkillInstallPolicy,
   SkillInstallScope,
   SkillRelationKind,
+  SkillUseClient,
   SlackAuthorFilter,
   SlackScopeKind,
   SlackThreadSurface,
@@ -443,6 +444,26 @@ export const skillInstallation = pgTable(
       t.client,
     ),
     index("skill_installation_skill").on(t.org_id, t.skill_artifact_id, t.updated_at),
+  ],
+)
+
+export const skillUse = pgTable(
+  "skill_use",
+  {
+    id: text("id").primaryKey(),
+    event_id: text("event_id").notNull(),
+    org_id: text("org_id").notNull(),
+    skill_artifact_id: text("skill_artifact_id").notNull(),
+    skill_version: integer("skill_version").notNull(),
+    used_by: text("used_by").notNull(),
+    client: text("client").$type<SkillUseClient>().notNull(),
+    useful: integer("useful"),
+    occurred_at: text("occurred_at").notNull(),
+    updated_at: text("updated_at").notNull(),
+  },
+  (t) => [
+    uniqueIndex("skill_use_event").on(t.org_id, t.skill_artifact_id, t.used_by, t.event_id),
+    index("skill_use_skill").on(t.org_id, t.skill_artifact_id, t.occurred_at),
   ],
 )
 
@@ -1238,6 +1259,7 @@ const TABLES = [
   workflowStepAttempt,
   skillRelation,
   skillInstallation,
+  skillUse,
   artifactSkillLink,
   plan,
   connection,

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -33,6 +33,8 @@ import type {
   SkillInstallScope,
   SkillRelationKind,
   SkillUseClient,
+  SkillUseEvidence,
+  SkillUseStage,
   SlackAuthorFilter,
   SlackScopeKind,
   SlackThreadSurface,
@@ -457,6 +459,10 @@ export const skillUse = pgTable(
     skill_version: integer("skill_version").notNull(),
     used_by: text("used_by").notNull(),
     client: text("client").$type<SkillUseClient>().notNull(),
+    stage: text("stage").$type<SkillUseStage>().notNull().default("completed"),
+    evidence: text("evidence").$type<SkillUseEvidence>().notNull().default("claimed"),
+    skill_digest: text("skill_digest"),
+    opaque_session_id: text("opaque_session_id"),
     useful: integer("useful"),
     occurred_at: text("occurred_at").notNull(),
     updated_at: text("updated_at").notNull(),
@@ -464,6 +470,26 @@ export const skillUse = pgTable(
   (t) => [
     uniqueIndex("skill_use_event").on(t.org_id, t.skill_artifact_id, t.used_by, t.event_id),
     index("skill_use_skill").on(t.org_id, t.skill_artifact_id, t.occurred_at),
+  ],
+)
+
+export const skillScanCoverage = pgTable(
+  "skill_scan_coverage",
+  {
+    id: text("id").primaryKey(),
+    org_id: text("org_id").notNull(),
+    scanned_by: text("scanned_by").notNull(),
+    client: text("client").$type<SkillUseClient>().notNull(),
+    source_files: integer("source_files").notNull(),
+    sessions_scanned: integer("sessions_scanned").notNull(),
+    records_scanned: integer("records_scanned").notNull(),
+    parser_version: integer("parser_version").notNull(),
+    scanned_at: text("scanned_at").notNull(),
+    updated_at: text("updated_at").notNull(),
+  },
+  (t) => [
+    uniqueIndex("skill_scan_coverage_actor").on(t.org_id, t.scanned_by, t.client),
+    index("skill_scan_coverage_workspace").on(t.org_id, t.scanned_at),
   ],
 )
 
@@ -1259,6 +1285,7 @@ const TABLES = [
   workflowStepAttempt,
   skillRelation,
   skillInstallation,
+  skillScanCoverage,
   skillUse,
   artifactSkillLink,
   plan,

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -82,6 +82,7 @@ import type {
   NewSignupAttribution,
   NewSkillInstallation,
   NewSkillRelation,
+  NewSkillUse,
   NewSlackSubscription,
   NewTemplateLibrary,
   NewTemplateLibraryEntry,
@@ -116,8 +117,10 @@ import type {
   SharedStateWrite,
   SignupAttributionRecord,
   SkillInstallationRecord,
+  SkillLocalUsageBucket,
   SkillRelationRecord,
   SkillUsageBucket,
+  SkillUseRecord,
   SlackAuthorFilter,
   SlackInstallRecord,
   SlackSubscriptionRecord,
@@ -234,6 +237,7 @@ import {
   signupAttribution,
   skillInstallation,
   skillRelation,
+  skillUse,
   slackInstall,
   slackSubscription,
   slackThreadLink,
@@ -293,6 +297,7 @@ export const schema = {
   workflowStepAttempt,
   skillRelation,
   skillInstallation,
+  skillUse,
   artifactSkillLink,
   plan,
   connection,
@@ -349,6 +354,7 @@ const _schemaShapes: Shapes<typeof schema> = {
   workflowStepAttempt: true,
   skillRelation: true,
   skillInstallation: true,
+  skillUse: true,
   artifactSkillLink: true,
   plan: true,
   connection: true,
@@ -6000,6 +6006,36 @@ export class PgMetaStore implements MetaStore {
         ),
       )
       .orderBy(desc(skillInstallation.updated_at), asc(skillInstallation.client))
+  }
+  async recordSkillUse(use: NewSkillUse): Promise<SkillUseRecord> {
+    const rows = await this.db
+      .insert(skillUse)
+      .values(use)
+      .onConflictDoUpdate({
+        target: [skillUse.org_id, skillUse.skill_artifact_id, skillUse.used_by, skillUse.event_id],
+        set: {
+          ...(use.useful !== undefined ? { useful: use.useful } : {}),
+          updated_at: use.updated_at,
+        },
+      })
+      .returning()
+    return one(rows)
+  }
+  skillLocalUsage(skillArtifactId: string, orgId: string): Promise<SkillLocalUsageBucket[]> {
+    return this.db
+      .select({
+        skill_version: skillUse.skill_version,
+        client: skillUse.client,
+        count: count(),
+        useful: sql<number>`cast(sum(case when ${skillUse.useful} = 1 then 1 else 0 end) as integer)`,
+        not_useful: sql<number>`cast(sum(case when ${skillUse.useful} = 0 then 1 else 0 end) as integer)`,
+        unrated: sql<number>`cast(sum(case when ${skillUse.useful} is null then 1 else 0 end) as integer)`,
+        last_used_at: max(skillUse.occurred_at),
+      })
+      .from(skillUse)
+      .where(and(eq(skillUse.org_id, orgId), eq(skillUse.skill_artifact_id, skillArtifactId)))
+      .groupBy(skillUse.skill_version, skillUse.client)
+      .orderBy(desc(max(skillUse.occurred_at))) as Promise<SkillLocalUsageBucket[]>
   }
   async linkArtifactSkill(link: NewArtifactSkillLink): Promise<ArtifactSkillLinkRecord> {
     const rows = await this.db

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -82,6 +82,7 @@ import type {
   NewSignupAttribution,
   NewSkillInstallation,
   NewSkillRelation,
+  NewSkillScanCoverage,
   NewSkillUse,
   NewSlackSubscription,
   NewTemplateLibrary,
@@ -119,6 +120,7 @@ import type {
   SkillInstallationRecord,
   SkillLocalUsageBucket,
   SkillRelationRecord,
+  SkillScanCoverageRecord,
   SkillUsageBucket,
   SkillUseRecord,
   SlackAuthorFilter,
@@ -237,6 +239,7 @@ import {
   signupAttribution,
   skillInstallation,
   skillRelation,
+  skillScanCoverage,
   skillUse,
   slackInstall,
   slackSubscription,
@@ -297,6 +300,7 @@ export const schema = {
   workflowStepAttempt,
   skillRelation,
   skillInstallation,
+  skillScanCoverage,
   skillUse,
   artifactSkillLink,
   plan,
@@ -354,6 +358,7 @@ const _schemaShapes: Shapes<typeof schema> = {
   workflowStepAttempt: true,
   skillRelation: true,
   skillInstallation: true,
+  skillScanCoverage: true,
   skillUse: true,
   artifactSkillLink: true,
   plan: true,
@@ -6014,7 +6019,12 @@ export class PgMetaStore implements MetaStore {
       .onConflictDoUpdate({
         target: [skillUse.org_id, skillUse.skill_artifact_id, skillUse.used_by, skillUse.event_id],
         set: {
+          stage: use.stage,
+          evidence: use.evidence,
+          skill_digest: use.skill_digest ?? null,
+          opaque_session_id: use.opaque_session_id ?? null,
           ...(use.useful !== undefined ? { useful: use.useful } : {}),
+          occurred_at: use.occurred_at,
           updated_at: use.updated_at,
         },
       })
@@ -6026,6 +6036,8 @@ export class PgMetaStore implements MetaStore {
       .select({
         skill_version: skillUse.skill_version,
         client: skillUse.client,
+        stage: skillUse.stage,
+        evidence: skillUse.evidence,
         count: count(),
         useful: sql<number>`cast(sum(case when ${skillUse.useful} = 1 then 1 else 0 end) as integer)`,
         not_useful: sql<number>`cast(sum(case when ${skillUse.useful} = 0 then 1 else 0 end) as integer)`,
@@ -6034,8 +6046,33 @@ export class PgMetaStore implements MetaStore {
       })
       .from(skillUse)
       .where(and(eq(skillUse.org_id, orgId), eq(skillUse.skill_artifact_id, skillArtifactId)))
-      .groupBy(skillUse.skill_version, skillUse.client)
+      .groupBy(skillUse.skill_version, skillUse.client, skillUse.stage, skillUse.evidence)
       .orderBy(desc(max(skillUse.occurred_at))) as Promise<SkillLocalUsageBucket[]>
+  }
+  async upsertSkillScanCoverage(coverage: NewSkillScanCoverage): Promise<SkillScanCoverageRecord> {
+    const rows = await this.db
+      .insert(skillScanCoverage)
+      .values(coverage)
+      .onConflictDoUpdate({
+        target: [skillScanCoverage.org_id, skillScanCoverage.scanned_by, skillScanCoverage.client],
+        set: {
+          source_files: coverage.source_files,
+          sessions_scanned: coverage.sessions_scanned,
+          records_scanned: coverage.records_scanned,
+          parser_version: coverage.parser_version,
+          scanned_at: coverage.scanned_at,
+          updated_at: coverage.updated_at,
+        },
+      })
+      .returning()
+    return one(rows)
+  }
+  listSkillScanCoverage(orgId: string): Promise<SkillScanCoverageRecord[]> {
+    return this.db
+      .select()
+      .from(skillScanCoverage)
+      .where(eq(skillScanCoverage.org_id, orgId))
+      .orderBy(desc(skillScanCoverage.scanned_at)) as Promise<SkillScanCoverageRecord[]>
   }
   async linkArtifactSkill(link: NewArtifactSkillLink): Promise<ArtifactSkillLinkRecord> {
     const rows = await this.db

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -73,6 +73,7 @@ import type {
   NewSignupAttribution,
   NewSkillInstallation,
   NewSkillRelation,
+  NewSkillUse,
   NewSlackSubscription,
   NewTemplateLibrary,
   NewTemplateLibraryEntry,
@@ -104,8 +105,10 @@ import type {
   SharedStateWrite,
   SignupAttributionRecord,
   SkillInstallationRecord,
+  SkillLocalUsageBucket,
   SkillRelationRecord,
   SkillUsageBucket,
+  SkillUseRecord,
   SlackAuthorFilter,
   SlackInstallRecord,
   SlackSubscriptionRecord,
@@ -220,6 +223,7 @@ import {
   signupAttribution,
   skillInstallation,
   skillRelation,
+  skillUse,
   slackInstall,
   slackSubscription,
   slackThreadLink,
@@ -415,6 +419,7 @@ export const schema = {
   workflowStepAttempt,
   skillRelation,
   skillInstallation,
+  skillUse,
   artifactSkillLink,
   plan,
   connection,
@@ -471,6 +476,7 @@ const _schemaShapes: Shapes<typeof schema> = {
   workflowStepAttempt: true,
   skillRelation: true,
   skillInstallation: true,
+  skillUse: true,
   artifactSkillLink: true,
   plan: true,
   connection: true,
@@ -4816,6 +4822,38 @@ export function makeRepos(db: SqliteDb) {
       )
       .orderBy(desc(skillInstallation.updated_at), asc(skillInstallation.client))
       .all()) as SkillInstallationRecord[]
+  const recordSkillUse = async (use: NewSkillUse): Promise<SkillUseRecord> =>
+    (await db
+      .insert(skillUse)
+      .values(use)
+      .onConflictDoUpdate({
+        target: [skillUse.org_id, skillUse.skill_artifact_id, skillUse.used_by, skillUse.event_id],
+        set: {
+          ...(use.useful !== undefined ? { useful: use.useful } : {}),
+          updated_at: use.updated_at,
+        },
+      })
+      .returning()
+      .get()) as SkillUseRecord
+  const skillLocalUsage = async (
+    skillArtifactId: string,
+    orgId: string,
+  ): Promise<SkillLocalUsageBucket[]> =>
+    (await db
+      .select({
+        skill_version: skillUse.skill_version,
+        client: skillUse.client,
+        count: sql<number>`count(*)`,
+        useful: sql<number>`sum(case when ${skillUse.useful} = 1 then 1 else 0 end)`,
+        not_useful: sql<number>`sum(case when ${skillUse.useful} = 0 then 1 else 0 end)`,
+        unrated: sql<number>`sum(case when ${skillUse.useful} is null then 1 else 0 end)`,
+        last_used_at: sql<string>`max(${skillUse.occurred_at})`,
+      })
+      .from(skillUse)
+      .where(and(eq(skillUse.org_id, orgId), eq(skillUse.skill_artifact_id, skillArtifactId)))
+      .groupBy(skillUse.skill_version, skillUse.client)
+      .orderBy(desc(sql`max(${skillUse.occurred_at})`))
+      .all()) as SkillLocalUsageBucket[]
   const linkArtifactSkill = async (link: NewArtifactSkillLink): Promise<ArtifactSkillLinkRecord> =>
     (await db
       .insert(artifactSkillLink)
@@ -5631,6 +5669,7 @@ export function makeRepos(db: SqliteDb) {
       .where(or(eq(skillRelation.source_artifact_id, id), eq(skillRelation.target_artifact_id, id)))
       .run()
     await db.delete(skillInstallation).where(eq(skillInstallation.skill_artifact_id, id)).run()
+    await db.delete(skillUse).where(eq(skillUse.skill_artifact_id, id)).run()
     await db
       .delete(artifactSkillLink)
       .where(or(eq(artifactSkillLink.artifact_id, id), eq(artifactSkillLink.skill_artifact_id, id)))
@@ -6032,6 +6071,8 @@ export function makeRepos(db: SqliteDb) {
     listSkillRelations,
     upsertSkillInstallation,
     listSkillInstallations,
+    recordSkillUse,
+    skillLocalUsage,
     linkArtifactSkill,
     listArtifactSkillLinks,
     listArtifactSkillLinkHistory,

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -73,6 +73,7 @@ import type {
   NewSignupAttribution,
   NewSkillInstallation,
   NewSkillRelation,
+  NewSkillScanCoverage,
   NewSkillUse,
   NewSlackSubscription,
   NewTemplateLibrary,
@@ -107,6 +108,7 @@ import type {
   SkillInstallationRecord,
   SkillLocalUsageBucket,
   SkillRelationRecord,
+  SkillScanCoverageRecord,
   SkillUsageBucket,
   SkillUseRecord,
   SlackAuthorFilter,
@@ -223,6 +225,7 @@ import {
   signupAttribution,
   skillInstallation,
   skillRelation,
+  skillScanCoverage,
   skillUse,
   slackInstall,
   slackSubscription,
@@ -419,6 +422,7 @@ export const schema = {
   workflowStepAttempt,
   skillRelation,
   skillInstallation,
+  skillScanCoverage,
   skillUse,
   artifactSkillLink,
   plan,
@@ -476,6 +480,7 @@ const _schemaShapes: Shapes<typeof schema> = {
   workflowStepAttempt: true,
   skillRelation: true,
   skillInstallation: true,
+  skillScanCoverage: true,
   skillUse: true,
   artifactSkillLink: true,
   plan: true,
@@ -4829,7 +4834,12 @@ export function makeRepos(db: SqliteDb) {
       .onConflictDoUpdate({
         target: [skillUse.org_id, skillUse.skill_artifact_id, skillUse.used_by, skillUse.event_id],
         set: {
+          stage: use.stage,
+          evidence: use.evidence,
+          skill_digest: use.skill_digest ?? null,
+          opaque_session_id: use.opaque_session_id ?? null,
           ...(use.useful !== undefined ? { useful: use.useful } : {}),
+          occurred_at: use.occurred_at,
           updated_at: use.updated_at,
         },
       })
@@ -4843,6 +4853,8 @@ export function makeRepos(db: SqliteDb) {
       .select({
         skill_version: skillUse.skill_version,
         client: skillUse.client,
+        stage: skillUse.stage,
+        evidence: skillUse.evidence,
         count: sql<number>`count(*)`,
         useful: sql<number>`sum(case when ${skillUse.useful} = 1 then 1 else 0 end)`,
         not_useful: sql<number>`sum(case when ${skillUse.useful} = 0 then 1 else 0 end)`,
@@ -4851,9 +4863,35 @@ export function makeRepos(db: SqliteDb) {
       })
       .from(skillUse)
       .where(and(eq(skillUse.org_id, orgId), eq(skillUse.skill_artifact_id, skillArtifactId)))
-      .groupBy(skillUse.skill_version, skillUse.client)
+      .groupBy(skillUse.skill_version, skillUse.client, skillUse.stage, skillUse.evidence)
       .orderBy(desc(sql`max(${skillUse.occurred_at})`))
       .all()) as SkillLocalUsageBucket[]
+  const upsertSkillScanCoverage = async (
+    coverage: NewSkillScanCoverage,
+  ): Promise<SkillScanCoverageRecord> =>
+    (await db
+      .insert(skillScanCoverage)
+      .values(coverage)
+      .onConflictDoUpdate({
+        target: [skillScanCoverage.org_id, skillScanCoverage.scanned_by, skillScanCoverage.client],
+        set: {
+          source_files: coverage.source_files,
+          sessions_scanned: coverage.sessions_scanned,
+          records_scanned: coverage.records_scanned,
+          parser_version: coverage.parser_version,
+          scanned_at: coverage.scanned_at,
+          updated_at: coverage.updated_at,
+        },
+      })
+      .returning()
+      .get()) as SkillScanCoverageRecord
+  const listSkillScanCoverage = async (orgId: string): Promise<SkillScanCoverageRecord[]> =>
+    (await db
+      .select()
+      .from(skillScanCoverage)
+      .where(eq(skillScanCoverage.org_id, orgId))
+      .orderBy(desc(skillScanCoverage.scanned_at))
+      .all()) as SkillScanCoverageRecord[]
   const linkArtifactSkill = async (link: NewArtifactSkillLink): Promise<ArtifactSkillLinkRecord> =>
     (await db
       .insert(artifactSkillLink)
@@ -6073,6 +6111,8 @@ export function makeRepos(db: SqliteDb) {
     listSkillInstallations,
     recordSkillUse,
     skillLocalUsage,
+    upsertSkillScanCoverage,
+    listSkillScanCoverage,
     linkArtifactSkill,
     listArtifactSkillLinks,
     listArtifactSkillLinkHistory,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -32,6 +32,7 @@ import type {
   SkillInstallPolicy,
   SkillInstallScope,
   SkillRelationKind,
+  SkillUseClient,
   SlackAuthorFilter,
   SlackScopeKind,
   SlackThreadSurface,
@@ -506,6 +507,28 @@ export const skillInstallation = sqliteTable(
       t.client,
     ),
     index("skill_installation_skill").on(t.org_id, t.skill_artifact_id, t.updated_at),
+  ],
+)
+
+// A local client reports one row per real invocation. The caller owns event_id, so retries
+// update optional feedback instead of inflating the count. No prompt or filesystem path lands here.
+export const skillUse = sqliteTable(
+  "skill_use",
+  {
+    id: text("id").primaryKey(),
+    event_id: text("event_id").notNull(),
+    org_id: text("org_id").notNull(),
+    skill_artifact_id: text("skill_artifact_id").notNull(),
+    skill_version: integer("skill_version").notNull(),
+    used_by: text("used_by").notNull(),
+    client: text("client").$type<SkillUseClient>().notNull(),
+    useful: integer("useful"),
+    occurred_at: text("occurred_at").notNull(),
+    updated_at: text("updated_at").notNull(),
+  },
+  (t) => [
+    uniqueIndex("skill_use_event").on(t.org_id, t.skill_artifact_id, t.used_by, t.event_id),
+    index("skill_use_skill").on(t.org_id, t.skill_artifact_id, t.occurred_at),
   ],
 )
 
@@ -1458,6 +1481,7 @@ const TABLES = [
   workflowStepAttempt,
   skillRelation,
   skillInstallation,
+  skillUse,
   artifactSkillLink,
   plan,
   connection,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -33,6 +33,8 @@ import type {
   SkillInstallScope,
   SkillRelationKind,
   SkillUseClient,
+  SkillUseEvidence,
+  SkillUseStage,
   SlackAuthorFilter,
   SlackScopeKind,
   SlackThreadSurface,
@@ -522,6 +524,10 @@ export const skillUse = sqliteTable(
     skill_version: integer("skill_version").notNull(),
     used_by: text("used_by").notNull(),
     client: text("client").$type<SkillUseClient>().notNull(),
+    stage: text("stage").$type<SkillUseStage>().notNull().default("completed"),
+    evidence: text("evidence").$type<SkillUseEvidence>().notNull().default("claimed"),
+    skill_digest: text("skill_digest"),
+    opaque_session_id: text("opaque_session_id"),
     useful: integer("useful"),
     occurred_at: text("occurred_at").notNull(),
     updated_at: text("updated_at").notNull(),
@@ -529,6 +535,26 @@ export const skillUse = sqliteTable(
   (t) => [
     uniqueIndex("skill_use_event").on(t.org_id, t.skill_artifact_id, t.used_by, t.event_id),
     index("skill_use_skill").on(t.org_id, t.skill_artifact_id, t.occurred_at),
+  ],
+)
+
+export const skillScanCoverage = sqliteTable(
+  "skill_scan_coverage",
+  {
+    id: text("id").primaryKey(),
+    org_id: text("org_id").notNull(),
+    scanned_by: text("scanned_by").notNull(),
+    client: text("client").$type<SkillUseClient>().notNull(),
+    source_files: integer("source_files").notNull(),
+    sessions_scanned: integer("sessions_scanned").notNull(),
+    records_scanned: integer("records_scanned").notNull(),
+    parser_version: integer("parser_version").notNull(),
+    scanned_at: text("scanned_at").notNull(),
+    updated_at: text("updated_at").notNull(),
+  },
+  (t) => [
+    uniqueIndex("skill_scan_coverage_actor").on(t.org_id, t.scanned_by, t.client),
+    index("skill_scan_coverage_workspace").on(t.org_id, t.scanned_at),
   ],
 )
 
@@ -1481,6 +1507,7 @@ const TABLES = [
   workflowStepAttempt,
   skillRelation,
   skillInstallation,
+  skillScanCoverage,
   skillUse,
   artifactSkillLink,
   plan,

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -3491,6 +3491,61 @@ export function runStoreContract(
       ])
     })
 
+    it("deduplicates observed Skill use and stores scan coverage", async () => {
+      const skill = await store.createArtifact(newArtifact({ kind: "bundle" }))
+      const use = {
+        id: uuid(),
+        event_id: "scan-event-1",
+        org_id: ORG,
+        skill_artifact_id: skill.id,
+        skill_version: 2,
+        used_by: "u1",
+        client: "claude" as const,
+        stage: "loaded" as const,
+        evidence: "structured_log" as const,
+        skill_digest: "a".repeat(64),
+        opaque_session_id: "b".repeat(64),
+        occurred_at: "2026-09-05T20:00:00.000Z",
+        updated_at: "2026-09-05T20:00:00.000Z",
+      }
+      await store.recordSkillUse(use)
+      await store.recordSkillUse({ ...use, id: uuid(), useful: 1 })
+      expect(await store.skillLocalUsage(skill.id, ORG)).toMatchObject([
+        {
+          skill_version: 2,
+          client: "claude",
+          stage: "loaded",
+          evidence: "structured_log",
+          count: 1,
+          useful: 1,
+        },
+      ])
+
+      const coverage = {
+        id: uuid(),
+        org_id: ORG,
+        scanned_by: "u1",
+        client: "claude" as const,
+        source_files: 4,
+        sessions_scanned: 4,
+        records_scanned: 200,
+        parser_version: 1,
+        scanned_at: "2026-09-05T20:01:00.000Z",
+        updated_at: "2026-09-05T20:01:00.000Z",
+      }
+      await store.upsertSkillScanCoverage(coverage)
+      await store.upsertSkillScanCoverage({
+        ...coverage,
+        id: uuid(),
+        sessions_scanned: 5,
+        updated_at: "2026-09-05T20:02:00.000Z",
+      })
+      expect(await store.listSkillScanCoverage(ORG)).toMatchObject([
+        { client: "claude", sessions_scanned: 5 },
+      ])
+      expect(await store.listSkillScanCoverage(`org_${uuid()}`)).toEqual([])
+    })
+
     it("derives exact Context and Workflow usage and keeps Artifact provenance deterministic", async () => {
       const skill = await store.createArtifact(newArtifact({ kind: "bundle" }))
       await store.addVersion(skill.id, newVersion({ content_type: "derive/skill" }))


### PR DESCRIPTION
Derive can publish and install Skills, but local agent runs do not produce dependable usage data. This change adds explicit receipts and a private local scanner for Codex and Claude logs.

`derive skill scan` reads only appended log bytes. It emits one idempotent receipt when Claude records a Skill attribution or Codex reads a known installed `SKILL.md`. It uploads the Skill version, client, evidence type, stage, event time, and opaque session hash. It never uploads prompts, responses, tool arguments, file contents, repository paths, or user names.

`derive skill scan setup` installs asynchronous `SessionEnd` command hooks. `--schedule` adds an optional 30-minute OS fallback. Neither path calls an LLM. Failed uploads remain in a local spool. The Skill page shows evidence and scan coverage.

A seven-day dogfood scan read 372,000 local records and found six receipts in 7.6 seconds. A normal no-change incremental scan completed in 0.04 seconds.

Validation:

- `pnpm verify`
- `pnpm test:pg`
- 163 CLI tests, including parser, cursor, privacy, setup, and batch upload cases
- SQLite and Postgres store contracts
- API batch receipt and coverage tests

Terra medium deep dogfood:

- Fixed incremental Codex session and turn context
- Fixed client-scoped setup and unsupported-platform partial mutation
- Fixed quiet upload failure exit status
- Fixed malformed-spool overwrite and receipt loss
- 168 CLI tests pass; 34/34 guardrails pass
- Remaining rollout risk: explicit historical backfills are unbounded across large log directories
