### PR TITLE
Batch local skill usage uploads

### DIFF
--- a/packages/cli/bin/derive.js
+++ b/packages/cli/bin/derive.js
@@ -94,6 +94,8 @@ import {
 } from "../src/workflow.js"
 import { runGithubWorkflowHarness } from "../src/workflow-run.js"
 
+const SKILL_USAGE_BATCH_SIZE = 500
+
 const args = process.argv.slice(2)
 const cmd = args.shift()
 
@@ -1481,17 +1483,29 @@ if (cmd === "skill") {
       }
       const deriveClient = new DeriveClient(group.target.server, token)
       try {
-        await deriveClient.call("/v1/skill-usage/batch", {
-          method: "POST",
-          headers: group.target.workspace_id
-            ? { "x-derive-workspace": group.target.workspace_id }
-            : {},
-          body: JSON.stringify({
-            uses: group.events.map(({ target: _target, ...event }) => event),
-            coverage: group.coverage,
-          }),
-        })
-        sentIds.push(...group.events.map((event) => event.event_id))
+        const batches = group.events.length
+          ? Array.from(
+              { length: Math.ceil(group.events.length / SKILL_USAGE_BATCH_SIZE) },
+              (_, index) =>
+                group.events.slice(
+                  index * SKILL_USAGE_BATCH_SIZE,
+                  (index + 1) * SKILL_USAGE_BATCH_SIZE,
+                ),
+            )
+          : [[]]
+        for (const [index, batch] of batches.entries()) {
+          await deriveClient.call("/v1/skill-usage/batch", {
+            method: "POST",
+            headers: group.target.workspace_id
+              ? { "x-derive-workspace": group.target.workspace_id }
+              : {},
+            body: JSON.stringify({
+              uses: batch.map(({ target: _target, ...event }) => event),
+              coverage: index === batches.length - 1 ? group.coverage : [],
+            }),
+          })
+          sentIds.push(...batch.map((event) => event.event_id))
+        }
         for (const row of group.coverage) sentCoverage.add(row.client)
       } catch (error) {
         failed = error.message

--- a/packages/cli/test/skill-sync-all.test.js
+++ b/packages/cli/test/skill-sync-all.test.js
@@ -460,7 +460,7 @@ describe("derive skill scan", () => {
     expect(existsSync(join(root, ".claude", "settings.json"))).toBe(false)
   })
 
-  it("uploads scanned receipts and coverage as one batch", async () => {
+  it("uploads scanned receipts in API-sized batches", async () => {
     const received = []
     const server = http.createServer((request, response) => {
       if (request.url === "/v1/skill-usage/batch" && request.method === "POST") {
@@ -508,32 +508,38 @@ describe("derive skill scan", () => {
     )
     const log = join(home, ".claude", "projects", "project-a", "session-a.jsonl")
     mkdirSync(join(home, ".claude", "projects", "project-a"), { recursive: true })
-    writeFileSync(
-      log,
-      `${JSON.stringify({
+    const records = Array.from({ length: 501 }, (_, index) => [
+      {
+        type: "user",
+        timestamp: new Date().toISOString(),
+        sessionId: "session-a",
+        promptId: `prompt-${index}`,
+      },
+      {
         type: "assistant",
         timestamp: new Date().toISOString(),
         sessionId: "session-a",
         attributionSkill: "review-skill",
-      })}\n`,
-    )
+      },
+    ]).flat()
+    writeFileSync(log, `${records.map((record) => JSON.stringify(record)).join("\n")}\n`)
 
     const result = await run(project, base, ["skill", "scan", "--since", "30d", "--json"], {
       HOME: home,
     })
     expect(result.status).toBe(0)
-    expect(JSON.parse(result.stdout)).toMatchObject({ found: 1, uploaded: 1, pending: 0 })
-    expect(received).toHaveLength(1)
-    expect(received[0]).toMatchObject({
-      uses: [
-        expect.objectContaining({
-          skill_short_id: "review123",
-          client: "claude",
-          evidence: "structured_log",
-        }),
-      ],
-      coverage: [expect.objectContaining({ client: "claude", sessions_scanned: 1 })],
+    expect(JSON.parse(result.stdout)).toMatchObject({ found: 501, uploaded: 501, pending: 0 })
+    expect(received).toHaveLength(2)
+    expect(received.map((batch) => batch.uses.length)).toEqual([500, 1])
+    expect(received[0].coverage).toEqual([])
+    expect(received[0].uses[0]).toMatchObject({
+      skill_short_id: "review123",
+      client: "claude",
+      evidence: "structured_log",
     })
+    expect(received[1].coverage).toEqual([
+      expect.objectContaining({ client: "claude", sessions_scanned: 1 }),
+    ])
   })
 
   it("keeps a nonzero status for a quiet failed upload", async () => {


### PR DESCRIPTION
A 30-day local backfill produced 519 Skill usage receipts, but the API accepts at most 500 uses per request. The CLI now sends each target in batches of 500 and sends coverage only with the final batch, so partial failures keep unsent receipts and coverage in the spool.

Validation: `pnpm verify:affected` (34 guardrails, 196 tests across affected packages).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791305578&installation_model_id=428097&pr_number=893&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F893&signature=2bd83767f88184a439f3fbd089b27b6e6a5864e821b9749cc3de2d4c2b8b39a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->