### PR TITLE
Keep skill scan batches below timeout

### DIFF
--- a/packages/cli/bin/derive.js
+++ b/packages/cli/bin/derive.js
@@ -94,7 +94,7 @@ import {
 } from "../src/workflow.js"
 import { runGithubWorkflowHarness } from "../src/workflow-run.js"
 
-const SKILL_USAGE_BATCH_SIZE = 500
+const SKILL_USAGE_BATCH_SIZE = 20
 
 const args = process.argv.slice(2)
 const cmd = args.shift()

--- a/packages/cli/test/skill-sync-all.test.js
+++ b/packages/cli/test/skill-sync-all.test.js
@@ -529,15 +529,16 @@ describe("derive skill scan", () => {
     })
     expect(result.status).toBe(0)
     expect(JSON.parse(result.stdout)).toMatchObject({ found: 501, uploaded: 501, pending: 0 })
-    expect(received).toHaveLength(2)
-    expect(received.map((batch) => batch.uses.length)).toEqual([500, 1])
+    expect(received).toHaveLength(26)
+    expect(received.slice(0, -1).every((batch) => batch.uses.length === 20)).toBe(true)
+    expect(received.at(-1).uses).toHaveLength(1)
     expect(received[0].coverage).toEqual([])
     expect(received[0].uses[0]).toMatchObject({
       skill_short_id: "review123",
       client: "claude",
       evidence: "structured_log",
     })
-    expect(received[1].coverage).toEqual([
+    expect(received.at(-1).coverage).toEqual([
       expect.objectContaining({ client: "claude", sessions_scanned: 1 }),
     ])
   })


### PR DESCRIPTION
Large local backfills still exceeded the client timeout at 100 receipts per request. The scanner now sends 20 receipts per request. A 519-receipt production backfill completed with this size and cleared the local spool.

Validation: `pnpm verify:affected` (34 guardrails and 196 affected-package tests).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/894"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791306103&installation_model_id=428097&pr_number=894&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F894&signature=026a346724fa463683c954bf1c0cb275d1923d247d17e6ae5906e4acfc81477e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->