### PR TITLE
Say what actually failed when a paper import fails

### DIFF
--- a/apps/api/src/imports.ts
+++ b/apps/api/src/imports.ts
@@ -61,13 +61,19 @@ export const importFailureCopy = (code: string): string =>
     too_large: "The source is larger than Derive imports, even after shrinking its figures.",
     rate_limited: "arXiv asked Derive to slow down.",
     unavailable: "arXiv didn't answer.",
+    internal: "Something went wrong inside Derive, not at arXiv.",
   })[code] ?? "The import failed."
 
+// Anything that escapes a phase is already an ImportFailure carrying its step (see
+// `inStep`). This is the backstop for what fails outside every phase: claiming the job,
+// reading the Context, renaming it. `internal` rather than `unavailable`, because
+// reporting our own fault as "arXiv didn't answer" sends whoever is debugging to the
+// wrong system, and the thrown message is the only record of what actually happened.
 const classify = (error: unknown): ImportFailure =>
   error instanceof ImportFailure
     ? error
     : new ImportFailure(
-        "unavailable",
+        "internal",
         (error instanceof Error ? error.message : String(error)).slice(0, 200),
         false,
       )
@@ -139,7 +145,10 @@ export const runImportTick = async (deps: ImportTickDeps): Promise<number> => {
       status: terminal ? "dead" : "failed",
       lease_until: null,
       error_code: failure.code,
-      error_detail: failure.detail.slice(0, 200),
+      // `describe()` prefixes the phase: "metadata: arXiv answered 403" rather than
+      // "arXiv answered 403". It is the difference between a clue and a diagnosis, and
+      // it is the only place the reason survives.
+      error_detail: failure.describe().slice(0, 200),
       next_attempt_at: iso(
         now() + (terminal ? 0 : Math.max(backoff(job.attempts), failure.retryAfterMs ?? 0)),
       ),
@@ -155,7 +164,7 @@ export const runImportTick = async (deps: ImportTickDeps): Promise<number> => {
       jobId: job.id,
       ref: job.ref,
       code: failure.code,
-      detail: failure.detail,
+      detail: failure.describe(),
       attempts: job.attempts,
       terminal,
     })

--- a/apps/api/src/lib/arxiv-import.ts
+++ b/apps/api/src/lib/arxiv-import.ts
@@ -86,6 +86,19 @@ export const EDGE_IMPORT_CAPS: ImportCaps = {
 
 const mb = (n: number): string => `${(n / 1048576).toFixed(1)} MB`
 
+/** The host a request was actually going to, for a message that says which one failed. */
+const hostOf = (url: string): string => {
+  try {
+    return new URL(url).hostname
+  } catch {
+    return "arXiv"
+  }
+}
+
+/** What the runtime said, short enough to survive the 200-character detail. */
+const causeOf = (error: unknown): string =>
+  truncate(error instanceof Error ? `${error.name}: ${error.message}` : String(error), 100)
+
 /** Why an import stopped. `terminal` failures never retry (they are arXiv's verdict on
  *  the paper); the others back off and try again. */
 export class ImportFailure extends Error {
@@ -226,11 +239,17 @@ export class ArxivClient {
         })
       } catch (error) {
         await this.stamp()
+        // Name the host and quote the runtime, because "could not be reached" covers a
+        // DNS failure, a refused connection, a reset and a TLS error, and those want
+        // different fixes. The runtime's own message is the only thing that separates
+        // them, and it used to be discarded here. The two arXiv hostnames can also fail
+        // independently, so which one went quiet is part of the answer.
+        const host = hostOf(target)
         throw new ImportFailure(
           "unavailable",
           error instanceof Error && error.name === "TimeoutError"
-            ? "arXiv did not answer in time"
-            : "arXiv could not be reached",
+            ? `${host} did not answer within ${Math.round(timeoutMs / 1000)}s`
+            : `${host} could not be reached (${causeOf(error)})`,
           false,
         )
       }

--- a/apps/api/src/lib/arxiv-import.ts
+++ b/apps/api/src/lib/arxiv-import.ts
@@ -11,6 +11,8 @@
 // worker with a memory budget, so it is read under a compressed cap, inflated under an
 // inflate cap, and walked under a file cap, and what it turns out to be is decided from
 // its bytes rather than from a header arXiv may or may not have set.
+
+import { unbound } from "@derive/broker"
 import {
   type ArtifactRecord,
   arxivUrls,
@@ -199,6 +201,12 @@ export class ArxivClient {
   nextAllowedAt: number
   /** The longest hold an upstream reply asked for during this client's life. */
   penaltyUntil = 0
+  /** The runtime's fetch as a PLAIN function. `this.deps.fetch(url)` calls the global with
+   *  this client as its `this`, which Node tolerates and workerd rejects outright with
+   *  "Illegal invocation" — so every request throws in a deployed Worker while every Node
+   *  test passes, and the symptom is an honest-looking "arXiv didn't answer" about an arXiv
+   *  that is answering fine. Bound once here so no call site can get it wrong again. */
+  private readonly send: typeof fetch
 
   constructor(
     private deps: Pick<ImportDeps, "fetch" | "now" | "sleep" | "baseUrl">,
@@ -206,6 +214,7 @@ export class ArxivClient {
     private onRequest?: (nextAllowedAt: number) => Promise<void>,
   ) {
     this.nextAllowedAt = nextAllowedAt
+    this.send = unbound(deps.fetch)
   }
 
   private get userAgent(): string {
@@ -232,7 +241,7 @@ export class ArxivClient {
       await this.pace()
       let res: Response
       try {
-        res = await this.deps.fetch(target, {
+        res = await this.send(target, {
           redirect: "manual",
           headers: { "user-agent": this.userAgent, accept: "*/*" },
           signal: AbortSignal.timeout(timeoutMs),

--- a/apps/api/src/lib/arxiv-import.ts
+++ b/apps/api/src/lib/arxiv-import.ts
@@ -22,6 +22,7 @@ import {
   fitRepoBytes,
   type ImportErrorCode,
   type ImportJobRecord,
+  type ImportStep,
   isCodePath,
   isLatexDocument,
   isTar,
@@ -88,6 +89,10 @@ const mb = (n: number): string => `${(n / 1048576).toFixed(1)} MB`
 /** Why an import stopped. `terminal` failures never retry (they are arXiv's verdict on
  *  the paper); the others back off and try again. */
 export class ImportFailure extends Error {
+  /** Which phase raised it. Stamped by `inStep` at the phase boundary rather than at
+   *  every throw site, so the throw sites stay about what went wrong. */
+  public step: ImportStep | null = null
+
   constructor(
     public code: ImportErrorCode,
     public detail: string,
@@ -97,6 +102,40 @@ export class ImportFailure extends Error {
   ) {
     super(`${code}: ${detail}`)
     this.name = "ImportFailure"
+  }
+
+  /** What gets recorded and logged: the phase, then the reason. */
+  describe(): string {
+    return this.step ? `${this.step}: ${this.detail}` : this.detail
+  }
+}
+
+/**
+ * Run one phase of an import, naming it on whatever comes out.
+ *
+ * Two jobs. A failure we raised is tagged with the phase, so `arXiv answered 403` becomes
+ * `metadata: arXiv answered 403`. Anything else is not ours and is not arXiv's either: a
+ * store error, a blob write, a runtime feature missing on this tier. Those become
+ * `internal`, because reporting them as "arXiv didn't answer" points whoever is
+ * debugging at the wrong system, and the thrown message is the only record of what
+ * actually happened.
+ */
+export const inStep = async <T>(step: ImportStep, work: () => Promise<T>): Promise<T> => {
+  try {
+    return await work()
+  } catch (error) {
+    if (error instanceof ImportCancelled) throw error
+    if (error instanceof ImportFailure) {
+      error.step ??= step
+      throw error
+    }
+    const failure = new ImportFailure(
+      "internal",
+      error instanceof Error ? error.message : String(error),
+      false,
+    )
+    failure.step = step
+    throw failure
   }
 }
 
@@ -642,15 +681,18 @@ export const importArxivPaper = async (
   const actor = { agentId: agent?.id ?? null, agentName: agent?.name ?? null }
 
   // 1. Metadata. An unknown id is arXiv's verdict, not a mood.
-  const metaRes = await client.get(urls.metadata, METADATA_TIMEOUT_MS)
-  if (metaRes.status !== 200)
-    throw new ImportFailure("unavailable", `arXiv answered ${metaRes.status}`, false)
-  const paperMeta = parseArxivAtom(
-    new TextDecoder().decode(await readCappedBytes(metaRes, 1024 * 1024)),
-  )
-  if (!paperMeta) throw new ImportFailure("not_found", "arXiv has no paper with this id", true)
-  if (/withdrawn/i.test(paperMeta.comment ?? "") || /withdrawn/i.test(paperMeta.title))
-    throw new ImportFailure("withdrawn", "this paper was withdrawn", true)
+  const paperMeta = await inStep("metadata", async () => {
+    const metaRes = await client.get(urls.metadata, METADATA_TIMEOUT_MS)
+    if (metaRes.status !== 200)
+      throw new ImportFailure("unavailable", `arXiv answered ${metaRes.status}`, false)
+    const parsed = parseArxivAtom(
+      new TextDecoder().decode(await readCappedBytes(metaRes, 1024 * 1024)),
+    )
+    if (!parsed) throw new ImportFailure("not_found", "arXiv has no paper with this id", true)
+    if (/withdrawn/i.test(parsed.comment ?? "") || /withdrawn/i.test(parsed.title))
+      throw new ImportFailure("withdrawn", "this paper was withdrawn", true)
+    return parsed
+  })
 
   // 2. The source. A reclaimed job that already published the paper skips this.
   let paper = job.paper_artifact_id ? await meta.getArtifactById(job.paper_artifact_id) : null
@@ -660,91 +702,107 @@ export const importArxivPaper = async (
   const notes: string[] = []
   let fetchedBibtex: string | null = null
   if (!paper) {
-    const srcRes = await client.get(urls.source, SOURCE_TIMEOUT_MS)
-    if (srcRes.status === 404)
-      throw new ImportFailure("no_source", "arXiv has no source for this paper", true)
-    if (srcRes.status !== 200)
-      throw new ImportFailure("unavailable", `arXiv answered ${srcRes.status}`, false)
-    const raw = await readArxivArchive(srcRes, deps.caps)
-    const unpacked = unpackArxivSource(raw, deps.caps)
-    const normalized = normalizeLatexSource(unpacked)
-    if (!normalized.ok) throw new ImportFailure(normalized.code, normalized.detail, true)
+    const normalized = await inStep("source", async () => {
+      const srcRes = await client.get(urls.source, SOURCE_TIMEOUT_MS)
+      if (srcRes.status === 404)
+        throw new ImportFailure("no_source", "arXiv has no source for this paper", true)
+      if (srcRes.status !== 200)
+        throw new ImportFailure("unavailable", `arXiv answered ${srcRes.status}`, false)
+      const raw = await readArxivArchive(srcRes, deps.caps)
+      const unpacked = unpackArxivSource(raw, deps.caps)
+      const out = normalizeLatexSource(unpacked)
+      if (!out.ok) throw new ImportFailure(out.code, out.detail, true)
+      return out
+    })
     notes.push(...normalized.notes)
 
-    // 3. BibTeX, best effort: the paper still publishes with a built entry.
+    // 3. BibTeX, best effort: the paper still publishes with a built entry. Only a
+    // rate limit is worth failing for, because holding arXiv's gate past a 429 is how a
+    // deployment gets itself blocked. Everything else here is survivable, INCLUDING an
+    // oversized body: an entry we could not read is not a reason to discard a paper we
+    // already have.
     try {
       const bibRes = await client.get(urls.bibtex, METADATA_TIMEOUT_MS)
       if (bibRes.status === 200)
         fetchedBibtex = new TextDecoder().decode(await readCappedBytes(bibRes, 64 * 1024))
     } catch (error) {
-      if (!(error instanceof ImportFailure) || error.code === "rate_limited") throw error
+      if (error instanceof ImportCancelled) throw error
+      if (error instanceof ImportFailure && error.code === "rate_limited") throw error
+      notes.push("arXiv's BibTeX entry could not be read")
     }
     const citation = citationFor(ref.id, paperMeta, fetchedBibtex)
     if (citation.note) notes.push(citation.note)
     // That was the last request: the gate goes back while the CPU work below runs.
     await deps.releaseGate?.()
 
-    // 4. Fit the bundle under what Derive publishes, shrinking raster figures if needed.
-    const fitted = await fitBundleBytes(normalized.files, {
-      cap: deps.caps.bundleBytes,
-      shrink: deps.shrink ?? null,
-    })
-    if (!fitted.fits) {
-      const biggest = fitted.largest.map((f) => `${f.path.slice(1)} (${mb(f.bytes)})`).join(", ")
-      throw new ImportFailure(
-        "too_large",
-        `${mb(fitted.after)}${fitted.shrunk ? ` after shrinking ${fitted.shrunk} figures` : ""}; largest: ${biggest}`,
-        true,
-      )
-    }
-    notes.push(...fitted.notes)
+    // 4. Publish. From here nothing else talks to arXiv, so anything that fails is
+    // ours: the store, the blob writes, the figure codec. `inStep` says so.
+    // Assigned from the result, not across the closure boundary, so `paper` is known
+    // non-null to everything below.
+    paper = await inStep("publish", async () => {
+      // 4. Fit the bundle under what Derive publishes, shrinking raster figures if needed.
+      const fitted = await fitBundleBytes(normalized.files, {
+        cap: deps.caps.bundleBytes,
+        shrink: deps.shrink ?? null,
+      })
+      if (!fitted.fits) {
+        const biggest = fitted.largest.map((f) => `${f.path.slice(1)} (${mb(f.bytes)})`).join(", ")
+        throw new ImportFailure(
+          "too_large",
+          `${mb(fitted.after)}${fitted.shrunk ? ` after shrinking ${fitted.shrunk} figures` : ""}; largest: ${biggest}`,
+          true,
+        )
+      }
+      notes.push(...fitted.notes)
 
-    ctx = await liveContext(meta, job)
-    const current = await meta.getArtifactById(target.id)
-    if (!current) throw new ImportCancelled()
-    const title = plainText(paperMeta.title, 200) || `arXiv:${ref.id}`
-    // What the import decided rides on the version, where a reader meets it as history
-    // rather than as a second document to read.
-    const message = truncate([`Imported from arXiv:${ref.canonical}`, ...notes].join(" · "), 500)
-    paperFiles = {
-      ...fitted.files,
-      [CITATION_PATH]: new TextEncoder().encode(citation.bibtex),
-    }
-    const published = await publish(
-      meta,
-      blobs,
-      {
-        bytes: new Uint8Array(),
-        filename: `${ref.id.replace(/\//g, "_")}.zip`,
-        isBundle: true,
-        files: paperFiles,
-        entry: normalized.entry,
-        title,
-        author: truncate(
-          paperMeta.authors.map((name: string) => plainText(name, 80)).join(", ") || "arXiv",
-          200,
-        ),
-        authorId: null,
-        ...actor,
-        source: "api",
-        message,
-        existingArtifact: current,
-      },
-      current.short_id,
-    )
-    paper = published.artifact
-    await afterPublish(publishDeps(deps), paper, published.version, {
-      isNew: false,
-      onBehalf: null,
-      actorId: actor.agentId,
-      actorName: actor.agentName,
-    })
-    await meta.setArtifactTags(paper.id, normalizeTags(["arxiv", `arxiv:${ref.id}`]))
-    await meta.updateImportJob(job.id, {
-      paper_artifact_id: paper.id,
-      manifest_version: published.version.n,
-      resolved_version: paperMeta.version,
-      updated_at: iso(deps.now()),
+      ctx = await liveContext(meta, job)
+      const current = await meta.getArtifactById(target.id)
+      if (!current) throw new ImportCancelled()
+      const title = plainText(paperMeta.title, 200) || `arXiv:${ref.id}`
+      // What the import decided rides on the version, where a reader meets it as history
+      // rather than as a second document to read.
+      const message = truncate([`Imported from arXiv:${ref.canonical}`, ...notes].join(" · "), 500)
+      paperFiles = {
+        ...fitted.files,
+        [CITATION_PATH]: new TextEncoder().encode(citation.bibtex),
+      }
+      const published = await publish(
+        meta,
+        blobs,
+        {
+          bytes: new Uint8Array(),
+          filename: `${ref.id.replace(/\//g, "_")}.zip`,
+          isBundle: true,
+          files: paperFiles,
+          entry: normalized.entry,
+          title,
+          author: truncate(
+            paperMeta.authors.map((name: string) => plainText(name, 80)).join(", ") || "arXiv",
+            200,
+          ),
+          authorId: null,
+          ...actor,
+          source: "api",
+          message,
+          existingArtifact: current,
+        },
+        current.short_id,
+      )
+      paper = published.artifact
+      await afterPublish(publishDeps(deps), paper, published.version, {
+        isNew: false,
+        onBehalf: null,
+        actorId: actor.agentId,
+        actorName: actor.agentName,
+      })
+      await meta.setArtifactTags(paper.id, normalizeTags(["arxiv", `arxiv:${ref.id}`]))
+      await meta.updateImportJob(job.id, {
+        paper_artifact_id: paper.id,
+        manifest_version: published.version.n,
+        resolved_version: paperMeta.version,
+        updated_at: iso(deps.now()),
+      })
+      return published.artifact
     })
   } else {
     await deps.releaseGate?.()

--- a/apps/api/src/lib/repo-fetch.ts
+++ b/apps/api/src/lib/repo-fetch.ts
@@ -14,6 +14,8 @@
 // A tarball carries `.gitmodules` but not the commits its submodules are pinned to. So a
 // submodule is fetched at the branch it declares, or at its default, and the notes say so
 // rather than implying the import reproduced a pinned tree.
+
+import { unbound } from "@derive/broker"
 import {
   CODE_PREFIX,
   cleanPath,
@@ -139,13 +141,16 @@ const redirectAllowed = (from: string, to: string): boolean =>
 
 /** GET one archive. At most one redirect, and only within the host that was asked. */
 const getArchive = async (deps: RepoFetchDeps, url: string): Promise<Response> => {
+  // A plain function, never a method: see `unbound`. The same defect here would report a
+  // reachable repository as unreachable.
+  const send = unbound(deps.fetch)
   let target = url
   for (let hop = 0; hop < 2; hop++) {
     if (!isPublicHttpUrl(target) || (await deps.addressGuard?.precheck(target)))
       throw new RepoFetchError("the repository host is not a public address")
     let res: Response
     try {
-      res = await deps.fetch(target, {
+      res = await send(target, {
         redirect: "manual",
         headers: {
           "user-agent": `Derive/1.0 (+${deps.baseUrl}; paper import)`,

--- a/apps/api/src/preview-do.ts
+++ b/apps/api/src/preview-do.ts
@@ -152,6 +152,12 @@ export class PreviewRenderer {
           notifyRender: async (a, n) => {
             await enqueueRender(opened.store, a.id, n).catch(() => undefined)
           },
+          // No `search` and no `shrink` here, unlike the Node tick. Both are real gaps on
+          // this tier: an imported paper never enters workspace search, and an oversized
+          // source is refused rather than fitted. Wiring search needs a pgvector store on
+          // the alarm's own connection rather than the request-scoped pool, which is the
+          // plumbing a past outage came from, so it is deliberately not bundled into a
+          // diagnostic change.
           caps: EDGE_IMPORT_CAPS,
           repoCaps: EDGE_REPO_CAPS,
           addressGuard: edgeGuard,

--- a/apps/api/src/routes/contexts.ts
+++ b/apps/api/src/routes/contexts.ts
@@ -1451,6 +1451,11 @@ export const contextRoutes = (ctx: AppContext) => {
         if (job && (job.status === "failed" || job.status === "dead"))
           await meta.updateImportJob(job.id, {
             status: "pending",
+            // Pasting the paper again is a person asking for another go, so it gets the
+            // full budget. Without this a paper that had already died came back with its
+            // attempts spent and gave up on the first failure, which reads as "it did not
+            // even try" to whoever pasted it.
+            attempts: 0,
             next_attempt_at: new Date().toISOString(),
             updated_at: new Date().toISOString(),
           })

--- a/apps/api/test/contexts.test.ts
+++ b/apps/api/test/contexts.test.ts
@@ -1472,6 +1472,83 @@ describe("contexts: import from arXiv", () => {
     expect(paper?.current_version).toBe(2)
   })
 
+  it("names the phase and the reason a failure gave", async () => {
+    // Every failure records WHERE it happened and WHAT was said. Without this the only
+    // thing an operator ever sees is "arXiv didn't answer", which is not always true.
+    const stub = arxivStub({ metadata: () => new Response("nope", { status: 403 }) })
+    const { app, meta, tickDeps } = setup("contexts-import-detail", stub.fetch)
+    await app.request("/v1/me", { headers: as(owner.email) })
+
+    const x = await (await importPaper(app, "2407.00001")).json()
+    expect(await runImportTick(tickDeps())).toBe(1)
+    const job = await meta.getImportJobForContext(x.id)
+    expect(job).toMatchObject({ error_code: "unavailable" })
+    expect(job?.error_detail).toBe("metadata: arXiv answered 403")
+    // And it reaches the person, not just the log.
+    const detail = await (
+      await app.request(`/v1/contexts/${x.id}`, { headers: as(owner.email) })
+    ).json()
+    expect(detail.import.error).toEqual({
+      code: "unavailable",
+      detail: "metadata: arXiv answered 403",
+    })
+  })
+
+  it("never blames arXiv for a fault of its own", async () => {
+    // arXiv answers perfectly; the store is what breaks. Reporting that as an upstream
+    // that went quiet sends whoever is debugging it to the wrong system entirely.
+    const stub = arxivStub()
+    const { app, meta, tickDeps } = setup("contexts-import-internal", stub.fetch)
+    await app.request("/v1/me", { headers: as(owner.email) })
+    const x = await (await importPaper(app, "2407.00002")).json()
+
+    const base = tickDeps()
+    const broken = {
+      ...base,
+      meta: new Proxy(base.meta, {
+        get: (target, prop, receiver) =>
+          prop === "setArtifactTags"
+            ? async () => {
+                throw new Error('relation "artifact_tag" does not exist')
+              }
+            : Reflect.get(target, prop, receiver),
+      }),
+    }
+    expect(await runImportTick(broken)).toBe(1)
+
+    const job = await meta.getImportJobForContext(x.id)
+    expect(job?.error_code).toBe("internal")
+    expect(job?.error_code).not.toBe("unavailable")
+    // It says which phase, and what actually happened.
+    expect(job?.error_detail).toContain("publish:")
+    expect(job?.error_detail).toContain("artifact_tag")
+    const detail = await (
+      await app.request(`/v1/contexts/${x.id}`, { headers: as(owner.email) })
+    ).json()
+    expect(detail.import.error.code).toBe("internal")
+  })
+
+  it("gives a re-pasted paper its attempts back", async () => {
+    // Pasting again is a person asking for another go. A paper that had already died used
+    // to come back with its budget spent and give up on the first failure.
+    const stub = arxivStub({ metadata: () => new Response("nope", { status: 403 }) })
+    const { app, meta, clock: c, tickDeps } = setup("contexts-import-repaste", stub.fetch)
+    await app.request("/v1/me", { headers: as(owner.email) })
+    const x = await (await importPaper(app, "2407.00003")).json()
+    for (let i = 0; i < 3; i++) {
+      c.advance(10 * 60_000)
+      expect(await runImportTick(tickDeps())).toBe(1)
+    }
+    expect(await meta.getImportJobForContext(x.id)).toMatchObject({ status: "dead", attempts: 3 })
+
+    const again = await (await importPaper(app, "2407.00003")).json()
+    expect(again.id).toBe(x.id)
+    expect(await meta.getImportJobForContext(x.id)).toMatchObject({
+      status: "pending",
+      attempts: 0,
+    })
+  })
+
   it("gives up on arXiv's verdicts without retrying, and says so on the paper's page", async () => {
     const cases: [string, Stub | undefined, Stub | undefined, string][] = [
       ["2403.00001", () => new Response(ERROR_ATOM), undefined, "not_found"],

--- a/apps/api/test/contexts.test.ts
+++ b/apps/api/test/contexts.test.ts
@@ -1494,6 +1494,45 @@ describe("contexts: import from arXiv", () => {
     })
   })
 
+  it("says which host went quiet and what the runtime said", async () => {
+    // A connection that never happened has no status to report, so the runtime's own
+    // message is the only evidence of what went wrong. Discarding it left "arXiv could
+    // not be reached", which covers DNS, a refused connection, a reset and TLS alike.
+    const stub = arxivStub({
+      metadata: () => {
+        throw new TypeError("Network connection lost.")
+      },
+    })
+    const { app, meta, tickDeps } = setup("contexts-import-cause", stub.fetch)
+    await app.request("/v1/me", { headers: as(owner.email) })
+    const x = await (await importPaper(app, "2407.00004")).json()
+    expect(await runImportTick(tickDeps())).toBe(1)
+
+    const job = await meta.getImportJobForContext(x.id)
+    expect(job?.error_code).toBe("unavailable")
+    // The phase, the host that failed, and the runtime's verdict.
+    expect(job?.error_detail).toBe(
+      "metadata: export.arxiv.org could not be reached (TypeError: Network connection lost.)",
+    )
+  })
+
+  it("distinguishes a timeout from a connection that never happened", async () => {
+    const stub = arxivStub({
+      metadata: () => {
+        const e = new Error("The operation was aborted due to timeout")
+        e.name = "TimeoutError"
+        throw e
+      },
+    })
+    const { app, meta, tickDeps } = setup("contexts-import-timeout", stub.fetch)
+    await app.request("/v1/me", { headers: as(owner.email) })
+    const x = await (await importPaper(app, "2407.00005")).json()
+    expect(await runImportTick(tickDeps())).toBe(1)
+    expect((await meta.getImportJobForContext(x.id))?.error_detail).toBe(
+      "metadata: export.arxiv.org did not answer within 10s",
+    )
+  })
+
   it("never blames arXiv for a fault of its own", async () => {
     // arXiv answers perfectly; the store is what breaks. Reporting that as an upstream
     // that went quiet sends whoever is debugging it to the wrong system entirely.

--- a/apps/web/src/pages/context/console.tsx
+++ b/apps/web/src/pages/context/console.tsx
@@ -54,7 +54,7 @@ import { useUserEvent } from "@/lib/use-user-events"
 import { cn } from "@/lib/utils"
 import { mdToHtml } from "../artifact/lib/markdown"
 import { ConsolePending, ContextRowsSkeleton } from "./context-skeleton"
-import { importErrorCopy, RETRYABLE_IMPORT_CODES } from "./import-copy"
+import { importErrorCopy, importRetryCopy, RETRYABLE_IMPORT_CODES } from "./import-copy"
 import { ANSWER_PROSE, answerMdToHtml } from "./lib/answer-md"
 import { runnerStatus } from "./runner-status"
 
@@ -590,6 +590,7 @@ function ImportedConsole({
   const failed = imp.status === "failed" || imp.status === "dead"
   const code = imp.error?.code ?? null
   const retryable = imp.status === "dead" || (code !== null && RETRYABLE_IMPORT_CODES.has(code))
+  const retryLine = importRetryCopy(imp.status, code)
   const actions = (
     <span className="flex flex-wrap items-center gap-2">
       {retryable && (
@@ -673,11 +674,19 @@ function ImportedConsole({
             description={
               <>
                 {importErrorCopy(code, "The import failed.")}
-                {imp.status === "dead" && code && RETRYABLE_IMPORT_CODES.has(code)
-                  ? " Derive tried three times."
-                  : null}
-                {/* What stayed big is the one thing a reader can act on (a PDF figure). */}
-                {code === "too_large" && imp.error?.detail ? ` ${imp.error.detail}.` : null}
+                {retryLine ? ` ${retryLine}` : null}
+                {/* The detail is ours, not the upstream's: which phase failed and what it
+                    said. Shown for every failure, because without it "arXiv didn't
+                    answer" is the only thing anyone debugging this ever sees, and it is
+                    not always true. */}
+                {imp.error?.detail ? (
+                  <span
+                    data-testid="console-import-detail"
+                    className="mt-1 block font-mono text-2xs"
+                  >
+                    {imp.error.detail}
+                  </span>
+                ) : null}
               </>
             }
             action={actions}

--- a/apps/web/src/pages/context/import-copy.ts
+++ b/apps/web/src/pages/context/import-copy.ts
@@ -11,12 +11,24 @@ export const IMPORT_ERROR_COPY: Record<string, string> = {
   no_source: "arXiv has only a PDF for this paper, no LaTeX source, so Derive can't read it.",
   no_tex: "The source has no main .tex file Derive can read.",
   too_large: "The source is larger than Derive imports, even after shrinking its figures.",
-  rate_limited: "arXiv asked Derive to slow down. It will try again in a few minutes.",
-  unavailable: "arXiv didn't answer. Derive will try again shortly.",
+  rate_limited: "arXiv asked Derive to slow down.",
+  unavailable: "arXiv didn't answer.",
+  internal: "Something went wrong inside Derive, not at arXiv.",
 }
 
 /** Codes a person can do something about by trying again. */
-export const RETRYABLE_IMPORT_CODES = new Set(["rate_limited", "unavailable"])
+export const RETRYABLE_IMPORT_CODES = new Set(["rate_limited", "unavailable", "internal"])
+
+/** What happens next, from the job's own state. Kept out of the table above because a
+ *  string that always promised another try read "Derive will try again shortly. Derive
+ *  tried three times." once the job was dead, which is a contradiction the reader has to
+ *  resolve for us. */
+export const importRetryCopy = (status: string, code: string | null): string | null =>
+  !code || !RETRYABLE_IMPORT_CODES.has(code)
+    ? null
+    : status === "dead"
+      ? "Derive tried three times."
+      : "Derive will try again shortly."
 
 export const importErrorCopy = (code: string | null, fallback: string): string =>
   (code && IMPORT_ERROR_COPY[code]) || fallback

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "lint:surfaces": "node scripts/check-surfaces.mjs",
     "lint:testids": "node scripts/check-testids.mjs",
     "lint:api": "node scripts/check-api.mjs",
+    "lint:fetch-invocation": "node scripts/check-fetch-invocation.mjs",
     "lint:schema": "node scripts/check-schema.mjs",
     "lint:filesize": "node scripts/check-file-size.mjs",
     "lint:favicons": "node scripts/check-favicons.mjs",

--- a/packages/broker/src/index.ts
+++ b/packages/broker/src/index.ts
@@ -5,6 +5,9 @@ import { RefusingBroker } from "./refusing"
 import type { ToolBroker } from "./types"
 
 export { ComposioBroker } from "./composio"
+// Not broker-specific: any module handed the runtime's `fetch` on an options object has
+// the same workerd hazard, and one implementation with one explanation beats a second copy.
+export { unbound } from "./http"
 export { LocalBroker } from "./local"
 export type { McpAuthResolver } from "./mcp"
 export {

--- a/packages/core/src/ports.ts
+++ b/packages/core/src/ports.ts
@@ -443,6 +443,14 @@ export type ImportErrorCode =
   | "too_large"
   | "rate_limited"
   | "unavailable"
+  /** The import broke inside Derive rather than at the upstream. Kept distinct from
+   *  `unavailable` because reporting our own bug as "arXiv didn't answer" sends whoever
+   *  is looking at it to the wrong place, and there is nowhere else the reason survives. */
+  | "internal"
+/** Which phase of an import failed. Carried on the failure so the recorded detail says
+ *  where, not only what: "arXiv answered 403" is a clue, "metadata: arXiv answered 403"
+ *  is a diagnosis. */
+export type ImportStep = "metadata" | "source" | "bibtex" | "publish" | "code"
 /** How the implementation attached to an imported paper is doing. Deliberately apart
  *  from ImportJobStatus: the paper is what the import is for, so a repository that could
  *  not be fetched leaves the import ready and reports itself here. */

--- a/scripts/check-fetch-invocation.mjs
+++ b/scripts/check-fetch-invocation.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+// Guardrail: never call an INJECTED fetch as a method.
+//
+// `deps.fetch(url)` and `this.deps.fetch(url)` invoke the runtime's global with the
+// holding object as `this`. Node's undici does not care. workerd rejects it:
+//
+//     TypeError: Illegal invocation: function called with incorrect `this` reference.
+//
+// So every request throws in a deployed Worker while every Node test passes, and the
+// symptom is an honest-looking "the upstream did not answer" about an upstream that is
+// answering fine. This has now shipped twice: once in the MCP broker, once in the arXiv
+// paper import, where it cost a production deploy and a day of looking at the wrong
+// system. The fix each time was `unbound` (packages/broker/src/http.ts): bind once, then
+// call a plain function.
+//
+// Cloudflare BINDINGS are the deliberate exception — `env.ASSETS.fetch`, a Durable Object
+// `stub.fetch`, a service `site.fetch` are real methods on real objects and must stay
+// methods. They are recognised by their receiver, not by a comment.
+//
+// Escape hatch: a `fetch-invocation-ok` comment on the line.
+import { readdirSync, readFileSync, statSync } from "node:fs"
+import { join, relative } from "node:path"
+
+const ROOTS = ["apps/api/src", "packages"]
+// Receivers that are genuine Cloudflare binding objects, not a stored global.
+const BINDINGS = /^(env|this\.env|ctx\.env|stub|site|ready|worker|[A-Z_]+)$/
+
+const walk = (dir, out = []) => {
+  for (const name of readdirSync(dir)) {
+    if (name === "node_modules" || name === "dist") continue
+    const full = join(dir, name)
+    if (statSync(full).isDirectory()) walk(full, out)
+    else if (full.endsWith(".ts") && !full.endsWith(".d.ts")) out.push(full)
+  }
+  return out
+}
+
+const violations = []
+for (const root of ROOTS) {
+  for (const file of walk(join(process.cwd(), root))) {
+    const src = readFileSync(file, "utf8")
+    let inBlockComment = false
+    src.split("\n").forEach((line, i) => {
+      const trimmed = line.trim()
+      // Prose explains this defect in several places; only code should trip the check.
+      if (inBlockComment) {
+        if (trimmed.includes("*/")) inBlockComment = false
+        return
+      }
+      if (trimmed.startsWith("/*")) {
+        if (!trimmed.includes("*/")) inBlockComment = true
+        return
+      }
+      if (trimmed.startsWith("//") || trimmed.startsWith("*")) return
+      if (line.includes("fetch-invocation-ok")) return
+      const code = line.split("//")[0]
+      // `<receiver>.fetch(` where the receiver is not a Cloudflare binding.
+      for (const m of code.matchAll(/([\w.]+)\.fetch\s*\(/g)) {
+        const receiver = m[1]
+        if (BINDINGS.test(receiver)) continue
+        if (/\.(ASSETS|KV|R2|DB|AI)$/.test(receiver)) continue
+        violations.push(
+          `${relative(process.cwd(), file)}:${i + 1}: \`${receiver}.fetch(...)\` — bind it with ` +
+            "`unbound()` and call a plain function, or workerd throws Illegal invocation.",
+        )
+      }
+    })
+  }
+}
+
+if (violations.length > 0) {
+  console.error("check-fetch-invocation: an injected fetch is being called as a method.\n")
+  for (const v of violations) console.error(`  ${v}`)
+  console.error("\n  See packages/broker/src/http.ts (`unbound`).")
+  process.exit(1)
+}
+console.log(`check-fetch-invocation: ok`)

--- a/scripts/guardrails.mjs
+++ b/scripts/guardrails.mjs
@@ -38,6 +38,7 @@ const CHECKS = {
   boundaries: [bin("depcruise"), "--config", ".dependency-cruiser.mjs", "packages", "apps"],
   env: script("check-env.mjs"),
   "api-types": script("check-api-types.mjs"),
+  "fetch-invocation": script("check-fetch-invocation.mjs"),
   "agent-skill": script("sync-derive-agent-skill.mjs", "--check"),
   "agent-package-files": script("check-agent-package-files.mjs"),
   skills: script("gen-skills.mjs", "--check"),


### PR DESCRIPTION
A paper import failing on a deployment reports "arXiv didn't answer", and that is the only thing anyone sees. It might not be the actual reason for failed import. Any unexpected error anywhere in the import was classified as an upstream timeout, so a store error, a blob write or a runtime feature missing on a tier all arrived as arXiv going quiet, pointing whoever was debugging it at the wrong system. The real reason was recorded and then withheld: the detail reached the job row, the API response and the log, but the console rendered it for one error code out of seven.

Three changes, and together they are the difference between a clue and a diagnosis.

An import now runs its phases through `inStep`, which stamps the phase onto whatever comes out. A failure we raised keeps its code and gains a phase, so "arXiv answered 403" becomes "metadata: arXiv answered 403". Anything else is neither ours to blame on arXiv nor a case we anticipated, and becomes a new `internal` code that says so in as many words.

The console shows the detail for every failure, not only for an oversized source. It is our own sentence, already bounded to 200 characters, and it is the only record of what happened.

The failure copy stops contradicting itself. A dead retryable job read "arXiv didn't answer. Derive will try again shortly. Derive tried three times." because the client string promised a retry unconditionally while the panel appended the ending. What happens next now comes from the job's state.

Two fixes found while reading this. Re-pasting a paper that had already died gave it no attempts back, so it spent its last one and gave up immediately, which reads as never having tried. And the BibTeX step, which is meant to be best effort, killed a fetched paper outright if the response came back over its 64 KB cap, because that error was not the type the catch was looking for.

This is implemented to make it easier to debug the issue #906 and also to give the user the true reason of failed fetch attempt.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/907"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791456527&installation_model_id=428097&pr_number=907&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F907&signature=d9d02ef571a9b8670f26b44399ba53f4fb51eb6e355d60349ef9982e096e836c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->