### PR TITLE
Improve attended agent UX with W&B

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -297,6 +297,11 @@ DATA_DIR=./data
 # Requires DERIVE_MODEL_API_KEY and DERIVE_MODEL_NAME; all three or none.
 # DERIVE_MODEL_BASE_URL=https://api.fireworks.ai/inference/v1
 
+# W&B Inference bearer token for attended chat. When set, Derive uses DeepSeek V4 Flash
+# through W&B as the default agent model. It disables provider reasoning for fast first output.
+# If unset, Derive uses the configured DERIVE_MODEL_* gateway.
+# WANDB_API_KEY=wandb_v1_...
+
 # Bearer token for DERIVE_MODEL_BASE_URL. Read by the API process only and never forwarded
 # into a CLI runner's environment, so it cannot redirect a coding agent's credentials.
 # DERIVE_MODEL_API_KEY=sk-...

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -144,6 +144,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           AUTH_SECRET: ${{ secrets.DERIVE_AUTH_SECRET }}
           MODEL_KEY: ${{ secrets.DERIVE_MODEL_API_KEY }}
+          WANDB_KEY: ${{ secrets.WANDB_API_KEY }}
           OPENROUTER_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           MODEL_GATEWAYS: ${{ secrets.DERIVE_MODEL_GATEWAYS }}
           MODEL_DEFAULT: ${{ vars.DERIVE_MODEL_DEFAULT }}
@@ -163,6 +164,7 @@ jobs:
           # non-zero exit and kills the step — which is exactly how the first run of this
           # workflow failed, on an unset optional variable rather than on anything real.
           if [ -n "$MODEL_KEY" ]; then put DERIVE_MODEL_API_KEY "$MODEL_KEY"; fi
+          if [ -n "$WANDB_KEY" ]; then put WANDB_API_KEY "$WANDB_KEY"; fi
           # A SECOND provider, when one is configured. All optional: absent means the preview
           # runs on the single gateway exactly as it did before any of this existed.
           if [ -n "$OPENROUTER_KEY" ]; then put OPENROUTER_API_KEY "$OPENROUTER_KEY"; fi
@@ -175,10 +177,10 @@ jobs:
           if [ -n "$MODEL_NAMES" ]; then put DERIVE_MODEL_NAMES "$MODEL_NAMES"; fi
           # A preview with no model answers "no model is configured" in chat, which looks like a
           # regression rather than missing config. Say so once, here.
-          if [ -z "$MODEL_BASE_URL" ] || [ -z "$MODEL_NAME" ] || [ -z "$MODEL_KEY" ]; then
+          if { [ -z "$MODEL_BASE_URL" ] || [ -z "$MODEL_NAME" ] || [ -z "$MODEL_KEY" ]; } && [ -z "$WANDB_KEY" ]; then
             echo "::warning::Preview has no model gateway. Set repo variables DERIVE_MODEL_BASE_URL"\
-                 "and DERIVE_MODEL_NAME plus the DERIVE_MODEL_API_KEY secret, or chat and"\
-                 "automations will report that no model is connected."
+                 "and DERIVE_MODEL_NAME plus DERIVE_MODEL_API_KEY, or set WANDB_API_KEY. Chat"\
+                 "and automations otherwise report that no model is connected."
           fi
 
       # A preview that boots but 500s on the first authenticated request is worse than none,

--- a/apps/api/src/config-manifest.ts
+++ b/apps/api/src/config-manifest.ts
@@ -382,6 +382,12 @@ const CONFIG_VARS: ConfigVar[] = [
     example: "https://api.fireworks.ai/inference/v1",
   },
   {
+    name: "WANDB_API_KEY",
+    group: "advanced",
+    doc: "W&B Inference bearer token for attended chat. When set, Derive uses DeepSeek V4 Flash\nthrough W&B as the default agent model. It disables provider reasoning for fast first output.\nIf unset, Derive uses the configured DERIVE_MODEL_* gateway.",
+    example: "wandb_v1_...",
+  },
+  {
     name: "DERIVE_MODEL_API_KEY",
     group: "advanced",
     doc: "Bearer token for DERIVE_MODEL_BASE_URL. Read by the API process only and never forwarded\ninto a CLI runner's environment, so it cannot redirect a coding agent's credentials.",

--- a/apps/api/src/events.ts
+++ b/apps/api/src/events.ts
@@ -46,6 +46,9 @@ const DOMAIN_EVENTS = [
   // returns the tick instead of blocking to timeout. A wake only (the waiter
   // re-reads the transcript); the session stays `working`; not webhook-eligible.
   "session.progress",
+  // Ephemeral progress for an attended agent turn. The UI keeps this separate from answer
+  // text, so a tool call never looks like prose from the agent. Arguments are never included.
+  "session.activity",
   // A slice of the answer being written, for a reply the model is streaming. Emitted
   // on the ASKER's `u:<id>` channel with `session_id`, a monotonic `seq`, `text`, and the
   // `attempt` it belongs to — a reply the loop re-generates starts a new attempt, and a reader

--- a/apps/api/src/lib/chat-turn.ts
+++ b/apps/api/src/lib/chat-turn.ts
@@ -82,6 +82,8 @@ export interface ChatTurnInput {
   /** Which system prompt this turn speaks with. Absent = the workspace chat
    *  voice. "context_builder" = the guided create-a-context interview. */
   purpose?: "context_builder"
+  /** Ephemeral tool progress for a person watching this turn. Names only. */
+  onActivity?: (activity: { id: string; name: string; state: "running" | "complete" }) => void
 }
 
 /** The transcript as plain chat turns, oldest first. */
@@ -136,6 +138,8 @@ You are talking with ${input.asker.name ?? "someone"} in the workspace "${input.
 
 TOOLS: ${names.length ? names.join(", ") : "none on this turn"}. Use them rather than guessing — you are answering about THIS workspace, and you cannot know its contents from memory.
 
+The interface shows tool activity separately. When a tool is needed, call it immediately. Do not narrate what you are about to do, and do not write answer prose until the needed tools finish.
+
 Four things hold on every answer:
 - SEARCH BEFORE YOU ANSWER anything about what the workspace contains, and answer from what came back rather than from what sounds right.
 - LINK WHAT YOU USED: every document you name is a markdown link, [Q3 Roadmap](/artifacts/ab12cd34), using the short_id the tool returned. Never a bare short_id, never an invented one. Write the link PLAIN, never wrapped in bold or italics: emphasising the name produces a link whose bold closes inside it, which renders as literal asterisks around broken text. That is what a list of documents turns into when every name is emphasised.
@@ -160,6 +164,7 @@ export const runChatTurn = async (
 ): Promise<ChatTurnResult> => {
   const model = { id: deps.model.id, label: deps.model.label }
   const used: string[] = []
+  let activityIndex = 0
   const out = await runTurn({
     system: systemPrompt(input),
     messages: asTurns(input.transcript, (m) => ({
@@ -168,10 +173,20 @@ export const runChatTurn = async (
     })),
     contract: proseContract,
     callModel: deps.model.callModel as AgentLoopInput["callModel"],
+    // Attended chat must converge quickly. Four tool rounds plus one forced-answer turn is
+    // enough for workspace questions and avoids a long tool loop that feels stuck.
+    maxTurns: 5,
     tools: input.tools.tools,
     executeTool: async (name, args) => {
       if (!used.includes(name)) used.push(name)
-      return input.tools.execute(name, args)
+      activityIndex += 1
+      const id = `${activityIndex}-${name}`
+      input.onActivity?.({ id, name, state: "running" })
+      try {
+        return await input.tools.execute(name, args)
+      } finally {
+        input.onActivity?.({ id, name, state: "complete" })
+      }
     },
     // `land` is unreachable: proseContract never yields a revision, so there is nothing to
     // land — this lane's writes ride its TOOLS (chat-tools' publish), which carry their own

--- a/apps/api/src/lib/model-catalog.ts
+++ b/apps/api/src/lib/model-catalog.ts
@@ -96,6 +96,17 @@ export interface GatewayConfig {
  * wants its interactive turns slower. Hosts that do not understand the field ignore it.
  */
 const NO_THINKING = { reasoning: { enabled: false } } as const
+const WANDB_NO_THINKING = { chat_template_kwargs: { enable_thinking: false } } as const
+export const WANDB_BASE_URL = "https://api.inference.wandb.ai/v1"
+export const WANDB_DEEPSEEK_MODEL = "deepseek-ai/DeepSeek-V4-Flash-0731"
+
+export const preferredChatGateway = (
+  legacy: GatewayConfig | null | undefined,
+  wandbApiKey: string | null | undefined,
+): GatewayConfig | null =>
+  wandbApiKey
+    ? { baseUrl: WANDB_BASE_URL, apiKey: wandbApiKey, model: WANDB_DEEPSEEK_MODEL }
+    : (legacy ?? null)
 
 /** Keep interactive replies from winning on time-to-first-token only to then dribble output.
  *  This is a PREFERENCE, not a gate: OpenRouter moves slower endpoints behind the preferred
@@ -151,6 +162,14 @@ const openRouterGateway = (baseUrl: string): boolean => {
   }
 }
 
+const wandbGateway = (baseUrl: string): boolean => {
+  try {
+    return new URL(baseUrl).hostname.toLowerCase() === "api.inference.wandb.ai"
+  } catch {
+    return false
+  }
+}
+
 const providerList = (raw: string | undefined): string[] => {
   const seen = new Set<string>()
   const out: string[] = []
@@ -191,7 +210,7 @@ export const callModelFromGateway = (
       : undefined
   const extraBody = {
     ...(provider ? { provider } : {}),
-    ...NO_THINKING,
+    ...(wandbGateway(gw.baseUrl) ? WANDB_NO_THINKING : NO_THINKING),
   }
   const serverTools = openRouterGateway(gw.baseUrl) ? OPENROUTER_SERVER_TOOLS : []
   return openAiCompatModel({

--- a/apps/api/src/lib/session-stream.ts
+++ b/apps/api/src/lib/session-stream.ts
@@ -228,7 +228,9 @@ export const makeDeltaStream = (opts: DeltaStreamOpts): DeltaStream => {
           // Hold back a marker-length tail: `<revi` now could be `<revision` next slice, and
           // showing it and retracting it would be worse than showing it a beat later.
           queue(seen.slice(0, Math.max(0, seen.length - MARKER_HOLDBACK)))
-          if (buffer.length >= maxChars || now() - oldestAt >= maxMs) flushBuffer()
+          // The first readable slice is the time-to-first-token experience. Publish it at once;
+          // after that, use the normal coalescing limits to keep the realtime path inexpensive.
+          if (seq === 0 || buffer.length >= maxChars || now() - oldestAt >= maxMs) flushBuffer()
         },
       })
     },

--- a/apps/api/src/node.ts
+++ b/apps/api/src/node.ts
@@ -29,7 +29,7 @@ import { sweepExpiredDrafts } from "./lib/drafts"
 import { buildAuthEmail, emailDeliverySender, logEmailSender, resendEmailSender } from "./lib/email"
 import { workspaceIdsFromEnv } from "./lib/env"
 import { sharpShrinker } from "./lib/image-shrink-node"
-import { catalogFromGateway, type GatewayConfig } from "./lib/model-catalog"
+import { catalogFromGateway, type GatewayConfig, preferredChatGateway } from "./lib/model-catalog"
 import { getInstanceSlot, modelSource, readLibrary } from "./lib/model-library"
 import { NODE_REPO_CAPS } from "./lib/repo-fetch"
 import { mountWeb } from "./lib/serve-web"
@@ -377,11 +377,12 @@ const modelGateway = (): GatewayConfig | null => {
 
 // The model catalog, built before the channel senders because the Slack ingest sender needs
 // it (an @Derive mention typed in a thread runs the same turn the web app's mention does).
-const gatewayModels = catalogFromGateway(modelGateway())
+const selectedModelGateway = preferredChatGateway(modelGateway(), process.env.WANDB_API_KEY)
+const gatewayModels = catalogFromGateway(selectedModelGateway)
 // …and the LIVE view of it: the configured catalog widened, per turn, by the operator's model
 // library. This sender is built once at boot and outlives every settings change, so it takes
 // the source rather than the catalog — see lib/model-library.ts.
-const gatewayModelSource = modelSource(gatewayModels, modelGateway(), () => readLibrary(meta))
+const gatewayModelSource = modelSource(gatewayModels, selectedModelGateway, () => readLibrary(meta))
 
 const channelSenders: ChannelSenders = {
   email: emailDeliverySender(

--- a/apps/api/src/routes/contexts.ts
+++ b/apps/api/src/routes/contexts.ts
@@ -361,6 +361,14 @@ export const contextRoutes = (ctx: AppContext) => {
           workspaceName: ws?.name ?? "this workspace",
           asker: { name: me.name ?? me.username ?? null, role: seat.role },
           skills: tools.skills,
+          onActivity: (activity) => {
+            const event = {
+              type: "session.activity" as const,
+              session_id: s.id,
+              ...activity,
+            }
+            void bus.publish(`u:${s.asker_id}`, event)
+          },
           ...(builderTools ? { purpose: "context_builder" as const } : {}),
         },
       ),

--- a/apps/api/src/webhook-do.ts
+++ b/apps/api/src/webhook-do.ts
@@ -10,7 +10,7 @@ import { tickStore } from "./edge-pg"
 import { cloudflareEmailSender, type SendEmailBinding } from "./email-cf"
 import { answerDeriveMention } from "./lib/comment-turn"
 import { emailDeliverySender } from "./lib/email"
-import { catalogFromGateway } from "./lib/model-catalog"
+import { catalogFromGateway, preferredChatGateway } from "./lib/model-catalog"
 import { modelSource, readLibrary } from "./lib/model-library"
 import { makeSlackIngestSender, makeSlackSender } from "./lib/slack-comments"
 import { makeSlackDmSender } from "./lib/slack-dm"
@@ -47,6 +47,7 @@ export interface WebhookOutboxEnv {
   DERIVE_MODEL_NAMES?: string
   DERIVE_MODEL_PROVIDERS?: string
   DERIVE_MODEL_AUTO_PROVIDERS?: string
+  WANDB_API_KEY?: string
   DERIVE_CHAT_ALLOWLIST?: string
 }
 
@@ -69,7 +70,8 @@ const mentionAnswerer = (env: WebhookOutboxEnv, store: MetaStore) => {
           autoProviders: env.DERIVE_MODEL_AUTO_PROVIDERS,
         }
       : undefined
-  const models = catalogFromGateway(gw)
+  const selectedGateway = preferredChatGateway(gw, env.WANDB_API_KEY)
+  const models = catalogFromGateway(selectedGateway)
   if (!models || !env.BUCKET || !env.BASE_URL) return undefined
   return answerDeriveMention({
     meta: store,
@@ -77,7 +79,7 @@ const mentionAnswerer = (env: WebhookOutboxEnv, store: MetaStore) => {
     bus: { publish: () => {}, subscribe: () => () => {} } as never,
     baseUrl: env.BASE_URL,
     // Per turn, not held: the same operator library the API tier reads (lib/model-library.ts).
-    models: modelSource(models, gw, () => readLibrary(store)),
+    models: modelSource(models, selectedGateway, () => readLibrary(store)),
     notify: async () => {},
     chatAllowlist: (env.DERIVE_CHAT_ALLOWLIST ?? "")
       .split(",")

--- a/apps/api/src/worker.ts
+++ b/apps/api/src/worker.ts
@@ -36,7 +36,7 @@ import {
   superAdminsFromEnv,
   workspaceIdsFromEnv,
 } from "./lib/env"
-import { catalogFromGateway, type GatewayConfig } from "./lib/model-catalog"
+import { catalogFromGateway, type GatewayConfig, preferredChatGateway } from "./lib/model-catalog"
 import { getInstanceSlot } from "./lib/model-library"
 import { nativeLimiter } from "./lib/rate-limit"
 import { liveD1, requestD1 } from "./lib/request-d1"
@@ -168,6 +168,8 @@ export interface Env {
   /** Eligible upstream backends for live performance routing. Takes precedence over the fixed
    *  DERIVE_MODEL_PROVIDERS order when present. */
   DERIVE_MODEL_AUTO_PROVIDERS?: string
+  /** Preferred attended-chat provider. DeepSeek V4 Flash is selected when this key exists. */
+  WANDB_API_KEY?: string
   /** Additional providers as JSON — see parseGatewaysJson. Each carries its own key, models and
    *  backend routing, so a fourth provider is a list entry rather than four more variables. */
   DERIVE_MODEL_GATEWAYS?: string
@@ -304,7 +306,8 @@ const handle = (req: Request, env: Env, ctx: ExecutionContext): Response | Promi
         // seat keeps being billed until an unrelated membership change happens to heal it.
         purgeUserData: (userId) => purgeUserDataAndSyncSeats(meta, billing, userId),
       })
-      const models = catalogFromGateway(workerGateway(env))
+      const selectedGateway = preferredChatGateway(workerGateway(env), env.WANDB_API_KEY)
+      const models = catalogFromGateway(selectedGateway)
       app = createApp({
         meta,
         // The static operator/CI bearer (isToken). The Node entry wires this via
@@ -320,12 +323,12 @@ const handle = (req: Request, env: Env, ctx: ExecutionContext): Response | Promi
         // Both from ONE construction: `callModel` is the catalog's default entry, so a lane that
         // picks a model and a lane that does not can never disagree about what "the model" is.
         callModel: models?.resolve(null)?.callModel,
-        automationOperatorPays: env.DERIVE_LOOP_RUNS === "1" && workerGateway(env) !== undefined,
+        automationOperatorPays: env.DERIVE_LOOP_RUNS === "1" && selectedGateway !== null,
         models: models ?? undefined,
         // The gateway that catalog was built from, so the operator's model library can reach an
         // id the environment never named — same endpoint, same key, no new secret. Without it
         // the library can still relabel and pin a lane, but not ADD. See lib/model-library.ts.
-        modelGateway: workerGateway(env),
+        modelGateway: selectedGateway ?? undefined,
         // Code Mode stays read-only in mcp-tools/code.ts. The dynamic Worker receives no parent
         // bindings or network access; its find/read calls return through Workers RPC to this host.
         codeSandbox: cloudflareSandbox(env.LOADER, () => {
@@ -648,7 +651,7 @@ async function withHostedDispatch(
   // there" — that is FALSE and was worth a release: derive.to sets all three, because holding
   // the key and spending it for every workspace IS the hosted posture. `operatorPays` below
   // depends on the same fact.
-  const gateway = workerGateway(env)
+  const gateway = preferredChatGateway(workerGateway(env), env.WANDB_API_KEY) ?? undefined
   /**
    * The operator's live pin for the automation lane, resolved at DISPATCH and read by the loop.
    *

--- a/apps/api/test/model-openai.test.ts
+++ b/apps/api/test/model-openai.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from "vitest"
-import { callModelFromGateway } from "../src/lib/model-catalog"
+import {
+  callModelFromGateway,
+  preferredChatGateway,
+  WANDB_BASE_URL,
+  WANDB_DEEPSEEK_MODEL,
+} from "../src/lib/model-catalog"
 import { openAiCompatModel } from "../src/lib/model-openai"
 
 // The OPENAI-COMPATIBLE adapter. Everything here is the mapping between the two wire formats,
@@ -209,6 +214,26 @@ describe("gateway provider routing", () => {
     })
     expect(body?.tools).toBeUndefined()
     expect(body?.max_tool_calls).toBeUndefined()
+  })
+
+  it("uses the W&B chat template switch to disable thinking", async () => {
+    const body = await routedBody({
+      baseUrl: WANDB_BASE_URL,
+      apiKey: "k",
+      model: WANDB_DEEPSEEK_MODEL,
+    })
+    expect(body?.chat_template_kwargs).toEqual({ enable_thinking: false })
+    expect(body?.reasoning).toBeUndefined()
+  })
+
+  it("prefers W&B DeepSeek when its key is configured", () => {
+    const legacy = { baseUrl: "https://openrouter.ai/api/v1", apiKey: "old", model: "old" }
+    expect(preferredChatGateway(legacy, "wandb-key")).toEqual({
+      baseUrl: WANDB_BASE_URL,
+      apiKey: "wandb-key",
+      model: WANDB_DEEPSEEK_MODEL,
+    })
+    expect(preferredChatGateway(legacy, undefined)).toBe(legacy)
   })
 })
 

--- a/apps/api/test/session-stream.test.ts
+++ b/apps/api/test/session-stream.test.ts
@@ -29,13 +29,12 @@ const harness = (over: { now?: () => number; flushChars?: number; flushMs?: numb
 const call = (fn: AgentLoopInput["callModel"]) => fn({ system: "", messages: [], tools: [] })
 
 describe("delta coalescing", () => {
-  it("buffers small pieces instead of publishing each one", async () => {
-    // A frozen clock: only the SIZE boundary can fire, so this isolates it from the age one.
+  it("publishes the first readable slice immediately, then coalesces", async () => {
     const { sent, stream } = harness({ now: () => 0 })
-    await call(stream.wrap(emitting(["a", "b", "c"])))
-    expect(sent).toEqual([]) // still buffered — three tokens are not three publishes
+    await call(stream.wrap(emitting(["a first readable phrase", "b", "c"])))
+    expect(sent).toHaveLength(1)
     stream.flush()
-    expect(sent).toMatchObject([{ seq: 1, text: "abc" }])
+    expect(sent.map((slice) => slice.text).join("")).toBe("a first readable phrasebc")
   })
 
   it("flushes on the size boundary mid-reply", async () => {
@@ -271,9 +270,7 @@ describe("a re-generated reply", () => {
     expect(sent.map((s) => s.seq)).toEqual([...sent.map((s) => s.seq)].sort((a, b) => a - b))
   })
 
-  it("drops text still buffered from an attempt that was abandoned", async () => {
-    // Text the model emitted but that never flushed belongs to a reply being thrown away.
-    // Publishing it later would put words on screen the transcript will never contain.
+  it("marks an abandoned first slice so the next attempt replaces it", async () => {
     const sent: { seq: number; text: string; attempt: number }[] = []
     const stream = makeDeltaStream({
       publish: (s) => {
@@ -286,7 +283,7 @@ describe("a re-generated reply", () => {
       return { text: "abandoned", toolUses: [], costUsd: null, done: true }
     }) as AgentLoopInput["callModel"])
     await first({ system: "", messages: [], tools: [] })
-    // No flush between attempts — the next call must discard that buffer, not inherit it.
+    // The next attempt has a new id, so the client replaces the fast provisional slice.
     const second = stream.wrap((async ({ onDelta }) => {
       onDelta?.("real answer")
       return { text: "real answer", toolUses: [], costUsd: null, done: true }
@@ -294,9 +291,9 @@ describe("a re-generated reply", () => {
     await second({ system: "", messages: [], tools: [] })
     stream.flush()
 
-    expect(sent).toHaveLength(1)
-    expect(sent[0]?.text).toBe("real answer")
-    expect(sent[0]?.text).not.toContain("abandoned")
+    expect(sent).toHaveLength(2)
+    expect(sent.map((slice) => slice.attempt)).toEqual([1, 2])
+    expect(sent[1]?.text).toBe("real answer")
   })
 })
 

--- a/apps/web/src/components/chat/chat-thread.tsx
+++ b/apps/web/src/components/chat/chat-thread.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button"
 import { useCopy } from "@/lib/clipboard"
 import { isInAppPath } from "@/lib/in-app-path"
 import { REVEAL } from "@/lib/interaction"
+import type { SessionActivity } from "@/lib/session-delta"
 import { cn } from "@/lib/utils"
 import { mdToHtml } from "@/pages/artifact/lib/markdown"
 import { ANSWER_PROSE, answerMdToHtml } from "@/pages/context/lib/answer-md"
@@ -45,6 +46,7 @@ export function ChatThread(props: {
   /** The reply being written, when the gateway streams one. "" means nothing in flight, which
    *  is also what a non-streaming turn looks like — the surface falls back to the spinner. */
   streaming?: string
+  activity?: SessionActivity[]
   /** What to show before the first message. */
   empty: ReactNode
   onPoll: () => void
@@ -53,7 +55,7 @@ export function ChatThread(props: {
    *  stays full-bleed. Omitted, rows render as-is (the rail, which is already narrow). */
   row?: (children: ReactNode) => ReactNode
 }) {
-  const { messages, working, streaming, empty, onPoll, className, row } = props
+  const { messages, working, streaming, activity = [], empty, onPoll, className, row } = props
   const endRef = useRef<HTMLDivElement | null>(null)
   const scrollRef = useRef<HTMLDivElement | null>(null)
   const navigate = useNavigate()
@@ -151,7 +153,8 @@ export function ChatThread(props: {
               second, stalled turn. Falls back to the spinner while the model has not emitted
               yet, and whenever nothing is streaming at all, so a turn with no deltas looks
               exactly as it always did. */}
-          {streaming ? wrap(<Streaming text={streaming} />) : working ? wrap(<Thinking />) : null}
+          {working && wrap(<Activity activity={activity} answering={!!streaming} />)}
+          {streaming ? wrap(<Streaming text={streaming} />) : null}
           <div ref={endRef} />
         </div>
       )}
@@ -256,12 +259,33 @@ function Bubble({ msg }: { msg: ChatMessage }) {
   )
 }
 
-function Thinking() {
+const ACTIVITY_WORDS: Record<string, string> = {
+  find: "Searching the workspace",
+  read: "Reading documents",
+  publish: "Writing a document",
+  use: "Using a Context",
+}
+
+function Activity({ activity, answering }: { activity: SessionActivity[]; answering: boolean }) {
+  const running = [...activity].reverse().find((item) => item.state === "running")
+  const label = running
+    ? (ACTIVITY_WORDS[running.name] ?? "Working with the workspace")
+    : activity.length
+      ? `${activity.length} ${activity.length === 1 ? "step" : "steps"}`
+      : "Thinking"
   return (
-    <div className="flex justify-start" data-testid="chat-thinking">
-      <div className="flex items-center gap-2 rounded-lg bg-muted px-3 py-2 text-sm text-muted-foreground">
-        <Icon name="sparkles" className="size-3.5 animate-pulse" />
-        Working…
+    <div
+      className="flex justify-start"
+      data-testid="chat-activity"
+      role="status"
+      aria-live="polite"
+    >
+      <div className="flex items-center gap-2 px-1 py-0.5 text-sm text-muted-foreground">
+        <Icon
+          name={running || !answering ? "sparkles" : "check"}
+          className={cn("size-3.5", (running || !activity.length) && "animate-pulse")}
+        />
+        {label}
       </div>
     </div>
   )

--- a/apps/web/src/components/chat/use-chat-session.ts
+++ b/apps/web/src/components/chat/use-chat-session.ts
@@ -1,5 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from "react"
-import { applyDelta, type DeltaState, EMPTY_DELTA, supersededBy } from "@/lib/session-delta"
+import {
+  applyActivity,
+  applyDelta,
+  type DeltaState,
+  EMPTY_DELTA,
+  type SessionActivity,
+  supersededBy,
+} from "@/lib/session-delta"
 import { usePageVisible } from "@/lib/use-page-visible"
 import { useUserEvent } from "@/lib/use-user-events"
 import type { ChatMessage } from "./chat-thread"
@@ -77,6 +84,7 @@ export function useChatSession(opts: ChatSessionOptions) {
   // The accumulation rules live in lib/session-delta.ts, shared with the context console so the
   // two surfaces cannot drift — they did, and one of them was wrong.
   const [delta, setDelta] = useState<DeltaState>(EMPTY_DELTA)
+  const [activity, setActivity] = useState<SessionActivity[]>([])
   // Agent rows seen so far, so a NEW one can be told from one that was already there.
   const agentCount = useRef(0)
   // The lane's callbacks, held in a ref so a caller may define them inline without every
@@ -119,6 +127,7 @@ export function useChatSession(opts: ChatSessionOptions) {
     setMessages([])
     setError(null)
     setDelta(EMPTY_DELTA)
+    setActivity([])
     agentCount.current = 0
   }, [opts.resetKey])
 
@@ -129,6 +138,7 @@ export function useChatSession(opts: ChatSessionOptions) {
       setSessionId(id)
       setMessages([])
       setDelta(EMPTY_DELTA)
+      setActivity([])
       agentCount.current = 0
       setError(null)
       await refresh(id)
@@ -141,6 +151,7 @@ export function useChatSession(opts: ChatSessionOptions) {
     setSessionId(null)
     setMessages([])
     setDelta(EMPTY_DELTA)
+    setActivity([])
     agentCount.current = 0
     setError(null)
     setState("answered")
@@ -159,6 +170,8 @@ export function useChatSession(opts: ChatSessionOptions) {
       }
       setMessages((m) => [...m, optimistic])
       setState("working")
+      setDelta(EMPTY_DELTA)
+      setActivity([])
       try {
         if (!sessionId) {
           // The first message OPENS the session, so merely looking at a chat surface creates
@@ -203,6 +216,19 @@ export function useChatSession(opts: ChatSessionOptions) {
 
   useUserEvent("session.delta", (e) => setDelta((s) => applyDelta(s, e.data, sessionId)), live)
 
+  useUserEvent(
+    "session.activity",
+    (e) => {
+      setActivity((s) => applyActivity(s, e.data, sessionId))
+      try {
+        if ((JSON.parse(e.data) as { state?: string }).state === "running") clearStream()
+      } catch {
+        /* malformed activity is ignored by applyActivity too */
+      }
+    },
+    live,
+  )
+
   // The turn ended. Read the transcript NOW rather than waiting out the poll — this is the
   // event the whole streaming path builds to, and it is what swaps the provisional text for
   // the persisted reply.
@@ -226,6 +252,7 @@ export function useChatSession(opts: ChatSessionOptions) {
     /** The reply being written, or "" when there is nothing in flight. Render it as a
      *  provisional agent bubble; it is replaced by the real message when the turn settles. */
     streaming: delta.text,
+    activity,
     error,
     send,
     poll,

--- a/apps/web/src/components/chrome/palette-ask.tsx
+++ b/apps/web/src/components/chrome/palette-ask.tsx
@@ -116,6 +116,7 @@ export function PaletteAsk(props: {
           messages={chat.messages}
           working={chat.working}
           streaming={chat.streaming}
+          activity={chat.activity}
           onPoll={chat.poll}
           className="px-3 py-3"
           empty={

--- a/apps/web/src/lib/session-delta.test.ts
+++ b/apps/web/src/lib/session-delta.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { applyDelta, EMPTY_DELTA, supersededBy } from "./session-delta"
+import { applyActivity, applyDelta, EMPTY_DELTA, supersededBy } from "./session-delta"
 
 // These rules used to live inline in two components, written two different ways, and one of
 // them was wrong in a way only a second question in a conversation would reveal. That is the
@@ -63,5 +63,33 @@ describe("when the streamed text is superseded", () => {
     expect(supersededBy(1, 1)).toBe(false) // turn 2 streaming, turn 1's answer still sitting there
     expect(supersededBy(2, 1)).toBe(true) // turn 2's answer landed
     expect(supersededBy(0, 0)).toBe(false)
+  })
+})
+
+describe("tool activity", () => {
+  it("adds a tool and updates the same activity when it completes", () => {
+    const running = applyActivity(
+      [],
+      JSON.stringify({ session_id: S, id: "1-find", name: "find", state: "running" }),
+      S,
+    )
+    const complete = applyActivity(
+      running,
+      JSON.stringify({ session_id: S, id: "1-find", name: "find", state: "complete" }),
+      S,
+    )
+    expect(complete).toEqual([{ id: "1-find", name: "find", state: "complete" }])
+  })
+
+  it("ignores another session and malformed activity", () => {
+    const state = [{ id: "1-find", name: "find", state: "running" as const }]
+    expect(
+      applyActivity(
+        state,
+        JSON.stringify({ session_id: "other", id: "2-read", name: "read", state: "running" }),
+        S,
+      ),
+    ).toBe(state)
+    expect(applyActivity(state, "not json", S)).toBe(state)
   })
 })

--- a/apps/web/src/lib/session-delta.ts
+++ b/apps/web/src/lib/session-delta.ts
@@ -24,6 +24,36 @@ export interface DeltaState {
 
 export const EMPTY_DELTA: DeltaState = { text: "", seq: 0, attempt: 0 }
 
+export interface SessionActivity {
+  id: string
+  name: string
+  state: "running" | "complete"
+}
+
+export const applyActivity = (
+  state: SessionActivity[],
+  raw: string,
+  sessionId: string | null,
+): SessionActivity[] => {
+  let p: { session_id?: string; id?: string; name?: string; state?: string }
+  try {
+    p = JSON.parse(raw) as typeof p
+  } catch {
+    return state
+  }
+  if (
+    !sessionId ||
+    p.session_id !== sessionId ||
+    !p.id ||
+    !p.name ||
+    (p.state !== "running" && p.state !== "complete")
+  )
+    return state
+  const next: SessionActivity = { id: p.id, name: p.name, state: p.state }
+  const at = state.findIndex((item) => item.id === p.id)
+  return at === -1 ? [...state, next] : state.map((item, i) => (i === at ? next : item))
+}
+
 /**
  * Fold one `session.delta` event into the current state. Returns the SAME object when the event
  * is not ours or not usable, so a caller can skip a re-render on identity.

--- a/apps/web/src/pages/artifact/artifact-chat.tsx
+++ b/apps/web/src/pages/artifact/artifact-chat.tsx
@@ -2,6 +2,7 @@ import { ChatComposer } from "@/components/chat/chat-composer"
 import { type ChatMessage, ChatThread } from "@/components/chat/chat-thread"
 import { Icon } from "@/components/icons"
 import { EmptyState } from "@/components/shared/empty-state"
+import type { SessionActivity } from "@/lib/session-delta"
 import { cn } from "@/lib/utils"
 
 // CHAT WITH THIS DOCUMENT — the right-rail sibling of the comments panel.
@@ -27,19 +28,21 @@ export function ArtifactChat(props: {
   /** The reply being written, when the gateway streams one. "" means nothing in flight, which
    *  is also what a non-streaming turn looks like — the panel falls back to the spinner. */
   streaming?: string
+  activity?: SessionActivity[]
   disabled?: boolean
   /** Why chat cannot be used, when it cannot (no model configured, no permission). */
   notice?: string
   onSend: (body: string) => Promise<void>
   onPoll: () => void
 }) {
-  const { messages, working, streaming, disabled, notice, onSend, onPoll } = props
+  const { messages, working, streaming, activity, disabled, notice, onSend, onPoll } = props
   return (
     <div className="flex min-h-0 flex-1 flex-col" data-testid="artifact-chat">
       <ChatThread
         messages={messages}
         working={working}
         streaming={streaming}
+        activity={activity}
         onPoll={onPoll}
         className="px-3 py-3"
         empty={

--- a/apps/web/src/pages/artifact/index.tsx
+++ b/apps/web/src/pages/artifact/index.tsx
@@ -1882,6 +1882,7 @@ export function Artifact({ template = false }: { template?: boolean }) {
                   messages={chat.messages}
                   working={chat.working}
                   streaming={chat.streaming}
+                  activity={chat.activity}
                   notice={chat.error ?? undefined}
                   onSend={(b) => chat.send(b)}
                   onPoll={chat.poll}

--- a/apps/web/src/pages/artifact/lib/use-artifact-chat.ts
+++ b/apps/web/src/pages/artifact/lib/use-artifact-chat.ts
@@ -28,6 +28,7 @@ export function useArtifactChat(shortId: string) {
     messages: chat.messages,
     working: chat.working,
     streaming: chat.streaming,
+    activity: chat.activity,
     error: chat.error,
     send: chat.send,
     poll: chat.poll,

--- a/apps/web/src/pages/chat/index.tsx
+++ b/apps/web/src/pages/chat/index.tsx
@@ -231,6 +231,7 @@ export function ChatPage() {
         messages={chat.messages}
         working={chat.working}
         streaming={chat.streaming}
+        activity={chat.activity}
         onPoll={chat.poll}
         className="py-6"
         row={measure}

--- a/apps/web/src/pages/context/builder.tsx
+++ b/apps/web/src/pages/context/builder.tsx
@@ -132,6 +132,7 @@ export function ContextBuilderPage() {
               messages={chat.messages}
               working={chat.working}
               streaming={chat.streaming}
+              activity={chat.activity}
               onPoll={chat.poll}
               className="px-3 py-3"
               empty={


### PR DESCRIPTION
## Summary

- Use W&B as the provider for attended agent requests.
- Show live tool activity separately from answer text.
- Send the first readable response slice immediately.
- Keep attended turns short and responsive.

## Verification

- `pnpm verify`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/916"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791701193&installation_model_id=428097&pr_number=916&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F916&signature=8d64292e6d1f55756d01d44048d55a9b76e49a6461db0f8575b143bfdbe1f9fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->