### PR TITLE
Harden Derive scans against receipt loss and incorrect attribution

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -219,7 +219,27 @@ calls stay separate by client, session, and source.
 
 The scanner checks every workspace available to the selected account before it rejects an artifact
 as unavailable. It keeps unresolved receipts in the local spool. A later scan can resolve them after
-an account or server switch. The scanner sends no artifact content while it resolves the target.
+an account switch on the same server. Pending receipts stay bound to their original server, including
+when a backfill sees them again; switching servers does not forward those receipts to the new server.
+The scanner sends no artifact content while it resolves the target.
+
+Both scanners preserve session and turn context across idle scans and detect replaced or
+copytruncated logs with a cursor fingerprint. Upgrading a pre-fingerprint Skill cursor preserves its
+offset; use an explicit `--since` backfill to revisit earlier activity. Undated events are excluded
+from dated backfills. Artifact receipts recognize direct Derive tools, named orchestration results,
+and Derive code-mode reads, and ignore failed results and other services' tools.
+
+`--dry-run` and `status` leave local scan files and installation records unchanged. Dry runs can
+preview older project Skill pins without first migrating their installation records. Rerunning
+`setup` initializes only previously unseen logs and preserves existing cursors and pending calls.
+Setup installs asynchronous hooks with a five-minute timeout and repairs older three-second hooks.
+
+Each scanner holds an exclusive local lock while it changes cursors, spools, or upload acknowledgements.
+Overlapping runs exit with a retryable error; accepted batches are removed and failed batches stay
+pending. Artifact and Skill uploads use batches of at most 20 events. Locks are released on normal
+exit, errors, SIGINT, and SIGTERM. After an uncatchable kill or power loss, the error names the lock
+file: inspect its recorded PID and remove only that lock once the process is confirmed stopped.
+Do not remove the cursor or spool files to resolve a lock.
 
 The artifact page can show another artifact published later in the same opaque session. This is an
 observed sequence, not provenance. Derive does not create a run, attach the artifact to a node, or

--- a/packages/cli/bin/derive.js
+++ b/packages/cli/bin/derive.js
@@ -85,6 +85,7 @@ import { createAgent, createContext, saveAgentToken } from "../src/context.js"
 import { setupDeriveScan } from "../src/derive-scan-setup.js"
 import { readTarget, uploadArtifact } from "../src/publish.js"
 import { DeriveClient, parseManifest } from "../src/runner.js"
+import { acquireScanLock } from "../src/scan-state.js"
 import {
   addToSkillScanSpool,
   commitSkillScanState,
@@ -106,6 +107,51 @@ import {
 import { runGithubWorkflowHarness } from "../src/workflow-run.js"
 
 const SKILL_USAGE_BATCH_SIZE = 20
+const ARTIFACT_SCAN_BATCH_SIZE = 20
+
+// Pins written before scan existed are usable in a preview too. Materialize
+// them in memory for dry runs; only an actual scan repairs the registry.
+const projectScanInstalls = (cfg, target, persist) => {
+  const installs = listSkillInstalls()
+  for (const pin of cfg?.skills ?? [])
+    for (const client of ["claude", "codex"]) {
+      const installed = pin.installs?.[client]
+      if (!installed) continue
+      const dir = skillSlug(installed.name ?? pin.name)
+      if (!dir) continue
+      const candidates = [
+        {
+          scope: "project",
+          path: join(".", client === "codex" ? ".agents" : ".claude", "skills", dir),
+        },
+        {
+          scope: "personal",
+          path: join(homedir(), client === "codex" ? ".codex" : ".claude", "skills", dir),
+        },
+      ]
+      for (const candidate of candidates) {
+        if (!existsSync(candidate.path)) continue
+        installs.push(
+          recordSkillInstall(
+            {
+              id: pin.id,
+              version: installed.version ?? pin.version,
+              name: installed.name ?? pin.name,
+              client,
+              path: candidate.path,
+              digest: installed.digest ?? null,
+              scope: candidate.scope,
+              server: target.server,
+              workspaceId: target.workspaceId,
+              accountId: target.accountId,
+            },
+            { persist },
+          ),
+        )
+      }
+    }
+  return installs
+}
 
 const args = process.argv.slice(2)
 const cmd = args.shift()
@@ -1390,7 +1436,14 @@ if (cmd === "scan") {
     process.exit(0)
   }
 
+  if (flags["dry-run"] === "true" && action === "setup") {
+    console.error("error: --dry-run is for scanning; setup changes hooks and cursors")
+    process.exit(1)
+  }
+  const releaseArtifactLock = flags["dry-run"] === "true" ? () => {} : acquireScanLock("artifact")
+
   if (action === "setup") {
+    const releaseSkillLock = acquireScanLock("skill")
     await Promise.all([
       scanArtifactLogs({ baseline: true, client: flags.client }),
       scanSkillLogs({ baseline: true, client: flags.client }),
@@ -1399,6 +1452,7 @@ if (cmd === "scan") {
       schedule: flags.schedule === "true",
       client: flags.client,
     })
+    releaseSkillLock()
     if (flags.json) console.log(JSON.stringify(setup))
     else {
       for (const hook of setup.hooks)
@@ -1420,6 +1474,7 @@ if (cmd === "scan") {
     }),
     flags["dry-run"] === "true"
       ? scanSkillLogs({
+          installs: projectScanInstalls(cfg, resolved, false),
           since: flags.since,
           initialBaseline: true,
           dryRun: true,
@@ -1431,7 +1486,7 @@ if (cmd === "scan") {
     const output = {
       dry_run: true,
       artifacts: artifactResult.events,
-      skills: skillResult?.events ?? [],
+      skills: (skillResult?.events ?? []).map(({ target: _target, ...event }) => event),
       coverage: artifactResult.coverage,
     }
     if (flags.json) console.log(JSON.stringify(output))
@@ -1500,8 +1555,13 @@ if (cmd === "scan") {
       let remaining = group.events
       for (const workspaceId of workspaceIds) {
         const batches = remaining.length
-          ? Array.from({ length: Math.ceil(remaining.length / 100) }, (_, index) =>
-              remaining.slice(index * 100, (index + 1) * 100),
+          ? Array.from(
+              { length: Math.ceil(remaining.length / ARTIFACT_SCAN_BATCH_SIZE) },
+              (_, index) =>
+                remaining.slice(
+                  index * ARTIFACT_SCAN_BATCH_SIZE,
+                  (index + 1) * ARTIFACT_SCAN_BATCH_SIZE,
+                ),
             )
           : [[]]
         const nextRemaining = []
@@ -1547,6 +1607,7 @@ if (cmd === "scan") {
   const rejectedIds = rejected.map((item) => (typeof item === "string" ? item : item?.event_id))
   spool = removeFromArtifactScanSpool([...recorded, ...rejectedIds], !uploadError)
   spool = markArtifactScanUnavailable(unavailable)
+  releaseArtifactLock()
 
   const childArgs = [fileURLToPath(import.meta.url), "skill", "scan", "--quiet", "--json"]
   childArgs.push("--initial-baseline")
@@ -1625,40 +1686,11 @@ if (cmd === "skill") {
     }
 
     const r = resolvePublish(flags, cfg)
-    // Backfill the local install registry for pins created before Skill scan existed.
-    for (const pin of cfg?.skills ?? []) {
-      for (const client of ["claude", "codex"]) {
-        const installed = pin.installs?.[client]
-        if (!installed) continue
-        const dir = skillSlug(installed.name ?? pin.name)
-        if (!dir) continue
-        const candidates = [
-          {
-            scope: "project",
-            path: join(".", client === "codex" ? ".agents" : ".claude", "skills", dir),
-          },
-          {
-            scope: "personal",
-            path: join(homedir(), client === "codex" ? ".codex" : ".claude", "skills", dir),
-          },
-        ]
-        for (const candidate of candidates) {
-          if (!existsSync(candidate.path)) continue
-          recordSkillInstall({
-            id: pin.id,
-            version: installed.version ?? pin.version,
-            name: installed.name ?? pin.name,
-            client,
-            path: candidate.path,
-            digest: installed.digest ?? null,
-            scope: candidate.scope,
-            server: r.server,
-            workspaceId: r.workspaceId,
-            accountId: r.accountId,
-          })
-        }
-      }
+    if (flags["dry-run"] === "true" && action === "setup") {
+      console.error("error: --dry-run is for scanning; setup changes hooks and cursors")
+      process.exit(1)
     }
+    if (action !== "status" && flags["dry-run"] !== "true") acquireScanLock("skill")
 
     if (action === "status") {
       const status = skillScanStatus()
@@ -1695,6 +1727,7 @@ if (cmd === "skill") {
     }
 
     const result = await scanSkillLogs({
+      installs: projectScanInstalls(cfg, r, flags["dry-run"] !== "true"),
       since: flags.since,
       baseline: flags.baseline === "true",
       initialBaseline: flags["initial-baseline"] === "true",

--- a/packages/cli/src/artifact-scan.js
+++ b/packages/cli/src/artifact-scan.js
@@ -1,55 +1,22 @@
-import { createHash, randomBytes } from "node:crypto"
-import {
-  closeSync,
-  createReadStream,
-  mkdirSync,
-  openSync,
-  readFileSync,
-  readSync,
-  renameSync,
-  statSync,
-  writeFileSync,
-} from "node:fs"
+import { createHash } from "node:crypto"
+import { createReadStream, statSync } from "node:fs"
 import { homedir } from "node:os"
-import { basename, dirname, join } from "node:path"
+import { basename, join } from "node:path"
+import {
+  scanConfigRoot as configRoot,
+  readScanJson as readJson,
+  sourceCheckpoint,
+  writeScanJson as writeJson,
+} from "./scan-state.js"
 import { discoverSkillLogSources, parseSince } from "./skill-scan.js"
 
-export const ARTIFACT_SCAN_PARSER_VERSION = 1
+export const ARTIFACT_SCAN_PARSER_VERSION = 2
 
-const configRoot = () => process.env.DERIVE_CONFIG_DIR ?? join(homedir(), ".config", "derive")
 const statePath = () => join(configRoot(), "artifact-scan.json")
 const spoolPath = () => join(configRoot(), "artifact-scan-spool.json")
 const hash = (value) => createHash("sha256").update(value).digest("hex")
 
-const readJson = (path, fallback) => {
-  try {
-    return JSON.parse(readFileSync(path, "utf8"))
-  } catch {
-    return fallback
-  }
-}
-
-const writeJson = (path, value) => {
-  mkdirSync(dirname(path), { recursive: true })
-  const temporary = `${path}.${process.pid}.${randomBytes(5).toString("hex")}.tmp`
-  writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 })
-  renameSync(temporary, path)
-}
-
 const sourceIdentity = (stats) => `${stats.dev}:${stats.ino}`
-
-const sourceCheckpoint = (path, offset) => {
-  const length = Math.min(4096, offset)
-  if (length === 0) return hash("")
-  const buffer = Buffer.alloc(length)
-  const descriptor = openSync(path, "r")
-  try {
-    const read = readSync(descriptor, buffer, 0, length, offset - length)
-    return hash(buffer.subarray(0, read))
-  } finally {
-    closeSync(descriptor)
-  }
-}
 
 const completeLines = async (path, start, onLine) => {
   let carry = Buffer.alloc(0)
@@ -77,17 +44,21 @@ const timestampOf = (record) => {
 }
 
 const operationForName = (name) => {
-  const match = /(?:^|__)(read|catch_up|publish)$/.exec(String(name ?? ""))
+  const match = /^(?:mcp__derive__|derive[.])(read|catch_up|publish)$/.exec(String(name ?? ""))
   return match?.[1] ?? null
 }
 
 const operationsFromCall = (name, raw) => {
+  // The server's code tool exposes only reads. Its returned tool_calls list
+  // and wrapped result are handled just like a direct read receipt.
+  if (name === "mcp__derive__derive_code" || name === "derive.derive_code") return ["read"]
   const direct = operationForName(name)
   if (direct) return [direct]
   if (typeof raw !== "string") return []
   const found = []
-  const pattern = /tools\.mcp__derive__(read|catch_up|publish)\s*\(/g
-  for (const match of raw.matchAll(pattern)) found.push(match[1])
+  const pattern = /tools\.mcp__derive__(read|catch_up|publish|derive_code)\s*\(/g
+  for (const match of raw.matchAll(pattern))
+    found.push(match[1] === "derive_code" ? "read" : match[1])
   return [...new Set(found)]
 }
 
@@ -101,22 +72,48 @@ const outputStrings = (value) => {
 
 const positiveVersion = (value) => {
   if (Number.isInteger(value) && value > 0) return value
-  const match = /^(\d+)/.exec(String(value ?? ""))
+  const match = /^(\d+)(?: \(current\))?$/.exec(String(value ?? ""))
   const parsed = match ? Number(match[1]) : 0
   return Number.isInteger(parsed) && parsed > 0 ? parsed : null
 }
 
-const addArtifactResult = (found, value, expected) => {
-  if (!value || typeof value !== "object") return
+const addArtifactResult = (found, value, expected, depth = 0) => {
+  if (!value || typeof value !== "object" || depth > 16) return
   if (Array.isArray(value)) {
-    for (const item of value) addArtifactResult(found, item, expected)
+    for (const item of value) addArtifactResult(found, item, expected, depth + 1)
     return
   }
-  if (typeof value.text === "string") extractArtifactResults(value.text, expected, found)
-  if (Array.isArray(value.content)) addArtifactResult(found, value.content, expected)
+  if (
+    value.isError === true ||
+    value.is_error === true ||
+    value.ok === false ||
+    value.published === false ||
+    value.error
+  )
+    return
+  if (Array.isArray(value.tool_calls)) {
+    // Search listings also contain IDs and versions. A code-mode result is
+    // read evidence only when its receipt confirms reads, without mixed tools.
+    if (
+      !value.tool_calls.length ||
+      !value.tool_calls.every((name) => ["read", "catch_up"].includes(name))
+    )
+      return
+    if (typeof value.result === "string")
+      extractArtifactResults(value.result, ["read"], found, depth + 1)
+  }
+  if (["artifact", "match", "context"].includes(value.type)) return
   const shortId = typeof value.short_id === "string" ? value.short_id : null
   const version = positiveVersion(value.version ?? value.to_version ?? value.to ?? value.head)
-  if (!shortId || !version) return
+  if (!shortId || !version) {
+    if (typeof value.text === "string")
+      extractArtifactResults(value.text, expected, found, depth + 1)
+    // Orchestrators emit named result objects. Walk objects, never arbitrary
+    // string fields such as prompts or the body of a recognized artifact.
+    for (const [key, nested] of Object.entries(value))
+      if (key !== "text" && key !== "logs") addArtifactResult(found, nested, expected, depth + 1)
+    return
+  }
   const action =
     value.published === true || (expected.length === 1 && expected[0] === "publish")
       ? "published"
@@ -128,16 +125,18 @@ const addArtifactResult = (found, value, expected) => {
   })
 }
 
-function extractArtifactResults(text, expected, found = new Map()) {
+function extractArtifactResults(text, expected, found = new Map(), depth = 0) {
+  if (depth > 16) return found
   const trimmed = String(text ?? "").trim()
   if (!trimmed) return found
   try {
-    addArtifactResult(found, JSON.parse(trimmed), expected)
+    addArtifactResult(found, JSON.parse(trimmed), expected, depth + 1)
+    return found
   } catch {
     // Tool wrappers can prefix a JSON content block with timing output. Parse each JSON line.
     for (const line of trimmed.split("\n")) {
       try {
-        addArtifactResult(found, JSON.parse(line), expected)
+        addArtifactResult(found, JSON.parse(line), expected, depth + 1)
       } catch {
         /* use the bounded text receipts below */
       }
@@ -279,7 +278,15 @@ const parseClaudeRecord = (record, state, context, events, observedAt) => {
       )
     } else if (block?.type === "tool_result") {
       const output = typeof block.content === "string" ? block.content : (block.content ?? [])
-      completeCall(state, events, "claude", context, block.tool_use_id, output, timestampOf(record))
+      completeCall(
+        state,
+        events,
+        "claude",
+        context,
+        block.tool_use_id,
+        block.is_error ? [] : output,
+        timestampOf(record),
+      )
     }
   }
 }
@@ -291,6 +298,8 @@ export async function scanArtifactLogs(options = {}) {
   const state = readJson(statePath(), defaultState())
   state.sources ??= {}
   state.sessions ??= { claude: {}, codex: {} }
+  state.sessions.claude ??= {}
+  state.sessions.codex ??= {}
   state.pending ??= { claude: {}, codex: {} }
   state.pending.claude ??= {}
   state.pending.codex ??= {}
@@ -318,6 +327,9 @@ export async function scanArtifactLogs(options = {}) {
     if (sinceMs !== null && stats.mtimeMs < sinceMs) continue
     const identity = sourceIdentity(stats)
     const saved = state.sources[source.path]
+    // Setup may initialize a new source, but cannot consume an existing source
+    // without first spooling its receipts.
+    if (options.baseline && saved) continue
     let start = 0
     if (sinceMs === null) {
       if (
@@ -407,10 +419,14 @@ export function commitArtifactScanState(state) {
 }
 
 export function readArtifactScanSpool() {
-  const spool = readJson(spoolPath(), { version: 1, pending: [], coverage: [] })
-  if (!Array.isArray(spool.pending) || !Array.isArray(spool.coverage))
-    throw new Error(`cannot read artifact scan spool at ${spoolPath()}`)
-  return spool
+  try {
+    const spool = readJson(spoolPath(), { version: 1, pending: [], coverage: [] })
+    if (!Array.isArray(spool.pending) || !Array.isArray(spool.coverage))
+      throw new Error("expected pending and coverage arrays")
+    return spool
+  } catch (error) {
+    throw new Error(`cannot read artifact scan spool at ${spoolPath()}: ${error.message}`)
+  }
 }
 
 export function addToArtifactScanSpool(events, coverage, target) {
@@ -418,10 +434,13 @@ export function addToArtifactScanSpool(events, coverage, target) {
   const pending = new Map(
     (spool.pending ?? []).map((event) => [
       event.event_id,
-      event.retry_unavailable ? { ...event, target, retry_unavailable: false } : event,
+      event.retry_unavailable && event.target?.server === target.server
+        ? { ...event, target, retry_unavailable: false }
+        : event,
     ]),
   )
-  for (const event of events) pending.set(event.event_id, { ...event, target })
+  for (const event of events)
+    if (!pending.has(event.event_id)) pending.set(event.event_id, { ...event, target })
   const next = { version: 1, pending: [...pending.values()], coverage, target }
   writeJson(spoolPath(), next)
   return next

--- a/packages/cli/src/derive-scan-setup.js
+++ b/packages/cli/src/derive-scan-setup.js
@@ -31,13 +31,15 @@ const setSessionEndHook = (path, command) => {
   for (const group of config.hooks.SessionEnd)
     for (const hook of group?.hooks ?? [])
       if (isDeriveScanHook(hook)) {
-        if (hook.command === command) return false
+        if (hook.command === command && hook.async === true && hook.timeout === 300) return false
         hook.command = command
+        hook.async = true
+        hook.timeout = 300
         writeJson(path, config)
         return true
       }
   config.hooks.SessionEnd.push({
-    hooks: [{ type: "command", command, async: true, timeout: 3 }],
+    hooks: [{ type: "command", command, async: true, timeout: 300 }],
   })
   writeJson(path, config)
   return true

--- a/packages/cli/src/scan-state.js
+++ b/packages/cli/src/scan-state.js
@@ -1,0 +1,92 @@
+import { createHash, randomBytes } from "node:crypto"
+import {
+  closeSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs"
+import { homedir } from "node:os"
+import { dirname, join } from "node:path"
+
+export const scanConfigRoot = () =>
+  process.env.DERIVE_CONFIG_DIR ?? join(homedir(), ".config", "derive")
+
+// Only a missing file means an empty store. Never overwrite unreadable state.
+export const readScanJson = (path, fallback) => {
+  try {
+    const value = JSON.parse(readFileSync(path, "utf8"))
+    if (!value || typeof value !== "object" || Array.isArray(value))
+      throw new Error("expected a JSON object")
+    return value
+  } catch (error) {
+    if (error.code === "ENOENT") return fallback
+    throw new Error(`cannot read ${path}: ${error.message}`)
+  }
+}
+
+export const writeScanJson = (path, value) => {
+  mkdirSync(dirname(path), { recursive: true })
+  const temporary = `${path}.${process.pid}.${randomBytes(5).toString("hex")}.tmp`
+  writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 })
+  renameSync(temporary, path)
+}
+
+export const sourceCheckpoint = (path, offset) => {
+  const length = Math.min(4096, offset)
+  const digest = createHash("sha256")
+  if (length === 0) return digest.update("").digest("hex")
+  const buffer = Buffer.alloc(length)
+  const descriptor = openSync(path, "r")
+  try {
+    const read = readSync(descriptor, buffer, 0, length, offset - length)
+    return digest.update(buffer.subarray(0, read)).digest("hex")
+  } finally {
+    closeSync(descriptor)
+  }
+}
+
+// Hold the lock for the entire scan/spool/upload transaction. Each parser owns
+// separate state, so the generic command can invoke the Skill scanner safely.
+export const acquireScanLock = (kind) => {
+  const path = join(scanConfigRoot(), `${kind}-scan.lock`)
+  mkdirSync(dirname(path), { recursive: true })
+  let descriptor
+  try {
+    descriptor = openSync(path, "wx", 0o600)
+  } catch (error) {
+    if (error.code !== "EEXIST") throw error
+    throw new Error(
+      `${kind} scan is locked at ${path}; retry after the other scan exits. If it was killed, remove this lock only after confirming its recorded PID is no longer running.`,
+    )
+  }
+  writeFileSync(
+    descriptor,
+    JSON.stringify({ pid: process.pid, started_at: new Date().toISOString() }),
+  )
+  closeSync(descriptor)
+  let released = false
+  const release = () => {
+    if (released) return
+    released = true
+    unlinkSync(path)
+    process.off("exit", release)
+    process.off("SIGINT", interrupt)
+    process.off("SIGTERM", terminate)
+  }
+  const interrupt = () => {
+    release()
+    process.exit(130)
+  }
+  const terminate = () => {
+    release()
+    process.exit(143)
+  }
+  process.once("exit", release)
+  process.once("SIGINT", interrupt)
+  process.once("SIGTERM", terminate)
+  return release
+}

--- a/packages/cli/src/skill-scan-setup.js
+++ b/packages/cli/src/skill-scan-setup.js
@@ -21,20 +21,22 @@ const writeJson = (path, value) => {
   renameSync(temporary, path)
 }
 
-const hasDeriveHook = (groups) =>
-  groups.some((group) =>
-    (group?.hooks ?? []).some(
-      (hook) => typeof hook?.command === "string" && hook.command.includes(DERIVE_HOOK_MARKER),
-    ),
-  )
-
 const addSessionEndHook = (path, command) => {
   const config = readJson(path)
   config.hooks ??= {}
   config.hooks.SessionEnd ??= []
-  if (hasDeriveHook(config.hooks.SessionEnd)) return false
+  for (const group of config.hooks.SessionEnd)
+    for (const hook of group?.hooks ?? [])
+      if (typeof hook?.command === "string" && hook.command.includes(DERIVE_HOOK_MARKER)) {
+        if (hook.command === command && hook.async === true && hook.timeout === 300) return false
+        hook.command = command
+        hook.async = true
+        hook.timeout = 300
+        writeJson(path, config)
+        return true
+      }
   config.hooks.SessionEnd.push({
-    hooks: [{ type: "command", command, async: true, timeout: 3 }],
+    hooks: [{ type: "command", command, async: true, timeout: 300 }],
   })
   writeJson(path, config)
   return true

--- a/packages/cli/src/skill-scan.js
+++ b/packages/cli/src/skill-scan.js
@@ -1,38 +1,19 @@
-import { createHash, randomBytes } from "node:crypto"
-import {
-  createReadStream,
-  existsSync,
-  mkdirSync,
-  readdirSync,
-  readFileSync,
-  renameSync,
-  statSync,
-  writeFileSync,
-} from "node:fs"
+import { createHash } from "node:crypto"
+import { createReadStream, existsSync, readdirSync, readFileSync, statSync } from "node:fs"
 import { homedir } from "node:os"
-import { basename, dirname, join, resolve } from "node:path"
+import { basename, join, resolve } from "node:path"
+import {
+  scanConfigRoot as configRoot,
+  readScanJson as readJson,
+  sourceCheckpoint,
+  writeScanJson as writeJson,
+} from "./scan-state.js"
 
-export const SKILL_SCAN_PARSER_VERSION = 1
+export const SKILL_SCAN_PARSER_VERSION = 2
 
-const configRoot = () => process.env.DERIVE_CONFIG_DIR ?? join(homedir(), ".config", "derive")
 const installsPath = () => join(configRoot(), "skill-installs.json")
 const scanStatePath = () => join(configRoot(), "skill-scan.json")
 const spoolPath = () => join(configRoot(), "skill-scan-spool.json")
-
-const readJson = (path, fallback) => {
-  try {
-    return JSON.parse(readFileSync(path, "utf8"))
-  } catch {
-    return fallback
-  }
-}
-
-const writeJson = (path, value) => {
-  mkdirSync(dirname(path), { recursive: true })
-  const temporary = `${path}.${process.pid}.${randomBytes(5).toString("hex")}.tmp`
-  writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 })
-  renameSync(temporary, path)
-}
 
 const hash = (value) => createHash("sha256").update(value).digest("hex")
 
@@ -44,9 +25,7 @@ export function listSkillInstalls() {
   return Array.isArray(data.installs) ? data.installs.filter((item) => !item.removed_at) : []
 }
 
-export function recordSkillInstall(install) {
-  const data = readJson(installsPath(), { version: 1, installs: [] })
-  const installs = Array.isArray(data.installs) ? data.installs : []
+export function recordSkillInstall(install, { persist = true } = {}) {
   const normalized = {
     id: install.id,
     version: install.version,
@@ -60,6 +39,9 @@ export function recordSkillInstall(install) {
     account_id: install.accountId ?? null,
     updated_at: new Date().toISOString(),
   }
+  if (!persist) return normalized
+  const data = readJson(installsPath(), { version: 1, installs: [] })
+  const installs = Array.isArray(data.installs) ? data.installs : []
   const key = installKey(normalized)
   const next = installs.filter((item) => installKey(item) !== key)
   next.push(normalized)
@@ -188,6 +170,7 @@ const eventFor = ({ install, client, session, turn, occurredAt, evidence }) => (
 })
 
 const parseClaudeLine = (record, context, installs, sinceMs) => {
+  if (record?.sessionId) context.session = record.sessionId
   if (record?.type === "user") context.turn = record.promptId ?? record.uuid ?? context.turn
   const attribution =
     typeof record?.attributionSkill === "string"
@@ -195,7 +178,7 @@ const parseClaudeLine = (record, context, installs, sinceMs) => {
       : null
   if (!attribution) return []
   const occurredAt = timestampOf(record)
-  if (sinceMs !== null && occurredAt && Date.parse(occurredAt) < sinceMs) return []
+  if (sinceMs !== null && (!occurredAt || Date.parse(occurredAt) < sinceMs)) return []
   return installs
     .filter((install) => installAliases(install).has(attribution))
     .map((install) =>
@@ -224,7 +207,7 @@ const parseCodexLine = (record, context, installs, sinceMs) => {
   const text = record?.type === "response_item" ? codexToolText(payload) : ""
   if (!text) return []
   const occurredAt = timestampOf(record)
-  if (sinceMs !== null && occurredAt && Date.parse(occurredAt) < sinceMs) return []
+  if (sinceMs !== null && (!occurredAt || Date.parse(occurredAt) < sinceMs)) return []
   return installs
     .filter((install) => codexPatterns(install).some((pattern) => text.includes(pattern)))
     .map((install) =>
@@ -286,9 +269,18 @@ export async function scanSkillLogs(options = {}) {
     if (sinceMs !== null && stats.mtimeMs < sinceMs) continue
     const identity = sourceIdentity(stats)
     const saved = state.sources[source.path]
+    if (options.baseline && saved) continue
     let start = 0
     if (sinceMs === null) {
-      if (saved?.identity === identity && saved.offset <= stats.size) start = saved.offset
+      if (
+        saved?.identity === identity &&
+        saved.offset <= stats.size &&
+        // Older cursors had no fingerprint. Preserve their offset on upgrade
+        // instead of silently turning the next scan into a historical backfill.
+        (saved.checkpoint_hash === undefined ||
+          saved.checkpoint_hash === sourceCheckpoint(source.path, saved.offset))
+      )
+        start = saved.offset
       else if (
         options.baseline ||
         (options.initialBaseline && !state.initialized_clients[source.client])
@@ -296,10 +288,6 @@ export async function scanSkillLogs(options = {}) {
         start = stats.size
     }
     coverage[source.client].source_files++
-    if (start === stats.size) {
-      state.sources[source.path] = { identity, offset: stats.size, client: source.client }
-      continue
-    }
     // A session header is normally written once, before later turns. Keep the
     // parser context beside the byte offset so an incremental scan can attribute
     // a newly appended tool call to that same session and turn.
@@ -313,14 +301,8 @@ export async function scanSkillLogs(options = {}) {
     const clientInstalls = installs.filter((install) => install.client === source.client)
     const end = await completeLines(source.path, start, async (lineBytes) => {
       coverage[source.client].records_scanned++
-      const relevant =
-        source.client === "claude"
-          ? lineBytes.includes('"attributionSkill"') || lineBytes.includes('"type":"user"')
-          : lineBytes.includes('"type":"session_meta"') ||
-            lineBytes.includes('"type":"turn_context"') ||
-            lineBytes.includes("SKILL.md") ||
-            lineBytes.includes("skill.md")
-      if (!relevant) return
+      // JSON whitespace is not fixed, and event_msg records can carry the next
+      // turn id. Filtering on serialized substrings loses that context.
       let record
       try {
         record = JSON.parse(lineBytes.toString("utf8").replace(/\r$/, ""))
@@ -341,6 +323,7 @@ export async function scanSkillLogs(options = {}) {
       client: source.client,
       session: context.session,
       turn: context.turn,
+      checkpoint_hash: sourceCheckpoint(source.path, end),
     }
   }
 

--- a/packages/cli/test/skill-sync-all.test.js
+++ b/packages/cli/test/skill-sync-all.test.js
@@ -5,8 +5,13 @@ import http from "node:http"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, describe, expect, it } from "vitest"
-import { commitArtifactScanState, scanArtifactLogs } from "../src/artifact-scan.js"
+import {
+  addToArtifactScanSpool,
+  commitArtifactScanState,
+  scanArtifactLogs,
+} from "../src/artifact-scan.js"
 import { setupDeriveScan } from "../src/derive-scan-setup.js"
+import { acquireScanLock } from "../src/scan-state.js"
 import { addToSkillScanSpool, recordSkillInstall, scanSkillLogs } from "../src/skill-scan.js"
 import { setupSkillScan } from "../src/skill-scan-setup.js"
 
@@ -373,6 +378,8 @@ describe("derive skill scan", () => {
         })}\n`,
       )
       expect((await scanSkillLogs({ home })).events).toEqual([])
+      // A scheduled no-op between the header and append must preserve context too.
+      expect((await scanSkillLogs({ home })).events).toEqual([])
       writeFileSync(
         log,
         `${JSON.stringify({
@@ -615,6 +622,237 @@ describe("derive skill scan", () => {
 })
 
 describe("derive scan", () => {
+  const scanFixture = async (work) => {
+    const root = mkdtempSync(join(tmpdir(), "derive-scan-regression-"))
+    dirs.push(root)
+    const previous = process.env.DERIVE_CONFIG_DIR
+    process.env.DERIVE_CONFIG_DIR = root
+    const log = join(root, "session.jsonl")
+    const sources = [{ client: "codex", path: log }]
+    const now = Date.parse("2026-09-08")
+    const records = (name = "mcp__derive__read", output = { short_id: "scan1234", version: 2 }) => [
+      { type: "session_meta", payload: { id: "scan-session" } },
+      {
+        type: "response_item",
+        timestamp: "2026-09-07T12:00:00.000Z",
+        payload: { type: "function_call", name, call_id: "scan-call", arguments: "{}" },
+      },
+      {
+        type: "response_item",
+        timestamp: "2026-09-07T12:00:01.000Z",
+        payload: {
+          type: "function_call_output",
+          call_id: "scan-call",
+          output: JSON.stringify(output),
+        },
+      },
+    ]
+    const write = (rows, append = false) =>
+      writeFileSync(log, `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`, {
+        flag: append ? "a" : "w",
+      })
+    try {
+      await work({ root, log, sources, now, records, write })
+    } finally {
+      if (previous === undefined) delete process.env.DERIVE_CONFIG_DIR
+      else process.env.DERIVE_CONFIG_DIR = previous
+    }
+  }
+
+  it("preserves malformed artifact spools instead of replacing pending receipts", async () => {
+    await scanFixture(({ root }) => {
+      const path = join(root, "artifact-scan-spool.json")
+      for (const contents of ["{broken", "null", "[]", '{"pending":[]}']) {
+        writeFileSync(path, contents)
+        expect(() => addToArtifactScanSpool([], [], {})).toThrow("cannot read artifact scan spool")
+        expect(readFileSync(path, "utf8")).toBe(contents)
+      }
+    })
+  })
+
+  for (const [label, scan] of [
+    ["artifact", scanArtifactLogs],
+    ["Skill", scanSkillLogs],
+  ]) {
+    it(`keeps an existing ${label} cursor and pending events when setup runs again`, async () => {
+      await scanFixture(async ({ root, sources, records, write, now }) => {
+        write(records())
+        await scan({ sources, now, baseline: true })
+        const stateFile = join(
+          root,
+          label === "artifact" ? "artifact-scan.json" : "skill-scan.json",
+        )
+        const initialSources = JSON.parse(readFileSync(stateFile, "utf8")).sources
+        write(records(), true)
+        await scan({ sources, now, baseline: true })
+        expect(JSON.parse(readFileSync(stateFile, "utf8")).sources).toEqual(initialSources)
+      })
+    })
+  }
+
+  it("ignores other services' read tools and failed Derive results", async () => {
+    await scanFixture(async ({ sources, write, records, now }) => {
+      for (const [name, output] of [
+        ["mcp__other__read", { short_id: "scan1234", version: 2 }],
+        ["mcp__derive__publish", { published: false, short_id: "scan1234", version: 2 }],
+        [
+          "mcp__derive__read",
+          {
+            isError: true,
+            content: [{ type: "text", text: JSON.stringify({ short_id: "scan1234", version: 2 }) }],
+          },
+        ],
+        ["mcp__derive__read", { short_id: "scan1234", version: "2oops" }],
+      ]) {
+        write(records(name, output))
+        expect(
+          (await scanArtifactLogs({ sources, now, since: "30d", dryRun: true })).events,
+        ).toEqual([])
+      }
+    })
+  })
+
+  it("extracts receipts inside named orchestration results", async () => {
+    await scanFixture(async ({ sources, write, records, now }) => {
+      const rows = records("exec", {
+        result: {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({ short_id: "scan1234", version: "2 (current)" }),
+            },
+          ],
+        },
+      })
+      rows[1].payload.arguments =
+        'text({ result: await tools.mcp__derive__read({ short_id: "scan1234" }) })'
+      write(rows)
+      expect((await scanArtifactLogs({ sources, now, since: "30d" })).events).toEqual([
+        expect.objectContaining({
+          artifact_short_id: "scan1234",
+          artifact_version: 2,
+          action: "read",
+        }),
+      ])
+    })
+  })
+
+  it("recognizes bulk reads through Derive code mode", async () => {
+    await scanFixture(async ({ sources, write, records, now }) => {
+      write(
+        records("mcp__derive__derive_code", {
+          result: { results: [{ index: 0, value: { short_id: "scan1234", version: 2 } }] },
+          tool_calls: ["read"],
+        }),
+      )
+      expect((await scanArtifactLogs({ sources, now, since: "30d" })).events).toEqual([
+        expect.objectContaining({ artifact_short_id: "scan1234", artifact_version: 2 }),
+      ])
+      write(
+        records("mcp__derive__derive_code", {
+          result: "---\nshort_id: scan1234\nversion: 2 (current)\n---\n# A read",
+          tool_calls: ["read"],
+        }),
+      )
+      expect((await scanArtifactLogs({ sources, now, since: "30d" })).events).toHaveLength(1)
+      write(
+        records("mcp__derive__derive_code", {
+          result: [{ type: "artifact", short_id: "scan1234", version: 2 }],
+          tool_calls: ["find"],
+        }),
+      )
+      expect((await scanArtifactLogs({ sources, now, since: "30d" })).events).toEqual([])
+    })
+  })
+
+  it("excludes a second writer until the first scan releases its lock", async () => {
+    await scanFixture(() => {
+      const release = acquireScanLock("artifact")
+      try {
+        expect(() => acquireScanLock("artifact")).toThrow("scan is locked")
+        const releaseSkill = acquireScanLock("skill")
+        releaseSkill()
+      } finally {
+        release()
+      }
+      const retry = acquireScanLock("artifact")
+      retry()
+    })
+  })
+
+  it("keeps pending receipts bound to their original server during a backfill", async () => {
+    await scanFixture(() => {
+      const original = { server: "https://first.derive.test", account_id: "first" }
+      const other = { server: "https://other.derive.test", account_id: "other" }
+      const event = { event_id: "a".repeat(64), artifact_short_id: "scan1234" }
+      addToArtifactScanSpool([event], [], original)
+      const replay = addToArtifactScanSpool([event], [], other)
+      expect(replay.pending).toEqual([{ ...event, target: original }])
+    })
+  })
+
+  it("replays replaced Skill logs and keeps turn changes across JSON formatting", async () => {
+    await scanFixture(async ({ root, log, sources, now, write }) => {
+      const skill = {
+        id: "skill123",
+        version: 1,
+        name: "review",
+        client: "codex",
+        path: join(root, "review"),
+        server: "https://derive.test",
+      }
+      const options = { sources, now, installs: [skill] }
+      write([{ type: "session_meta", payload: { id: "old" } }])
+      await scanSkillLogs(options)
+      const rows = [
+        { type: "session_meta", payload: { id: "replacement-with-a-longer-name" } },
+        { type: "event_msg", payload: { turn_id: "new-turn" } },
+        {
+          type: "response_item",
+          timestamp: "2026-09-07T12:00:00.000Z",
+          payload: {
+            type: "function_call",
+            call_id: "file-read",
+            arguments: JSON.stringify({ cmd: `cat ${skill.path}/SKILL.md` }),
+          },
+        },
+      ]
+      writeFileSync(
+        log,
+        `${rows.map((row) => JSON.stringify(row).replaceAll('":', '": ')).join("\n")}\n`,
+      )
+      const result = await scanSkillLogs(options)
+      expect(result.events).toHaveLength(1)
+      expect(result.state.sources[log].turn).toBe("new-turn")
+      expect(result.state.sources[log].session).toBe("replacement-with-a-longer-name")
+    })
+  })
+
+  it("does not treat undated Skill activity as recent during a backfill", async () => {
+    await scanFixture(async ({ root, sources, now, write }) => {
+      const skill = {
+        id: "skill123",
+        version: 1,
+        client: "codex",
+        path: join(root, "review"),
+        server: "https://derive.test",
+      }
+      write([
+        {
+          type: "response_item",
+          payload: {
+            type: "function_call",
+            call_id: "undated",
+            arguments: JSON.stringify({ cmd: `cat ${skill.path}/SKILL.md` }),
+          },
+        },
+      ])
+      expect(
+        (await scanSkillLogs({ sources, now, installs: [skill], since: "30d" })).events,
+      ).toEqual([])
+    })
+  })
+
   it("records exact Codex and Claude artifact results without content or local identity", async () => {
     const root = mkdtempSync(join(tmpdir(), "derive-artifact-scan-"))
     dirs.push(root)
@@ -1240,6 +1478,141 @@ describe("derive scan", () => {
     expect(config.hooks.SessionEnd[0].hooks[0].command).toBe(
       '"/usr/bin/node" "/derive.js" scan --quiet --client codex',
     )
+    expect(config.hooks.SessionEnd[0].hooks[0].timeout).toBe(300)
+    expect(
+      setupDeriveScan({
+        home,
+        node: "/usr/bin/node",
+        cli: "/derive.js",
+        client: "codex",
+        activate: false,
+      }).hooks[0].changed,
+    ).toBe(false)
+  })
+
+  it("previews legacy project pins without creating or changing local scan state", async () => {
+    const project = mkdtempSync(join(tmpdir(), "derive-scan-preview-"))
+    dirs.push(project)
+    const home = join(project, "home")
+    const skillPath = join(project, ".agents", "skills", "Review")
+    mkdirSync(skillPath, { recursive: true })
+    writeFileSync(
+      join(project, "derive.json"),
+      JSON.stringify({
+        entry: "index.md",
+        skills: [
+          { id: "review123", version: 2, name: "Review", installs: { codex: { version: 2 } } },
+        ],
+      }),
+    )
+    const logs = join(home, ".codex", "sessions")
+    mkdirSync(logs, { recursive: true })
+    writeFileSync(
+      join(logs, "preview.jsonl"),
+      `${JSON.stringify({ type: "response_item", timestamp: new Date().toISOString(), payload: { type: "function_call", call_id: "preview", arguments: JSON.stringify({ cmd: `cat ${skillPath}/SKILL.md` }) } })}\n`,
+    )
+    for (const command of [["skill", "scan"], ["scan"]]) {
+      const result = await run(
+        project,
+        "https://derive.test",
+        [...command, "--dry-run", "--since", "30d", "--json"],
+        { HOME: home },
+      )
+      expect(result.status).toBe(0)
+      const parsed = JSON.parse(result.stdout)
+      expect(parsed.events ?? parsed.skills).toEqual([
+        expect.objectContaining({ skill_short_id: "review123", skill_version: 2 }),
+      ])
+      expect(existsSync(join(project, ".derive-test-config"))).toBe(false)
+    }
+    const status = await run(
+      project,
+      "https://derive.test",
+      ["skill", "scan", "status", "--json"],
+      { HOME: home },
+    )
+    expect(status.status).toBe(0)
+    expect(existsSync(join(project, ".derive-test-config"))).toBe(false)
+  })
+
+  it("retains a failed upload batch and retries it without rescanning receipts", async () => {
+    const project = mkdtempSync(join(tmpdir(), "derive-scan-batch-retry-"))
+    dirs.push(project)
+    const home = join(project, "home")
+    let fail = true
+    const batches = []
+    const server = http.createServer((request, response) => {
+      if (request.url === "/v1/workspaces") {
+        response.writeHead(200, { "content-type": "application/json" })
+        response.end(JSON.stringify({ workspaces: [] }))
+        return
+      }
+      let body = ""
+      request.on("data", (chunk) => (body += chunk))
+      request.on("end", () => {
+        const parsed = JSON.parse(body)
+        batches.push(parsed.events.length)
+        if (fail && batches.length === 2) {
+          response.writeHead(503)
+          response.end("temporary outage")
+        } else {
+          response.writeHead(200, { "content-type": "application/json" })
+          response.end(
+            JSON.stringify({
+              recorded: parsed.events.map((event) => event.event_id),
+              rejected: [],
+            }),
+          )
+        }
+      })
+    })
+    servers.push(server)
+    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve))
+    const base = `http://127.0.0.1:${server.address().port}`
+    const logs = join(home, ".codex", "sessions")
+    mkdirSync(logs, { recursive: true })
+    const timestamp = new Date().toISOString()
+    const rows = Array.from({ length: 21 }, (_, index) => [
+      {
+        type: "response_item",
+        timestamp,
+        payload: {
+          type: "function_call",
+          name: "mcp__derive__read",
+          call_id: `read-${index}`,
+          arguments: "{}",
+        },
+      },
+      {
+        type: "response_item",
+        timestamp,
+        payload: {
+          type: "function_call_output",
+          call_id: `read-${index}`,
+          output: JSON.stringify({ short_id: "read1234", version: 1 }),
+        },
+      },
+    ]).flat()
+    writeFileSync(
+      join(logs, "batch.jsonl"),
+      `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`,
+    )
+    const first = await run(project, base, ["scan", "--since", "30d", "--quiet", "--json"], {
+      HOME: home,
+    })
+    expect(first.status).toBe(1)
+    expect(JSON.parse(first.stdout).artifacts).toMatchObject({
+      found: 21,
+      uploaded: 20,
+      pending: 1,
+    })
+    fail = false
+    const retry = await run(project, base, ["scan", "--json"], { HOME: home })
+    expect(retry.status).toBe(0)
+    expect(JSON.parse(retry.stdout).artifacts).toMatchObject({ found: 0, uploaded: 1, pending: 0 })
+    expect(batches).toEqual([20, 1, 1])
+    expect(existsSync(join(project, ".derive-test-config", "artifact-scan.lock"))).toBe(false)
+    expect(existsSync(join(project, ".derive-test-config", "skill-scan.lock"))).toBe(false)
   })
 
   it("baselines both scanners on the first generic command", async () => {
@@ -1473,10 +1846,12 @@ describe("derive scan", () => {
     ])
   })
 
-  it("keeps an unavailable receipt until another server accepts it", async () => {
+  it("does not send an unavailable receipt to another server", async () => {
     const project = mkdtempSync(join(tmpdir(), "derive-generic-scan-server-retry-"))
     dirs.push(project)
     const home = join(project, "home")
+    const received = []
+    let firstAvailable = false
     const makeServer = (workspace, accepts) =>
       http.createServer((request, response) => {
         if (request.url === "/v1/workspaces") {
@@ -1493,11 +1868,12 @@ describe("derive scan", () => {
         request.on("data", (chunk) => (body += chunk))
         request.on("end", () => {
           const parsed = JSON.parse(body || "{}")
+          received.push({ workspace, count: parsed.events.length })
           const ids = parsed.events.map((event) => event.event_id)
           response.writeHead(200, { "content-type": "application/json" })
           response.end(
             JSON.stringify(
-              accepts
+              accepts || (workspace === "workspace-a" && firstAvailable)
                 ? { recorded: ids, rejected: [], coverage: parsed.coverage.length }
                 : {
                     recorded: [],
@@ -1558,8 +1934,14 @@ describe("derive scan", () => {
     expect(second.status).toBe(0)
     expect(JSON.parse(second.stdout).artifacts).toMatchObject({
       found: 0,
-      uploaded: 1,
-      pending: 0,
+      uploaded: 0,
+      pending: 1,
     })
+    expect(
+      received.filter((item) => item.workspace === "workspace-b").every((item) => item.count === 0),
+    ).toBe(true)
+    firstAvailable = true
+    const third = await run(project, firstBase, ["scan", "--json"], { HOME: home })
+    expect(JSON.parse(third.stdout).artifacts).toMatchObject({ found: 0, uploaded: 1, pending: 0 })
   })
 })


### PR DESCRIPTION
Superseded by PR #902. Commit 81372f97 reconciles the remaining correctness fixes while preserving #902's stronger locking and diagnostics. All 225 CLI tests and required push checks pass. The rebuilt package passes preview smoke tests. Merge #902 for the combined scanner and loop recovery release.

Original review and implementation notes follow.

[Reviewable Derive handoff: fixes, evidence, and operating notes](https://derive.to/artifacts/derive-scan-reliability-review-and-pr-903-xa3pja7c)

## Problem

Repeated setup could advance a scan cursor without spooling the discovered receipts, and an idle Skill scan discarded the session and turn needed to attribute the next append. Artifact scans also treated malformed spools as empty and could misclassify failed or unrelated tool results.

## Changes

- Preserve existing cursors on setup; retain Skill session/turn context during idle scans and fingerprint replaced logs without replaying old cursors on upgrade.
- Refuse unreadable scan state and malformed spools. Lock each scanner's scan/spool/upload transaction so overlapping hooks cannot overwrite another run's progress.
- Recognize named orchestration results and Derive code-mode read receipts; exclude failed results, search listings, mixed code-mode calls, unrelated services, and invalid versions.
- Keep pending artifact receipts on their original server, including backfills; retain same-server account recovery. Reduce artifact upload batches to 20 and preserve failed batches for retry.
- Make dry-run and status leave scan files and installation records unchanged while still previewing legacy project pins. Exclude undated Skill activity from dated backfills.
- Repair existing three-second hooks to use a five-minute timeout. Document recovery and observation boundaries.

## Validation

Six regression cases reproduced failures before the fixes. The CLI suite now has 194 passing tests, including 13 added cases covering malformed spools, repeated setup, code-mode reads, lock exclusion, cross-server isolation, replaced logs, date filtering, dry-run immutability, and partial upload failure followed by a successful retry. Full `pnpm verify` passes locally: 3,427 tests passed, 15 skipped by existing suite configuration.

## Review notes

The cross-server retry test now explicitly requires pending receipts to remain on their original server; a different server must not receive them just because it becomes the CLI default. Existing event identities remain unchanged for replay deduplication. Parser versions advance to 2.

Locks release on normal exit, errors, SIGINT and SIGTERM. An uncatchable kill or power loss can leave a lock requiring the documented PID check and manual lock removal. Mixed-tool code-mode results are conservatively skipped because their returned artifacts cannot be reliably attributed to a read. Skill observations still reflect local attribution/path evidence, not proof of useful execution. No production scan, scheduler activation, or retrospective upload was run for this change.
