### PR TITLE
feat(billing): gate the white-label switch on plan entitlement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,13 @@ for the recommended install and verification flow.
   dependencies reach outside the published set.
 
 ### Changed
+- **The white-label switch is gated on the plan, not just the render.** A Free
+  workspace used to be able to flip "White-label shared pages" on with no effect, since
+  the Made-with-Derive mark is entitlement-checked at render. Now the settings API
+  refuses to turn it on for an unentitled workspace (402 `billing_required`), the
+  settings page shows an "Upgrade to Team" link in place of the switch, and
+  `GET /v1/billing` reports the entitlement as `white_label`. Turning it off is always
+  allowed. Beta-grace instances and subscribed workspaces are unchanged.
 - **The activity "New" marker is the account's position, not the browser's.** The
   workspace Activity page and every artifact's activity rail measure "new" against a
   per-user, per-stream position kept on the server (`GET`/`PUT /v1/seen`), so every device

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -92,6 +92,10 @@ const billingBlockCopy = (baseUrl: string) => {
       code: "billing_required",
       message: `Free covers 3 editor seats, so this workspace needs the Team plan to add more editors. An owner can upgrade at ${billingUrl}.`,
     },
+    white_label: {
+      code: "billing_required",
+      message: `White-label shared pages is a Team-plan feature, so the Made-with-Derive mark stays on until this workspace upgrades. An owner can upgrade at ${billingUrl}.`,
+    },
     storage: {
       code: "storage_exceeded",
       message: `This workspace is out of storage, so this save was refused. Upgrade for more at ${billingUrl}.`,

--- a/apps/api/src/routes/billing.ts
+++ b/apps/api/src/routes/billing.ts
@@ -62,6 +62,9 @@ export const billingRoutes = (ctx: AppContext) => {
       enforce_at: deps.billingEnforceAt ?? null,
       beta,
       subscribed: state.subscriptionActive,
+      // May this workspace hide the Made-with-Derive mark? The settings page swaps the
+      // white-label switch for an upgrade link when this is false.
+      white_label: state.whiteLabelEntitled,
       blocked: state.blockedReason ? blockCopy[state.blockedReason] : null,
     })
   })

--- a/apps/api/src/routes/workspace.ts
+++ b/apps/api/src/routes/workspace.ts
@@ -77,6 +77,8 @@ export const workspaceRoutes = (ctx: AppContext) => {
     workspaceRole,
     seatGrantGate,
     workspacesOf,
+    billingState,
+    blockCopy,
   } = ctx
   const { privateOwnerId, oauthGrant, inviteLimiter, limited } = ctx
   const billing = deps.billing
@@ -760,6 +762,14 @@ export const workspaceRoutes = (ctx: AppContext) => {
         return bail(fail(c, 400, "a workspace-listed default needs default workspace access"))
       if (next.defaultListed === "public" && next.defaultLinkRole === "none")
         return bail(fail(c, 400, "a publicly-listed default needs a default link role"))
+      // Turning white-label on needs the Team entitlement. Render already ignores the
+      // flag for an unentitled workspace (effectiveWhiteLabel), so this is not a security
+      // gate; it exists so the settings page can offer an upgrade instead of a switch
+      // that does nothing. Off is always allowed.
+      if (flat.whiteLabel && !(await billingState(org)).whiteLabelEntitled)
+        return bail(
+          fail(c, 402, blockCopy.white_label.message, { code: blockCopy.white_label.code }),
+        )
       await meta.setOrgSettings(org, next)
       return c.json(next)
     },

--- a/apps/api/test/billing-gate.test.ts
+++ b/apps/api/test/billing-gate.test.ts
@@ -123,6 +123,31 @@ describe("billing gate", () => {
     expect(paidDetail.badge).toBe(false)
   })
 
+  it("white-label toggle: enforced-free PATCH 402s, off always allowed, beta and subscribed pass", async () => {
+    const patch = (app: ReturnType<typeof makeAuthedApp>["app"], on: boolean) =>
+      app.request("/v1/workspace/settings", jsonAs(as("u1@x.test"), { whiteLabel: on }, "PATCH"))
+    // Enforced, no subscription: turning white-label ON is refused with the upgrade code
+    // and nothing is persisted; turning it OFF is always fine.
+    const made = makeAuthedApp("wl_patch_enforced", THREE, "editor", {
+      deps: { billing: new FakeBilling(), billingEnforceAt: PAST },
+    })
+    const refused = await patch(made.app, true)
+    expect(refused.status).toBe(402)
+    expect((await refused.json()).code).toBe("billing_required")
+    expect((await made.meta.getOrgSettings("default")).whiteLabel).toBe(false)
+    expect((await patch(made.app, false)).status).toBe(200)
+    // Same workspace once subscribed: entitled, the toggle takes.
+    await seedSub(made.meta, "active")
+    const paid = await patch(made.app, true)
+    expect(paid.status).toBe(200)
+    expect((await paid.json()).whiteLabel).toBe(true)
+    // Beta grace: the toggle works without a subscription.
+    const beta = makeAuthedApp("wl_patch_beta", THREE, "editor", {
+      deps: { billing: new FakeBilling() },
+    })
+    expect((await patch(beta.app, true)).status).toBe(200)
+  })
+
   it("blocked destination workspace: anonymous draft claim refuses with 402", async () => {
     const { app: drafts, meta } = makeAuthedApp("bg_claim", THREE, "editor", {
       deps: {

--- a/apps/api/test/billing.test.ts
+++ b/apps/api/test/billing.test.ts
@@ -42,6 +42,17 @@ describe("billing routes", () => {
     expect(body.seats).toBe(4)
     expect(body.subscribed).toBe(false)
     expect(body.beta).toBe(true)
+    expect(body.white_label).toBe(true)
+  })
+
+  it("GET /v1/billing: white_label is the entitlement, not the toggle", async () => {
+    const { app, fake } = boot("br_white_label", PAST)
+    const free = await (await app.request("/v1/billing", { headers: as("u1@x.test") })).json()
+    expect(free.white_label).toBe(false)
+    fake.subscriptions.set("sub_1", SNAP)
+    await hook(app, { type: "customer.subscription.updated", snapshot: SNAP })
+    const paid = await (await app.request("/v1/billing", { headers: as("u1@x.test") })).json()
+    expect(paid.white_label).toBe(true)
   })
 
   it("checkout: owner gets a URL, quantity = live seats", async () => {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -388,6 +388,8 @@ export type BillingInfo = {
   enforce_at: string | null
   beta: boolean
   subscribed: boolean
+  /** May hide the Made-with-Derive mark (subscribed, or beta grace). */
+  white_label: boolean
   blocked: { code: "billing_required" | "billing_lapsed"; message: string } | null
 }
 /** Slack connection status for a workspace. Generated from the OpenAPI spec. */

--- a/apps/web/src/pages/settings/general-section.tsx
+++ b/apps/web/src/pages/settings/general-section.tsx
@@ -1,4 +1,5 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query"
+import { Link } from "@tanstack/react-router"
 import { useEffect, useState } from "react"
 import { api, type OrgSettings } from "@/api"
 import { useShell } from "@/components/chrome/shell-context"
@@ -26,7 +27,12 @@ import {
 } from "@/components/ui/select-menu"
 import { Switch } from "@/components/ui/switch"
 import { reloadAfterWorkspaceChange } from "@/lib/persist"
-import { workspaceQuery, workspaceSettingsQuery, workspacesQuery } from "@/lib/queries"
+import {
+  billingQuery,
+  workspaceQuery,
+  workspaceSettingsQuery,
+  workspacesQuery,
+} from "@/lib/queries"
 import { snapshot, useApiMutation } from "@/lib/use-api-mutation"
 import { useOneShotParams } from "@/lib/use-one-shot-params"
 import { SettingsSection } from "./settings-section"
@@ -246,6 +252,11 @@ export function GeneralSection() {
 function SharingDefaults() {
   const qc = useQueryClient()
   const { data: settings, isError, refetch } = useQuery(workspaceSettingsQuery())
+  // White-label is a Team feature: the server 402s an unentitled workspace that tries
+  // to turn it on, so a Free workspace gets an upgrade link where the switch would be.
+  // Until billing answers, the switch renders disabled rather than briefly usable.
+  const { data: billing } = useQuery(billingQuery())
+  const whiteLabelLocked = billing ? !billing.white_label : false
 
   const update = useApiMutation({
     mutationFn: (patch: Partial<OrgSettings>) => api.updateWorkspaceSettings(patch),
@@ -334,16 +345,28 @@ function SharingDefaults() {
         </SelectMenu>
       </SettingRow>
       <SettingRow
-        htmlFor="toggle-white-label"
+        htmlFor={whiteLabelLocked ? undefined : "toggle-white-label"}
         label="White-label shared pages"
         description="Hide the Made-with-Derive mark on public artifacts and embeds, and allow the bare embed (?chrome=none). A Team-plan feature."
       >
-        <Switch
-          id="toggle-white-label"
-          data-testid="toggle-white-label"
-          checked={settings.whiteLabel}
-          onCheckedChange={(next) => set("whiteLabel", next)}
-        />
+        {whiteLabelLocked ? (
+          <Link
+            to="/settings/$section"
+            params={{ section: "billing" }}
+            data-testid="white-label-upgrade"
+            className="text-sm font-medium underline underline-offset-2 hover:text-foreground"
+          >
+            Upgrade to Team
+          </Link>
+        ) : (
+          <Switch
+            id="toggle-white-label"
+            data-testid="toggle-white-label"
+            checked={settings.whiteLabel}
+            disabled={!billing}
+            onCheckedChange={(next) => set("whiteLabel", next)}
+          />
+        )}
       </SettingRow>
     </SettingsGroup>
   )


### PR DESCRIPTION
A Free workspace could flip "White-label shared pages" on and nothing changed: entitlement is checked at render, so the switch was a silent no-op. This closes the gap at the switch.

- `PATCH /v1/workspace/settings` returns 402 `billing_required` when an unentitled workspace sends `whiteLabel: true`. Turning it off is always allowed. Beta grace and subscribed workspaces are unchanged.
- `GET /v1/billing` now returns `white_label`, the entitlement, so the client doesn't re-derive the rule.
- General settings shows an "Upgrade to Team" link in place of the switch when `white_label` is false. The switch is held disabled until billing loads so it never flashes usable.
- New block copy entry `white_label` in `context.ts`, same code the upgrade dialog already maps.
- Tests: billing-gate covers enforced-free 402, off allowed, subscribed pass, beta pass; billing covers the new field. Changelog entry under Unreleased.

Local pre-push failures were the known mcp/slack/contexts timeout flake (different set each run); every affected suite passes in isolation. CI runs the full verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LEFfJjXat2Mizz7ZxEAijj

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/derive-to/codesmith/derive/pr/918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791735902&installation_model_id=428097&pr_number=918&repository=derive-to%2Fderive&return_to=https%3A%2F%2Fgithub.com%2Fderive-to%2Fderive%2Fpull%2F918&signature=1b8ad9a462ed68f25291a3128ee3e89562de3708d00bb39dc6ad0b7b71917ece"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->