### PR TITLE
Count AI artifact opens

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -3577,24 +3577,20 @@
             "properties": {
               "total": {
                 "type": "number",
-                "description": "AI opens across bounded per-reader counters"
+                "description": "AI opens across bounded per-version counters"
               },
               "recent": {
                 "type": "array",
                 "items": {
                   "type": "object",
                   "properties": {
-                    "client": {
-                      "type": "string",
-                      "description": "MCP client or registered agent name"
-                    },
                     "version": {
                       "type": "number",
                       "description": "Artifact version returned"
                     },
                     "opens": {
                       "type": "number",
-                      "description": "Opens by this reader for this version"
+                      "description": "AI opens for this version"
                     },
                     "at": {
                       "type": "string",
@@ -3602,7 +3598,6 @@
                     }
                   },
                   "required": [
-                    "client",
                     "version",
                     "opens",
                     "at"

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -3577,33 +3577,34 @@
             "properties": {
               "total": {
                 "type": "number",
-                "description": "Artifact reads through the Derive MCP read tool"
-              },
-              "last24h": {
-                "type": "number",
-                "description": "MCP reads in the trailing 24 hours"
+                "description": "AI opens across bounded per-reader counters"
               },
               "recent": {
                 "type": "array",
                 "items": {
                   "type": "object",
                   "properties": {
-                    "agent": {
+                    "client": {
                       "type": "string",
-                      "description": "Agent or OAuth client name"
+                      "description": "MCP client or registered agent name"
                     },
                     "version": {
                       "type": "number",
-                      "description": "Artifact version returned to the agent"
+                      "description": "Artifact version returned"
+                    },
+                    "opens": {
+                      "type": "number",
+                      "description": "Opens by this reader for this version"
                     },
                     "at": {
                       "type": "string",
-                      "description": "When that agent last read the artifact"
+                      "description": "Most recent open time (ISO timestamp)"
                     }
                   },
                   "required": [
-                    "agent",
+                    "client",
                     "version",
+                    "opens",
                     "at"
                   ]
                 }
@@ -3611,7 +3612,6 @@
             },
             "required": [
               "total",
-              "last24h",
               "recent"
             ]
           }

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -3571,6 +3571,49 @@
                 "at"
               ]
             }
+          },
+          "agentReads": {
+            "type": "object",
+            "properties": {
+              "total": {
+                "type": "number",
+                "description": "Artifact reads through the Derive MCP read tool"
+              },
+              "last24h": {
+                "type": "number",
+                "description": "MCP reads in the trailing 24 hours"
+              },
+              "recent": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "agent": {
+                      "type": "string",
+                      "description": "Agent or OAuth client name"
+                    },
+                    "version": {
+                      "type": "number",
+                      "description": "Artifact version returned to the agent"
+                    },
+                    "at": {
+                      "type": "string",
+                      "description": "When that agent last read the artifact"
+                    }
+                  },
+                  "required": [
+                    "agent",
+                    "version",
+                    "at"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "total",
+              "last24h",
+              "recent"
+            ]
           }
         },
         "required": [
@@ -3581,7 +3624,8 @@
           "reads",
           "perVersion",
           "daily",
-          "recent"
+          "recent",
+          "agentReads"
         ]
       },
       "Webhook": {

--- a/apps/api/src/mcp-tools/read.ts
+++ b/apps/api/src/mcp-tools/read.ts
@@ -35,6 +35,7 @@ import { boundSources, sourceTools } from "../lib/chat-sources"
 import { clip, MAX_CHARS } from "../lib/clip"
 import { pickVariant, rendersOff } from "../lib/collect-render"
 import { assembleContextPackage } from "../lib/context-package"
+import { sha256 } from "../lib/crypto"
 import { documentStructure } from "../lib/doc-structure-cache"
 import {
   buildFocusIndex,
@@ -238,6 +239,7 @@ export function registerReadTool(tc: ToolContext): void {
     staleNote,
     actingFor,
     agent,
+    clientId,
     ownerId,
     inGrant,
     resolveWs,
@@ -251,17 +253,20 @@ export function registerReadTool(tc: ToolContext): void {
     return documentStructure(v.blob_key, source, contentType)
   }
 
-  // Reuse the browser view ledger with a distinct actor kind. This keeps one retention
-  // path and one analytics query surface. The background helper keeps the write outside
-  // the hosted response path; no model call or observer is involved.
-  const recordAgentRead = (artifact: ArtifactRecord, version: number): void => {
+  // One row per exact version and opaque reader. Repeated opens increment the row,
+  // so observability is a bounded counter rather than an event log. The hosted
+  // response does not wait for this write and no model call is involved.
+  const countAgentOpen = (artifact: ArtifactRecord, version: number): void => {
+    const openedAt = new Date().toISOString()
     ctx.background(
-      ctx.meta.recordView({
-        id: newId("v"),
+      ctx.meta.incrementArtifactRead({
+        id: newId("arc"),
+        org_id: artifact.org_id,
         artifact_id: artifact.id,
-        version,
-        viewer: agent.name,
-        viewer_kind: "agent",
+        artifact_version: version,
+        reader_hash: sha256(`${agent.id}\0${clientId}`),
+        client: agent.name,
+        opened_at: openedAt,
       }),
     )
   }
@@ -459,7 +464,7 @@ export function registerReadTool(tc: ToolContext): void {
         if (r && r.a.current_content_type === SKILL_CONTENT_TYPE) {
           const reading = await skillReading(ctx, r.a)
           if (reading) {
-            recordAgentRead(r.a, r.a.current_version)
+            countAgentOpen(r.a, r.a.current_version)
             return json({
               uri: short_id,
               mimeType: "text/markdown",
@@ -698,7 +703,7 @@ export function registerReadTool(tc: ToolContext): void {
       const v =
         envelope?.artifact.id === a.id ? envelope.version : await ctx.meta.getVersion(a.id, n)
       if (!v) return err(`Version ${n} of "${short_id}" is unavailable.`)
-      recordAgentRead(a, n)
+      countAgentOpen(a, n)
       const url = artifactUrl(ctx.deps.baseUrl, a)
 
       // The render rung: the version's screenshot, so an agent SEES what it shipped.

--- a/apps/api/src/mcp-tools/read.ts
+++ b/apps/api/src/mcp-tools/read.ts
@@ -251,6 +251,21 @@ export function registerReadTool(tc: ToolContext): void {
     return documentStructure(v.blob_key, source, contentType)
   }
 
+  // Reuse the browser view ledger with a distinct actor kind. This keeps one retention
+  // path and one analytics query surface. The background helper keeps the write outside
+  // the hosted response path; no model call or observer is involved.
+  const recordAgentRead = (artifact: ArtifactRecord, version: number): void => {
+    ctx.background(
+      ctx.meta.recordView({
+        id: newId("v"),
+        artifact_id: artifact.id,
+        version,
+        viewer: agent.name,
+        viewer_kind: "agent",
+      }),
+    )
+  }
+
   // READ CONTENT --------------------------------------------------------------
   server.registerTool(
     "read",
@@ -443,7 +458,8 @@ export function registerReadTool(tc: ToolContext): void {
         if (r && "error" in r) return err(r.error)
         if (r && r.a.current_content_type === SKILL_CONTENT_TYPE) {
           const reading = await skillReading(ctx, r.a)
-          if (reading)
+          if (reading) {
+            recordAgentRead(r.a, r.a.current_version)
             return json({
               uri: short_id,
               mimeType: "text/markdown",
@@ -451,6 +467,7 @@ export function registerReadTool(tc: ToolContext): void {
               // 100MB zip upload, and this response has no outline rung to fall to.
               content: clip(reading.body + skillFilesFooter(r.a.short_id, reading.others)),
             })
+          }
         }
         return err(
           `No skill "${name}". Core: ${CORE_SKILLS.map((s) => s.name).join(", ")}; workspace skills: read derive://skills for the catalog.`,
@@ -681,6 +698,7 @@ export function registerReadTool(tc: ToolContext): void {
       const v =
         envelope?.artifact.id === a.id ? envelope.version : await ctx.meta.getVersion(a.id, n)
       if (!v) return err(`Version ${n} of "${short_id}" is unavailable.`)
+      recordAgentRead(a, n)
       const url = artifactUrl(ctx.deps.baseUrl, a)
 
       // The render rung: the version's screenshot, so an agent SEES what it shipped.

--- a/apps/api/src/mcp-tools/read.ts
+++ b/apps/api/src/mcp-tools/read.ts
@@ -35,7 +35,6 @@ import { boundSources, sourceTools } from "../lib/chat-sources"
 import { clip, MAX_CHARS } from "../lib/clip"
 import { pickVariant, rendersOff } from "../lib/collect-render"
 import { assembleContextPackage } from "../lib/context-package"
-import { sha256 } from "../lib/crypto"
 import { documentStructure } from "../lib/doc-structure-cache"
 import {
   buildFocusIndex,
@@ -53,14 +52,14 @@ import type { ToolContext } from "../mcp-tool-context"
 import {
   clipDoc,
   DATA_SERIES_MAX,
-  doc,
   err,
   FULL_DOC_MAX,
   formatLabel,
   historyNotPublic,
   IMAGE_INLINE_MAX,
-  json,
   manifestOf,
+  doc as mcpDoc,
+  json as mcpJson,
   PAGE_MAP_MAX,
   parseLineRange,
   parseVersionRange,
@@ -239,7 +238,6 @@ export function registerReadTool(tc: ToolContext): void {
     staleNote,
     actingFor,
     agent,
-    clientId,
     ownerId,
     inGrant,
     resolveWs,
@@ -253,9 +251,9 @@ export function registerReadTool(tc: ToolContext): void {
     return documentStructure(v.blob_key, source, contentType)
   }
 
-  // One row per exact version and opaque reader. Repeated opens increment the row,
-  // so observability is a bounded counter rather than an event log. The hosted
-  // response does not wait for this write and no model call is involved.
+  // One row per exact version. Repeated opens increment the row, so observability
+  // stays a bounded counter rather than an event log. The hosted response does not
+  // wait for this write and no model call is involved.
   const countAgentOpen = (artifact: ArtifactRecord, version: number): void => {
     const openedAt = new Date().toISOString()
     ctx.background(
@@ -264,8 +262,6 @@ export function registerReadTool(tc: ToolContext): void {
         org_id: artifact.org_id,
         artifact_id: artifact.id,
         artifact_version: version,
-        reader_hash: sha256(`${agent.id}\0${clientId}`),
-        client: agent.name,
         opened_at: openedAt,
       }),
     )
@@ -277,10 +273,8 @@ export function registerReadTool(tc: ToolContext): void {
     {
       description:
         "Read an artifact. Small docs return whole; large docs return an outline. `focus` returns matching parts in one call. `map` then `node` addresses one part. format:'html' gives exact source for publish edits. Also reads contexts and derive:// URIs. Chains: `derive_code`. See derive://skills/finding.",
-      // readOnlyHint stays true despite two incidental write paths below (the lazy
-      // derived-fact backfill and the render self-heal re-queue): both are deterministic
-      // recomputations/cache-fills of already-published bytes — the class of side effect
-      // an HTTP GET tolerates — never a mutation of anything a user authored.
+      // readOnlyHint stays true despite incidental writes below: the usage counter,
+      // lazy derived-fact backfill, and render self-heal never mutate authored content.
       annotations: {
         title: "Read an artifact",
         readOnlyHint: true,
@@ -356,6 +350,21 @@ export function registerReadTool(tc: ToolContext): void {
       },
     },
     async (input) => {
+      let openTarget: { artifact: ArtifactRecord; version: number } | null = null
+      let openCounted = false
+      const countOpen = (): void => {
+        if (!openTarget || openCounted) return
+        countAgentOpen(openTarget.artifact, openTarget.version)
+        openCounted = true
+      }
+      const json = (...args: Parameters<typeof mcpJson>): ReturnType<typeof mcpJson> => {
+        countOpen()
+        return mcpJson(...args)
+      }
+      const doc = (...args: Parameters<typeof mcpDoc>): ReturnType<typeof mcpDoc> => {
+        countOpen()
+        return mcpDoc(...args)
+      }
       const bulkEnvelope = (input as typeof input & { [CODE_READ_ENVELOPE]?: CodeReadEnvelope })[
         CODE_READ_ENVELOPE
       ]
@@ -464,7 +473,7 @@ export function registerReadTool(tc: ToolContext): void {
         if (r && r.a.current_content_type === SKILL_CONTENT_TYPE) {
           const reading = await skillReading(ctx, r.a)
           if (reading) {
-            countAgentOpen(r.a, r.a.current_version)
+            openTarget = { artifact: r.a, version: r.a.current_version }
             return json({
               uri: short_id,
               mimeType: "text/markdown",
@@ -703,7 +712,23 @@ export function registerReadTool(tc: ToolContext): void {
       const v =
         envelope?.artifact.id === a.id ? envelope.version : await ctx.meta.getVersion(a.id, n)
       if (!v) return err(`Version ${n} of "${short_id}" is unavailable.`)
-      countAgentOpen(a, n)
+      // Reject impossible selector combinations before counting the version open.
+      if (render && (section || lines || wantMap || node || focus))
+        return err(
+          "`render` is a view of the whole version — pass it alone (with `version` for history).",
+        )
+      if (data !== undefined && (section || lines || render || focus))
+        return err(
+          "`data` reads a version's stored facts — pass it alone (with `version` for history), not with section/lines/render/focus.",
+        )
+      if (focus && (section || lines || wantMap || node))
+        return err(
+          "Pass `focus` alone (with `format` and `version`), not with another part selector.",
+        )
+      if (wantMap && node) return err("Pass `map` OR `node`, not both.")
+      if ((wantMap || node) && (section || lines || render))
+        return err("`map`/`node` address the document's parts — pass with `version` only.")
+      openTarget = { artifact: a, version: n }
       const url = artifactUrl(ctx.deps.baseUrl, a)
 
       // The render rung: the version's screenshot, so an agent SEES what it shipped.
@@ -715,10 +740,6 @@ export function registerReadTool(tc: ToolContext): void {
         // `map`/`node` belong here too: this branch runs BEFORE the map rung below, so its
         // own guard against `render` never fires. Found on the preview — read(map, render)
         // silently returned a screenshot to a caller who asked for the structure.
-        if (section || lines || wantMap || node || focus)
-          return err(
-            "`render` is a view of the whole version — pass it alone (with `version` for history).",
-          )
         const label =
           render === "top"
             ? "the top of the page, 1200x630"
@@ -807,6 +828,7 @@ export function registerReadTool(tc: ToolContext): void {
                 bytes: shot.length,
                 note: `Too large to inline over MCP — open ${url} to view the page.`,
               })
+            countOpen()
             return {
               content: [
                 {
@@ -849,10 +871,6 @@ export function registerReadTool(tc: ToolContext): void {
       // The data rung: a version's structured facts, queried instead of re-parsed. A
       // whole-version view like `render`, so it can't combine with a within-doc selector.
       if (data !== undefined) {
-        if (section || lines || render || focus)
-          return err(
-            "`data` reads a version's stored facts — pass it alone (with `version` for history), not with section/lines/render/focus.",
-          )
         // The TREND read: one slot across a range of versions, in one call and one query.
         // Versions are already the time axis, so this is the whole reason facts exist —
         // "how did this move over thirty days" without fetching thirty versions.
@@ -988,14 +1006,6 @@ export function registerReadTool(tc: ToolContext): void {
       // Reject incompatible part selectors before any source blob read. These checks also
       // keep the error text stable for focus, whose branch used to do the same validation
       // only after a potentially multi-megabyte source load.
-      if (focus && (section || lines || wantMap || node))
-        return err(
-          "Pass `focus` alone (with `format` and `version`), not with another part selector.",
-        )
-      if (wantMap && node) return err("Pass `map` OR `node`, not both.")
-      if ((wantMap || node) && (section || lines || render))
-        return err("`map`/`node` address the document's parts — pass with `version` only.")
-
       // Publish derivation already stores the bounded wire map. Serve it before loading and
       // parsing the source. Missing, stale, or corrupt cache rows fall
       // through to the source path below, so authored bytes remain the authority.
@@ -1498,6 +1508,7 @@ export function registerReadTool(tc: ToolContext): void {
             url: pageUrl,
             note: "Too large to inline over MCP — open the url to view it.",
           })
+        countOpen()
         return {
           content: [
             {

--- a/apps/api/src/routes/analytics.ts
+++ b/apps/api/src/routes/analytics.ts
@@ -53,6 +53,17 @@ export const analyticsRoutes = (ctx: AppContext) => {
             .describe("The user's avatar URL, or null/absent for anonymous viewers"),
         }),
       ),
+      agentReads: z.object({
+        total: z.number().describe("Artifact reads through the Derive MCP read tool"),
+        last24h: z.number().describe("MCP reads in the trailing 24 hours"),
+        recent: z.array(
+          z.object({
+            agent: z.string().describe("Agent or OAuth client name"),
+            version: z.number().describe("Artifact version returned to the agent"),
+            at: z.string().describe("When that agent last read the artifact"),
+          }),
+        ),
+      }),
     })
     .openapi("Analytics")
 

--- a/apps/api/src/routes/analytics.ts
+++ b/apps/api/src/routes/analytics.ts
@@ -54,12 +54,11 @@ export const analyticsRoutes = (ctx: AppContext) => {
         }),
       ),
       agentReads: z.object({
-        total: z.number().describe("AI opens across bounded per-reader counters"),
+        total: z.number().describe("AI opens across bounded per-version counters"),
         recent: z.array(
           z.object({
-            client: z.string().describe("MCP client or registered agent name"),
             version: z.number().describe("Artifact version returned"),
-            opens: z.number().describe("Opens by this reader for this version"),
+            opens: z.number().describe("AI opens for this version"),
             at: z.string().describe("Most recent open time (ISO timestamp)"),
           }),
         ),

--- a/apps/api/src/routes/analytics.ts
+++ b/apps/api/src/routes/analytics.ts
@@ -54,13 +54,13 @@ export const analyticsRoutes = (ctx: AppContext) => {
         }),
       ),
       agentReads: z.object({
-        total: z.number().describe("Artifact reads through the Derive MCP read tool"),
-        last24h: z.number().describe("MCP reads in the trailing 24 hours"),
+        total: z.number().describe("AI opens across bounded per-reader counters"),
         recent: z.array(
           z.object({
-            agent: z.string().describe("Agent or OAuth client name"),
-            version: z.number().describe("Artifact version returned to the agent"),
-            at: z.string().describe("When that agent last read the artifact"),
+            client: z.string().describe("MCP client or registered agent name"),
+            version: z.number().describe("Artifact version returned"),
+            opens: z.number().describe("Opens by this reader for this version"),
+            at: z.string().describe("Most recent open time (ISO timestamp)"),
           }),
         ),
       }),
@@ -146,7 +146,10 @@ export const analyticsRoutes = (ctx: AppContext) => {
         actor.kind === "token" ||
         (actor.kind === "user" && (actor.orgRole != null || actor.artifactRole != null))
       if (!collaborator) return bail(fail(c, 404, "not found"))
-      const stats = await meta.viewStats(artifact.id)
+      const [stats, agentReads] = await Promise.all([
+        meta.viewStats(artifact.id),
+        meta.artifactReadStats(artifact.id, artifact.org_id),
+      ])
       // Recent user-viewers are stored by id (stable); resolve to a public handle
       // (or display name) + avatar — never the email (off the wire, like the rosters).
       const userIds = stats.recent.filter((r) => r.kind === "user").map((r) => r.viewer)
@@ -158,7 +161,7 @@ export const analyticsRoutes = (ctx: AppContext) => {
           return { ...r, viewer: u?.name ?? u?.username ?? "Someone", avatar: u?.image ?? null }
         })
       }
-      return c.json(stats)
+      return c.json({ ...stats, agentReads })
     },
   )
 

--- a/apps/api/src/routes/artifacts.ts
+++ b/apps/api/src/routes/artifacts.ts
@@ -2655,6 +2655,22 @@ export const artifactRoutes = (ctx: AppContext) => {
     const version = await meta.getVersion(artifact.id, v)
     if (!version) return fail(c, 404, `no version ${v}`)
 
+    const countAiOpen =
+      c.req.header("X-Derive-AI-Read") === "1" && (isToken(c) || (await agentFor(c)) !== null)
+    const opened = <T extends Response>(response: T): T => {
+      if (!countAiOpen) return response
+      background(
+        meta.incrementArtifactRead({
+          id: newId("arc"),
+          org_id: artifact.org_id,
+          artifact_id: artifact.id,
+          artifact_version: v,
+          opened_at: new Date().toISOString(),
+        }),
+      )
+      return response
+    }
+
     const formatQ = c.req.query("format")
     const format = formatQ === "markdown" || formatQ === "text" ? formatQ : null
     // "*" forces full content — the escape hatch a caller uses after already
@@ -2688,8 +2704,12 @@ export const artifactRoutes = (ctx: AppContext) => {
       const src = await sourceText(version)
       if (src === null) return fail(c, 500, "blob missing")
       if (outline) {
+        const sections = outlineOf(src, version.content_type)
         c.header("X-Derive-Format", "outline")
-        return c.json({ sections: outlineOf(src, version.content_type) })
+        const response = c.json({ sections })
+        // The stdio MCP falls through to a content request when the outline is empty.
+        // Count only the request that returns the useful reading, not both probes.
+        return sections.length ? opened(response) : response
       }
       if (section) {
         const slice = sectionOf(src, version.content_type, section)
@@ -2698,25 +2718,27 @@ export const artifactRoutes = (ctx: AppContext) => {
         c.header("X-Derive-Format", format ?? "raw")
         c.header("X-Derive-Section", section)
         c.header("Content-Type", "text/plain; charset=utf-8")
-        return c.body(body)
+        return opened(c.body(body))
       }
       const body = present(src, version.content_type)
       c.header("X-Derive-Format", format ?? "raw")
       c.header("X-Derive-Sections", String(outlineOf(src, version.content_type).length))
       c.header("Content-Type", "text/plain; charset=utf-8")
-      return c.body(body)
+      return opened(c.body(body))
     }
 
     // Bundle.
     if (outline) {
       c.header("X-Derive-Format", "outline")
-      return c.json({
-        entry: cleanPath(manifest.entry),
-        pages: Object.keys(manifest.files).map((p) => ({
-          path: cleanPath(p),
-          type: manifest.files[p]?.type,
-        })),
-      })
+      return opened(
+        c.json({
+          entry: cleanPath(manifest.entry),
+          pages: Object.keys(manifest.files).map((p) => ({
+            path: cleanPath(p),
+            type: manifest.files[p]?.type,
+          })),
+        }),
+      )
     }
     // Split on the LAST '#' — matches the MCP `read` tool's page#slug parsing, so a
     // page path/slug resolves to the same (pagePath, slug) pair on both surfaces.
@@ -2741,7 +2763,7 @@ export const artifactRoutes = (ctx: AppContext) => {
         SAFE_BINARY_CONTENT_TYPES.has(fileBaseType) ? file.type : "application/octet-stream",
       )
       c.header("X-Derive-Format", "raw")
-      return c.body(toBody(bytes))
+      return opened(c.body(toBody(bytes)))
     }
     const raw = new TextDecoder().decode(bytes)
     if (slug) {
@@ -2750,13 +2772,13 @@ export const artifactRoutes = (ctx: AppContext) => {
       c.header("X-Derive-Format", format ?? "raw")
       c.header("X-Derive-Section", `${pagePath}#${slug}`)
       c.header("Content-Type", "text/plain; charset=utf-8")
-      return c.body(present(slice, file.type))
+      return opened(c.body(present(slice, file.type)))
     }
     c.header("X-Derive-Format", format ?? "raw")
     c.header("X-Derive-Section", pagePath)
     c.header("X-Derive-Sections", String(outlineOf(raw, file.type).length))
     c.header("Content-Type", "text/plain; charset=utf-8")
-    return c.body(present(raw, file.type))
+    return opened(c.body(present(raw, file.type)))
   })
 
   // Live editor preview: render a markdown draft to the exact published HTML.

--- a/apps/api/test/analytics.test.ts
+++ b/apps/api/test/analytics.test.ts
@@ -56,8 +56,6 @@ describe("view analytics", () => {
         org_id: artifact.org_id,
         artifact_id: artifact.id,
         artifact_version: 2,
-        reader_hash: "opaque-reader",
-        client: "Codex",
         opened_at: new Date().toISOString(),
       })
 
@@ -74,7 +72,7 @@ describe("view analytics", () => {
     expect(a.recent.every((r: { kind: string }) => r.kind === "anon")).toBe(true)
     expect(a.agentReads).toMatchObject({
       total: 2,
-      recent: [expect.objectContaining({ client: "Codex", version: 2, opens: 2 })],
+      recent: [expect.objectContaining({ version: 2, opens: 2 })],
     })
 
     // Batch counts surface on the library listing.

--- a/apps/api/test/analytics.test.ts
+++ b/apps/api/test/analytics.test.ts
@@ -48,6 +48,19 @@ describe("view analytics", () => {
       body: JSON.stringify({ version: 2 }),
     })
 
+    const artifact = await meta.getByShortId(short_id)
+    if (!artifact) throw new Error("artifact was not published")
+    for (let index = 0; index < 2; index += 1)
+      await meta.incrementArtifactRead({
+        id: `arc_analytics_${index}`,
+        org_id: artifact.org_id,
+        artifact_id: artifact.id,
+        artifact_version: 2,
+        reader_hash: "opaque-reader",
+        client: "Codex",
+        opened_at: new Date().toISOString(),
+      })
+
     const a = await (await app.request(`/v1/artifacts/${short_id}/analytics`)).json()
     expect(a.total).toBe(3) // viewerA@v1 (de-duped from 3), viewerA@v2, viewerB@v2
     expect(a.last24h).toBe(3) // every view was just recorded, so all are inside the window
@@ -59,6 +72,10 @@ describe("view analytics", () => {
     expect(a.daily.reduce((s: number, d: { count: number }) => s + d.count, 0)).toBe(3)
     expect(a.recent.length).toBe(2) // per-viewer, newest-first
     expect(a.recent.every((r: { kind: string }) => r.kind === "anon")).toBe(true)
+    expect(a.agentReads).toMatchObject({
+      total: 2,
+      recent: [expect.objectContaining({ client: "Codex", version: 2, opens: 2 })],
+    })
 
     // Batch counts surface on the library listing.
     const list = await (await app.request("/v1/artifacts")).json()

--- a/apps/api/test/content-params.test.ts
+++ b/apps/api/test/content-params.test.ts
@@ -1,5 +1,5 @@
 import { zipSync } from "fflate"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import { anonApp, app, meta, TEST_TOKEN, upload } from "./helpers"
 
 const bearer = { authorization: `Bearer ${TEST_TOKEN}` }
@@ -32,9 +32,11 @@ describe("/v1/artifacts/:shortId/content — format, section, outline params", (
       "plain text",
     )
 
-    expect(await meta.artifactReadStats(artifact.id, artifact.org_id)).toEqual({
-      total: 1,
-      recent: [expect.objectContaining({ version: 1, opens: 1 })],
+    await vi.waitFor(async () => {
+      expect(await meta.artifactReadStats(artifact.id, artifact.org_id)).toEqual({
+        total: 1,
+        recent: [expect.objectContaining({ version: 1, opens: 1 })],
+      })
     })
   })
 

--- a/apps/api/test/content-params.test.ts
+++ b/apps/api/test/content-params.test.ts
@@ -1,10 +1,43 @@
 import { zipSync } from "fflate"
 import { describe, expect, it } from "vitest"
-import { app, TEST_TOKEN, upload } from "./helpers"
+import { anonApp, app, meta, TEST_TOKEN, upload } from "./helpers"
 
 const bearer = { authorization: `Bearer ${TEST_TOKEN}` }
 
 describe("/v1/artifacts/:shortId/content — format, section, outline params", () => {
+  it("counts one stdio open after an empty outline probe and skips failed reads", async () => {
+    const { short_id } = await (
+      await upload("plain.md", "plain text", { visibility: "public" })
+    ).json()
+    const artifact = await meta.getByShortId(short_id)
+    if (!artifact) throw new Error("artifact was not published")
+    const aiRead = { headers: { "x-derive-ai-read": "1" } }
+
+    expect(await (await app.request(`/v1/artifacts/${short_id}/content`)).text()).toBe("plain text")
+    expect(
+      await (
+        await anonApp.request(`/v1/artifacts/${short_id}/content`, {
+          headers: { "x-derive-ai-read": "1" },
+        })
+      ).text(),
+    ).toBe("plain text")
+    expect((await meta.artifactReadStats(artifact.id, artifact.org_id)).total).toBe(0)
+    expect(
+      (await app.request(`/v1/artifacts/${short_id}/content?section=missing`, aiRead)).status,
+    ).toBe(404)
+    expect(
+      await (await app.request(`/v1/artifacts/${short_id}/content?outline=1`, aiRead)).json(),
+    ).toEqual({ sections: [] })
+    expect(await (await app.request(`/v1/artifacts/${short_id}/content`, aiRead)).text()).toBe(
+      "plain text",
+    )
+
+    expect(await meta.artifactReadStats(artifact.id, artifact.org_id)).toEqual({
+      total: 1,
+      recent: [expect.objectContaining({ version: 1, opens: 1 })],
+    })
+  })
+
   it("defaults to raw source; format=markdown converts; format=text is flat text", async () => {
     const html =
       "<html><head><style>body{color:red}</style></head><body><h1>Doc</h1><p>hi</p></body></html>"

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -112,10 +112,19 @@ describe("remote MCP endpoint (/mcp)", () => {
       expect(toolText(await call(app, token, "read", { short_id: shortId }))).toContain(
         "Read counters",
       )
+    expect(
+      toolText(
+        await call(app, token, "read", {
+          short_id: shortId,
+          render: "top",
+          section: "invalid-combination",
+        }),
+      ),
+    ).toContain("pass it alone")
 
     expect(await meta.artifactReadStats(artifact.id, artifact.org_id)).toEqual({
       total: 3,
-      recent: [expect.objectContaining({ client: "Claude", version: 1, opens: 3 })],
+      recent: [expect.objectContaining({ version: 1, opens: 3 })],
     })
     expect((await meta.viewStats(artifact.id)).total).toBe(0)
   })

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -96,6 +96,27 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(r.wwwAuth).toContain("oauth-protected-resource")
   })
 
+  it("records artifact reads as agent activity without inflating browser views", async () => {
+    const { app, token, meta } = appWithGrant(
+      dir,
+      "read-activity",
+      "openid derive:read derive:publish",
+    )
+    const { short_id: shortId } = (await (await publish(app, token, "Read activity")).json()) as {
+      short_id: string
+    }
+    const artifact = await meta.getByShortId(shortId)
+    if (!artifact) throw new Error("artifact was not published")
+
+    expect(toolText(await call(app, token, "read", { short_id: shortId }))).toContain(
+      "Read activity",
+    )
+    const stats = await meta.viewStats(artifact.id)
+    expect(stats.total).toBe(0)
+    expect(stats.agentReads).toMatchObject({ total: 1, last24h: 1 })
+    expect(stats.agentReads.recent[0]).toMatchObject({ agent: "Claude", version: 1 })
+  })
+
   it("initializes (identity in instructions) and lists the consolidated tools", async () => {
     const { app, token } = appWithGrant(dir, "init", "openid derive:read derive:publish")
     const init = await rpc(app, token, initBody)

--- a/apps/api/test/mcp.test.ts
+++ b/apps/api/test/mcp.test.ts
@@ -96,25 +96,28 @@ describe("remote MCP endpoint (/mcp)", () => {
     expect(r.wwwAuth).toContain("oauth-protected-resource")
   })
 
-  it("records artifact reads as agent activity without inflating browser views", async () => {
+  it("counts repeated AI artifact opens without keeping an event log", async () => {
     const { app, token, meta } = appWithGrant(
       dir,
-      "read-activity",
+      "read-counters",
       "openid derive:read derive:publish",
     )
-    const { short_id: shortId } = (await (await publish(app, token, "Read activity")).json()) as {
+    const { short_id: shortId } = (await (await publish(app, token, "Read counters")).json()) as {
       short_id: string
     }
     const artifact = await meta.getByShortId(shortId)
     if (!artifact) throw new Error("artifact was not published")
 
-    expect(toolText(await call(app, token, "read", { short_id: shortId }))).toContain(
-      "Read activity",
-    )
-    const stats = await meta.viewStats(artifact.id)
-    expect(stats.total).toBe(0)
-    expect(stats.agentReads).toMatchObject({ total: 1, last24h: 1 })
-    expect(stats.agentReads.recent[0]).toMatchObject({ agent: "Claude", version: 1 })
+    for (let index = 0; index < 3; index += 1)
+      expect(toolText(await call(app, token, "read", { short_id: shortId }))).toContain(
+        "Read counters",
+      )
+
+    expect(await meta.artifactReadStats(artifact.id, artifact.org_id)).toEqual({
+      total: 3,
+      recent: [expect.objectContaining({ client: "Claude", version: 1, opens: 3 })],
+    })
+    expect((await meta.viewStats(artifact.id)).total).toBe(0)
   })
 
   it("initializes (identity in instructions) and lists the consolidated tools", async () => {

--- a/apps/api/test/round-trip-budget.test.ts
+++ b/apps/api/test/round-trip-budget.test.ts
@@ -558,15 +558,15 @@ describe("MCP tool calls stay within their round-trip budget", () => {
       expect(catchUpCalls, `${gone} escaped the catch-up batch`).not.toContain(gone)
     expect(catchUpCalls.length).toBeLessThanOrEqual(3)
     // One shared MCP bootstrap read, one joined artifact + selected-version envelope,
-    // then one background activity receipt. The hosted response does not wait for the
-    // receipt, but the instrumented store still sees it. Authorization adds no read.
+    // then one background counter increment. The hosted response does not wait for the
+    // counter, and authorization adds no read.
     expect(readCalls).toContain("artifactWithVersion")
-    expect(readCalls).toContain("recordView")
+    expect(readCalls).toContain("incrementArtifactRead")
     expect(readCalls).not.toContain("getByShortId")
     expect(readCalls).not.toContain("getVersion")
     expect(readCalls.length).toBeLessThanOrEqual(3)
     expect(mapCalls).toContain("artifactWithVersionData")
-    expect(mapCalls).toContain("recordView")
+    expect(mapCalls).toContain("incrementArtifactRead")
     expect(mapCalls).not.toContain("getByShortId")
     expect(mapCalls).not.toContain("getVersion")
     expect(mapCalls).not.toContain("getVersionData")

--- a/apps/api/test/round-trip-budget.test.ts
+++ b/apps/api/test/round-trip-budget.test.ts
@@ -557,18 +557,20 @@ describe("MCP tool calls stay within their round-trip budget", () => {
     for (const gone of ["listVersions", "listComments", "listReviewRounds", "getVersionData"])
       expect(catchUpCalls, `${gone} escaped the catch-up batch`).not.toContain(gone)
     expect(catchUpCalls.length).toBeLessThanOrEqual(3)
-    // One shared MCP bootstrap read, then one joined artifact + selected-version envelope.
-    // The grant snapshot also supplies the live workspace role, so authorization adds no
-    // metadata read. The handler must not quietly restore either serial lookup.
+    // One shared MCP bootstrap read, one joined artifact + selected-version envelope,
+    // then one background activity receipt. The hosted response does not wait for the
+    // receipt, but the instrumented store still sees it. Authorization adds no read.
     expect(readCalls).toContain("artifactWithVersion")
+    expect(readCalls).toContain("recordView")
     expect(readCalls).not.toContain("getByShortId")
     expect(readCalls).not.toContain("getVersion")
-    expect(readCalls.length).toBeLessThanOrEqual(2)
+    expect(readCalls.length).toBeLessThanOrEqual(3)
     expect(mapCalls).toContain("artifactWithVersionData")
+    expect(mapCalls).toContain("recordView")
     expect(mapCalls).not.toContain("getByShortId")
     expect(mapCalls).not.toContain("getVersion")
     expect(mapCalls).not.toContain("getVersionData")
-    expect(mapCalls.length).toBeLessThanOrEqual(2)
+    expect(mapCalls.length).toBeLessThanOrEqual(3)
     expect(workspaceCalls).toEqual(["oauthGrantWithWorkspaces"])
     expect(reactCalls.length).toBeLessThanOrEqual(4)
     // set_state went 8 → 9 when resolving a thread started keeping its mirrored Slack cards in

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -8063,14 +8063,12 @@ export interface components {
                 avatar?: string | null;
             }[];
             agentReads: {
-                /** @description AI opens across bounded per-reader counters */
+                /** @description AI opens across bounded per-version counters */
                 total: number;
                 recent: {
-                    /** @description MCP client or registered agent name */
-                    client: string;
                     /** @description Artifact version returned */
                     version: number;
-                    /** @description Opens by this reader for this version */
+                    /** @description AI opens for this version */
                     opens: number;
                     /** @description Most recent open time (ISO timestamp) */
                     at: string;

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -8062,6 +8062,20 @@ export interface components {
                 /** @description The user's avatar URL, or null/absent for anonymous viewers */
                 avatar?: string | null;
             }[];
+            agentReads: {
+                /** @description Artifact reads through the Derive MCP read tool */
+                total: number;
+                /** @description MCP reads in the trailing 24 hours */
+                last24h: number;
+                recent: {
+                    /** @description Agent or OAuth client name */
+                    agent: string;
+                    /** @description Artifact version returned to the agent */
+                    version: number;
+                    /** @description When that agent last read the artifact */
+                    at: string;
+                }[];
+            };
         };
         Webhook: {
             id: string;

--- a/apps/web/src/api-types.ts
+++ b/apps/web/src/api-types.ts
@@ -8063,16 +8063,16 @@ export interface components {
                 avatar?: string | null;
             }[];
             agentReads: {
-                /** @description Artifact reads through the Derive MCP read tool */
+                /** @description AI opens across bounded per-reader counters */
                 total: number;
-                /** @description MCP reads in the trailing 24 hours */
-                last24h: number;
                 recent: {
-                    /** @description Agent or OAuth client name */
-                    agent: string;
-                    /** @description Artifact version returned to the agent */
+                    /** @description MCP client or registered agent name */
+                    client: string;
+                    /** @description Artifact version returned */
                     version: number;
-                    /** @description When that agent last read the artifact */
+                    /** @description Opens by this reader for this version */
+                    opens: number;
+                    /** @description Most recent open time (ISO timestamp) */
                     at: string;
                 }[];
             };

--- a/apps/web/src/pages/artifact/insights-history.tsx
+++ b/apps/web/src/pages/artifact/insights-history.tsx
@@ -140,7 +140,7 @@ export function Insights({
                 <StatTile value={data.last24h} label="last 24hrs" />
                 <StatTile
                   value={data.agentReads.total}
-                  label={data.agentReads.total === 1 ? "AI read" : "AI reads"}
+                  label={data.agentReads.total === 1 ? "AI open" : "AI opens"}
                 />
               </div>
               {data.total > 0 && (
@@ -227,15 +227,18 @@ export function Insights({
                     )}
                     {data.agentReads.recent.map((r) => (
                       <div
-                        key={`${r.agent}:${r.version}:${r.at}`}
+                        key={`${r.client}:${r.version}`}
                         className="flex items-center gap-2 text-sm"
                       >
                         <Icon name="sparkles" className="size-4.5 text-muted-foreground" />
                         <span className="flex-1 truncate font-medium">
-                          {r.agent} · v{r.version}
+                          {r.client} · v{r.version}
                         </span>
-                        <span className="font-mono text-2xs text-muted-foreground">
-                          {ago(r.at)}
+                        <span
+                          className="font-mono text-2xs text-muted-foreground"
+                          title={`${r.opens} opens · ${new Date(r.at).toLocaleString()}`}
+                        >
+                          {r.opens.toLocaleString()} · {ago(r.at)}
                         </span>
                       </div>
                     ))}

--- a/apps/web/src/pages/artifact/insights-history.tsx
+++ b/apps/web/src/pages/artifact/insights-history.tsx
@@ -169,36 +169,38 @@ export function Insights({
               )}
             </div>
 
-            <div className="grid gap-6 sm:grid-cols-2">
-              <div>
-                <Eyebrow as="div" className="mb-2">
-                  Per version
-                </Eyebrow>
-                <div className="flex flex-col gap-1.5">
-                  {[...data.perVersion]
-                    .sort((a, b) => b.version - a.version)
-                    .map((v) => (
-                      <div key={v.version} className="flex items-center gap-2 text-sm">
-                        <span className="w-8 shrink-0 font-mono text-2xs text-muted-foreground tabular-nums">
-                          v{v.version}
-                        </span>
-                        <div className="h-2.5 flex-1 overflow-hidden rounded-full bg-secondary">
-                          <div
-                            className="h-full rounded-full bg-chart-1"
-                            style={{ width: `${(v.count / vmax) * 100}%` }}
-                          />
+            <div className={cn("grid gap-6", data.perVersion.length > 0 && "sm:grid-cols-2")}>
+              {data.perVersion.length > 0 && (
+                <div>
+                  <Eyebrow as="div" className="mb-2">
+                    Views per version
+                  </Eyebrow>
+                  <div className="flex flex-col gap-1.5">
+                    {[...data.perVersion]
+                      .sort((a, b) => b.version - a.version)
+                      .map((v) => (
+                        <div key={v.version} className="flex items-center gap-2 text-sm">
+                          <span className="w-8 shrink-0 font-mono text-2xs text-muted-foreground tabular-nums">
+                            v{v.version}
+                          </span>
+                          <div className="h-2.5 flex-1 overflow-hidden rounded-full bg-secondary">
+                            <div
+                              className="h-full rounded-full bg-chart-1"
+                              style={{ width: `${(v.count / vmax) * 100}%` }}
+                            />
+                          </div>
+                          <span className="w-10 shrink-0 text-right font-mono text-2xs text-muted-foreground tabular-nums">
+                            {v.count}
+                          </span>
                         </div>
-                        <span className="w-10 shrink-0 text-right font-mono text-2xs text-muted-foreground tabular-nums">
-                          {v.count}
-                        </span>
-                      </div>
-                    ))}
+                      ))}
+                  </div>
                 </div>
-              </div>
+              )}
 
               <div>
                 <Eyebrow as="div" className="mb-2">
-                  Viewed by
+                  Recent activity
                 </Eyebrow>
                 {namedRecent.length === 0 &&
                 data.anonViewers === 0 &&

--- a/apps/web/src/pages/artifact/insights-history.tsx
+++ b/apps/web/src/pages/artifact/insights-history.tsx
@@ -226,14 +226,9 @@ export function Insights({
                       </div>
                     )}
                     {data.agentReads.recent.map((r) => (
-                      <div
-                        key={`${r.client}:${r.version}`}
-                        className="flex items-center gap-2 text-sm"
-                      >
+                      <div key={r.version} className="flex items-center gap-2 text-sm">
                         <Icon name="sparkles" className="size-4.5 text-muted-foreground" />
-                        <span className="flex-1 truncate font-medium">
-                          {r.client} · v{r.version}
-                        </span>
+                        <span className="flex-1 truncate font-medium">AI · v{r.version}</span>
                         <span
                           className="font-mono text-2xs text-muted-foreground"
                           title={`${r.opens} opens · ${new Date(r.at).toLocaleString()}`}

--- a/apps/web/src/pages/artifact/insights-history.tsx
+++ b/apps/web/src/pages/artifact/insights-history.tsx
@@ -25,7 +25,7 @@ function StatTile({ value, label }: { value: number; label: string }) {
   )
 }
 
-const INSIGHT_STATS = ["viewers", "views", "last24h"]
+const INSIGHT_STATS = ["viewers", "views", "last24h", "agentReads"]
 const INSIGHT_ROWS = ["a", "b", "c", "d"]
 
 // First-load placeholder that mirrors the resolved dialog's own layout: the stat row
@@ -138,6 +138,10 @@ export function Insights({
                 <StatTile value={data.unique} label={data.unique === 1 ? "viewer" : "viewers"} />
                 <StatTile value={data.total} label={data.total === 1 ? "view" : "views"} />
                 <StatTile value={data.last24h} label="last 24hrs" />
+                <StatTile
+                  value={data.agentReads.total}
+                  label={data.agentReads.total === 1 ? "AI read" : "AI reads"}
+                />
               </div>
               {data.total > 0 && (
                 <div className="ml-auto min-w-40 flex-1">
@@ -196,8 +200,10 @@ export function Insights({
                 <Eyebrow as="div" className="mb-2">
                   Viewed by
                 </Eyebrow>
-                {namedRecent.length === 0 && data.anonViewers === 0 ? (
-                  <div className="text-sm text-muted-foreground">No views yet.</div>
+                {namedRecent.length === 0 &&
+                data.anonViewers === 0 &&
+                data.agentReads.recent.length === 0 ? (
+                  <div className="text-sm text-muted-foreground">No activity yet.</div>
                 ) : (
                   <div className="flex flex-col gap-1.5">
                     {namedRecent.map((r) => (
@@ -219,6 +225,20 @@ export function Insights({
                         + {data.anonViewers.toLocaleString()} anonymous
                       </div>
                     )}
+                    {data.agentReads.recent.map((r) => (
+                      <div
+                        key={`${r.agent}:${r.version}:${r.at}`}
+                        className="flex items-center gap-2 text-sm"
+                      >
+                        <Icon name="sparkles" className="size-4.5 text-muted-foreground" />
+                        <span className="flex-1 truncate font-medium">
+                          {r.agent} · v{r.version}
+                        </span>
+                        <span className="font-mono text-2xs text-muted-foreground">
+                          {ago(r.at)}
+                        </span>
+                      </div>
+                    ))}
                   </div>
                 )}
               </div>

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -408,12 +408,10 @@ CREATE TABLE IF NOT EXISTS artifact_read_counter (
   org_id TEXT NOT NULL,
   artifact_id TEXT NOT NULL,
   artifact_version INTEGER NOT NULL,
-  reader_hash TEXT NOT NULL,
-  client TEXT NOT NULL,
   opens INTEGER NOT NULL DEFAULT 1,
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
   last_opened_at TEXT NOT NULL,
-  UNIQUE (artifact_id, artifact_version, reader_hash)
+  UNIQUE (artifact_id, artifact_version)
 );
 
 CREATE TABLE IF NOT EXISTS artifact_skill_link (

--- a/deploy/d1-schema.sql
+++ b/deploy/d1-schema.sql
@@ -403,6 +403,19 @@ CREATE TABLE IF NOT EXISTS skill_use (
   UNIQUE (org_id, skill_artifact_id, used_by, event_id)
 );
 
+CREATE TABLE IF NOT EXISTS artifact_read_counter (
+  id TEXT PRIMARY KEY,
+  org_id TEXT NOT NULL,
+  artifact_id TEXT NOT NULL,
+  artifact_version INTEGER NOT NULL,
+  reader_hash TEXT NOT NULL,
+  client TEXT NOT NULL,
+  opens INTEGER NOT NULL DEFAULT 1,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  last_opened_at TEXT NOT NULL,
+  UNIQUE (artifact_id, artifact_version, reader_hash)
+);
+
 CREATE TABLE IF NOT EXISTS artifact_skill_link (
   id TEXT PRIMARY KEY,
   org_id TEXT NOT NULL,
@@ -888,6 +901,8 @@ CREATE INDEX IF NOT EXISTS skill_installation_skill ON skill_installation (org_i
 CREATE INDEX IF NOT EXISTS skill_scan_coverage_workspace ON skill_scan_coverage (org_id, scanned_at);
 
 CREATE INDEX IF NOT EXISTS skill_use_skill ON skill_use (org_id, skill_artifact_id, occurred_at);
+
+CREATE INDEX IF NOT EXISTS artifact_read_counter_artifact ON artifact_read_counter (org_id, artifact_id, last_opened_at);
 
 CREATE INDEX IF NOT EXISTS artifact_skill_link_skill ON artifact_skill_link (org_id, skill_artifact_id, created_at);
 

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -4419,15 +4419,12 @@ export interface ViewStats {
   recent: { viewer: string; kind: "user" | "anon"; at: string; avatar?: string | null }[]
 }
 
-/** A bounded AI-read counter. One row survives per artifact version and opaque reader.
- * It keeps frequency and last-use evidence without retaining an event history. */
+/** A bounded AI-read counter. One row survives per artifact version. */
 export interface ArtifactReadCounterRecord {
   id: string
   org_id: string
   artifact_id: string
   artifact_version: number
-  reader_hash: string
-  client: string
   opens: number
   created_at: string
   last_opened_at: string
@@ -4438,14 +4435,12 @@ export interface NewArtifactReadCounter {
   org_id: string
   artifact_id: string
   artifact_version: number
-  reader_hash: string
-  client: string
   opened_at: string
 }
 
 export interface ArtifactReadStats {
   total: number
-  recent: { client: string; version: number; opens: number; at: string }[]
+  recent: { version: number; opens: number; at: string }[]
 }
 
 // open      — live feedback awaiting a reply/resolution

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -4394,7 +4394,7 @@ export interface NewView {
   artifact_id: string
   version: number
   viewer: string
-  viewer_kind: "user" | "anon"
+  viewer_kind: "user" | "anon" | "agent"
 }
 
 export interface ViewStats {
@@ -4413,6 +4413,13 @@ export interface ViewStats {
   daily: { day: string; count: number }[]
   /** Most-recent distinct viewers, newest first. `avatar` is set for users. */
   recent: { viewer: string; kind: "user" | "anon"; at: string; avatar?: string | null }[]
+  /** MCP artifact reads. These stay separate from browser views so an agent cannot
+   *  inflate the audience metrics. Each successful read tool call is one event. */
+  agentReads: {
+    total: number
+    last24h: number
+    recent: { agent: string; version: number; at: string }[]
+  }
 }
 
 // open      — live feedback awaiting a reply/resolution

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -1047,6 +1047,10 @@ export interface ArtifactQueryStore {
   pruneViewsByViewers(viewers: string[]): Promise<number>
   /** Aggregated view analytics for one artifact. */
   viewStats(artifactId: string): Promise<ViewStats>
+  /** Increment one bounded AI-read counter. The store keeps no per-open event rows. */
+  incrementArtifactRead(read: NewArtifactReadCounter): Promise<void>
+  /** Aggregate AI reads and return the most recently active counters. */
+  artifactReadStats(artifactId: string, orgId: string): Promise<ArtifactReadStats>
   /** Total view counts for many artifacts at once (no N+1). */
   viewCounts(artifactIds: string[]): Promise<Record<string, number>>
   /** For each artifact id, true iff its CURRENT version has a ready preview render.
@@ -4394,7 +4398,7 @@ export interface NewView {
   artifact_id: string
   version: number
   viewer: string
-  viewer_kind: "user" | "anon" | "agent"
+  viewer_kind: "user" | "anon"
 }
 
 export interface ViewStats {
@@ -4413,13 +4417,35 @@ export interface ViewStats {
   daily: { day: string; count: number }[]
   /** Most-recent distinct viewers, newest first. `avatar` is set for users. */
   recent: { viewer: string; kind: "user" | "anon"; at: string; avatar?: string | null }[]
-  /** MCP artifact reads. These stay separate from browser views so an agent cannot
-   *  inflate the audience metrics. Each successful read tool call is one event. */
-  agentReads: {
-    total: number
-    last24h: number
-    recent: { agent: string; version: number; at: string }[]
-  }
+}
+
+/** A bounded AI-read counter. One row survives per artifact version and opaque reader.
+ * It keeps frequency and last-use evidence without retaining an event history. */
+export interface ArtifactReadCounterRecord {
+  id: string
+  org_id: string
+  artifact_id: string
+  artifact_version: number
+  reader_hash: string
+  client: string
+  opens: number
+  created_at: string
+  last_opened_at: string
+}
+
+export interface NewArtifactReadCounter {
+  id: string
+  org_id: string
+  artifact_id: string
+  artifact_version: number
+  reader_hash: string
+  client: string
+  opened_at: string
+}
+
+export interface ArtifactReadStats {
+  total: number
+  recent: { client: string; version: number; opens: number; at: string }[]
 }
 
 // open      — live feedback awaiting a reply/resolution

--- a/packages/db/src/d1.ts
+++ b/packages/db/src/d1.ts
@@ -77,11 +77,11 @@ export function createD1Store(d1: D1Database): MetaStore {
       await db.run(
         sql`INSERT INTO view (id, artifact_id, version, viewer, viewer_kind) VALUES (${v.id}, ${v.artifact_id}, ${v.version}, ${v.viewer}, ${v.viewer_kind})`,
       )
-      // Agent reads are activity, not audience activation.
-      if (v.viewer_kind !== "agent")
-        await db.run(
-          sql`UPDATE artifact SET first_foreign_view_at = ${new Date().toISOString()} WHERE id = ${v.artifact_id} AND first_foreign_view_at IS NULL`,
-        )
+      // Activation stamp: first non-author view only (the route already excluded
+      // owner self-views). WHERE IS NULL keeps it a one-time write.
+      await db.run(
+        sql`UPDATE artifact SET first_foreign_view_at = ${new Date().toISOString()} WHERE id = ${v.artifact_id} AND first_foreign_view_at IS NULL`,
+      )
     },
     // See MetaStore.confirmRead. One idempotent statement, so the repeat heartbeats
     // that follow cost a single indexed probe.
@@ -134,13 +134,13 @@ export function createD1Store(d1: D1Database): MetaStore {
       const cutoff = new Date(Date.now() - VIEW_WINDOW_MS).toISOString()
       const dayAgo = new Date(Date.now() - LAST_24H_MS).toISOString()
       const tot = (await db.get(
-        sql`SELECT count(*) n FROM view WHERE artifact_id=${artifactId} AND viewer_kind!='agent'`,
+        sql`SELECT count(*) n FROM view WHERE artifact_id=${artifactId}`,
       )) as { n: number }
       const day = (await db.get(
-        sql`SELECT count(*) n FROM view WHERE artifact_id=${artifactId} AND viewer_kind!='agent' AND created_at>=${dayAgo}`,
+        sql`SELECT count(*) n FROM view WHERE artifact_id=${artifactId} AND created_at>=${dayAgo}`,
       )) as { n: number }
       const uni = (await db.get(
-        sql`SELECT count(DISTINCT viewer) n FROM view WHERE artifact_id=${artifactId} AND viewer_kind!='agent'`,
+        sql`SELECT count(DISTINCT viewer) n FROM view WHERE artifact_id=${artifactId}`,
       )) as { n: number }
       const anon = (await db.get(
         sql`SELECT count(DISTINCT viewer) n FROM view WHERE artifact_id=${artifactId} AND viewer_kind='anon'`,
@@ -149,13 +149,13 @@ export function createD1Store(d1: D1Database): MetaStore {
         sql`SELECT count(*) n FROM view_read WHERE artifact_id=${artifactId}`,
       )) as { n: number }
       const perVersion = (await db.all(
-        sql`SELECT version, count(*) count FROM view WHERE artifact_id=${artifactId} AND viewer_kind!='agent' GROUP BY version ORDER BY version`,
+        sql`SELECT version, count(*) count FROM view WHERE artifact_id=${artifactId} GROUP BY version ORDER BY version`,
       )) as { version: number; count: number }[]
       const daily = (await db.all(
-        sql`SELECT substr(created_at,1,10) day, count(*) count FROM view WHERE artifact_id=${artifactId} AND viewer_kind!='agent' AND created_at>=${cutoff} GROUP BY day ORDER BY day`,
+        sql`SELECT substr(created_at,1,10) day, count(*) count FROM view WHERE artifact_id=${artifactId} AND created_at>=${cutoff} GROUP BY day ORDER BY day`,
       )) as { day: string; count: number }[]
       const recent = (await db.all(
-        sql`SELECT viewer, viewer_kind kind, max(created_at) at FROM view WHERE artifact_id=${artifactId} AND viewer_kind!='agent' GROUP BY viewer, viewer_kind ORDER BY at DESC LIMIT 8`,
+        sql`SELECT viewer, viewer_kind kind, max(created_at) at FROM view WHERE artifact_id=${artifactId} GROUP BY viewer, viewer_kind ORDER BY at DESC LIMIT 8`,
       )) as { viewer: string; kind: "user" | "anon"; at: string }[]
       return {
         total: tot.n,
@@ -166,14 +166,6 @@ export function createD1Store(d1: D1Database): MetaStore {
         perVersion,
         daily,
         recent,
-        agentReads: {
-          ...((await db.get(
-            sql`SELECT count(*) total, count(CASE WHEN created_at>=${dayAgo} THEN 1 END) last24h FROM view WHERE artifact_id=${artifactId} AND viewer_kind='agent'`,
-          )) as { total: number; last24h: number }),
-          recent: (await db.all(
-            sql`SELECT viewer agent, version, created_at at FROM view WHERE artifact_id=${artifactId} AND viewer_kind='agent' ORDER BY created_at DESC LIMIT 8`,
-          )) as { agent: string; version: number; at: string }[],
-        },
       }
     },
     viewCounts: async (artifactIds: string[]): Promise<Record<string, number>> => {
@@ -183,7 +175,7 @@ export function createD1Store(d1: D1Database): MetaStore {
         sql`, `,
       )
       const rows = (await db.all(
-        sql`SELECT artifact_id, count(*) c FROM view WHERE viewer_kind!='agent' AND artifact_id IN (${ids}) GROUP BY artifact_id`,
+        sql`SELECT artifact_id, count(*) c FROM view WHERE artifact_id IN (${ids}) GROUP BY artifact_id`,
       )) as { artifact_id: string; c: number }[]
       const out: Record<string, number> = {}
       for (const r of rows) out[r.artifact_id] = r.c

--- a/packages/db/src/d1.ts
+++ b/packages/db/src/d1.ts
@@ -77,11 +77,11 @@ export function createD1Store(d1: D1Database): MetaStore {
       await db.run(
         sql`INSERT INTO view (id, artifact_id, version, viewer, viewer_kind) VALUES (${v.id}, ${v.artifact_id}, ${v.version}, ${v.viewer}, ${v.viewer_kind})`,
       )
-      // Activation stamp: first non-author view only (the route already excluded
-      // owner self-views). WHERE IS NULL keeps it a one-time write.
-      await db.run(
-        sql`UPDATE artifact SET first_foreign_view_at = ${new Date().toISOString()} WHERE id = ${v.artifact_id} AND first_foreign_view_at IS NULL`,
-      )
+      // Agent reads are activity, not audience activation.
+      if (v.viewer_kind !== "agent")
+        await db.run(
+          sql`UPDATE artifact SET first_foreign_view_at = ${new Date().toISOString()} WHERE id = ${v.artifact_id} AND first_foreign_view_at IS NULL`,
+        )
     },
     // See MetaStore.confirmRead. One idempotent statement, so the repeat heartbeats
     // that follow cost a single indexed probe.
@@ -134,13 +134,13 @@ export function createD1Store(d1: D1Database): MetaStore {
       const cutoff = new Date(Date.now() - VIEW_WINDOW_MS).toISOString()
       const dayAgo = new Date(Date.now() - LAST_24H_MS).toISOString()
       const tot = (await db.get(
-        sql`SELECT count(*) n FROM view WHERE artifact_id=${artifactId}`,
+        sql`SELECT count(*) n FROM view WHERE artifact_id=${artifactId} AND viewer_kind!='agent'`,
       )) as { n: number }
       const day = (await db.get(
-        sql`SELECT count(*) n FROM view WHERE artifact_id=${artifactId} AND created_at>=${dayAgo}`,
+        sql`SELECT count(*) n FROM view WHERE artifact_id=${artifactId} AND viewer_kind!='agent' AND created_at>=${dayAgo}`,
       )) as { n: number }
       const uni = (await db.get(
-        sql`SELECT count(DISTINCT viewer) n FROM view WHERE artifact_id=${artifactId}`,
+        sql`SELECT count(DISTINCT viewer) n FROM view WHERE artifact_id=${artifactId} AND viewer_kind!='agent'`,
       )) as { n: number }
       const anon = (await db.get(
         sql`SELECT count(DISTINCT viewer) n FROM view WHERE artifact_id=${artifactId} AND viewer_kind='anon'`,
@@ -149,13 +149,13 @@ export function createD1Store(d1: D1Database): MetaStore {
         sql`SELECT count(*) n FROM view_read WHERE artifact_id=${artifactId}`,
       )) as { n: number }
       const perVersion = (await db.all(
-        sql`SELECT version, count(*) count FROM view WHERE artifact_id=${artifactId} GROUP BY version ORDER BY version`,
+        sql`SELECT version, count(*) count FROM view WHERE artifact_id=${artifactId} AND viewer_kind!='agent' GROUP BY version ORDER BY version`,
       )) as { version: number; count: number }[]
       const daily = (await db.all(
-        sql`SELECT substr(created_at,1,10) day, count(*) count FROM view WHERE artifact_id=${artifactId} AND created_at>=${cutoff} GROUP BY day ORDER BY day`,
+        sql`SELECT substr(created_at,1,10) day, count(*) count FROM view WHERE artifact_id=${artifactId} AND viewer_kind!='agent' AND created_at>=${cutoff} GROUP BY day ORDER BY day`,
       )) as { day: string; count: number }[]
       const recent = (await db.all(
-        sql`SELECT viewer, viewer_kind kind, max(created_at) at FROM view WHERE artifact_id=${artifactId} GROUP BY viewer, viewer_kind ORDER BY at DESC LIMIT 8`,
+        sql`SELECT viewer, viewer_kind kind, max(created_at) at FROM view WHERE artifact_id=${artifactId} AND viewer_kind!='agent' GROUP BY viewer, viewer_kind ORDER BY at DESC LIMIT 8`,
       )) as { viewer: string; kind: "user" | "anon"; at: string }[]
       return {
         total: tot.n,
@@ -166,6 +166,14 @@ export function createD1Store(d1: D1Database): MetaStore {
         perVersion,
         daily,
         recent,
+        agentReads: {
+          ...((await db.get(
+            sql`SELECT count(*) total, count(CASE WHEN created_at>=${dayAgo} THEN 1 END) last24h FROM view WHERE artifact_id=${artifactId} AND viewer_kind='agent'`,
+          )) as { total: number; last24h: number }),
+          recent: (await db.all(
+            sql`SELECT viewer agent, version, created_at at FROM view WHERE artifact_id=${artifactId} AND viewer_kind='agent' ORDER BY created_at DESC LIMIT 8`,
+          )) as { agent: string; version: number; at: string }[],
+        },
       }
     },
     viewCounts: async (artifactIds: string[]): Promise<Record<string, number>> => {
@@ -175,7 +183,7 @@ export function createD1Store(d1: D1Database): MetaStore {
         sql`, `,
       )
       const rows = (await db.all(
-        sql`SELECT artifact_id, count(*) c FROM view WHERE artifact_id IN (${ids}) GROUP BY artifact_id`,
+        sql`SELECT artifact_id, count(*) c FROM view WHERE viewer_kind!='agent' AND artifact_id IN (${ids}) GROUP BY artifact_id`,
       )) as { artifact_id: string; c: number }[]
       const out: Record<string, number> = {}
       for (const r of rows) out[r.artifact_id] = r.c

--- a/packages/db/src/parity.ts
+++ b/packages/db/src/parity.ts
@@ -17,6 +17,7 @@ import type {
   AgentRecord,
   ArtifactInviteRecord,
   ArtifactMemberRecord,
+  ArtifactReadCounterRecord,
   ArtifactRecord,
   ArtifactSkillLinkRecord,
   AssetRecord,
@@ -92,6 +93,7 @@ export interface TypedTables {
   skillRelation: SkillRelationRecord
   skillInstallation: SkillInstallationRecord
   skillUse: SkillUseRecord
+  artifactReadCounter: ArtifactReadCounterRecord
   skillScanCoverage: SkillScanCoverageRecord
   artifactSkillLink: ArtifactSkillLinkRecord
   plan: PlanRecord

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -480,18 +480,12 @@ export const artifactReadCounter = pgTable(
     org_id: text("org_id").notNull(),
     artifact_id: text("artifact_id").notNull(),
     artifact_version: integer("artifact_version").notNull(),
-    reader_hash: text("reader_hash").notNull(),
-    client: text("client").notNull(),
     opens: integer("opens").notNull().default(1),
     created_at: text("created_at").notNull().$defaultFn(isoNow),
     last_opened_at: text("last_opened_at").notNull(),
   },
   (t) => [
-    uniqueIndex("artifact_read_counter_reader").on(
-      t.artifact_id,
-      t.artifact_version,
-      t.reader_hash,
-    ),
+    uniqueIndex("artifact_read_counter_version").on(t.artifact_id, t.artifact_version),
     index("artifact_read_counter_artifact").on(t.org_id, t.artifact_id, t.last_opened_at),
   ],
 )

--- a/packages/db/src/pg-schema.ts
+++ b/packages/db/src/pg-schema.ts
@@ -473,6 +473,29 @@ export const skillUse = pgTable(
   ],
 )
 
+export const artifactReadCounter = pgTable(
+  "artifact_read_counter",
+  {
+    id: text("id").primaryKey(),
+    org_id: text("org_id").notNull(),
+    artifact_id: text("artifact_id").notNull(),
+    artifact_version: integer("artifact_version").notNull(),
+    reader_hash: text("reader_hash").notNull(),
+    client: text("client").notNull(),
+    opens: integer("opens").notNull().default(1),
+    created_at: text("created_at").notNull().$defaultFn(isoNow),
+    last_opened_at: text("last_opened_at").notNull(),
+  },
+  (t) => [
+    uniqueIndex("artifact_read_counter_reader").on(
+      t.artifact_id,
+      t.artifact_version,
+      t.reader_hash,
+    ),
+    index("artifact_read_counter_artifact").on(t.org_id, t.artifact_id, t.last_opened_at),
+  ],
+)
+
 export const skillScanCoverage = pgTable(
   "skill_scan_coverage",
   {
@@ -1287,6 +1310,7 @@ const TABLES = [
   skillInstallation,
   skillScanCoverage,
   skillUse,
+  artifactReadCounter,
   artifactSkillLink,
   plan,
   connection,

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -6045,19 +6045,12 @@ export class PgMetaStore implements MetaStore {
         org_id: read.org_id,
         artifact_id: read.artifact_id,
         artifact_version: read.artifact_version,
-        reader_hash: read.reader_hash,
-        client: read.client,
         opens: 1,
         last_opened_at: read.opened_at,
       })
       .onConflictDoUpdate({
-        target: [
-          artifactReadCounter.artifact_id,
-          artifactReadCounter.artifact_version,
-          artifactReadCounter.reader_hash,
-        ],
+        target: [artifactReadCounter.artifact_id, artifactReadCounter.artifact_version],
         set: {
-          client: read.client,
           opens: sql`${artifactReadCounter.opens} + 1`,
           last_opened_at: read.opened_at,
         },
@@ -6067,20 +6060,18 @@ export class PgMetaStore implements MetaStore {
   async artifactReadStats(artifactId: string, orgId: string): Promise<ArtifactReadStats> {
     const rows = await this.db
       .select({
-        client: artifactReadCounter.client,
         version: artifactReadCounter.artifact_version,
-        opens: sql<number>`sum(${artifactReadCounter.opens})::int`,
-        at: max(artifactReadCounter.last_opened_at),
+        opens: artifactReadCounter.opens,
+        at: artifactReadCounter.last_opened_at,
       })
       .from(artifactReadCounter)
       .where(
         and(eq(artifactReadCounter.artifact_id, artifactId), eq(artifactReadCounter.org_id, orgId)),
       )
-      .groupBy(artifactReadCounter.client, artifactReadCounter.artifact_version)
-      .orderBy(desc(max(artifactReadCounter.last_opened_at)))
+      .orderBy(desc(artifactReadCounter.last_opened_at))
     return {
       total: rows.reduce((sum, row) => sum + row.opens, 0),
-      recent: rows.filter((row): row is typeof row & { at: string } => row.at !== null).slice(0, 8),
+      recent: rows.slice(0, 8),
     }
   }
   skillLocalUsage(skillArtifactId: string, orgId: string): Promise<SkillLocalUsageBucket[]> {

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -5,6 +5,7 @@ import type {
   ArtifactDetailOpts,
   ArtifactInviteRecord,
   ArtifactMemberRecord,
+  ArtifactReadStats,
   ArtifactRecord,
   ArtifactSkillLinkRecord,
   AssetRecord,
@@ -52,6 +53,7 @@ import type {
   NewArtifact,
   NewArtifactInvite,
   NewArtifactMember,
+  NewArtifactReadCounter,
   NewArtifactSkillLink,
   NewAsset,
   NewAuditLog,
@@ -200,6 +202,7 @@ import {
   artifactFavorite,
   artifactInvite,
   artifactMember,
+  artifactReadCounter,
   artifactSkillLink,
   artifactTag,
   asset,
@@ -302,6 +305,7 @@ export const schema = {
   skillInstallation,
   skillScanCoverage,
   skillUse,
+  artifactReadCounter,
   artifactSkillLink,
   plan,
   connection,
@@ -360,6 +364,7 @@ const _schemaShapes: Shapes<typeof schema> = {
   skillInstallation: true,
   skillScanCoverage: true,
   skillUse: true,
+  artifactReadCounter: true,
   artifactSkillLink: true,
   plan: true,
   connection: true,
@@ -1692,7 +1697,7 @@ export class PgMetaStore implements MetaStore {
       if (views)
         branches.push(
           `SELECT 'view', artifact_id, count(*)::text, NULL, NULL FROM view
-            WHERE viewer_kind!='agent' AND artifact_id = ANY(${page}) GROUP BY artifact_id`,
+            WHERE artifact_id = ANY(${page}) GROUP BY artifact_id`,
         )
       if (viewerId) {
         const viewer = bind(viewerId)
@@ -2319,12 +2324,12 @@ export class PgMetaStore implements MetaStore {
       `INSERT INTO view (id, artifact_id, version, viewer, viewer_kind) VALUES ($1,$2,$3,$4,$5)`,
       [v.id, v.artifact_id, v.version, v.viewer, v.viewer_kind],
     )
-    // Agent reads are activity, not audience activation.
-    if (v.viewer_kind !== "agent")
-      await this.pool.query(
-        `UPDATE artifact SET first_foreign_view_at = $1 WHERE id = $2 AND first_foreign_view_at IS NULL`,
-        [new Date().toISOString(), v.artifact_id],
-      )
+    // Activation stamp: first non-author view only (the route already excluded
+    // owner self-views). WHERE IS NULL keeps it a one-time write.
+    await this.pool.query(
+      `UPDATE artifact SET first_foreign_view_at = $1 WHERE id = $2 AND first_foreign_view_at IS NULL`,
+      [new Date().toISOString(), v.artifact_id],
+    )
   }
 
   async confirmRead(artifactId: string, viewer: string, viewedBeforeIso: string): Promise<void> {
@@ -2378,48 +2383,33 @@ export class PgMetaStore implements MetaStore {
   async viewStats(artifactId: string): Promise<ViewStats> {
     const cutoff = new Date(Date.now() - VIEW_WINDOW_MS).toISOString()
     const dayAgo = new Date(Date.now() - LAST_24H_MS).toISOString()
-    const [tot, day, uni, anon, reads, perV, daily, recent, agentCounts, agentRecent] =
-      await Promise.all([
-        this.pool.query(
-          `SELECT count(*)::int n FROM view WHERE artifact_id=$1 AND viewer_kind!='agent'`,
-          [artifactId],
-        ),
-        this.pool.query(
-          `SELECT count(*)::int n FROM view WHERE artifact_id=$1 AND viewer_kind!='agent' AND created_at>=$2`,
-          [artifactId, dayAgo],
-        ),
-        this.pool.query(
-          `SELECT count(DISTINCT viewer)::int n FROM view WHERE artifact_id=$1 AND viewer_kind!='agent'`,
-          [artifactId],
-        ),
-        this.pool.query(
-          `SELECT count(DISTINCT viewer)::int n FROM view WHERE artifact_id=$1 AND viewer_kind='anon'`,
-          [artifactId],
-        ),
-        this.pool.query(`SELECT count(*)::int n FROM view_read WHERE artifact_id=$1`, [artifactId]),
-        this.pool.query(
-          `SELECT version, count(*)::int c FROM view WHERE artifact_id=$1 AND viewer_kind!='agent' GROUP BY version ORDER BY version`,
-          [artifactId],
-        ),
-        this.pool.query(
-          `SELECT substr(created_at,1,10) AS "day", count(*)::int c FROM view WHERE artifact_id=$1 AND viewer_kind!='agent' AND created_at>=$2 GROUP BY 1 ORDER BY 1`,
-          [artifactId, cutoff],
-        ),
-        this.pool.query(
-          `SELECT viewer, viewer_kind, max(created_at) "at" FROM view WHERE artifact_id=$1 AND viewer_kind!='agent' GROUP BY viewer, viewer_kind ORDER BY 3 DESC LIMIT 8`,
-          [artifactId],
-        ),
-        this.pool.query(
-          `SELECT count(*)::int total,
-                count(*) FILTER (WHERE created_at >= $2)::int "last24h"
-           FROM view WHERE artifact_id=$1 AND viewer_kind='agent'`,
-          [artifactId, dayAgo],
-        ),
-        this.pool.query(
-          `SELECT viewer, version, created_at "at" FROM view WHERE artifact_id=$1 AND viewer_kind='agent' ORDER BY created_at DESC LIMIT 8`,
-          [artifactId],
-        ),
-      ])
+    const [tot, day, uni, anon, reads, perV, daily, recent] = await Promise.all([
+      this.pool.query(`SELECT count(*)::int n FROM view WHERE artifact_id=$1`, [artifactId]),
+      this.pool.query(`SELECT count(*)::int n FROM view WHERE artifact_id=$1 AND created_at>=$2`, [
+        artifactId,
+        dayAgo,
+      ]),
+      this.pool.query(`SELECT count(DISTINCT viewer)::int n FROM view WHERE artifact_id=$1`, [
+        artifactId,
+      ]),
+      this.pool.query(
+        `SELECT count(DISTINCT viewer)::int n FROM view WHERE artifact_id=$1 AND viewer_kind='anon'`,
+        [artifactId],
+      ),
+      this.pool.query(`SELECT count(*)::int n FROM view_read WHERE artifact_id=$1`, [artifactId]),
+      this.pool.query(
+        `SELECT version, count(*)::int c FROM view WHERE artifact_id=$1 GROUP BY version ORDER BY version`,
+        [artifactId],
+      ),
+      this.pool.query(
+        `SELECT substr(created_at,1,10) AS "day", count(*)::int c FROM view WHERE artifact_id=$1 AND created_at>=$2 GROUP BY 1 ORDER BY 1`,
+        [artifactId, cutoff],
+      ),
+      this.pool.query(
+        `SELECT viewer, viewer_kind, max(created_at) "at" FROM view WHERE artifact_id=$1 GROUP BY viewer, viewer_kind ORDER BY 3 DESC LIMIT 8`,
+        [artifactId],
+      ),
+    ])
     return {
       total: tot.rows[0].n,
       last24h: day.rows[0].n,
@@ -2429,15 +2419,6 @@ export class PgMetaStore implements MetaStore {
       perVersion: perV.rows.map((r) => ({ version: r.version, count: r.c })),
       daily: daily.rows.map((r) => ({ day: r.day, count: r.c })),
       recent: recent.rows.map((r) => ({ viewer: r.viewer, kind: r.viewer_kind, at: r.at })),
-      agentReads: {
-        total: agentCounts.rows[0].total,
-        last24h: agentCounts.rows[0].last24h,
-        recent: agentRecent.rows.map((r) => ({
-          agent: r.viewer,
-          version: r.version,
-          at: r.at,
-        })),
-      },
     }
   }
 
@@ -2445,7 +2426,7 @@ export class PgMetaStore implements MetaStore {
     if (artifactIds.length === 0) return {}
     const ph = artifactIds.map((_, i) => `$${i + 1}`).join(",")
     const { rows } = await this.pool.query(
-      `SELECT artifact_id, count(*)::int c FROM view WHERE viewer_kind!='agent' AND artifact_id IN (${ph}) GROUP BY artifact_id`,
+      `SELECT artifact_id, count(*)::int c FROM view WHERE artifact_id IN (${ph}) GROUP BY artifact_id`,
       artifactIds,
     )
     const out: Record<string, number> = {}
@@ -6055,6 +6036,53 @@ export class PgMetaStore implements MetaStore {
       .returning()
     return one(rows)
   }
+
+  async incrementArtifactRead(read: NewArtifactReadCounter): Promise<void> {
+    await this.db
+      .insert(artifactReadCounter)
+      .values({
+        id: read.id,
+        org_id: read.org_id,
+        artifact_id: read.artifact_id,
+        artifact_version: read.artifact_version,
+        reader_hash: read.reader_hash,
+        client: read.client,
+        opens: 1,
+        last_opened_at: read.opened_at,
+      })
+      .onConflictDoUpdate({
+        target: [
+          artifactReadCounter.artifact_id,
+          artifactReadCounter.artifact_version,
+          artifactReadCounter.reader_hash,
+        ],
+        set: {
+          client: read.client,
+          opens: sql`${artifactReadCounter.opens} + 1`,
+          last_opened_at: read.opened_at,
+        },
+      })
+  }
+
+  async artifactReadStats(artifactId: string, orgId: string): Promise<ArtifactReadStats> {
+    const rows = await this.db
+      .select({
+        client: artifactReadCounter.client,
+        version: artifactReadCounter.artifact_version,
+        opens: sql<number>`sum(${artifactReadCounter.opens})::int`,
+        at: max(artifactReadCounter.last_opened_at),
+      })
+      .from(artifactReadCounter)
+      .where(
+        and(eq(artifactReadCounter.artifact_id, artifactId), eq(artifactReadCounter.org_id, orgId)),
+      )
+      .groupBy(artifactReadCounter.client, artifactReadCounter.artifact_version)
+      .orderBy(desc(max(artifactReadCounter.last_opened_at)))
+    return {
+      total: rows.reduce((sum, row) => sum + row.opens, 0),
+      recent: rows.filter((row): row is typeof row & { at: string } => row.at !== null).slice(0, 8),
+    }
+  }
   skillLocalUsage(skillArtifactId: string, orgId: string): Promise<SkillLocalUsageBucket[]> {
     return this.db
       .select({
@@ -7001,6 +7029,7 @@ export class PgMetaStore implements MetaStore {
           or(eq(skillRelation.source_artifact_id, id), eq(skillRelation.target_artifact_id, id)),
         )
       await tx.delete(skillInstallation).where(eq(skillInstallation.skill_artifact_id, id))
+      await tx.delete(artifactReadCounter).where(eq(artifactReadCounter.artifact_id, id))
       await tx
         .delete(artifactSkillLink)
         .where(
@@ -7040,6 +7069,10 @@ export class PgMetaStore implements MetaStore {
   async moveArtifactOrg(artifactId: string, targetOrgId: string): Promise<void> {
     await this.db.transaction(async (tx) => {
       await tx.update(artifact).set({ org_id: targetOrgId }).where(eq(artifact.id, artifactId))
+      await tx
+        .update(artifactReadCounter)
+        .set({ org_id: targetOrgId })
+        .where(eq(artifactReadCounter.artifact_id, artifactId))
       await tx.delete(collectionItem).where(eq(collectionItem.artifact_id, artifactId))
       await tx.update(webhook).set({ artifact_id: null }).where(eq(webhook.artifact_id, artifactId))
     })

--- a/packages/db/src/pg.ts
+++ b/packages/db/src/pg.ts
@@ -1692,7 +1692,7 @@ export class PgMetaStore implements MetaStore {
       if (views)
         branches.push(
           `SELECT 'view', artifact_id, count(*)::text, NULL, NULL FROM view
-            WHERE artifact_id = ANY(${page}) GROUP BY artifact_id`,
+            WHERE viewer_kind!='agent' AND artifact_id = ANY(${page}) GROUP BY artifact_id`,
         )
       if (viewerId) {
         const viewer = bind(viewerId)
@@ -2319,12 +2319,12 @@ export class PgMetaStore implements MetaStore {
       `INSERT INTO view (id, artifact_id, version, viewer, viewer_kind) VALUES ($1,$2,$3,$4,$5)`,
       [v.id, v.artifact_id, v.version, v.viewer, v.viewer_kind],
     )
-    // Activation stamp: first non-author view only (the route already excluded
-    // owner self-views). WHERE IS NULL keeps it a one-time write.
-    await this.pool.query(
-      `UPDATE artifact SET first_foreign_view_at = $1 WHERE id = $2 AND first_foreign_view_at IS NULL`,
-      [new Date().toISOString(), v.artifact_id],
-    )
+    // Agent reads are activity, not audience activation.
+    if (v.viewer_kind !== "agent")
+      await this.pool.query(
+        `UPDATE artifact SET first_foreign_view_at = $1 WHERE id = $2 AND first_foreign_view_at IS NULL`,
+        [new Date().toISOString(), v.artifact_id],
+      )
   }
 
   async confirmRead(artifactId: string, viewer: string, viewedBeforeIso: string): Promise<void> {
@@ -2378,33 +2378,48 @@ export class PgMetaStore implements MetaStore {
   async viewStats(artifactId: string): Promise<ViewStats> {
     const cutoff = new Date(Date.now() - VIEW_WINDOW_MS).toISOString()
     const dayAgo = new Date(Date.now() - LAST_24H_MS).toISOString()
-    const [tot, day, uni, anon, reads, perV, daily, recent] = await Promise.all([
-      this.pool.query(`SELECT count(*)::int n FROM view WHERE artifact_id=$1`, [artifactId]),
-      this.pool.query(`SELECT count(*)::int n FROM view WHERE artifact_id=$1 AND created_at>=$2`, [
-        artifactId,
-        dayAgo,
-      ]),
-      this.pool.query(`SELECT count(DISTINCT viewer)::int n FROM view WHERE artifact_id=$1`, [
-        artifactId,
-      ]),
-      this.pool.query(
-        `SELECT count(DISTINCT viewer)::int n FROM view WHERE artifact_id=$1 AND viewer_kind='anon'`,
-        [artifactId],
-      ),
-      this.pool.query(`SELECT count(*)::int n FROM view_read WHERE artifact_id=$1`, [artifactId]),
-      this.pool.query(
-        `SELECT version, count(*)::int c FROM view WHERE artifact_id=$1 GROUP BY version ORDER BY version`,
-        [artifactId],
-      ),
-      this.pool.query(
-        `SELECT substr(created_at,1,10) AS "day", count(*)::int c FROM view WHERE artifact_id=$1 AND created_at>=$2 GROUP BY 1 ORDER BY 1`,
-        [artifactId, cutoff],
-      ),
-      this.pool.query(
-        `SELECT viewer, viewer_kind, max(created_at) "at" FROM view WHERE artifact_id=$1 GROUP BY viewer, viewer_kind ORDER BY 3 DESC LIMIT 8`,
-        [artifactId],
-      ),
-    ])
+    const [tot, day, uni, anon, reads, perV, daily, recent, agentCounts, agentRecent] =
+      await Promise.all([
+        this.pool.query(
+          `SELECT count(*)::int n FROM view WHERE artifact_id=$1 AND viewer_kind!='agent'`,
+          [artifactId],
+        ),
+        this.pool.query(
+          `SELECT count(*)::int n FROM view WHERE artifact_id=$1 AND viewer_kind!='agent' AND created_at>=$2`,
+          [artifactId, dayAgo],
+        ),
+        this.pool.query(
+          `SELECT count(DISTINCT viewer)::int n FROM view WHERE artifact_id=$1 AND viewer_kind!='agent'`,
+          [artifactId],
+        ),
+        this.pool.query(
+          `SELECT count(DISTINCT viewer)::int n FROM view WHERE artifact_id=$1 AND viewer_kind='anon'`,
+          [artifactId],
+        ),
+        this.pool.query(`SELECT count(*)::int n FROM view_read WHERE artifact_id=$1`, [artifactId]),
+        this.pool.query(
+          `SELECT version, count(*)::int c FROM view WHERE artifact_id=$1 AND viewer_kind!='agent' GROUP BY version ORDER BY version`,
+          [artifactId],
+        ),
+        this.pool.query(
+          `SELECT substr(created_at,1,10) AS "day", count(*)::int c FROM view WHERE artifact_id=$1 AND viewer_kind!='agent' AND created_at>=$2 GROUP BY 1 ORDER BY 1`,
+          [artifactId, cutoff],
+        ),
+        this.pool.query(
+          `SELECT viewer, viewer_kind, max(created_at) "at" FROM view WHERE artifact_id=$1 AND viewer_kind!='agent' GROUP BY viewer, viewer_kind ORDER BY 3 DESC LIMIT 8`,
+          [artifactId],
+        ),
+        this.pool.query(
+          `SELECT count(*)::int total,
+                count(*) FILTER (WHERE created_at >= $2)::int "last24h"
+           FROM view WHERE artifact_id=$1 AND viewer_kind='agent'`,
+          [artifactId, dayAgo],
+        ),
+        this.pool.query(
+          `SELECT viewer, version, created_at "at" FROM view WHERE artifact_id=$1 AND viewer_kind='agent' ORDER BY created_at DESC LIMIT 8`,
+          [artifactId],
+        ),
+      ])
     return {
       total: tot.rows[0].n,
       last24h: day.rows[0].n,
@@ -2414,6 +2429,15 @@ export class PgMetaStore implements MetaStore {
       perVersion: perV.rows.map((r) => ({ version: r.version, count: r.c })),
       daily: daily.rows.map((r) => ({ day: r.day, count: r.c })),
       recent: recent.rows.map((r) => ({ viewer: r.viewer, kind: r.viewer_kind, at: r.at })),
+      agentReads: {
+        total: agentCounts.rows[0].total,
+        last24h: agentCounts.rows[0].last24h,
+        recent: agentRecent.rows.map((r) => ({
+          agent: r.viewer,
+          version: r.version,
+          at: r.at,
+        })),
+      },
     }
   }
 
@@ -2421,7 +2445,7 @@ export class PgMetaStore implements MetaStore {
     if (artifactIds.length === 0) return {}
     const ph = artifactIds.map((_, i) => `$${i + 1}`).join(",")
     const { rows } = await this.pool.query(
-      `SELECT artifact_id, count(*)::int c FROM view WHERE artifact_id IN (${ph}) GROUP BY artifact_id`,
+      `SELECT artifact_id, count(*)::int c FROM view WHERE viewer_kind!='agent' AND artifact_id IN (${ph}) GROUP BY artifact_id`,
       artifactIds,
     )
     const out: Record<string, number> = {}

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -4858,19 +4858,12 @@ export function makeRepos(db: SqliteDb) {
         org_id: read.org_id,
         artifact_id: read.artifact_id,
         artifact_version: read.artifact_version,
-        reader_hash: read.reader_hash,
-        client: read.client,
         opens: 1,
         last_opened_at: read.opened_at,
       })
       .onConflictDoUpdate({
-        target: [
-          artifactReadCounter.artifact_id,
-          artifactReadCounter.artifact_version,
-          artifactReadCounter.reader_hash,
-        ],
+        target: [artifactReadCounter.artifact_id, artifactReadCounter.artifact_version],
         set: {
-          client: read.client,
           opens: sql`${artifactReadCounter.opens} + 1`,
           last_opened_at: read.opened_at,
         },
@@ -4883,21 +4876,19 @@ export function makeRepos(db: SqliteDb) {
   ): Promise<ArtifactReadStats> => {
     const rows = await db
       .select({
-        client: artifactReadCounter.client,
         version: artifactReadCounter.artifact_version,
-        opens: sql<number>`sum(${artifactReadCounter.opens})`,
-        at: max(artifactReadCounter.last_opened_at),
+        opens: artifactReadCounter.opens,
+        at: artifactReadCounter.last_opened_at,
       })
       .from(artifactReadCounter)
       .where(
         and(eq(artifactReadCounter.artifact_id, artifactId), eq(artifactReadCounter.org_id, orgId)),
       )
-      .groupBy(artifactReadCounter.client, artifactReadCounter.artifact_version)
-      .orderBy(desc(max(artifactReadCounter.last_opened_at)))
+      .orderBy(desc(artifactReadCounter.last_opened_at))
       .all()
     return {
       total: rows.reduce((sum, row) => sum + row.opens, 0),
-      recent: rows.filter((row): row is typeof row & { at: string } => row.at !== null).slice(0, 8),
+      recent: rows.slice(0, 8),
     }
   }
   const skillLocalUsage = async (

--- a/packages/db/src/repos.ts
+++ b/packages/db/src/repos.ts
@@ -3,6 +3,7 @@ import type {
   AgentRecord,
   ArtifactInviteRecord,
   ArtifactMemberRecord,
+  ArtifactReadStats,
   ArtifactRecord,
   ArtifactSkillLinkRecord,
   AssetRecord,
@@ -43,6 +44,7 @@ import type {
   NewArtifact,
   NewArtifactInvite,
   NewArtifactMember,
+  NewArtifactReadCounter,
   NewArtifactSkillLink,
   NewAsset,
   NewAuditLog,
@@ -187,6 +189,7 @@ import {
   artifactFavorite,
   artifactInvite,
   artifactMember,
+  artifactReadCounter,
   artifactSkillLink,
   artifactTag,
   asset,
@@ -424,6 +427,7 @@ export const schema = {
   skillInstallation,
   skillScanCoverage,
   skillUse,
+  artifactReadCounter,
   artifactSkillLink,
   plan,
   connection,
@@ -482,6 +486,7 @@ const _schemaShapes: Shapes<typeof schema> = {
   skillInstallation: true,
   skillScanCoverage: true,
   skillUse: true,
+  artifactReadCounter: true,
   artifactSkillLink: true,
   plan: true,
   connection: true,
@@ -4845,6 +4850,56 @@ export function makeRepos(db: SqliteDb) {
       })
       .returning()
       .get()) as SkillUseRecord
+  const incrementArtifactRead = async (read: NewArtifactReadCounter): Promise<void> => {
+    await db
+      .insert(artifactReadCounter)
+      .values({
+        id: read.id,
+        org_id: read.org_id,
+        artifact_id: read.artifact_id,
+        artifact_version: read.artifact_version,
+        reader_hash: read.reader_hash,
+        client: read.client,
+        opens: 1,
+        last_opened_at: read.opened_at,
+      })
+      .onConflictDoUpdate({
+        target: [
+          artifactReadCounter.artifact_id,
+          artifactReadCounter.artifact_version,
+          artifactReadCounter.reader_hash,
+        ],
+        set: {
+          client: read.client,
+          opens: sql`${artifactReadCounter.opens} + 1`,
+          last_opened_at: read.opened_at,
+        },
+      })
+      .run()
+  }
+  const artifactReadStats = async (
+    artifactId: string,
+    orgId: string,
+  ): Promise<ArtifactReadStats> => {
+    const rows = await db
+      .select({
+        client: artifactReadCounter.client,
+        version: artifactReadCounter.artifact_version,
+        opens: sql<number>`sum(${artifactReadCounter.opens})`,
+        at: max(artifactReadCounter.last_opened_at),
+      })
+      .from(artifactReadCounter)
+      .where(
+        and(eq(artifactReadCounter.artifact_id, artifactId), eq(artifactReadCounter.org_id, orgId)),
+      )
+      .groupBy(artifactReadCounter.client, artifactReadCounter.artifact_version)
+      .orderBy(desc(max(artifactReadCounter.last_opened_at)))
+      .all()
+    return {
+      total: rows.reduce((sum, row) => sum + row.opens, 0),
+      recent: rows.filter((row): row is typeof row & { at: string } => row.at !== null).slice(0, 8),
+    }
+  }
   const skillLocalUsage = async (
     skillArtifactId: string,
     orgId: string,
@@ -5708,6 +5763,7 @@ export function makeRepos(db: SqliteDb) {
       .run()
     await db.delete(skillInstallation).where(eq(skillInstallation.skill_artifact_id, id)).run()
     await db.delete(skillUse).where(eq(skillUse.skill_artifact_id, id)).run()
+    await db.delete(artifactReadCounter).where(eq(artifactReadCounter.artifact_id, id)).run()
     await db
       .delete(artifactSkillLink)
       .where(or(eq(artifactSkillLink.artifact_id, id), eq(artifactSkillLink.skill_artifact_id, id)))
@@ -5739,6 +5795,11 @@ export function makeRepos(db: SqliteDb) {
   // Sequential move (used by D1). better-sqlite3 + pg override with a transaction.
   const moveArtifactOrg = async (artifactId: string, targetOrgId: string): Promise<void> => {
     await db.update(artifact).set({ org_id: targetOrgId }).where(eq(artifact.id, artifactId)).run()
+    await db
+      .update(artifactReadCounter)
+      .set({ org_id: targetOrgId })
+      .where(eq(artifactReadCounter.artifact_id, artifactId))
+      .run()
     // Keep the search-index row's org in step so the moved artifact is findable in its
     // new workspace immediately (its text is unchanged by a move — only the scope is).
     // A stale org here could never LEAK it: listArtifacts re-checks org against the live
@@ -6110,6 +6171,8 @@ export function makeRepos(db: SqliteDb) {
     upsertSkillInstallation,
     listSkillInstallations,
     recordSkillUse,
+    incrementArtifactRead,
+    artifactReadStats,
     skillLocalUsage,
     upsertSkillScanCoverage,
     listSkillScanCoverage,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -538,6 +538,31 @@ export const skillUse = sqliteTable(
   ],
 )
 
+// AI artifact activity is a counter, not an event log. One row per exact version and
+// opaque reader bounds storage while preserving total opens and the last open time.
+export const artifactReadCounter = sqliteTable(
+  "artifact_read_counter",
+  {
+    id: text("id").primaryKey(),
+    org_id: text("org_id").notNull(),
+    artifact_id: text("artifact_id").notNull(),
+    artifact_version: integer("artifact_version").notNull(),
+    reader_hash: text("reader_hash").notNull(),
+    client: text("client").notNull(),
+    opens: integer("opens").notNull().default(1),
+    created_at: text("created_at").notNull().default(now),
+    last_opened_at: text("last_opened_at").notNull(),
+  },
+  (t) => [
+    uniqueIndex("artifact_read_counter_reader").on(
+      t.artifact_id,
+      t.artifact_version,
+      t.reader_hash,
+    ),
+    index("artifact_read_counter_artifact").on(t.org_id, t.artifact_id, t.last_opened_at),
+  ],
+)
+
 export const skillScanCoverage = sqliteTable(
   "skill_scan_coverage",
   {
@@ -1509,6 +1534,7 @@ const TABLES = [
   skillInstallation,
   skillScanCoverage,
   skillUse,
+  artifactReadCounter,
   artifactSkillLink,
   plan,
   connection,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -538,8 +538,8 @@ export const skillUse = sqliteTable(
   ],
 )
 
-// AI artifact activity is a counter, not an event log. One row per exact version and
-// opaque reader bounds storage while preserving total opens and the last open time.
+// AI artifact activity is a counter, not an event log. One row per artifact version
+// preserves total opens and the last open time with no reader identity.
 export const artifactReadCounter = sqliteTable(
   "artifact_read_counter",
   {
@@ -547,18 +547,12 @@ export const artifactReadCounter = sqliteTable(
     org_id: text("org_id").notNull(),
     artifact_id: text("artifact_id").notNull(),
     artifact_version: integer("artifact_version").notNull(),
-    reader_hash: text("reader_hash").notNull(),
-    client: text("client").notNull(),
     opens: integer("opens").notNull().default(1),
     created_at: text("created_at").notNull().default(now),
     last_opened_at: text("last_opened_at").notNull(),
   },
   (t) => [
-    uniqueIndex("artifact_read_counter_reader").on(
-      t.artifact_id,
-      t.artifact_version,
-      t.reader_hash,
-    ),
+    uniqueIndex("artifact_read_counter_version").on(t.artifact_id, t.artifact_version),
     index("artifact_read_counter_artifact").on(t.org_id, t.artifact_id, t.last_opened_at),
   ],
 )

--- a/packages/db/src/sqlite.ts
+++ b/packages/db/src/sqlite.ts
@@ -383,13 +383,13 @@ export function createSqliteStore(path: string): MetaStore & { close(): void } {
           `INSERT INTO view (id, artifact_id, version, viewer, viewer_kind) VALUES (?,?,?,?,?)`,
         )
         .run(v.id, v.artifact_id, v.version, v.viewer, v.viewer_kind)
-      // Activation stamp: first non-author view only (the route already excluded
-      // owner self-views). WHERE IS NULL keeps it a one-time write.
-      raw
-        .prepare(
-          `UPDATE artifact SET first_foreign_view_at = ? WHERE id = ? AND first_foreign_view_at IS NULL`,
-        )
-        .run(new Date().toISOString(), v.artifact_id)
+      // Agent reads are activity, not audience activation.
+      if (v.viewer_kind !== "agent")
+        raw
+          .prepare(
+            `UPDATE artifact SET first_foreign_view_at = ? WHERE id = ? AND first_foreign_view_at IS NULL`,
+          )
+          .run(new Date().toISOString(), v.artifact_id)
     },
     // See MetaStore.confirmRead. One idempotent statement, so the repeat heartbeats
     // that follow cost a single indexed probe.
@@ -433,13 +433,19 @@ export function createSqliteStore(path: string): MetaStore & { close(): void } {
       const dayAgo = new Date(Date.now() - LAST_24H_MS).toISOString()
       const n = (q: string, ...p: unknown[]) => (raw.prepare(q).get(...p) as { n: number }).n
       return {
-        total: n(`SELECT count(*) n FROM view WHERE artifact_id=?`, artifactId),
+        total: n(
+          `SELECT count(*) n FROM view WHERE artifact_id=? AND viewer_kind!='agent'`,
+          artifactId,
+        ),
         last24h: n(
-          `SELECT count(*) n FROM view WHERE artifact_id=? AND created_at>=?`,
+          `SELECT count(*) n FROM view WHERE artifact_id=? AND viewer_kind!='agent' AND created_at>=?`,
           artifactId,
           dayAgo,
         ),
-        unique: n(`SELECT count(DISTINCT viewer) n FROM view WHERE artifact_id=?`, artifactId),
+        unique: n(
+          `SELECT count(DISTINCT viewer) n FROM view WHERE artifact_id=? AND viewer_kind!='agent'`,
+          artifactId,
+        ),
         anonViewers: n(
           `SELECT count(DISTINCT viewer) n FROM view WHERE artifact_id=? AND viewer_kind='anon'`,
           artifactId,
@@ -447,19 +453,31 @@ export function createSqliteStore(path: string): MetaStore & { close(): void } {
         reads: n(`SELECT count(*) n FROM view_read WHERE artifact_id=?`, artifactId),
         perVersion: raw
           .prepare(
-            `SELECT version, count(*) count FROM view WHERE artifact_id=? GROUP BY version ORDER BY version`,
+            `SELECT version, count(*) count FROM view WHERE artifact_id=? AND viewer_kind!='agent' GROUP BY version ORDER BY version`,
           )
           .all(artifactId) as { version: number; count: number }[],
         daily: raw
           .prepare(
-            `SELECT substr(created_at,1,10) day, count(*) count FROM view WHERE artifact_id=? AND created_at>=? GROUP BY day ORDER BY day`,
+            `SELECT substr(created_at,1,10) day, count(*) count FROM view WHERE artifact_id=? AND viewer_kind!='agent' AND created_at>=? GROUP BY day ORDER BY day`,
           )
           .all(artifactId, cutoff) as { day: string; count: number }[],
         recent: raw
           .prepare(
-            `SELECT viewer, viewer_kind kind, max(created_at) at FROM view WHERE artifact_id=? GROUP BY viewer, viewer_kind ORDER BY at DESC LIMIT 8`,
+            `SELECT viewer, viewer_kind kind, max(created_at) at FROM view WHERE artifact_id=? AND viewer_kind!='agent' GROUP BY viewer, viewer_kind ORDER BY at DESC LIMIT 8`,
           )
           .all(artifactId) as { viewer: string; kind: "user" | "anon"; at: string }[],
+        agentReads: {
+          ...(raw
+            .prepare(
+              `SELECT count(*) total, count(CASE WHEN created_at>=? THEN 1 END) last24h FROM view WHERE artifact_id=? AND viewer_kind='agent'`,
+            )
+            .get(dayAgo, artifactId) as { total: number; last24h: number }),
+          recent: raw
+            .prepare(
+              `SELECT viewer agent, version, created_at at FROM view WHERE artifact_id=? AND viewer_kind='agent' ORDER BY created_at DESC LIMIT 8`,
+            )
+            .all(artifactId) as { agent: string; version: number; at: string }[],
+        },
       }
     },
     viewCounts: async (artifactIds): Promise<Record<string, number>> => {
@@ -467,7 +485,7 @@ export function createSqliteStore(path: string): MetaStore & { close(): void } {
       const ph = artifactIds.map(() => "?").join(",")
       const rows = raw
         .prepare(
-          `SELECT artifact_id, count(*) c FROM view WHERE artifact_id IN (${ph}) GROUP BY artifact_id`,
+          `SELECT artifact_id, count(*) c FROM view WHERE viewer_kind!='agent' AND artifact_id IN (${ph}) GROUP BY artifact_id`,
         )
         .all(...artifactIds) as { artifact_id: string; c: number }[]
       const out: Record<string, number> = {}

--- a/packages/db/src/sqlite.ts
+++ b/packages/db/src/sqlite.ts
@@ -29,6 +29,7 @@ import {
   artifact,
   artifactFavorite,
   artifactMember,
+  artifactReadCounter,
   artifactTag,
   auditLog,
   CONTEXT_SESSION_RELAX_SQLITE,
@@ -310,6 +311,7 @@ export function createSqliteStore(path: string): MetaStore & { close(): void } {
         db.delete(webhook).where(eq(webhook.artifact_id, id)).run()
         db.delete(sharedStateActivity).where(eq(sharedStateActivity.artifact_id, id)).run()
         db.delete(sharedState).where(eq(sharedState.artifact_id, id)).run()
+        db.delete(artifactReadCounter).where(eq(artifactReadCounter.artifact_id, id)).run()
         db.delete(versionData).where(eq(versionData.artifact_id, id)).run()
         db.delete(version).where(eq(version.artifact_id, id)).run()
         db.delete(comment).where(eq(comment.artifact_id, id)).run()
@@ -339,6 +341,10 @@ export function createSqliteStore(path: string): MetaStore & { close(): void } {
     moveArtifactOrg: async (artifactId: string, targetOrgId: string): Promise<void> => {
       raw.transaction(() => {
         db.update(artifact).set({ org_id: targetOrgId }).where(eq(artifact.id, artifactId)).run()
+        db.update(artifactReadCounter)
+          .set({ org_id: targetOrgId })
+          .where(eq(artifactReadCounter.artifact_id, artifactId))
+          .run()
         db.delete(collectionItem).where(eq(collectionItem.artifact_id, artifactId)).run()
         db.update(webhook)
           .set({ artifact_id: null })
@@ -383,13 +389,13 @@ export function createSqliteStore(path: string): MetaStore & { close(): void } {
           `INSERT INTO view (id, artifact_id, version, viewer, viewer_kind) VALUES (?,?,?,?,?)`,
         )
         .run(v.id, v.artifact_id, v.version, v.viewer, v.viewer_kind)
-      // Agent reads are activity, not audience activation.
-      if (v.viewer_kind !== "agent")
-        raw
-          .prepare(
-            `UPDATE artifact SET first_foreign_view_at = ? WHERE id = ? AND first_foreign_view_at IS NULL`,
-          )
-          .run(new Date().toISOString(), v.artifact_id)
+      // Activation stamp: first non-author view only (the route already excluded
+      // owner self-views). WHERE IS NULL keeps it a one-time write.
+      raw
+        .prepare(
+          `UPDATE artifact SET first_foreign_view_at = ? WHERE id = ? AND first_foreign_view_at IS NULL`,
+        )
+        .run(new Date().toISOString(), v.artifact_id)
     },
     // See MetaStore.confirmRead. One idempotent statement, so the repeat heartbeats
     // that follow cost a single indexed probe.
@@ -433,19 +439,13 @@ export function createSqliteStore(path: string): MetaStore & { close(): void } {
       const dayAgo = new Date(Date.now() - LAST_24H_MS).toISOString()
       const n = (q: string, ...p: unknown[]) => (raw.prepare(q).get(...p) as { n: number }).n
       return {
-        total: n(
-          `SELECT count(*) n FROM view WHERE artifact_id=? AND viewer_kind!='agent'`,
-          artifactId,
-        ),
+        total: n(`SELECT count(*) n FROM view WHERE artifact_id=?`, artifactId),
         last24h: n(
-          `SELECT count(*) n FROM view WHERE artifact_id=? AND viewer_kind!='agent' AND created_at>=?`,
+          `SELECT count(*) n FROM view WHERE artifact_id=? AND created_at>=?`,
           artifactId,
           dayAgo,
         ),
-        unique: n(
-          `SELECT count(DISTINCT viewer) n FROM view WHERE artifact_id=? AND viewer_kind!='agent'`,
-          artifactId,
-        ),
+        unique: n(`SELECT count(DISTINCT viewer) n FROM view WHERE artifact_id=?`, artifactId),
         anonViewers: n(
           `SELECT count(DISTINCT viewer) n FROM view WHERE artifact_id=? AND viewer_kind='anon'`,
           artifactId,
@@ -453,31 +453,19 @@ export function createSqliteStore(path: string): MetaStore & { close(): void } {
         reads: n(`SELECT count(*) n FROM view_read WHERE artifact_id=?`, artifactId),
         perVersion: raw
           .prepare(
-            `SELECT version, count(*) count FROM view WHERE artifact_id=? AND viewer_kind!='agent' GROUP BY version ORDER BY version`,
+            `SELECT version, count(*) count FROM view WHERE artifact_id=? GROUP BY version ORDER BY version`,
           )
           .all(artifactId) as { version: number; count: number }[],
         daily: raw
           .prepare(
-            `SELECT substr(created_at,1,10) day, count(*) count FROM view WHERE artifact_id=? AND viewer_kind!='agent' AND created_at>=? GROUP BY day ORDER BY day`,
+            `SELECT substr(created_at,1,10) day, count(*) count FROM view WHERE artifact_id=? AND created_at>=? GROUP BY day ORDER BY day`,
           )
           .all(artifactId, cutoff) as { day: string; count: number }[],
         recent: raw
           .prepare(
-            `SELECT viewer, viewer_kind kind, max(created_at) at FROM view WHERE artifact_id=? AND viewer_kind!='agent' GROUP BY viewer, viewer_kind ORDER BY at DESC LIMIT 8`,
+            `SELECT viewer, viewer_kind kind, max(created_at) at FROM view WHERE artifact_id=? GROUP BY viewer, viewer_kind ORDER BY at DESC LIMIT 8`,
           )
           .all(artifactId) as { viewer: string; kind: "user" | "anon"; at: string }[],
-        agentReads: {
-          ...(raw
-            .prepare(
-              `SELECT count(*) total, count(CASE WHEN created_at>=? THEN 1 END) last24h FROM view WHERE artifact_id=? AND viewer_kind='agent'`,
-            )
-            .get(dayAgo, artifactId) as { total: number; last24h: number }),
-          recent: raw
-            .prepare(
-              `SELECT viewer agent, version, created_at at FROM view WHERE artifact_id=? AND viewer_kind='agent' ORDER BY created_at DESC LIMIT 8`,
-            )
-            .all(artifactId) as { agent: string; version: number; at: string }[],
-        },
       }
     },
     viewCounts: async (artifactIds): Promise<Record<string, number>> => {
@@ -485,7 +473,7 @@ export function createSqliteStore(path: string): MetaStore & { close(): void } {
       const ph = artifactIds.map(() => "?").join(",")
       const rows = raw
         .prepare(
-          `SELECT artifact_id, count(*) c FROM view WHERE viewer_kind!='agent' AND artifact_id IN (${ph}) GROUP BY artifact_id`,
+          `SELECT artifact_id, count(*) c FROM view WHERE artifact_id IN (${ph}) GROUP BY artifact_id`,
         )
         .all(...artifactIds) as { artifact_id: string; c: number }[]
       const out: Record<string, number> = {}

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -1846,28 +1846,26 @@ export function runStoreContract(
   })
 
   describe(`${label}: views + analytics`, () => {
-    it("keeps AI opens in bounded per-reader counters", async () => {
+    it("keeps AI opens in bounded per-version counters", async () => {
       const a = await store.createArtifact(newArtifact())
       const openedAt = new Date().toISOString()
-      const open = (id: string, readerHash: string, client: string, version = 1) =>
+      const open = (id: string, version = 1) =>
         store.incrementArtifactRead({
           id,
           org_id: ORG,
           artifact_id: a.id,
           artifact_version: version,
-          reader_hash: readerHash,
-          client,
           opened_at: openedAt,
         })
-      await open(uuid(), "machine-a", "Codex")
-      await open(uuid(), "machine-a", "Codex")
-      await open(uuid(), "machine-b", "Codex")
-      await open(uuid(), "machine-c", "Claude", 2)
+      await open(uuid())
+      await open(uuid())
+      await open(uuid())
+      await open(uuid(), 2)
 
       const stats = await store.artifactReadStats(a.id, ORG)
       expect(stats.total).toBe(4)
-      expect(stats.recent).toContainEqual({ client: "Codex", version: 1, opens: 3, at: openedAt })
-      expect(stats.recent).toContainEqual({ client: "Claude", version: 2, opens: 1, at: openedAt })
+      expect(stats.recent).toContainEqual({ version: 1, opens: 3, at: openedAt })
+      expect(stats.recent).toContainEqual({ version: 2, opens: 1, at: openedAt })
       // AI activity never changes the browser audience or activation metrics.
       expect((await store.viewStats(a.id)).total).toBe(0)
       expect((await store.getByShortId(a.short_id))?.first_foreign_view_at).toBeNull()

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -1846,6 +1846,33 @@ export function runStoreContract(
   })
 
   describe(`${label}: views + analytics`, () => {
+    it("keeps AI opens in bounded per-reader counters", async () => {
+      const a = await store.createArtifact(newArtifact())
+      const openedAt = new Date().toISOString()
+      const open = (id: string, readerHash: string, client: string, version = 1) =>
+        store.incrementArtifactRead({
+          id,
+          org_id: ORG,
+          artifact_id: a.id,
+          artifact_version: version,
+          reader_hash: readerHash,
+          client,
+          opened_at: openedAt,
+        })
+      await open(uuid(), "machine-a", "Codex")
+      await open(uuid(), "machine-a", "Codex")
+      await open(uuid(), "machine-b", "Codex")
+      await open(uuid(), "machine-c", "Claude", 2)
+
+      const stats = await store.artifactReadStats(a.id, ORG)
+      expect(stats.total).toBe(4)
+      expect(stats.recent).toContainEqual({ client: "Codex", version: 1, opens: 3, at: openedAt })
+      expect(stats.recent).toContainEqual({ client: "Claude", version: 2, opens: 1, at: openedAt })
+      // AI activity never changes the browser audience or activation metrics.
+      expect((await store.viewStats(a.id)).total).toBe(0)
+      expect((await store.getByShortId(a.short_id))?.first_foreign_view_at).toBeNull()
+    })
+
     it("records views and aggregates stats, de-dups, prunes", async () => {
       const a = await store.createArtifact(newArtifact())
       await store.recordView({
@@ -1862,15 +1889,7 @@ export function runStoreContract(
         viewer: "anon1",
         viewer_kind: "anon",
       })
-      await store.recordView({
-        id: uuid(),
-        artifact_id: a.id,
-        version: 1,
-        viewer: "Claude",
-        viewer_kind: "agent",
-      })
       const stats = await store.viewStats(a.id)
-      // Agent reads use the same retained event ledger but never inflate audience.
       expect(stats.total).toBe(2)
       expect(stats.unique).toBe(2)
       expect(stats.anonViewers).toBe(1)
@@ -1879,8 +1898,6 @@ export function runStoreContract(
       // The rolling 24h window powers the Insights "24h" tile. Both rows were just
       // recorded, so all of them fall inside it.
       expect(stats.last24h).toBe(2)
-      expect(stats.agentReads).toMatchObject({ total: 1, last24h: 1 })
-      expect(stats.agentReads.recent[0]).toMatchObject({ agent: "Claude", version: 1 })
       expect((await store.viewCounts([a.id]))[a.id]).toBe(2)
       expect(await store.viewedSince(a.id, "amy", 1, "2000-01-01T00:00:00.000Z")).toBe(true)
       // Cleanup helpers.
@@ -1921,15 +1938,6 @@ export function runStoreContract(
 
     it("stamps first_foreign_view_at on the first view only (the activation moment)", async () => {
       const a = await store.createArtifact(newArtifact())
-      expect((await store.getByShortId(a.short_id))?.first_foreign_view_at).toBeNull()
-
-      await store.recordView({
-        id: uuid(),
-        artifact_id: a.id,
-        version: 1,
-        viewer: "Claude",
-        viewer_kind: "agent",
-      })
       expect((await store.getByShortId(a.short_id))?.first_foreign_view_at).toBeNull()
 
       await store.recordView({

--- a/packages/db/test/store-contract.ts
+++ b/packages/db/test/store-contract.ts
@@ -1862,7 +1862,15 @@ export function runStoreContract(
         viewer: "anon1",
         viewer_kind: "anon",
       })
+      await store.recordView({
+        id: uuid(),
+        artifact_id: a.id,
+        version: 1,
+        viewer: "Claude",
+        viewer_kind: "agent",
+      })
       const stats = await store.viewStats(a.id)
+      // Agent reads use the same retained event ledger but never inflate audience.
       expect(stats.total).toBe(2)
       expect(stats.unique).toBe(2)
       expect(stats.anonViewers).toBe(1)
@@ -1871,6 +1879,8 @@ export function runStoreContract(
       // The rolling 24h window powers the Insights "24h" tile. Both rows were just
       // recorded, so all of them fall inside it.
       expect(stats.last24h).toBe(2)
+      expect(stats.agentReads).toMatchObject({ total: 1, last24h: 1 })
+      expect(stats.agentReads.recent[0]).toMatchObject({ agent: "Claude", version: 1 })
       expect((await store.viewCounts([a.id]))[a.id]).toBe(2)
       expect(await store.viewedSince(a.id, "amy", 1, "2000-01-01T00:00:00.000Z")).toBe(true)
       // Cleanup helpers.
@@ -1911,6 +1921,15 @@ export function runStoreContract(
 
     it("stamps first_foreign_view_at on the first view only (the activation moment)", async () => {
       const a = await store.createArtifact(newArtifact())
+      expect((await store.getByShortId(a.short_id))?.first_foreign_view_at).toBeNull()
+
+      await store.recordView({
+        id: uuid(),
+        artifact_id: a.id,
+        version: 1,
+        viewer: "Claude",
+        viewer_kind: "agent",
+      })
       expect((await store.getByShortId(a.short_id))?.first_foreign_view_at).toBeNull()
 
       await store.recordView({

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -184,7 +184,7 @@ export interface ViewStatsJson {
   recent: { viewer: string; kind: "user" | "anon"; at: string }[]
   agentReads: {
     total: number
-    recent: { client: string; version: number; opens: number; at: string }[]
+    recent: { version: number; opens: number; at: string }[]
   }
 }
 
@@ -540,7 +540,7 @@ export function createClient(opts: ClientOptions): DeriveClient {
       if (opts?.format) q.set("format", opts.format)
       const qs = q.toString()
       const res = await f(`${base}/v1/artifacts/${shortId}/content${qs ? `?${qs}` : ""}`, {
-        headers: authHeaders,
+        headers: { ...authHeaders, "x-derive-ai-read": "1" },
       })
       if (!res.ok) {
         const body = (await res.json().catch(() => ({}))) as { error?: string }
@@ -582,7 +582,9 @@ export function createClient(opts: ClientOptions): DeriveClient {
     async getOutline(shortId, version) {
       const q = new URLSearchParams({ outline: "1" })
       if (version) q.set("v", String(version))
-      const res = await f(`${base}/v1/artifacts/${shortId}/content?${q}`, { headers: authHeaders })
+      const res = await f(`${base}/v1/artifacts/${shortId}/content?${q}`, {
+        headers: { ...authHeaders, "x-derive-ai-read": "1" },
+      })
       if (!res.ok) return { sections: [], pages: null }
       const body = (await res.json()) as {
         sections?: OutlineSectionJson[]

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -184,8 +184,7 @@ export interface ViewStatsJson {
   recent: { viewer: string; kind: "user" | "anon"; at: string }[]
   agentReads: {
     total: number
-    last24h: number
-    recent: { agent: string; version: number; at: string }[]
+    recent: { client: string; version: number; opens: number; at: string }[]
   }
 }
 

--- a/packages/mcp/src/client.ts
+++ b/packages/mcp/src/client.ts
@@ -182,6 +182,11 @@ export interface ViewStatsJson {
   perVersion: { version: number; count: number }[]
   daily: { day: string; count: number }[]
   recent: { viewer: string; kind: "user" | "anon"; at: string }[]
+  agentReads: {
+    total: number
+    last24h: number
+    recent: { agent: string; version: number; at: string }[]
+  }
 }
 
 /** A library is an access-scoped catalog of immutable template starters. */


### PR DESCRIPTION
Derive can show browser views, but artifact opens through MCP are invisible. This change counts successful artifact versions opened through hosted and local MCP clients.

Storage stays small. Derive keeps one counter row per artifact version. Repeated opens increment that row and update its last-opened time. Derive stores no per-open event log, machine identity, client identity, prompt, transcript, or human identity.

Artifact Insights shows total AI opens and recent version counters. Browser reads, anonymous requests, and failed reads do not count. The response does not wait for the counter write, and the path makes no LLM call.

Validation: `pnpm verify` (34 guardrails, all typechecks, 3,182 tests). Terra medium completed a final review with no findings.
