### PR TITLE
Release chore: cli 0.6.0, mcp 0.7.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,7 @@ apps/docs/.astro/
 apps/docs/src/content/docs/
 apps/docs/src/generated/
 apps/docs/public/
+
+# Local knowledge-graph output from the understand-anything tooling. Untracked, but
+# biome scans the working tree and fails `pnpm run ci` on its generated JSON.
+.ua/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,13 @@ for the recommended install and verification flow.
   (`derived_from LIKE 'derive://templates/%'`; none on derive.to) can clear them with
   `deploy/drop-built-in-template-lineage.sql`; until then those rows read as
   underived.
+- `@derive-to/mcp` 0.7.0 — the stdio server drops the two retired template resources
+  and its `@derive-to/templates` dependency, so nothing it ships resolves outside the
+  published set. Inline content that opens with `\documentclass` or `\begin{document}`
+  now falls back to `index.tex` rather than `index.md`, so a paper is never stored as
+  Markdown. The bundled SKILL.md gains the inline shared-state contract (the artifact
+  sandbox has no browser storage; use `derive.shared`) and the code-mode retrieval
+  guidance. Its `@derive-to/cli` dependency resolves to 0.6.0.
 - **Proposals and the approval step.** The two review ceremonies are gone: ask-first
   candidate versions awaiting an editor's decision, and the `approved` round state with
   its served-version pointer. Review is one loop: every write publishes live as a kept,
@@ -238,12 +245,18 @@ for the recommended install and verification flow.
   always opens a review round — its reveal is never silent.
 
 ### Added
-- `@derive-to/cli` 0.6.0 adds `derive workflow run`, a one-shot Codex harness for
-  Derive graph runs dispatched through reviewed `derive-*.yml` GitHub Actions.
-  The job authenticates passwordlessly with GitHub OIDC, receives only the exact
-  version-pinned graph plus a short-lived run capability, and reports Context and
-  terminal receipts back to Derive; no standing Derive token or prompt is stored
-  in GitHub.
+- `@derive-to/cli` 0.6.0 adds two commands. `derive workflow run` is a one-shot Codex
+  harness for Derive graph runs dispatched through reviewed `derive-*.yml` GitHub
+  Actions: the job authenticates passwordlessly with GitHub OIDC, receives only the
+  exact version-pinned graph plus a short-lived run capability, and reports Context and
+  terminal receipts back to Derive, so no standing Derive token or prompt is stored in
+  GitHub. `derive scan` reads local Claude Code and Codex history and sends Derive the
+  receipts for artifacts and Skills used on this machine. `derive scan setup` wires it
+  into the local agent's hooks, and with `--schedule` also installs a recurring OS job
+  (launchd, systemd, or Task Scheduler); `derive scan status` reports the parser version
+  and what is still pending; `--since` and `--dry-run` bound a manual pass.
+  Receipts upload in batches under a lock, so an interrupted or overlapping scan
+  neither double-counts nor exceeds its timeout.
 - **Reversible artifact archiving.** Artifacts can leave the active library without being
   deleted, appear in a dedicated archive, and be restored later.
 - **A standalone public documentation site.** `docs.derive.to` now publishes the product,

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@derive-to/mcp",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "type": "module",
   "description": "Stdio MCP server for Derive — find, read, comment on, and publish durable artifacts from compatible agents.",
   "mcpName": "to.derive/derive",


### PR DESCRIPTION
`@derive-to/cli` 0.6.0 was bumped in #874 but never published, so the registry still
serves 0.5.0 while two commands landed on top of it. The changelog entry now covers
both: `derive workflow run`, and `derive scan` with its `setup`, `status`, `--since`
and `--dry-run` surfaces.

`@derive-to/mcp` goes to 0.7.0. The published 0.6.0 predates the template retirement
in #795, so the stdio server it serves still registers the two `derive://templates`
resources and still depends on `@derive-to/templates`, which this repository no longer
builds. 0.7.0 drops both, falls back to `index.tex` for LaTeX input, and carries the
SKILL.md shared-state and code-mode guidance.

Publish the CLI first. `mcp`'s `@derive-to/cli` dependency resolves at pack time, so
mcp 0.7.0 does not install until cli 0.6.0 is on the registry — verified by installing
the packed tarball on its own, which fails `ETARGET` for `@derive-to/cli@0.6.0`.

`.ua/` is ignored. The understand-anything tooling writes generated JSON there, and
biome scans the working tree and fails `pnpm run ci` on it — the same reason
`coverage/` is ignored.

## Verification

- `pnpm verify` exits 0; 36/36 guardrails pass, including `agent-package-files`
  (pack contents plus published-set dependency closure).
- Packed both with `pnpm pack`: the mcp manifest resolves `@derive-to/cli` to the
  literal `0.6.0`, not the `workspace:` protocol that made 0.4.0 uninstallable.
- Installed the cli tarball into a scratch project: the `derive` binary runs and both
  shipped skill trees are present.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/908"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791500373&installation_model_id=428097&pr_number=908&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F908&signature=93779e6cc8a02098d96f3f5969583d92354678ae4a2a082afd907f8e84aea8bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->