### PR TITLE
Boot the Worker before shipping it, not after

### DIFF
--- a/apps/api/src/imports.ts
+++ b/apps/api/src/imports.ts
@@ -36,14 +36,20 @@ export const IMPORT_MAX_ATTEMPTS = 3
 export interface ImportTickDeps extends Omit<ImportDeps, "now" | "sleep"> {
   now?: () => number
   sleep?: (ms: number) => Promise<void>
-  /** Names this worker in the lease row; defaults to a per-process id. */
+  /** Names this worker in the lease row; defaults to a fresh id per tick. */
   holder?: string
 }
 
 const backoff = (attempts: number): number =>
   Math.min(RETRY_MAX_MS, RETRY_BASE_MS * 2 ** Math.max(0, attempts - 1))
 const iso = (ms: number): string => new Date(ms).toISOString()
-const defaultHolder = `import_${crypto.randomUUID().slice(0, 12)}`
+// Minted per tick, never at module load: workerd forbids generating random values in
+// global scope, and a deploy whose module body does it is rejected outright.
+// Per TICK, not memoised per process, and that part is not incidental: the release and
+// restamp paths match on `holder` alone, so two ticks sharing one id lets a tick whose
+// lease already lapsed null out the row a live tick is holding, and a third worker then
+// takes a gate someone is still talking to arXiv through.
+const defaultHolder = (): string => `import_${crypto.randomUUID().slice(0, 12)}`
 
 /** The copy an error code carries into the job row and the failed manifest. */
 export const importFailureCopy = (code: string): string =>
@@ -74,7 +80,7 @@ const classify = (error: unknown): ImportFailure =>
 export const runImportTick = async (deps: ImportTickDeps): Promise<number> => {
   const now = deps.now ?? (() => Date.now())
   const sleep = deps.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)))
-  const holder = deps.holder ?? defaultHolder
+  const holder = deps.holder ?? defaultHolder()
   const scope = deps.baseUrl.replace(/\/$/, "")
   const startedAt = now()
   if (

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "precommit": "pnpm run ci",
     "prepare": "git config core.hooksPath .githooks || true",
     "lint:hyperdrive": "node scripts/check-hyperdrive-no-pool.mjs",
+    "lint:worker-boots": "node scripts/check-worker-boots.mjs",
     "lint:boundaries": "depcruise --config .dependency-cruiser.mjs packages apps",
     "lint:env": "node scripts/check-env.mjs",
     "lint:api-types": "node scripts/check-api-types.mjs",

--- a/scripts/check-worker-boots.mjs
+++ b/scripts/check-worker-boots.mjs
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+// Guardrail: the deployed Worker must actually BOOT.
+//
+// workerd evaluates the entry module and everything it statically imports, once at
+// startup, in "global scope" — where timers, asynchronous I/O (an awaited fetch,
+// connect) and CRYPTOGRAPHIC randomness (crypto.getRandomValues / randomUUID, and
+// node:crypto's) are all forbidden. `Math.random()` and `Date.now()` are fine. A
+// bundle whose module body does a forbidden one is rejected by the Cloudflare API at
+// deploy time: the script never ships, and prod stays on the previous version until
+// someone lands a fix.
+//
+// Nothing else in the pipeline ever instantiates the Worker. `pnpm dev`, `pnpm test`
+// and the tsx server run apps/api under NODE, which allows all of them; the workerd
+// lane (`pnpm --filter @derive/api test:worker`) picks four library modules across
+// three test files and never loads the deployed entry; `wrangler deploy --dry-run`
+// bundles without starting an isolate. So the first runtime ever to evaluate `main`
+// was production's own `wrangler deploy` — which runs on main only, after merge,
+// never on a PR. A module-scope `crypto.randomUUID()` was enough to block a deploy.
+//
+// This bundles src/worker.ts exactly as the deploy does and starts it in wrangler's
+// own pinned workerd: the same engine as production's, at the compatibility date and
+// flags read from wrangler.toml, though Cloudflare's build is typically newer. It
+// fails with the same error the Cloudflare API returns. ~2s, no network, no
+// credentials, no web build, no Docker.
+//
+// WHAT IT DOES NOT COVER, stated plainly:
+//  - An un-awaited module-scope `fetch()` returns a rejected promise instead of
+//    throwing, so it boots here — and passes Cloudflare's validation too.
+//  - Bindings. Nothing is bound, so a config/script mismatch (a durable_objects
+//    class_name that is no longer exported, say) is left to the dry run and the deploy.
+//  - `[env.*]` overrides of the compatibility settings; the first match in the file
+//    wins, which is the deploy's own behaviour only while no such table exists.
+//
+// The fix is always the same shape: move the work out of the module body and into
+// the handler — a `const` becomes a function, or a lazily-initialised `let`.
+import { spawnSync } from "node:child_process"
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { createRequire } from "node:module"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..")
+const api = join(root, "apps/api")
+// process.exit skips `finally`, so the scratch bundle is cleaned up here instead.
+let cleanup = () => {}
+const fail = (...lines) => {
+  cleanup()
+  for (const line of lines) console.error(line)
+  process.exit(1)
+}
+
+// Compatibility settings come from wrangler.toml so this can never drift from the
+// deploy. The date is required — booting on a different one would test a runtime the
+// deploy never uses. Flags are genuinely optional in TOML, and none means none, which
+// is what the deploy would see too.
+const config = readFileSync(join(api, "wrangler.toml"), "utf8")
+const compatibilityDate = config.match(/^compatibility_date\s*=\s*"([^"]+)"/m)?.[1]
+const compatibilityFlags = (
+  config.match(/^compatibility_flags\s*=\s*\[([^\]]*)\]/m)?.[1].match(/"([^"]+)"/g) ?? []
+).map((flag) => flag.slice(1, -1))
+if (!compatibilityDate)
+  fail("worker boots: no compatibility_date in apps/api/wrangler.toml — cannot match the deploy.")
+
+const tmp = mkdtempSync(join(tmpdir(), "derive-worker-boot-"))
+const out = join(tmp, "bundle")
+// An empty assets directory: the boot check must not require a web build.
+const assets = join(tmp, "assets")
+mkdirSync(assets)
+cleanup = () => rmSync(tmp, { recursive: true, force: true })
+
+try {
+  const bundled = spawnSync(
+    join(api, "node_modules", ".bin", "wrangler"),
+    // --containers-rollout=none: wrangler builds the [[containers]] image even on a
+    // dry run, which would put a Docker daemon and a multi-minute cold image pull in
+    // front of every commit. None of it reaches the module scope this check reads.
+    ["deploy", "--dry-run", "--containers-rollout=none", `--outdir=${out}`, `--assets=${assets}`],
+    {
+      cwd: api,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        FORCE_COLOR: "0",
+        NO_COLOR: "1",
+        // A check that runs on every commit must not phone home, and must not add a
+        // log file per run to the global wrangler directory forever.
+        WRANGLER_SEND_METRICS: "false",
+        WRANGLER_SEND_ERROR_REPORTS: "false",
+        WRANGLER_LOG_PATH: join(tmp, "wrangler.log"),
+      },
+    },
+  )
+  if (bundled.status !== 0)
+    fail(
+      "worker boots: the Worker did not bundle.\n",
+      bundled.stderr || bundled.stdout || String(bundled.error),
+    )
+
+  const entry = join(out, "worker.js")
+  const fromApi = createRequire(join(api, "package.json"))
+  const fromWrangler = createRequire(fromApi.resolve("wrangler/package.json"))
+  const { Miniflare, NoOpLog } = await import(pathToFileURL(fromWrangler.resolve("miniflare")))
+  const mf = new Miniflare({
+    // The startup failure is reported below, mapped back to its source; the
+    // runtime's own stderr would only be noise ahead of it. Miniflare still keeps
+    // what it needs to build the error this check reads.
+    log: new NoOpLog(),
+    handleRuntimeStdio: (stdout, stderr) => {
+      stdout.resume()
+      stderr.resume()
+    },
+    modulesRoot: out,
+    // Listed explicitly: the bundle carries dynamic imports that miniflare's own
+    // module collector refuses to walk.
+    modules: [{ type: "ESModule", path: entry }],
+    compatibilityDate,
+    compatibilityFlags,
+  })
+  try {
+    await Promise.race([
+      mf.ready,
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error("workerd did not start within 60s")), 60_000).unref(),
+      ),
+    ])
+  } catch (error) {
+    const message = String(error?.cause?.message ?? error?.message ?? error)
+    const uncaught = message.match(/Uncaught .*/)?.[0] ?? message
+    // esbuild stamps each module with a `// <path>` banner, so the generated line the
+    // runtime names walks back to the file that owns it. That location sits on the
+    // runtime's next stderr line, not on the message itself.
+    const at = message.match(/worker\.js:(\d+):(\d+)/)
+    let where = ""
+    if (at) {
+      const lines = readFileSync(entry, "utf8").split("\n")
+      const index = Number(at[1]) - 1
+      for (let i = index; i >= 0; i--) {
+        // A banner is a lone specifier: it carries a `/`, `.` or `:`. That covers
+        // .json and the extensionless virtual modules (`node-built-in-modules:...`,
+        // wrangler's unenv polyfills) that anchoring on JS extensions would skip —
+        // skipping one blames the module before it — while still rejecting esbuild's
+        // `@__PURE__` annotations and any one-word comment in the source.
+        const banner = lines[i].match(/^\/\/ (\S*[/.:]\S*)$/)
+        if (banner) {
+          where = `\n  in ${banner[1]}\n  ${lines[index]?.trim().slice(0, 160)}`
+          break
+        }
+      }
+    }
+    // Only the global-scope failure gets the global-scope advice. Anything else the
+    // runtime refuses to start on — an unknown compatibility flag, say — would be
+    // actively misdirected by it.
+    const globalScope = /Disallowed operation called within global scope/.test(message)
+    fail(
+      `worker boots: apps/api/src/worker.ts does not start in workerd.\n\n  ${uncaught}${where}\n`,
+      ...(globalScope
+        ? [
+            "  Module bodies run in global scope, where timers, awaited I/O and cryptographic",
+            "  randomness are banned (Math.random and Date.now are fine).",
+            "  Move the work into a handler: make the `const` a function, or initialise it lazily.",
+          ]
+        : [
+            "  That is a startup failure rather than a global-scope one — read the error above.",
+            "  If it names a compatibility flag, wrangler's pinned workerd is simply older than",
+            "  the build Cloudflare validates against, and the deploy itself may be fine.",
+          ]),
+    )
+  } finally {
+    await mf.dispose().catch(() => undefined)
+  }
+} finally {
+  cleanup()
+}
+console.log("worker boots: ok — src/worker.ts evaluates in workerd")

--- a/scripts/guardrails.mjs
+++ b/scripts/guardrails.mjs
@@ -30,6 +30,7 @@ const CHECKS = {
   api: script("check-api.mjs"),
   schema: script("check-schema.mjs"),
   hyperdrive: script("check-hyperdrive-no-pool.mjs"),
+  "worker-boots": script("check-worker-boots.mjs"),
   filesize: script("check-file-size.mjs"),
   favicons: script("check-favicons.mjs"),
   "anchor-client": script("check-anchor-client.mjs"),


### PR DESCRIPTION
## What broke

The CI run for #901 on `main` failed its `deploy` job three times over, and production is
still serving the previous version. Every other lane was green.

```
Uncaught Error: Disallowed operation called within global scope. Asynchronous I/O
(ex: fetch() or connect()), setting a timeout, and generating random values are not
allowed within global scope.
  at apps/api/src/imports.ts:46:40   [code: 10021]
```

`imports.ts` minted the import worker's lease-holder id at module load:

```ts
const defaultHolder = `import_${crypto.randomUUID().slice(0, 12)}`
```

It reaches the Worker bundle through `preview-do.ts`, so workerd evaluates it at startup,
in global scope, where cryptographic randomness is banned. The Cloudflare API rejects the
upload, so the script never ships.

## Why it reached production

Nothing in the pipeline ever *instantiated* the Worker before the production deploy:

| Gate | Runtime | Catches it? |
|---|---|---|
| `pnpm dev`, `pnpm test`, tsx server | Node | No — Node allows all of it |
| `test:worker` (workerd lane) | workerd | No — four library modules across three test files, never the entry |
| `wrangler deploy --dry-run` | none | No — bundles without starting an isolate |
| `wrangler deploy` | workerd | Yes — but `push`-only, so never on a PR |

Production's own deploy was the smoke test for whether the Worker starts at all. The
`randomUUID` was simply the first module-scope violation to hit it.

## The fix

**1. Mint the holder per tick** (`apps/api/src/imports.ts`).

Per tick rather than memoised per process is deliberate, and an audit pass constructed why:
`updateImportLease` matches on `holder` alone (`packages/db/src/repos.ts:4024`, mirrored in
`pg.ts:4971`), so two ticks sharing one id lets a tick whose lease has lapsed null out the
row a *live* tick holds — and a third worker then takes a gate someone is still talking to
arXiv through. Per-tick ids make that unconstructible. Nothing reads holder identity across
ticks: `import_job` has no holder column, reclaim is purely temporal, and it is never logged.

**2. Add `pnpm lint:worker-boots`** (`scripts/check-worker-boots.mjs`), wired into the
guardrails.

It bundles `src/worker.ts` exactly as the deploy does and starts it in wrangler's own pinned
workerd, at the compatibility date and flags read from `wrangler.toml`. It fails with the
same error the Cloudflare API returns, in ~2s, with no network, credentials, web build or
Docker, and walks the bundle offset back to the source file that owns it:

```
worker boots: apps/api/src/worker.ts does not start in workerd.

  Uncaught Error: Disallowed operation called within global scope. ...
  in src/imports.ts
  var defaultHolder = `import_${crypto.randomUUID().slice(0, 12)}`;

  Module bodies run in global scope, where timers, awaited I/O and cryptographic
  randomness are banned (Math.random and Date.now are fine).
```

Riding `check` → `gate` means it blocks the deploy from the PR stage, and
`verify:affected` runs it on every push.

## What the audit changed

Three independent reviewers were told to refute the change. What they found and what it cost:

- **`--dry-run` builds the container image.** `wrangler.toml` declares `[[containers]]`, and
  wrangler builds it even on a dry run — so the check hard-required a running Docker daemon
  inside `git commit`, and would have paid a cold 627 MB image build on every PR in the lane
  whose header documents "one commit added 137 seconds to every PR". Fixed with
  `--containers-rollout=none`; the emitted bundle is byte-identical.
- **Telemetry and log litter.** Wrangler phoned home with a stable device id and appended a
  log file to the global wrangler directory on every run. Now set
  `WRANGLER_SEND_METRICS`/`WRANGLER_SEND_ERROR_REPORTS=false` and redirect `WRANGLER_LOG_PATH`
  into the scratch dir, matching what `deploy-docs` in ci.yml already does.
- **Misdirecting advice.** A startup failure that is *not* a global-scope violation — an
  unknown compatibility flag, say — used to get the global-scope hint anyway. The advice is
  now conditional on the actual error.
- **Banner mis-attribution.** The source-file walk anchored on JS extensions, so it skipped
  esbuild's `.json` and virtual modules and blamed the module before them (5 live sites in
  today's bundle). Broadened; 16 more modules are now attributable.
- **Overstated claims, all corrected in the header:** workerd evaluates the entry's *static*
  import graph, not "every module"; `Math.random()` is *not* banned, only cryptographic
  randomness; and wrangler's pinned workerd is the same engine as production's at the same
  compatibility date, but typically an older build — not literally "the runtime that
  validates the deploy".
- A stale JSDoc on `holder` that still said "per-process id".

## Deliberately not covered

Named in the script's header rather than left silent: an un-awaited module-scope `fetch()`
(it boots here, and passes Cloudflare's validation too); binding/config mismatches, since
nothing is bound; and `[env.*]` compatibility overrides, none of which exist today. Also
untested: no test would fail if someone memoised the holder id — catching that needs two
concurrent slow ticks on a shared fake clock, which is disproportionate for a hypothetical,
and the boot check already catches the variant that actually happened.

## Verification

- `pnpm verify` green: 36/36 guardrails, typecheck, every suite (1827 API tests).
- Red→green demonstrated across the fix: reinstating the module-scope line makes
  `lint:worker-boots` fail with the production error and naming `src/imports.ts`; the fix
  makes it pass.
- Re-verified with the Docker daemon stubbed out, and with a bogus compatibility flag to
  exercise the non-global-scope advice path.
- After the fix the whole bundle boots clean, so this was the only violation in the graph.

https://claude.ai/code/session_01G1yjcQQgVzvw5UuLU6pKvb

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/905"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791447943&installation_model_id=428097&pr_number=905&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F905&signature=c717703aaf4a1bf5b7e0088bd68d941ed676315631c9a53c963324135041d6f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->